### PR TITLE
docs: rewrite gRPC proto documentation and add buf lint enforcement

### DIFF
--- a/.claude/hooks/lint-proto-on-edit.sh
+++ b/.claude/hooks/lint-proto-on-edit.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# PostToolUse hook: runs `buf lint` immediately after Claude edits or writes a .proto file, so
+# comment-coverage violations (.claude/rules/proto-documentation.md) surface within the same turn
+# instead of waiting for CI (tools/lint-proto.sh, wired into .github/workflows/ci-dev.yml). Reuses
+# that same script/buf.yaml/Docker image rather than duplicating the buf invocation.
+#
+# The `if` filter on the hook entries in .claude/settings.json already restricts invocation to
+# Edit(*.proto)/Write(*.proto) calls; the suffix check below is a cheap belt-and-braces fallback in
+# case that filter is ever loosened.
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+INPUT="$(cat)"
+FILE_PATH="$(printf '%s' "${INPUT}" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
+
+[[ "${FILE_PATH}" == *.proto ]] || exit 0
+
+if ! command -v docker >/dev/null 2>&1; then
+	echo "note: skipping buf lint for ${FILE_PATH} - docker not available on PATH" >&2
+	exit 0
+fi
+
+set +e
+LINT_OUTPUT="$("${PROJECT_DIR}/tools/lint-proto.sh" 2>&1)"
+LINT_EXIT=$?
+set -e
+
+if [[ ${LINT_EXIT} -ne 0 ]]; then
+	echo "buf lint failed after editing ${FILE_PATH} - fix the violation(s) below before continuing:" >&2
+	echo "${LINT_OUTPUT}" >&2
+	exit 2
+fi
+
+exit 0

--- a/.claude/rules/proto-documentation.md
+++ b/.claude/rules/proto-documentation.md
@@ -1,0 +1,98 @@
+---
+paths:
+  - "**/*.proto"
+---
+
+# Proto Documentation Convention
+
+`.proto` comments are the *only* documentation client implementers see — they are the source for
+generated Javadoc, and (via `csharp_namespace`) for the C# client's IDE tooltips, and for whatever
+TypeScript/other generators run downstream. A weak or wrong comment here ships to every language
+binding. Write for a client implementer who has never opened the Java engine source, not for a
+reader who already knows what the field does.
+
+## Every message and every field needs a real comment
+
+Not just present — informative. `// The X value.` on a field named `x` is not documentation, it's
+punctuation. If the field name already says everything a comment would say, the field is either
+well-named enough to need only a one-line confirmation of units/nullability/range (see below), or
+the field is one of the mechanical `oneof` dispatch wrappers exempted below.
+
+## Nullability of wrapper types
+
+evitaDB proto messages carry optional/nullable values almost exclusively as
+`google.protobuf.{Int32,Int64,String,Bool,...}Value` wrappers rather than proto3 `optional` scalars.
+An unset wrapper is indistinguishable from a wrapper set to the zero value unless the comment says
+what "unset" means. Every wrapper-typed field's comment must state the unset case explicitly.
+Model:
+
+```proto
+// Deprecation notice contains information about planned removal of this entity from the model / client API.
+// This allows to plan and evolve the schema allowing clients to adapt early to planned breaking changes.
+//
+// If notice is `null`, this schema is considered not deprecated.
+google.protobuf.StringValue deprecationNotice = 4;
+```
+(`GrpcEntitySchema.proto:36`)
+
+Don't write "optional" and stop — say what absence *means* in domain terms (falls back to a
+default, root of a hierarchy, feature disabled, etc.), not just that it can be absent.
+
+## Units
+
+Any numeric field carrying a physical quantity (time, size, count-with-a-scale) states its unit
+inline, in parentheses, at the end of the summary line. Model:
+
+```proto
+// Duration of time since the server was started (seconds)
+int64 uptime = 3;
+```
+(`GrpcEvitaManagementAPI.proto:17-18`)
+
+## Paging base index
+
+evitaDB has two distinct pagination models in the gRPC surface — say which one a field belongs to,
+every time:
+
+- **Page-based** (`pageNumber`/`pageSize`, e.g. `GrpcPaginatedList`): `pageNumber` is **1-indexed**
+  (page 1 is the first page) — see `io.evitadb.dataType.PaginatedList#getPageNumber`. State this
+  explicitly on both the request field that sets a desired page and the response field that reports
+  the current one; don't assume the reader knows evitaDB's convention.
+- **Strip/offset-based** (`offset`/`limit`, e.g. `GrpcStripList`): `offset` is a **0-indexed** count
+  of records to skip from the beginning, not a page number.
+
+When documenting a paging field, also state (or link to a message-level comment stating) the
+server-side maximum, if one is enforced, and what happens when the request exceeds it (clamped?
+rejected?) — verify against the handler, don't guess.
+
+## `oneof` exclusivity
+
+Every `oneof` block's comment states that exactly one member may be set (or, if the semantics
+differ — e.g. "at most one" vs "exactly one" — which one it actually is). State it once on the
+`oneof` keyword's comment, not on every member.
+
+## Deprecation
+
+- Every `[deprecated = true]` field or `option deprecated = true` message states *why* and, if
+  applicable, *what to use instead*, in prose — not just the compiler flag. Existing convention,
+  keep using it: `// deprecated in favor of \`replacementField\`` or `// RENAMED TO "newName"`.
+  A bare `[deprecated = true]` with no reason is not acceptable.
+- `// TOBEDONE: <what> (<issue URL>)` is this repo's accepted marker for deprecated-and-scheduled-
+  for-removal proto elements, matching the same convention already used on the Java side (see
+  `.claude/rules/deprecation-policy.md` and 60+ existing `TOBEDONE` occurrences under
+  `evita_api/`, `evita_query/`, etc.). It requires a linked GitHub issue — an un-linked `TOBEDONE`
+  or bare `TODO` is not acceptable in committed `.proto` files, same as `.java`.
+
+## No Javadoc markup
+
+`.proto` comments are read by non-Java client generators too. Never use Javadoc syntax
+(`{@link #FOO}`, `{@code ...}`) — it leaks into the generated C#/TypeScript/other-language comments
+verbatim and means nothing there. Use plain Markdown-ish prose or backtick code spans instead.
+
+## Field name typos
+
+If a field name itself is wrong (a shipped typo, e.g. `queryPriceModelValue` for "query price
+*mode*"), document the mismatch in the comment. **Never rename the field** to fix it — the field
+number is stable but the name drives generated accessor methods and JSON field mapping in every
+client language; renaming is a breaking change requiring its own deliberate migration, not a
+comment-quality fix.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/lint-proto-on-edit.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -7,6 +7,7 @@ on:
     branches: [ "dev" ]            # trap each push to dev branch
     paths:                         # but react only to changes in code or pipeline definition
       - evita*/**/*.java
+      - evita*/**/*.proto
       - evita*/**/pom.xml
       - pom.xml
       - evita_external_api/evita_external_api_lab/src/main/resources/META-INF/lab/gui/dist/**
@@ -31,6 +32,10 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 checkout sources
       with:
         persist-credentials: false
+
+    - name: Lint gRPC proto files with buf   # fails fast, before JDK setup/compile/tests - every
+      run: tools/lint-proto.sh               # message/field/enum/rpc/service must carry a real
+                                              # comment (.claude/rules/proto-documentation.md)
 
     - name: Detect RoaringBitmap module changes   # colocated vendor test suite - skip it unless
       id: roaring-filter                          # this push actually touches that module or the

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/schemaApi/model/EntitySchemaDescriptor.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/schemaApi/model/EntitySchemaDescriptor.java
@@ -73,7 +73,7 @@ public interface EntitySchemaDescriptor extends VersionedDescriptor, NamedSchema
 			Each entity must be part of at most single hierarchy (tree).
 			
 			Hierarchy can limit returned entities by using filtering constraints. It's also used for
-			computation of extra data - such as `hierarchyParentsOfSelf`. It can also invert type of returned entities in case extra result
+			computation of extra data - such as the `parents` requirement. It can also invert type of returned entities in case extra result
 			`hierarchyOfSelf` is requested.
 			""")
 		.type(nonNull(Boolean.class))

--- a/evita_external_api/evita_external_api_grpc/shared/buf.yaml
+++ b/evita_external_api/evita_external_api_grpc/shared/buf.yaml
@@ -1,0 +1,24 @@
+version: v2
+# Kept out of src/main/resources deliberately: everything under that tree is packaged as-is into
+# the evita_external_api_grpc_shared JAR (alongside the .proto sources themselves, so downstream
+# non-Java clients can extract and compile them directly) - this file is our own lint config, not
+# something meant to ship to consumers of the JAR.
+#
+# `path` below points at the proto module root (relative to this file): all .proto files there
+# import each other by bare filename (e.g. `import "GrpcEnums.proto";`), which only resolves
+# correctly if buf treats that exact directory as the module root rather than this one.
+modules:
+  - path: src/main/resources/META-INF/io/evitadb/externalApi/grpc
+lint:
+  use:
+    # COMMENTS enforces a non-empty leading comment on every message, field, enum, enum value,
+    # RPC and service - directly enforcing the "every message/field/enum needs a real comment"
+    # rule from .claude/rules/proto-documentation.md (repo root).
+    #
+    # Deliberately NOT using STANDARD/DEFAULT/BASIC: those bundle naming-convention rules
+    # (lower_snake_case field/enum names, file/package layout, versioned package suffixes) that
+    # conflict with this surface's established camelCase style, which exists to match the
+    # generated Java accessor names (`stringValue` -> `getStringValue()`) and is shared by every
+    # client language already relying on it. Enforcing them would demand renaming ~1000 existing
+    # fields - a massive breaking change, not what #1350 asked for.
+    - COMMENTS

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/DataItemMap.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/DataItemMap.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Structure that holds a map of values stored inside map of the complex object.
+ * Structure that holds a map-typed node of a complex associated data value's tree.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.DataItemMap}
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The stored named fields with associated values.
+   * The child nodes of this map node, keyed by property name.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -127,7 +127,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The stored named fields with associated values.
+   * The child nodes of this map node, keyed by property name.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -138,7 +138,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The stored named fields with associated values.
+   * The child nodes of this map node, keyed by property name.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -156,7 +156,7 @@ io.evitadb.externalApi.grpc.generated.GrpcDataItem defaultValue) {
   }
   /**
    * <pre>
-   * The stored named fields with associated values.
+   * The child nodes of this map node, keyed by property name.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -343,7 +343,7 @@ io.evitadb.externalApi.grpc.generated.GrpcDataItem defaultValue) {
   }
   /**
    * <pre>
-   * Structure that holds a map of values stored inside map of the complex object.
+   * Structure that holds a map-typed node of a complex associated data value's tree.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.DataItemMap}
@@ -576,7 +576,7 @@ io.evitadb.externalApi.grpc.generated.GrpcDataItem defaultValue) {
     }
     /**
      * <pre>
-     * The stored named fields with associated values.
+     * The child nodes of this map node, keyed by property name.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -597,7 +597,7 @@ io.evitadb.externalApi.grpc.generated.GrpcDataItem defaultValue) {
     }
     /**
      * <pre>
-     * The stored named fields with associated values.
+     * The child nodes of this map node, keyed by property name.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -608,7 +608,7 @@ io.evitadb.externalApi.grpc.generated.GrpcDataItem defaultValue) {
     }
     /**
      * <pre>
-     * The stored named fields with associated values.
+     * The child nodes of this map node, keyed by property name.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -625,7 +625,7 @@ io.evitadb.externalApi.grpc.generated.GrpcDataItem defaultValue) {
     }
     /**
      * <pre>
-     * The stored named fields with associated values.
+     * The child nodes of this map node, keyed by property name.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -647,7 +647,7 @@ io.evitadb.externalApi.grpc.generated.GrpcDataItem defaultValue) {
     }
     /**
      * <pre>
-     * The stored named fields with associated values.
+     * The child nodes of this map node, keyed by property name.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -670,7 +670,7 @@ io.evitadb.externalApi.grpc.generated.GrpcDataItem defaultValue) {
     }
     /**
      * <pre>
-     * The stored named fields with associated values.
+     * The child nodes of this map node, keyed by property name.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -687,7 +687,7 @@ io.evitadb.externalApi.grpc.generated.GrpcDataItem defaultValue) {
     }
     /**
      * <pre>
-     * The stored named fields with associated values.
+     * The child nodes of this map node, keyed by property name.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -706,7 +706,7 @@ io.evitadb.externalApi.grpc.generated.GrpcDataItem defaultValue) {
     }
     /**
      * <pre>
-     * The stored named fields with associated values.
+     * The child nodes of this map node, keyed by property name.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/DataItemMapOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/DataItemMapOrBuilder.java
@@ -33,7 +33,7 @@ public interface DataItemMapOrBuilder extends
 
   /**
    * <pre>
-   * The stored named fields with associated values.
+   * The child nodes of this map node, keyed by property name.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -41,7 +41,7 @@ public interface DataItemMapOrBuilder extends
   int getDataCount();
   /**
    * <pre>
-   * The stored named fields with associated values.
+   * The child nodes of this map node, keyed by property name.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -56,7 +56,7 @@ public interface DataItemMapOrBuilder extends
   getData();
   /**
    * <pre>
-   * The stored named fields with associated values.
+   * The child nodes of this map node, keyed by property name.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -65,7 +65,7 @@ public interface DataItemMapOrBuilder extends
   getDataMap();
   /**
    * <pre>
-   * The stored named fields with associated values.
+   * The child nodes of this map node, keyed by property name.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>
@@ -77,7 +77,7 @@ io.evitadb.externalApi.grpc.generated.GrpcDataItem getDataOrDefault(
 io.evitadb.externalApi.grpc.generated.GrpcDataItem defaultValue);
   /**
    * <pre>
-   * The stored named fields with associated values.
+   * The child nodes of this map node, keyed by property name.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcDataItem&gt; data = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/EvitaManagementServiceGrpc.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/EvitaManagementServiceGrpc.java
@@ -645,7 +645,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup.
+     * Procedure used to restore a catalog from a client-uploaded backup via true gRPC client
+     * streaming; see `RestoreCatalogUnary` for the chunked-unary alternative.
      * </pre>
      */
     default io.grpc.stub.StreamObserver<io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogRequest> restoreCatalog(
@@ -655,7 +656,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup (unary version for gRPC/web).
+     * Procedure used to restore a catalog from a client-uploaded backup, one chunk per call (unary
+     * version for gRPC/web, where true client streaming as in `RestoreCatalog` is unavailable).
      * </pre>
      */
     default void restoreCatalogUnary(io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogUnaryRequest request,
@@ -665,7 +667,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup.
+     * Procedure used to restore a catalog from a backup file already stored on the server, without
+     * re-uploading it.
      * </pre>
      */
     default void restoreCatalogFromServerFile(io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogFromServerFileRequest request,
@@ -735,7 +738,7 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to get file contents
+     * Procedure used to get file contents, streamed back to the client in chunks.
      * </pre>
      */
     default void fetchFile(io.evitadb.externalApi.grpc.generated.GrpcFetchFileRequest request,
@@ -846,7 +849,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup.
+     * Procedure used to restore a catalog from a client-uploaded backup via true gRPC client
+     * streaming; see `RestoreCatalogUnary` for the chunked-unary alternative.
      * </pre>
      */
     public io.grpc.stub.StreamObserver<io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogRequest> restoreCatalog(
@@ -857,7 +861,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup (unary version for gRPC/web).
+     * Procedure used to restore a catalog from a client-uploaded backup, one chunk per call (unary
+     * version for gRPC/web, where true client streaming as in `RestoreCatalog` is unavailable).
      * </pre>
      */
     public void restoreCatalogUnary(io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogUnaryRequest request,
@@ -868,7 +873,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup.
+     * Procedure used to restore a catalog from a backup file already stored on the server, without
+     * re-uploading it.
      * </pre>
      */
     public void restoreCatalogFromServerFile(io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogFromServerFileRequest request,
@@ -945,7 +951,7 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to get file contents
+     * Procedure used to get file contents, streamed back to the client in chunks.
      * </pre>
      */
     public void fetchFile(io.evitadb.externalApi.grpc.generated.GrpcFetchFileRequest request,
@@ -1040,7 +1046,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup.
+     * Procedure used to restore a catalog from a client-uploaded backup via true gRPC client
+     * streaming; see `RestoreCatalogUnary` for the chunked-unary alternative.
      * </pre>
      */
     @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/10918")
@@ -1052,7 +1059,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup (unary version for gRPC/web).
+     * Procedure used to restore a catalog from a client-uploaded backup, one chunk per call (unary
+     * version for gRPC/web, where true client streaming as in `RestoreCatalog` is unavailable).
      * </pre>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogUnaryResponse restoreCatalogUnary(io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogUnaryRequest request) throws io.grpc.StatusException {
@@ -1062,7 +1070,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup.
+     * Procedure used to restore a catalog from a backup file already stored on the server, without
+     * re-uploading it.
      * </pre>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogResponse restoreCatalogFromServerFile(io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogFromServerFileRequest request) throws io.grpc.StatusException {
@@ -1132,7 +1141,7 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to get file contents
+     * Procedure used to get file contents, streamed back to the client in chunks.
      * </pre>
      */
     @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/10918")
@@ -1226,7 +1235,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup (unary version for gRPC/web).
+     * Procedure used to restore a catalog from a client-uploaded backup, one chunk per call (unary
+     * version for gRPC/web, where true client streaming as in `RestoreCatalog` is unavailable).
      * </pre>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogUnaryResponse restoreCatalogUnary(io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogUnaryRequest request) {
@@ -1236,7 +1246,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup.
+     * Procedure used to restore a catalog from a backup file already stored on the server, without
+     * re-uploading it.
      * </pre>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogResponse restoreCatalogFromServerFile(io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogFromServerFileRequest request) {
@@ -1306,7 +1317,7 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to get file contents
+     * Procedure used to get file contents, streamed back to the client in chunks.
      * </pre>
      */
     public java.util.Iterator<io.evitadb.externalApi.grpc.generated.GrpcFetchFileResponse> fetchFile(
@@ -1403,7 +1414,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup (unary version for gRPC/web).
+     * Procedure used to restore a catalog from a client-uploaded backup, one chunk per call (unary
+     * version for gRPC/web, where true client streaming as in `RestoreCatalog` is unavailable).
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogUnaryResponse> restoreCatalogUnary(
@@ -1414,7 +1426,8 @@ public final class EvitaManagementServiceGrpc {
 
     /**
      * <pre>
-     * Procedure used to restore a catalog from backup.
+     * Procedure used to restore a catalog from a backup file already stored on the server, without
+     * re-uploading it.
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogResponse> restoreCatalogFromServerFile(

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryPageRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryPageRequest.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to GetMutationsHistoryPage request.
+ * Request for GetMutationsHistoryPage, a paged, reverse-chronological read of past mutations (catalog
+ * schema changes and entity mutations) that match the given criteria. Traversal is always reverse
+ * (newest first); there is currently no forward-traversal RPC (tracked in #1349).
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetMutationsHistoryPageRequest}
@@ -73,7 +75,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value page_;
   /**
    * <pre>
-   * The page number starting with 1
+   * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+   * Not rejected when it lands past the last available page - the response is simply empty; see the
+   * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -85,7 +89,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The page number starting with 1
+   * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+   * Not rejected when it lands past the last available page - the response is simply empty; see the
+   * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -97,7 +103,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The page number starting with 1
+   * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+   * Not rejected when it lands past the last available page - the response is simply empty; see the
+   * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -111,7 +119,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value pageSize_;
   /**
    * <pre>
-   * The size of the page to return
+   * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+   * exceeds the number of available mutations; the last page is simply shorter.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -123,7 +132,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The size of the page to return
+   * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+   * exceeds the number of available mutations; the last page is simply shorter.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -135,7 +145,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The size of the page to return
+   * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+   * exceeds the number of available mutations; the last page is simply shorter.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -149,7 +160,16 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value sinceVersion_;
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+   * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+   * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+   * than rejected.
+   *
+   * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+   * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+   * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+   * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+   * set `sinceIndex` explicitly together with `sinceVersion`.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -161,7 +181,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+   * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+   * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+   * than rejected.
+   *
+   * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+   * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+   * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+   * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+   * set `sinceIndex` explicitly together with `sinceVersion`.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -173,7 +202,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+   * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+   * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+   * than rejected.
+   *
+   * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+   * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+   * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+   * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+   * set `sinceIndex` explicitly together with `sinceVersion`.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -187,7 +225,10 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value sinceIndex_;
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+   * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+   * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+   * on `sinceVersion` above for the (common) case where this default currently does not apply.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -199,7 +240,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+   * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+   * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+   * on `sinceVersion` above for the (common) case where this default currently does not apply.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -211,7 +255,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+   * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+   * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+   * on `sinceVersion` above for the (common) case where this default currently does not apply.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -225,7 +272,9 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame_;
   /**
    * <pre>
-   * The time range within which the mutations should be found
+   * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+   * exclusive - the version resolved from it is excluded from the result, even though the underlying
+   * version-resolution lookup it uses is itself inclusive of that moment.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -237,7 +286,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The time range within which the mutations should be found
+   * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+   * exclusive - the version resolved from it is excluded from the result, even though the underlying
+   * version-resolution lookup it uses is itself inclusive of that moment.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -249,7 +300,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The time range within which the mutations should be found
+   * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+   * exclusive - the version resolved from it is excluded from the result, even though the underlying
+   * version-resolution lookup it uses is itself inclusive of that moment.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -264,7 +317,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria> criteria_;
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -275,7 +329,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -287,7 +342,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -298,7 +354,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -309,7 +366,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -324,7 +382,10 @@ private static final long serialVersionUID = 0L;
   private int content_ = 0;
   /**
    * <pre>
-   * The scope of the returned data - either header of the mutation, or the whole mutation
+   * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+   * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+   * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+   * received in full.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 7;</code>
@@ -335,7 +396,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The scope of the returned data - either header of the mutation, or the whole mutation
+   * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+   * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+   * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+   * received in full.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 7;</code>
@@ -597,7 +661,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to GetMutationsHistoryPage request.
+   * Request for GetMutationsHistoryPage, a paged, reverse-chronological read of past mutations (catalog
+   * schema changes and entity mutations) that match the given criteria. Traversal is always reverse
+   * (newest first); there is currently no forward-traversal RPC (tracked in #1349).
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetMutationsHistoryPageRequest}
@@ -949,7 +1015,9 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> pageBuilder_;
     /**
      * <pre>
-     * The page number starting with 1
+     * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+     * Not rejected when it lands past the last available page - the response is simply empty; see the
+     * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -960,7 +1028,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The page number starting with 1
+     * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+     * Not rejected when it lands past the last available page - the response is simply empty; see the
+     * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -975,7 +1045,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The page number starting with 1
+     * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+     * Not rejected when it lands past the last available page - the response is simply empty; see the
+     * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -995,7 +1067,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The page number starting with 1
+     * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+     * Not rejected when it lands past the last available page - the response is simply empty; see the
+     * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -1013,7 +1087,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The page number starting with 1
+     * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+     * Not rejected when it lands past the last available page - the response is simply empty; see the
+     * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -1038,7 +1114,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The page number starting with 1
+     * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+     * Not rejected when it lands past the last available page - the response is simply empty; see the
+     * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -1055,7 +1133,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The page number starting with 1
+     * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+     * Not rejected when it lands past the last available page - the response is simply empty; see the
+     * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -1067,7 +1147,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The page number starting with 1
+     * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+     * Not rejected when it lands past the last available page - the response is simply empty; see the
+     * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -1082,7 +1164,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The page number starting with 1
+     * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+     * Not rejected when it lands past the last available page - the response is simply empty; see the
+     * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -1106,7 +1190,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> pageSizeBuilder_;
     /**
      * <pre>
-     * The size of the page to return
+     * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+     * exceeds the number of available mutations; the last page is simply shorter.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -1117,7 +1202,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page to return
+     * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+     * exceeds the number of available mutations; the last page is simply shorter.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -1132,7 +1218,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page to return
+     * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+     * exceeds the number of available mutations; the last page is simply shorter.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -1152,7 +1239,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page to return
+     * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+     * exceeds the number of available mutations; the last page is simply shorter.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -1170,7 +1258,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page to return
+     * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+     * exceeds the number of available mutations; the last page is simply shorter.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -1195,7 +1284,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page to return
+     * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+     * exceeds the number of available mutations; the last page is simply shorter.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -1212,7 +1302,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page to return
+     * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+     * exceeds the number of available mutations; the last page is simply shorter.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -1224,7 +1315,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page to return
+     * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+     * exceeds the number of available mutations; the last page is simply shorter.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -1239,7 +1331,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page to return
+     * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+     * exceeds the number of available mutations; the last page is simply shorter.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -1263,7 +1356,16 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> sinceVersionBuilder_;
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+     * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+     * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+     * than rejected.
+     *
+     * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+     * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+     * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+     * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+     * set `sinceIndex` explicitly together with `sinceVersion`.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -1274,7 +1376,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+     * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+     * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+     * than rejected.
+     *
+     * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+     * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+     * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+     * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+     * set `sinceIndex` explicitly together with `sinceVersion`.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -1289,7 +1400,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+     * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+     * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+     * than rejected.
+     *
+     * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+     * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+     * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+     * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+     * set `sinceIndex` explicitly together with `sinceVersion`.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -1309,7 +1429,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+     * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+     * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+     * than rejected.
+     *
+     * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+     * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+     * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+     * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+     * set `sinceIndex` explicitly together with `sinceVersion`.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -1327,7 +1456,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+     * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+     * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+     * than rejected.
+     *
+     * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+     * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+     * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+     * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+     * set `sinceIndex` explicitly together with `sinceVersion`.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -1352,7 +1490,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+     * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+     * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+     * than rejected.
+     *
+     * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+     * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+     * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+     * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+     * set `sinceIndex` explicitly together with `sinceVersion`.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -1369,7 +1516,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+     * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+     * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+     * than rejected.
+     *
+     * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+     * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+     * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+     * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+     * set `sinceIndex` explicitly together with `sinceVersion`.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -1381,7 +1537,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+     * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+     * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+     * than rejected.
+     *
+     * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+     * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+     * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+     * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+     * set `sinceIndex` explicitly together with `sinceVersion`.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -1396,7 +1561,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+     * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+     * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+     * than rejected.
+     *
+     * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+     * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+     * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+     * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+     * set `sinceIndex` explicitly together with `sinceVersion`.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -1420,7 +1594,10 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> sinceIndexBuilder_;
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+     * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+     * on `sinceVersion` above for the (common) case where this default currently does not apply.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -1431,7 +1608,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+     * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+     * on `sinceVersion` above for the (common) case where this default currently does not apply.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -1446,7 +1626,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+     * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+     * on `sinceVersion` above for the (common) case where this default currently does not apply.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -1466,7 +1649,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+     * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+     * on `sinceVersion` above for the (common) case where this default currently does not apply.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -1484,7 +1670,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+     * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+     * on `sinceVersion` above for the (common) case where this default currently does not apply.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -1509,7 +1698,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+     * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+     * on `sinceVersion` above for the (common) case where this default currently does not apply.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -1526,7 +1718,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+     * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+     * on `sinceVersion` above for the (common) case where this default currently does not apply.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -1538,7 +1733,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+     * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+     * on `sinceVersion` above for the (common) case where this default currently does not apply.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -1553,7 +1751,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+     * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+     * on `sinceVersion` above for the (common) case where this default currently does not apply.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -1577,7 +1778,9 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange, io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange.Builder, io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeOrBuilder> timeFrameBuilder_;
     /**
      * <pre>
-     * The time range within which the mutations should be found
+     * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+     * exclusive - the version resolved from it is excluded from the result, even though the underlying
+     * version-resolution lookup it uses is itself inclusive of that moment.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -1588,7 +1791,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The time range within which the mutations should be found
+     * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+     * exclusive - the version resolved from it is excluded from the result, even though the underlying
+     * version-resolution lookup it uses is itself inclusive of that moment.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -1603,7 +1808,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The time range within which the mutations should be found
+     * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+     * exclusive - the version resolved from it is excluded from the result, even though the underlying
+     * version-resolution lookup it uses is itself inclusive of that moment.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -1623,7 +1830,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The time range within which the mutations should be found
+     * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+     * exclusive - the version resolved from it is excluded from the result, even though the underlying
+     * version-resolution lookup it uses is itself inclusive of that moment.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -1641,7 +1850,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The time range within which the mutations should be found
+     * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+     * exclusive - the version resolved from it is excluded from the result, even though the underlying
+     * version-resolution lookup it uses is itself inclusive of that moment.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -1666,7 +1877,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The time range within which the mutations should be found
+     * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+     * exclusive - the version resolved from it is excluded from the result, even though the underlying
+     * version-resolution lookup it uses is itself inclusive of that moment.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -1683,7 +1896,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The time range within which the mutations should be found
+     * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+     * exclusive - the version resolved from it is excluded from the result, even though the underlying
+     * version-resolution lookup it uses is itself inclusive of that moment.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -1695,7 +1910,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The time range within which the mutations should be found
+     * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+     * exclusive - the version resolved from it is excluded from the result, even though the underlying
+     * version-resolution lookup it uses is itself inclusive of that moment.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -1710,7 +1927,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The time range within which the mutations should be found
+     * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+     * exclusive - the version resolved from it is excluded from the result, even though the underlying
+     * version-resolution lookup it uses is itself inclusive of that moment.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -1743,7 +1962,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1757,7 +1977,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1771,7 +1992,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1785,7 +2007,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1806,7 +2029,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1824,7 +2048,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1844,7 +2069,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1865,7 +2091,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1883,7 +2110,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1901,7 +2129,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1920,7 +2149,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1937,7 +2167,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1954,7 +2185,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1965,7 +2197,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1979,7 +2212,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -1994,7 +2228,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -2005,7 +2240,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -2017,7 +2253,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -2044,7 +2281,10 @@ private static final long serialVersionUID = 0L;
     private int content_ = 0;
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+     * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+     * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+     * received in full.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 7;</code>
@@ -2055,7 +2295,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+     * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+     * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+     * received in full.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 7;</code>
@@ -2070,7 +2313,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+     * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+     * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+     * received in full.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 7;</code>
@@ -2083,7 +2329,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+     * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+     * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+     * received in full.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 7;</code>
@@ -2101,7 +2350,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+     * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+     * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+     * received in full.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 7;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryPageRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryPageRequestOrBuilder.java
@@ -33,7 +33,9 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
 
   /**
    * <pre>
-   * The page number starting with 1
+   * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+   * Not rejected when it lands past the last available page - the response is simply empty; see the
+   * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -42,7 +44,9 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   boolean hasPage();
   /**
    * <pre>
-   * The page number starting with 1
+   * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+   * Not rejected when it lands past the last available page - the response is simply empty; see the
+   * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -51,7 +55,9 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   com.google.protobuf.Int32Value getPage();
   /**
    * <pre>
-   * The page number starting with 1
+   * The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+   * Not rejected when it lands past the last available page - the response is simply empty; see the
+   * message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value page = 1;</code>
@@ -60,7 +66,8 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
 
   /**
    * <pre>
-   * The size of the page to return
+   * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+   * exceeds the number of available mutations; the last page is simply shorter.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -69,7 +76,8 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   boolean hasPageSize();
   /**
    * <pre>
-   * The size of the page to return
+   * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+   * exceeds the number of available mutations; the last page is simply shorter.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -78,7 +86,8 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   com.google.protobuf.Int32Value getPageSize();
   /**
    * <pre>
-   * The size of the page to return
+   * The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+   * exceeds the number of available mutations; the last page is simply shorter.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value pageSize = 2;</code>
@@ -87,7 +96,16 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
 
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+   * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+   * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+   * than rejected.
+   *
+   * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+   * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+   * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+   * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+   * set `sinceIndex` explicitly together with `sinceVersion`.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -96,7 +114,16 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   boolean hasSinceVersion();
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+   * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+   * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+   * than rejected.
+   *
+   * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+   * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+   * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+   * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+   * set `sinceIndex` explicitly together with `sinceVersion`.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -105,7 +132,16 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   com.google.protobuf.Int64Value getSinceVersion();
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+   * the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+   * the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+   * than rejected.
+   *
+   * Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+   * does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+   * as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+   * the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+   * set `sinceIndex` explicitly together with `sinceVersion`.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 3;</code>
@@ -114,7 +150,10 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
 
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+   * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+   * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+   * on `sinceVersion` above for the (common) case where this default currently does not apply.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -123,7 +162,10 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   boolean hasSinceIndex();
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+   * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+   * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+   * on `sinceVersion` above for the (common) case where this default currently does not apply.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -132,7 +174,10 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   com.google.protobuf.Int32Value getSinceIndex();
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+   * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+   * `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+   * on `sinceVersion` above for the (common) case where this default currently does not apply.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 4;</code>
@@ -141,7 +186,9 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
 
   /**
    * <pre>
-   * The time range within which the mutations should be found
+   * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+   * exclusive - the version resolved from it is excluded from the result, even though the underlying
+   * version-resolution lookup it uses is itself inclusive of that moment.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -150,7 +197,9 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   boolean hasTimeFrame();
   /**
    * <pre>
-   * The time range within which the mutations should be found
+   * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+   * exclusive - the version resolved from it is excluded from the result, even though the underlying
+   * version-resolution lookup it uses is itself inclusive of that moment.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -159,7 +208,9 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange getTimeFrame();
   /**
    * <pre>
-   * The time range within which the mutations should be found
+   * Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+   * exclusive - the version resolved from it is excluded from the result, even though the underlying
+   * version-resolution lookup it uses is itself inclusive of that moment.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange timeFrame = 5;</code>
@@ -168,7 +219,8 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
 
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -177,7 +229,8 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
       getCriteriaList();
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -185,7 +238,8 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria getCriteria(int index);
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -193,7 +247,8 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   int getCriteriaCount();
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -202,7 +257,8 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
       getCriteriaOrBuilderList();
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 6;</code>
@@ -212,7 +268,10 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
 
   /**
    * <pre>
-   * The scope of the returned data - either header of the mutation, or the whole mutation
+   * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+   * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+   * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+   * received in full.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 7;</code>
@@ -221,7 +280,10 @@ public interface GetMutationsHistoryPageRequestOrBuilder extends
   int getContentValue();
   /**
    * <pre>
-   * The scope of the returned data - either header of the mutation, or the whole mutation
+   * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+   * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+   * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+   * received in full.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 7;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryPageResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryPageResponse.java
@@ -29,7 +29,10 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to GetMutationsHistoryPage request.
+ * Response to GetMutationsHistoryPage request. Carries only the page's mutations - there is currently no
+ * total record count, `hasMore`, or `isLast` field (a pagination contract gap tracked in #1349), unlike
+ * `GrpcPaginatedList`/`GrpcDataChunk` elsewhere in this API. A client cannot reliably tell whether another
+ * page follows without requesting it and checking whether it comes back empty.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetMutationsHistoryPageResponse}
@@ -72,7 +75,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture> changeCapture_;
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The mutations on this page, newest first. Can be shorter than the requested page size - including
+   * empty - without that implying it is the last page; see the message-level note above.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -83,7 +87,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The mutations on this page, newest first. Can be shorter than the requested page size - including
+   * empty - without that implying it is the last page; see the message-level note above.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -95,7 +100,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The mutations on this page, newest first. Can be shorter than the requested page size - including
+   * empty - without that implying it is the last page; see the message-level note above.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -106,7 +112,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The mutations on this page, newest first. Can be shorter than the requested page size - including
+   * empty - without that implying it is the last page; see the message-level note above.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -117,7 +124,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The mutations on this page, newest first. Can be shorter than the requested page size - including
+   * empty - without that implying it is the last page; see the message-level note above.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -289,7 +297,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to GetMutationsHistoryPage request.
+   * Response to GetMutationsHistoryPage request. Carries only the page's mutations - there is currently no
+   * total record count, `hasMore`, or `isLast` field (a pagination contract gap tracked in #1349), unlike
+   * `GrpcPaginatedList`/`GrpcDataChunk` elsewhere in this API. A client cannot reliably tell whether another
+   * page follows without requesting it and checking whether it comes back empty.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetMutationsHistoryPageResponse}
@@ -520,7 +531,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -534,7 +546,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -548,7 +561,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -562,7 +576,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -583,7 +598,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -601,7 +617,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -621,7 +638,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -642,7 +660,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -660,7 +679,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -678,7 +698,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -697,7 +718,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -714,7 +736,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -731,7 +754,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -742,7 +766,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -756,7 +781,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -771,7 +797,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -782,7 +809,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -794,7 +822,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The mutations on this page, newest first. Can be shorter than the requested page size - including
+     * empty - without that implying it is the last page; see the message-level note above.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryPageResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryPageResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GetMutationsHistoryPageResponseOrBuilder extends
 
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The mutations on this page, newest first. Can be shorter than the requested page size - including
+   * empty - without that implying it is the last page; see the message-level note above.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -42,7 +43,8 @@ public interface GetMutationsHistoryPageResponseOrBuilder extends
       getChangeCaptureList();
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The mutations on this page, newest first. Can be shorter than the requested page size - including
+   * empty - without that implying it is the last page; see the message-level note above.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -50,7 +52,8 @@ public interface GetMutationsHistoryPageResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture getChangeCapture(int index);
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The mutations on this page, newest first. Can be shorter than the requested page size - including
+   * empty - without that implying it is the last page; see the message-level note above.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -58,7 +61,8 @@ public interface GetMutationsHistoryPageResponseOrBuilder extends
   int getChangeCaptureCount();
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The mutations on this page, newest first. Can be shorter than the requested page size - including
+   * empty - without that implying it is the last page; see the message-level note above.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -67,7 +71,8 @@ public interface GetMutationsHistoryPageResponseOrBuilder extends
       getChangeCaptureOrBuilderList();
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The mutations on this page, newest first. Can be shorter than the requested page size - including
+   * empty - without that implying it is the last page; see the message-level note above.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryRequest.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to GetMutationsHistoryPage request.
+ * Request for GetMutationsHistory, a streamed, reverse-chronological read of past mutations that match
+ * the given criteria - the unpaged sibling of GetMutationsHistoryPage. Traversal is always reverse
+ * (newest first); there is currently no forward-traversal RPC (tracked in #1349).
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetMutationsHistoryRequest}
@@ -73,7 +75,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value sinceVersion_;
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+   * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+   * current catalog version instead - the two can diverge under concurrent writes.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -85,7 +89,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+   * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+   * current catalog version instead - the two can diverge under concurrent writes.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -97,7 +103,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+   * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+   * current catalog version instead - the two can diverge under concurrent writes.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -111,7 +119,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value sinceIndex_;
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+   * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+   * filtering is applied within `sinceVersion` - all of that version's mutations are included.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -123,7 +133,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+   * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+   * filtering is applied within `sinceVersion` - all of that version's mutations are included.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -135,7 +147,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+   * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+   * filtering is applied within `sinceVersion` - all of that version's mutations are included.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -150,7 +164,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria> criteria_;
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -161,7 +176,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -173,7 +189,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -184,7 +201,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -195,7 +213,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -210,7 +229,10 @@ private static final long serialVersionUID = 0L;
   private int content_ = 0;
   /**
    * <pre>
-   * The scope of the returned data - either header of the mutation, or the whole mutation
+   * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+   * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+   * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+   * received in full.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -221,7 +243,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The scope of the returned data - either header of the mutation, or the whole mutation
+   * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+   * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+   * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+   * received in full.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -435,7 +460,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to GetMutationsHistoryPage request.
+   * Request for GetMutationsHistory, a streamed, reverse-chronological read of past mutations that match
+   * the given criteria - the unpaged sibling of GetMutationsHistoryPage. Traversal is always reverse
+   * (newest first); there is currently no forward-traversal RPC (tracked in #1349).
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetMutationsHistoryRequest}
@@ -721,7 +748,9 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> sinceVersionBuilder_;
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+     * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+     * current catalog version instead - the two can diverge under concurrent writes.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -732,7 +761,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+     * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+     * current catalog version instead - the two can diverge under concurrent writes.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -747,7 +778,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+     * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+     * current catalog version instead - the two can diverge under concurrent writes.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -767,7 +800,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+     * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+     * current catalog version instead - the two can diverge under concurrent writes.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -785,7 +820,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+     * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+     * current catalog version instead - the two can diverge under concurrent writes.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -810,7 +847,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+     * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+     * current catalog version instead - the two can diverge under concurrent writes.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -827,7 +866,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+     * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+     * current catalog version instead - the two can diverge under concurrent writes.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -839,7 +880,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+     * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+     * current catalog version instead - the two can diverge under concurrent writes.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -854,7 +897,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+     * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+     * current catalog version instead - the two can diverge under concurrent writes.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -878,7 +923,9 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> sinceIndexBuilder_;
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+     * filtering is applied within `sinceVersion` - all of that version's mutations are included.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -889,7 +936,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+     * filtering is applied within `sinceVersion` - all of that version's mutations are included.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -904,7 +953,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+     * filtering is applied within `sinceVersion` - all of that version's mutations are included.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -924,7 +975,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+     * filtering is applied within `sinceVersion` - all of that version's mutations are included.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -942,7 +995,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+     * filtering is applied within `sinceVersion` - all of that version's mutations are included.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -967,7 +1022,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+     * filtering is applied within `sinceVersion` - all of that version's mutations are included.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -984,7 +1041,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+     * filtering is applied within `sinceVersion` - all of that version's mutations are included.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -996,7 +1055,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+     * filtering is applied within `sinceVersion` - all of that version's mutations are included.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -1011,7 +1072,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+     * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+     * filtering is applied within `sinceVersion` - all of that version's mutations are included.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -1044,7 +1107,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1058,7 +1122,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1072,7 +1137,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1086,7 +1152,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1107,7 +1174,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1125,7 +1193,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1145,7 +1214,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1166,7 +1236,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1184,7 +1255,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1202,7 +1274,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1221,7 +1294,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1238,7 +1312,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1255,7 +1330,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1266,7 +1342,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1280,7 +1357,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1295,7 +1373,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1306,7 +1385,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1318,7 +1398,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1345,7 +1426,10 @@ private static final long serialVersionUID = 0L;
     private int content_ = 0;
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+     * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+     * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+     * received in full.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -1356,7 +1440,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+     * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+     * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+     * received in full.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -1371,7 +1458,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+     * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+     * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+     * received in full.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -1384,7 +1474,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+     * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+     * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+     * received in full.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -1402,7 +1495,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+     * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+     * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+     * received in full.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryRequestOrBuilder.java
@@ -33,7 +33,9 @@ public interface GetMutationsHistoryRequestOrBuilder extends
 
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+   * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+   * current catalog version instead - the two can diverge under concurrent writes.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -42,7 +44,9 @@ public interface GetMutationsHistoryRequestOrBuilder extends
   boolean hasSinceVersion();
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+   * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+   * current catalog version instead - the two can diverge under concurrent writes.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -51,7 +55,9 @@ public interface GetMutationsHistoryRequestOrBuilder extends
   com.google.protobuf.Int64Value getSinceVersion();
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+   * catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+   * current catalog version instead - the two can diverge under concurrent writes.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -60,7 +66,9 @@ public interface GetMutationsHistoryRequestOrBuilder extends
 
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+   * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+   * filtering is applied within `sinceVersion` - all of that version's mutations are included.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -69,7 +77,9 @@ public interface GetMutationsHistoryRequestOrBuilder extends
   boolean hasSinceIndex();
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+   * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+   * filtering is applied within `sinceVersion` - all of that version's mutations are included.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -78,7 +88,9 @@ public interface GetMutationsHistoryRequestOrBuilder extends
   com.google.protobuf.Int32Value getSinceIndex();
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+   * are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+   * filtering is applied within `sinceVersion` - all of that version's mutations are included.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -87,7 +99,8 @@ public interface GetMutationsHistoryRequestOrBuilder extends
 
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -96,7 +109,8 @@ public interface GetMutationsHistoryRequestOrBuilder extends
       getCriteriaList();
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -104,7 +118,8 @@ public interface GetMutationsHistoryRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria getCriteria(int index);
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -112,7 +127,8 @@ public interface GetMutationsHistoryRequestOrBuilder extends
   int getCriteriaCount();
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -121,7 +137,8 @@ public interface GetMutationsHistoryRequestOrBuilder extends
       getCriteriaOrBuilderList();
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -131,7 +148,10 @@ public interface GetMutationsHistoryRequestOrBuilder extends
 
   /**
    * <pre>
-   * The scope of the returned data - either header of the mutation, or the whole mutation
+   * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+   * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+   * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+   * received in full.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -140,7 +160,10 @@ public interface GetMutationsHistoryRequestOrBuilder extends
   int getContentValue();
   /**
    * <pre>
-   * The scope of the returned data - either header of the mutation, or the whole mutation
+   * Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+   * when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+   * enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+   * received in full.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryResponse.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to GetMutationsHistory request.
+ * Response to GetMutationsHistory request. The server sends one such message per mutation - each carries
+ * exactly one `changeCapture` entry, not a batch (see the RPC's streaming semantics).
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetMutationsHistoryResponse}
@@ -72,7 +73,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture> changeCapture_;
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The single mutation delivered by this stream message.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -83,7 +84,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The single mutation delivered by this stream message.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -95,7 +96,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The single mutation delivered by this stream message.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -106,7 +107,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The single mutation delivered by this stream message.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -117,7 +118,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The single mutation delivered by this stream message.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -289,7 +290,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to GetMutationsHistory request.
+   * Response to GetMutationsHistory request. The server sends one such message per mutation - each carries
+   * exactly one `changeCapture` entry, not a batch (see the RPC's streaming semantics).
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetMutationsHistoryResponse}
@@ -520,7 +522,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -534,7 +536,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -548,7 +550,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -562,7 +564,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -583,7 +585,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -601,7 +603,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -621,7 +623,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -642,7 +644,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -660,7 +662,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -678,7 +680,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -697,7 +699,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -714,7 +716,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -731,7 +733,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -742,7 +744,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -756,7 +758,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -771,7 +773,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -782,7 +784,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -794,7 +796,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations that match the criteria
+     * The single mutation delivered by this stream message.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetMutationsHistoryResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GetMutationsHistoryResponseOrBuilder extends
 
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The single mutation delivered by this stream message.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -42,7 +42,7 @@ public interface GetMutationsHistoryResponseOrBuilder extends
       getChangeCaptureList();
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The single mutation delivered by this stream message.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -50,7 +50,7 @@ public interface GetMutationsHistoryResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture getChangeCapture(int index);
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The single mutation delivered by this stream message.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -58,7 +58,7 @@ public interface GetMutationsHistoryResponseOrBuilder extends
   int getChangeCaptureCount();
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The single mutation delivered by this stream message.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>
@@ -67,7 +67,7 @@ public interface GetMutationsHistoryResponseOrBuilder extends
       getChangeCaptureOrBuilderList();
   /**
    * <pre>
-   * The list of mutations that match the criteria
+   * The single mutation delivered by this stream message.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture changeCapture = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryListRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryListRequest.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to GetTrafficHistoryList request.
+ * Request for a single bounded batch of past traffic records matching the given criteria.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficHistoryListRequest}
@@ -71,7 +71,10 @@ private static final long serialVersionUID = 0L;
   private int limit_ = 0;
   /**
    * <pre>
-   * The limit of records to return
+   * Maximum number of matching traffic records to return in this response. This is a plain result cap - not
+   * page-based or offset-based pagination - and the server enforces no upper bound of its own beyond it. To
+   * continue fetching beyond this limit, issue a new request with `criteria.sinceSessionSequenceId` and
+   * `criteria.sinceRecordSessionOffset` set to the position right after the last record already received.
    * </pre>
    *
    * <code>int32 limit = 1;</code>
@@ -86,7 +89,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria_;
   /**
    * <pre>
-   * The criteria of the traffic recording, allows to define constraints on the returned records
+   * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+   * are applied and all recorded traffic (up to `limit`) is eligible.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -98,7 +102,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the traffic recording, allows to define constraints on the returned records
+   * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+   * are applied and all recorded traffic (up to `limit`) is eligible.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -110,7 +115,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the traffic recording, allows to define constraints on the returned records
+   * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+   * are applied and all recorded traffic (up to `limit`) is eligible.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -295,7 +301,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to GetTrafficHistoryList request.
+   * Request for a single bounded batch of past traffic records matching the given criteria.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficHistoryListRequest}
@@ -497,7 +503,10 @@ private static final long serialVersionUID = 0L;
     private int limit_ ;
     /**
      * <pre>
-     * The limit of records to return
+     * Maximum number of matching traffic records to return in this response. This is a plain result cap - not
+     * page-based or offset-based pagination - and the server enforces no upper bound of its own beyond it. To
+     * continue fetching beyond this limit, issue a new request with `criteria.sinceSessionSequenceId` and
+     * `criteria.sinceRecordSessionOffset` set to the position right after the last record already received.
      * </pre>
      *
      * <code>int32 limit = 1;</code>
@@ -509,7 +518,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The limit of records to return
+     * Maximum number of matching traffic records to return in this response. This is a plain result cap - not
+     * page-based or offset-based pagination - and the server enforces no upper bound of its own beyond it. To
+     * continue fetching beyond this limit, issue a new request with `criteria.sinceSessionSequenceId` and
+     * `criteria.sinceRecordSessionOffset` set to the position right after the last record already received.
      * </pre>
      *
      * <code>int32 limit = 1;</code>
@@ -525,7 +537,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The limit of records to return
+     * Maximum number of matching traffic records to return in this response. This is a plain result cap - not
+     * page-based or offset-based pagination - and the server enforces no upper bound of its own beyond it. To
+     * continue fetching beyond this limit, issue a new request with `criteria.sinceSessionSequenceId` and
+     * `criteria.sinceRecordSessionOffset` set to the position right after the last record already received.
      * </pre>
      *
      * <code>int32 limit = 1;</code>
@@ -543,7 +558,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria, io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria.Builder, io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteriaOrBuilder> criteriaBuilder_;
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic (up to `limit`) is eligible.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -554,7 +570,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic (up to `limit`) is eligible.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -569,7 +586,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic (up to `limit`) is eligible.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -589,7 +607,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic (up to `limit`) is eligible.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -607,7 +626,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic (up to `limit`) is eligible.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -632,7 +652,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic (up to `limit`) is eligible.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -649,7 +670,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic (up to `limit`) is eligible.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -661,7 +683,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic (up to `limit`) is eligible.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -676,7 +699,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic (up to `limit`) is eligible.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryListRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryListRequestOrBuilder.java
@@ -33,7 +33,10 @@ public interface GetTrafficHistoryListRequestOrBuilder extends
 
   /**
    * <pre>
-   * The limit of records to return
+   * Maximum number of matching traffic records to return in this response. This is a plain result cap - not
+   * page-based or offset-based pagination - and the server enforces no upper bound of its own beyond it. To
+   * continue fetching beyond this limit, issue a new request with `criteria.sinceSessionSequenceId` and
+   * `criteria.sinceRecordSessionOffset` set to the position right after the last record already received.
    * </pre>
    *
    * <code>int32 limit = 1;</code>
@@ -43,7 +46,8 @@ public interface GetTrafficHistoryListRequestOrBuilder extends
 
   /**
    * <pre>
-   * The criteria of the traffic recording, allows to define constraints on the returned records
+   * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+   * are applied and all recorded traffic (up to `limit`) is eligible.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -52,7 +56,8 @@ public interface GetTrafficHistoryListRequestOrBuilder extends
   boolean hasCriteria();
   /**
    * <pre>
-   * The criteria of the traffic recording, allows to define constraints on the returned records
+   * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+   * are applied and all recorded traffic (up to `limit`) is eligible.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>
@@ -61,7 +66,8 @@ public interface GetTrafficHistoryListRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria getCriteria();
   /**
    * <pre>
-   * The criteria of the traffic recording, allows to define constraints on the returned records
+   * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+   * are applied and all recorded traffic (up to `limit`) is eligible.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryListResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryListResponse.java
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord> trafficRecord_;
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The matching traffic records, up to the requested `limit`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -83,7 +83,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The matching traffic records, up to the requested `limit`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -95,7 +95,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The matching traffic records, up to the requested `limit`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The matching traffic records, up to the requested `limit`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -117,7 +117,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The matching traffic records, up to the requested `limit`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -534,7 +534,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -548,7 +548,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -583,7 +583,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -601,7 +601,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -621,7 +621,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -642,7 +642,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -660,7 +660,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -678,7 +678,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -697,7 +697,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -714,7 +714,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -731,7 +731,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -742,7 +742,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -756,7 +756,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -771,7 +771,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -782,7 +782,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -794,7 +794,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The matching traffic records, up to the requested `limit`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryListResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryListResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GetTrafficHistoryListResponseOrBuilder extends
 
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The matching traffic records, up to the requested `limit`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -42,7 +42,7 @@ public interface GetTrafficHistoryListResponseOrBuilder extends
       getTrafficRecordList();
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The matching traffic records, up to the requested `limit`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -50,7 +50,7 @@ public interface GetTrafficHistoryListResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord getTrafficRecord(int index);
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The matching traffic records, up to the requested `limit`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -58,7 +58,7 @@ public interface GetTrafficHistoryListResponseOrBuilder extends
   int getTrafficRecordCount();
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The matching traffic records, up to the requested `limit`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -67,7 +67,7 @@ public interface GetTrafficHistoryListResponseOrBuilder extends
       getTrafficRecordOrBuilderList();
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The matching traffic records, up to the requested `limit`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryRequest.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to GetTrafficHistory request.
+ * Request for the streaming variant of the traffic history query; unlike GetTrafficHistoryListRequest, all
+ * matching records are streamed back without a result cap.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficHistoryRequest}
@@ -71,7 +72,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria_;
   /**
    * <pre>
-   * The criteria of the traffic recording, allows to define constraints on the returned records
+   * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+   * are applied and all recorded traffic is streamed back.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -83,7 +85,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the traffic recording, allows to define constraints on the returned records
+   * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+   * are applied and all recorded traffic is streamed back.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -95,7 +98,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the traffic recording, allows to define constraints on the returned records
+   * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+   * are applied and all recorded traffic is streamed back.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -269,7 +273,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to GetTrafficHistory request.
+   * Request for the streaming variant of the traffic history query; unlike GetTrafficHistoryListRequest, all
+   * matching records are streamed back without a result cap.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficHistoryRequest}
@@ -461,7 +466,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria, io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria.Builder, io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteriaOrBuilder> criteriaBuilder_;
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic is streamed back.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -472,7 +478,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic is streamed back.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -487,7 +494,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic is streamed back.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -507,7 +515,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic is streamed back.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -525,7 +534,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic is streamed back.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -550,7 +560,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic is streamed back.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -567,7 +578,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic is streamed back.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -579,7 +591,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic is streamed back.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -594,7 +607,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the traffic recording, allows to define constraints on the returned records
+     * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+     * are applied and all recorded traffic is streamed back.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryRequestOrBuilder.java
@@ -33,7 +33,8 @@ public interface GetTrafficHistoryRequestOrBuilder extends
 
   /**
    * <pre>
-   * The criteria of the traffic recording, allows to define constraints on the returned records
+   * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+   * are applied and all recorded traffic is streamed back.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -42,7 +43,8 @@ public interface GetTrafficHistoryRequestOrBuilder extends
   boolean hasCriteria();
   /**
    * <pre>
-   * The criteria of the traffic recording, allows to define constraints on the returned records
+   * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+   * are applied and all recorded traffic is streamed back.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>
@@ -51,7 +53,8 @@ public interface GetTrafficHistoryRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria getCriteria();
   /**
    * <pre>
-   * The criteria of the traffic recording, allows to define constraints on the returned records
+   * The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+   * are applied and all recorded traffic is streamed back.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingCaptureCriteria criteria = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryResponse.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to GetTrafficHistory request.
+ * A single streamed response frame carrying traffic records.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficHistoryResponse}
@@ -72,7 +72,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord> trafficRecord_;
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+   * record per frame).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -83,7 +84,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+   * record per frame).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -95,7 +97,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+   * record per frame).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -106,7 +109,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+   * record per frame).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -117,7 +121,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+   * record per frame).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -289,7 +294,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to GetTrafficHistory request.
+   * A single streamed response frame carrying traffic records.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficHistoryResponse}
@@ -520,7 +525,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -534,7 +540,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -548,7 +555,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -562,7 +570,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -583,7 +592,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -601,7 +611,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -621,7 +632,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -642,7 +654,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -660,7 +673,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -678,7 +692,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -697,7 +712,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -714,7 +730,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -731,7 +748,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -742,7 +760,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -756,7 +775,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -771,7 +791,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -782,7 +803,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -794,7 +816,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of traffic records that match the criteria
+     * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+     * record per frame).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficHistoryResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GetTrafficHistoryResponseOrBuilder extends
 
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+   * record per frame).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -42,7 +43,8 @@ public interface GetTrafficHistoryResponseOrBuilder extends
       getTrafficRecordList();
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+   * record per frame).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -50,7 +52,8 @@ public interface GetTrafficHistoryResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord getTrafficRecord(int index);
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+   * record per frame).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -58,7 +61,8 @@ public interface GetTrafficHistoryResponseOrBuilder extends
   int getTrafficRecordCount();
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+   * record per frame).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>
@@ -67,7 +71,8 @@ public interface GetTrafficHistoryResponseOrBuilder extends
       getTrafficRecordOrBuilderList();
   /**
    * <pre>
-   * The list of traffic records that match the criteria
+   * The traffic records carried by this streamed frame (the current server implementation emits exactly one
+   * record per frame).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecord trafficRecord = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingLabelNamesRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingLabelNamesRequest.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to GetTrafficRecordingLabelsNamesOrderedByCardinality request.
+ * Request to GetTrafficRecordingLabelsNamesOrderedByCardinality request.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficRecordingLabelNamesRequest}
@@ -71,7 +71,9 @@ private static final long serialVersionUID = 0L;
   private int limit_ = 0;
   /**
    * <pre>
-   * The limit of records to return
+   * Maximum number of label names to return, ordered by descending cardinality (most frequently used labels
+   * first). This is a plain result cap, not page-based or offset-based pagination; repeated calls do not support
+   * continuation.
    * </pre>
    *
    * <code>int32 limit = 1;</code>
@@ -86,7 +88,7 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.StringValue nameStartsWith_;
   /**
    * <pre>
-   * Allows to filter the returned labels by the name prefix
+   * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -98,7 +100,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Allows to filter the returned labels by the name prefix
+   * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -110,7 +112,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Allows to filter the returned labels by the name prefix
+   * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -295,7 +297,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to GetTrafficRecordingLabelsNamesOrderedByCardinality request.
+   * Request to GetTrafficRecordingLabelsNamesOrderedByCardinality request.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficRecordingLabelNamesRequest}
@@ -497,7 +499,9 @@ private static final long serialVersionUID = 0L;
     private int limit_ ;
     /**
      * <pre>
-     * The limit of records to return
+     * Maximum number of label names to return, ordered by descending cardinality (most frequently used labels
+     * first). This is a plain result cap, not page-based or offset-based pagination; repeated calls do not support
+     * continuation.
      * </pre>
      *
      * <code>int32 limit = 1;</code>
@@ -509,7 +513,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The limit of records to return
+     * Maximum number of label names to return, ordered by descending cardinality (most frequently used labels
+     * first). This is a plain result cap, not page-based or offset-based pagination; repeated calls do not support
+     * continuation.
      * </pre>
      *
      * <code>int32 limit = 1;</code>
@@ -525,7 +531,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The limit of records to return
+     * Maximum number of label names to return, ordered by descending cardinality (most frequently used labels
+     * first). This is a plain result cap, not page-based or offset-based pagination; repeated calls do not support
+     * continuation.
      * </pre>
      *
      * <code>int32 limit = 1;</code>
@@ -543,7 +551,7 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> nameStartsWithBuilder_;
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -554,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -569,7 +577,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -589,7 +597,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -607,7 +615,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -632,7 +640,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -649,7 +657,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -661,7 +669,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -676,7 +684,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingLabelNamesRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingLabelNamesRequestOrBuilder.java
@@ -33,7 +33,9 @@ public interface GetTrafficRecordingLabelNamesRequestOrBuilder extends
 
   /**
    * <pre>
-   * The limit of records to return
+   * Maximum number of label names to return, ordered by descending cardinality (most frequently used labels
+   * first). This is a plain result cap, not page-based or offset-based pagination; repeated calls do not support
+   * continuation.
    * </pre>
    *
    * <code>int32 limit = 1;</code>
@@ -43,7 +45,7 @@ public interface GetTrafficRecordingLabelNamesRequestOrBuilder extends
 
   /**
    * <pre>
-   * Allows to filter the returned labels by the name prefix
+   * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -52,7 +54,7 @@ public interface GetTrafficRecordingLabelNamesRequestOrBuilder extends
   boolean hasNameStartsWith();
   /**
    * <pre>
-   * Allows to filter the returned labels by the name prefix
+   * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>
@@ -61,7 +63,7 @@ public interface GetTrafficRecordingLabelNamesRequestOrBuilder extends
   com.google.protobuf.StringValue getNameStartsWith();
   /**
    * <pre>
-   * Allows to filter the returned labels by the name prefix
+   * Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.StringValue nameStartsWith = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingLabelNamesResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingLabelNamesResponse.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to GetTrafficRecordingLabelsNamesOrderedByCardinality response.
+ * Response to GetTrafficRecordingLabelsNamesOrderedByCardinality request.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficRecordingLabelNamesResponse}
@@ -74,7 +74,7 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
-   * The list of labels names that match the criteria
+   * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
    * </pre>
    *
    * <code>repeated string labelName = 1;</code>
@@ -86,7 +86,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of labels names that match the criteria
+   * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
    * </pre>
    *
    * <code>repeated string labelName = 1;</code>
@@ -97,7 +97,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of labels names that match the criteria
+   * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
    * </pre>
    *
    * <code>repeated string labelName = 1;</code>
@@ -109,7 +109,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of labels names that match the criteria
+   * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
    * </pre>
    *
    * <code>repeated string labelName = 1;</code>
@@ -286,7 +286,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to GetTrafficRecordingLabelsNamesOrderedByCardinality response.
+   * Response to GetTrafficRecordingLabelsNamesOrderedByCardinality request.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficRecordingLabelNamesResponse}
@@ -476,7 +476,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels names that match the criteria
+     * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
      * </pre>
      *
      * <code>repeated string labelName = 1;</code>
@@ -489,7 +489,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels names that match the criteria
+     * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
      * </pre>
      *
      * <code>repeated string labelName = 1;</code>
@@ -500,7 +500,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels names that match the criteria
+     * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
      * </pre>
      *
      * <code>repeated string labelName = 1;</code>
@@ -512,7 +512,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels names that match the criteria
+     * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
      * </pre>
      *
      * <code>repeated string labelName = 1;</code>
@@ -525,7 +525,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels names that match the criteria
+     * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
      * </pre>
      *
      * <code>repeated string labelName = 1;</code>
@@ -544,7 +544,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels names that match the criteria
+     * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
      * </pre>
      *
      * <code>repeated string labelName = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels names that match the criteria
+     * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
      * </pre>
      *
      * <code>repeated string labelName = 1;</code>
@@ -580,7 +580,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels names that match the criteria
+     * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
      * </pre>
      *
      * <code>repeated string labelName = 1;</code>
@@ -595,7 +595,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels names that match the criteria
+     * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
      * </pre>
      *
      * <code>repeated string labelName = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingLabelNamesResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingLabelNamesResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GetTrafficRecordingLabelNamesResponseOrBuilder extends
 
   /**
    * <pre>
-   * The list of labels names that match the criteria
+   * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
    * </pre>
    *
    * <code>repeated string labelName = 1;</code>
@@ -43,7 +43,7 @@ public interface GetTrafficRecordingLabelNamesResponseOrBuilder extends
       getLabelNameList();
   /**
    * <pre>
-   * The list of labels names that match the criteria
+   * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
    * </pre>
    *
    * <code>repeated string labelName = 1;</code>
@@ -52,7 +52,7 @@ public interface GetTrafficRecordingLabelNamesResponseOrBuilder extends
   int getLabelNameCount();
   /**
    * <pre>
-   * The list of labels names that match the criteria
+   * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
    * </pre>
    *
    * <code>repeated string labelName = 1;</code>
@@ -62,7 +62,7 @@ public interface GetTrafficRecordingLabelNamesResponseOrBuilder extends
   java.lang.String getLabelName(int index);
   /**
    * <pre>
-   * The list of labels names that match the criteria
+   * The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
    * </pre>
    *
    * <code>repeated string labelName = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingStatusResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingStatusResponse.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to StartTrafficRecording and  request.
+ * Response to StartTrafficRecording, StopTrafficRecording, and ExportTrafficRecording requests.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficRecordingStatusResponse}
@@ -269,7 +269,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to StartTrafficRecording and  request.
+   * Response to StartTrafficRecording, StopTrafficRecording, and ExportTrafficRecording requests.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficRecordingStatusResponse}

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingValuesNamesRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingValuesNamesRequest.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to GetTrafficRecordingLabelsValuesOrderedByCardinality request.
+ * Request to GetTrafficRecordingLabelsValuesOrderedByCardinality request.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficRecordingValuesNamesRequest}
@@ -72,7 +72,9 @@ private static final long serialVersionUID = 0L;
   private int limit_ = 0;
   /**
    * <pre>
-   * The limit of records to return
+   * Maximum number of label values to return, ordered by descending cardinality (most frequently used values
+   * first). This is a plain result cap, not page-based or offset-based pagination; repeated calls do not support
+   * continuation.
    * </pre>
    *
    * <code>int32 limit = 1;</code>
@@ -134,7 +136,7 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.StringValue valueStartsWith_;
   /**
    * <pre>
-   * Allows to filter the returned labels by the name prefix
+   * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -146,7 +148,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Allows to filter the returned labels by the name prefix
+   * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -158,7 +160,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Allows to filter the returned labels by the name prefix
+   * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -353,7 +355,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to GetTrafficRecordingLabelsValuesOrderedByCardinality request.
+   * Request to GetTrafficRecordingLabelsValuesOrderedByCardinality request.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficRecordingValuesNamesRequest}
@@ -569,7 +571,9 @@ private static final long serialVersionUID = 0L;
     private int limit_ ;
     /**
      * <pre>
-     * The limit of records to return
+     * Maximum number of label values to return, ordered by descending cardinality (most frequently used values
+     * first). This is a plain result cap, not page-based or offset-based pagination; repeated calls do not support
+     * continuation.
      * </pre>
      *
      * <code>int32 limit = 1;</code>
@@ -581,7 +585,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The limit of records to return
+     * Maximum number of label values to return, ordered by descending cardinality (most frequently used values
+     * first). This is a plain result cap, not page-based or offset-based pagination; repeated calls do not support
+     * continuation.
      * </pre>
      *
      * <code>int32 limit = 1;</code>
@@ -597,7 +603,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The limit of records to return
+     * Maximum number of label values to return, ordered by descending cardinality (most frequently used values
+     * first). This is a plain result cap, not page-based or offset-based pagination; repeated calls do not support
+     * continuation.
      * </pre>
      *
      * <code>int32 limit = 1;</code>
@@ -707,7 +715,7 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> valueStartsWithBuilder_;
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -718,7 +726,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -733,7 +741,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -753,7 +761,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -771,7 +779,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -796,7 +804,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -813,7 +821,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -825,7 +833,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -840,7 +848,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Allows to filter the returned labels by the name prefix
+     * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingValuesNamesRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingValuesNamesRequestOrBuilder.java
@@ -33,7 +33,9 @@ public interface GetTrafficRecordingValuesNamesRequestOrBuilder extends
 
   /**
    * <pre>
-   * The limit of records to return
+   * Maximum number of label values to return, ordered by descending cardinality (most frequently used values
+   * first). This is a plain result cap, not page-based or offset-based pagination; repeated calls do not support
+   * continuation.
    * </pre>
    *
    * <code>int32 limit = 1;</code>
@@ -63,7 +65,7 @@ public interface GetTrafficRecordingValuesNamesRequestOrBuilder extends
 
   /**
    * <pre>
-   * Allows to filter the returned labels by the name prefix
+   * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -72,7 +74,7 @@ public interface GetTrafficRecordingValuesNamesRequestOrBuilder extends
   boolean hasValueStartsWith();
   /**
    * <pre>
-   * Allows to filter the returned labels by the name prefix
+   * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>
@@ -81,7 +83,7 @@ public interface GetTrafficRecordingValuesNamesRequestOrBuilder extends
   com.google.protobuf.StringValue getValueStartsWith();
   /**
    * <pre>
-   * Allows to filter the returned labels by the name prefix
+   * Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.StringValue valueStartsWith = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingValuesNamesResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingValuesNamesResponse.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to GetTrafficRecordingLabelsValuesOrderedByCardinality response.
+ * Response to GetTrafficRecordingLabelsValuesOrderedByCardinality request.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficRecordingValuesNamesResponse}
@@ -74,7 +74,7 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
-   * The list of labels values that match the criteria
+   * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
    * </pre>
    *
    * <code>repeated string labelValue = 1;</code>
@@ -86,7 +86,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of labels values that match the criteria
+   * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
    * </pre>
    *
    * <code>repeated string labelValue = 1;</code>
@@ -97,7 +97,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of labels values that match the criteria
+   * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
    * </pre>
    *
    * <code>repeated string labelValue = 1;</code>
@@ -109,7 +109,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of labels values that match the criteria
+   * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
    * </pre>
    *
    * <code>repeated string labelValue = 1;</code>
@@ -286,7 +286,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to GetTrafficRecordingLabelsValuesOrderedByCardinality response.
+   * Response to GetTrafficRecordingLabelsValuesOrderedByCardinality request.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTrafficRecordingValuesNamesResponse}
@@ -476,7 +476,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels values that match the criteria
+     * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
      * </pre>
      *
      * <code>repeated string labelValue = 1;</code>
@@ -489,7 +489,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels values that match the criteria
+     * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
      * </pre>
      *
      * <code>repeated string labelValue = 1;</code>
@@ -500,7 +500,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels values that match the criteria
+     * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
      * </pre>
      *
      * <code>repeated string labelValue = 1;</code>
@@ -512,7 +512,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels values that match the criteria
+     * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
      * </pre>
      *
      * <code>repeated string labelValue = 1;</code>
@@ -525,7 +525,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels values that match the criteria
+     * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
      * </pre>
      *
      * <code>repeated string labelValue = 1;</code>
@@ -544,7 +544,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels values that match the criteria
+     * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
      * </pre>
      *
      * <code>repeated string labelValue = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels values that match the criteria
+     * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
      * </pre>
      *
      * <code>repeated string labelValue = 1;</code>
@@ -580,7 +580,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels values that match the criteria
+     * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
      * </pre>
      *
      * <code>repeated string labelValue = 1;</code>
@@ -595,7 +595,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of labels values that match the criteria
+     * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
      * </pre>
      *
      * <code>repeated string labelValue = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingValuesNamesResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTrafficRecordingValuesNamesResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GetTrafficRecordingValuesNamesResponseOrBuilder extends
 
   /**
    * <pre>
-   * The list of labels values that match the criteria
+   * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
    * </pre>
    *
    * <code>repeated string labelValue = 1;</code>
@@ -43,7 +43,7 @@ public interface GetTrafficRecordingValuesNamesResponseOrBuilder extends
       getLabelValueList();
   /**
    * <pre>
-   * The list of labels values that match the criteria
+   * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
    * </pre>
    *
    * <code>repeated string labelValue = 1;</code>
@@ -52,7 +52,7 @@ public interface GetTrafficRecordingValuesNamesResponseOrBuilder extends
   int getLabelValueCount();
   /**
    * <pre>
-   * The list of labels values that match the criteria
+   * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
    * </pre>
    *
    * <code>repeated string labelValue = 1;</code>
@@ -62,7 +62,7 @@ public interface GetTrafficRecordingValuesNamesResponseOrBuilder extends
   java.lang.String getLabelValue(int index);
   /**
    * <pre>
-   * The list of labels values that match the criteria
+   * The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
    * </pre>
    *
    * <code>repeated string labelValue = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTransactionOverviewRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTransactionOverviewRequest.java
@@ -73,7 +73,8 @@ private static final long serialVersionUID = 0L;
       emptyLongList();
   /**
    * <pre>
-   * The catalog version for which the transaction overview should be returned
+   * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+   * for the ordering and completeness contract of the response.
    * </pre>
    *
    * <code>repeated int64 catalogVersion = 1;</code>
@@ -86,7 +87,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The catalog version for which the transaction overview should be returned
+   * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+   * for the ordering and completeness contract of the response.
    * </pre>
    *
    * <code>repeated int64 catalogVersion = 1;</code>
@@ -97,7 +99,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The catalog version for which the transaction overview should be returned
+   * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+   * for the ordering and completeness contract of the response.
    * </pre>
    *
    * <code>repeated int64 catalogVersion = 1;</code>
@@ -484,7 +487,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The catalog version for which the transaction overview should be returned
+     * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+     * for the ordering and completeness contract of the response.
      * </pre>
      *
      * <code>repeated int64 catalogVersion = 1;</code>
@@ -497,7 +501,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The catalog version for which the transaction overview should be returned
+     * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+     * for the ordering and completeness contract of the response.
      * </pre>
      *
      * <code>repeated int64 catalogVersion = 1;</code>
@@ -508,7 +513,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The catalog version for which the transaction overview should be returned
+     * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+     * for the ordering and completeness contract of the response.
      * </pre>
      *
      * <code>repeated int64 catalogVersion = 1;</code>
@@ -520,7 +526,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The catalog version for which the transaction overview should be returned
+     * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+     * for the ordering and completeness contract of the response.
      * </pre>
      *
      * <code>repeated int64 catalogVersion = 1;</code>
@@ -539,7 +546,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The catalog version for which the transaction overview should be returned
+     * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+     * for the ordering and completeness contract of the response.
      * </pre>
      *
      * <code>repeated int64 catalogVersion = 1;</code>
@@ -556,7 +564,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The catalog version for which the transaction overview should be returned
+     * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+     * for the ordering and completeness contract of the response.
      * </pre>
      *
      * <code>repeated int64 catalogVersion = 1;</code>
@@ -574,7 +583,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The catalog version for which the transaction overview should be returned
+     * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+     * for the ordering and completeness contract of the response.
      * </pre>
      *
      * <code>repeated int64 catalogVersion = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTransactionOverviewRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTransactionOverviewRequestOrBuilder.java
@@ -33,7 +33,8 @@ public interface GetTransactionOverviewRequestOrBuilder extends
 
   /**
    * <pre>
-   * The catalog version for which the transaction overview should be returned
+   * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+   * for the ordering and completeness contract of the response.
    * </pre>
    *
    * <code>repeated int64 catalogVersion = 1;</code>
@@ -42,7 +43,8 @@ public interface GetTransactionOverviewRequestOrBuilder extends
   java.util.List<java.lang.Long> getCatalogVersionList();
   /**
    * <pre>
-   * The catalog version for which the transaction overview should be returned
+   * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+   * for the ordering and completeness contract of the response.
    * </pre>
    *
    * <code>repeated int64 catalogVersion = 1;</code>
@@ -51,7 +53,8 @@ public interface GetTransactionOverviewRequestOrBuilder extends
   int getCatalogVersionCount();
   /**
    * <pre>
-   * The catalog version for which the transaction overview should be returned
+   * The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+   * for the ordering and completeness contract of the response.
    * </pre>
    *
    * <code>repeated int64 catalogVersion = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTransactionOverviewResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTransactionOverviewResponse.java
@@ -29,7 +29,11 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to GetTransactionOverview request.
+ * Response to GetTransactionOverview request. Entries are ordered the same way as the requested
+ * `catalogVersion` list. The intended contract (per the underlying Java API) is that a version unknown
+ * to history is silently omitted rather than padded with an empty entry, so the response can be shorter
+ * than the request - but this is currently not honored: a single unknown/purged version makes the whole
+ * RPC fail instead of being omitted (known defect, tracked in #1349).
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTransactionOverviewResponse}
@@ -72,7 +76,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview> transactionOverviews_;
   /**
    * <pre>
-   * The list of transaction overviews that match the requested catalog versions
+   * The transaction overviews for the requested catalog versions, in request order - see the
+   * message-level note above for the current gap between the intended and actual completeness contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -83,7 +88,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of transaction overviews that match the requested catalog versions
+   * The transaction overviews for the requested catalog versions, in request order - see the
+   * message-level note above for the current gap between the intended and actual completeness contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -95,7 +101,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of transaction overviews that match the requested catalog versions
+   * The transaction overviews for the requested catalog versions, in request order - see the
+   * message-level note above for the current gap between the intended and actual completeness contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -106,7 +113,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of transaction overviews that match the requested catalog versions
+   * The transaction overviews for the requested catalog versions, in request order - see the
+   * message-level note above for the current gap between the intended and actual completeness contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -117,7 +125,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of transaction overviews that match the requested catalog versions
+   * The transaction overviews for the requested catalog versions, in request order - see the
+   * message-level note above for the current gap between the intended and actual completeness contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -289,7 +298,11 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to GetTransactionOverview request.
+   * Response to GetTransactionOverview request. Entries are ordered the same way as the requested
+   * `catalogVersion` list. The intended contract (per the underlying Java API) is that a version unknown
+   * to history is silently omitted rather than padded with an empty entry, so the response can be shorter
+   * than the request - but this is currently not honored: a single unknown/purged version makes the whole
+   * RPC fail instead of being omitted (known defect, tracked in #1349).
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GetTransactionOverviewResponse}
@@ -520,7 +533,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -534,7 +548,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -548,7 +563,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -562,7 +578,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -583,7 +600,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -601,7 +619,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -621,7 +640,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -642,7 +662,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -660,7 +681,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -678,7 +700,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -697,7 +720,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -714,7 +738,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -731,7 +756,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -742,7 +768,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -756,7 +783,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -771,7 +799,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -782,7 +811,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -794,7 +824,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of transaction overviews that match the requested catalog versions
+     * The transaction overviews for the requested catalog versions, in request order - see the
+     * message-level note above for the current gap between the intended and actual completeness contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTransactionOverviewResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GetTransactionOverviewResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GetTransactionOverviewResponseOrBuilder extends
 
   /**
    * <pre>
-   * The list of transaction overviews that match the requested catalog versions
+   * The transaction overviews for the requested catalog versions, in request order - see the
+   * message-level note above for the current gap between the intended and actual completeness contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -42,7 +43,8 @@ public interface GetTransactionOverviewResponseOrBuilder extends
       getTransactionOverviewsList();
   /**
    * <pre>
-   * The list of transaction overviews that match the requested catalog versions
+   * The transaction overviews for the requested catalog versions, in request order - see the
+   * message-level note above for the current gap between the intended and actual completeness contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -50,7 +52,8 @@ public interface GetTransactionOverviewResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview getTransactionOverviews(int index);
   /**
    * <pre>
-   * The list of transaction overviews that match the requested catalog versions
+   * The transaction overviews for the requested catalog versions, in request order - see the
+   * message-level note above for the current gap between the intended and actual completeness contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -58,7 +61,8 @@ public interface GetTransactionOverviewResponseOrBuilder extends
   int getTransactionOverviewsCount();
   /**
    * <pre>
-   * The list of transaction overviews that match the requested catalog versions
+   * The transaction overviews for the requested catalog versions, in request order - see the
+   * message-level note above for the current gap between the intended and actual completeness contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>
@@ -67,7 +71,8 @@ public interface GetTransactionOverviewResponseOrBuilder extends
       getTransactionOverviewsOrBuilderList();
   /**
    * <pre>
-   * The list of transaction overviews that match the requested catalog versions
+   * The transaction overviews for the requested catalog versions, in request order - see the
+   * message-level note above for the current gap between the intended and actual completeness contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTransactionOverview transactionOverviews = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcApiStatus.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcApiStatus.java
@@ -73,7 +73,8 @@ private static final long serialVersionUID = 0L;
   private boolean enabled_ = false;
   /**
    * <pre>
-   * True if the API is enabled
+   * True when this API is turned on in the server configuration. An enabled API can still be
+   * briefly not ready while the server is starting up - see `ready`.
    * </pre>
    *
    * <code>bool enabled = 1;</code>
@@ -88,7 +89,8 @@ private static final long serialVersionUID = 0L;
   private boolean ready_ = false;
   /**
    * <pre>
-   * API readiness status
+   * True when the API has finished initialization and is actually able to serve requests.
+   * Always false when `enabled` is false.
    * </pre>
    *
    * <code>bool ready = 2;</code>
@@ -105,7 +107,9 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
-   * list of base url of the web API
+   * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+   * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+   * name is singular.
    * </pre>
    *
    * <code>repeated string baseUrl = 3;</code>
@@ -117,7 +121,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * list of base url of the web API
+   * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+   * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+   * name is singular.
    * </pre>
    *
    * <code>repeated string baseUrl = 3;</code>
@@ -128,7 +134,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * list of base url of the web API
+   * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+   * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+   * name is singular.
    * </pre>
    *
    * <code>repeated string baseUrl = 3;</code>
@@ -140,7 +148,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * list of base url of the web API
+   * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+   * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+   * name is singular.
    * </pre>
    *
    * <code>repeated string baseUrl = 3;</code>
@@ -157,8 +167,9 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcEndpoint> endpoints_;
   /**
    * <pre>
-   * list of specific endpoints of particular API
-   * currently only system API provides list of endpoints
+   * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+   * endpoint and giving its URL(s). Currently only the system API populates this list; every
+   * other API reports it empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -169,8 +180,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * list of specific endpoints of particular API
-   * currently only system API provides list of endpoints
+   * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+   * endpoint and giving its URL(s). Currently only the system API populates this list; every
+   * other API reports it empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -182,8 +194,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * list of specific endpoints of particular API
-   * currently only system API provides list of endpoints
+   * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+   * endpoint and giving its URL(s). Currently only the system API populates this list; every
+   * other API reports it empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -194,8 +207,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * list of specific endpoints of particular API
-   * currently only system API provides list of endpoints
+   * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+   * endpoint and giving its URL(s). Currently only the system API populates this list; every
+   * other API reports it empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -206,8 +220,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * list of specific endpoints of particular API
-   * currently only system API provides list of endpoints
+   * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+   * endpoint and giving its URL(s). Currently only the system API populates this list; every
+   * other API reports it empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -686,7 +701,8 @@ private static final long serialVersionUID = 0L;
     private boolean enabled_ ;
     /**
      * <pre>
-     * True if the API is enabled
+     * True when this API is turned on in the server configuration. An enabled API can still be
+     * briefly not ready while the server is starting up - see `ready`.
      * </pre>
      *
      * <code>bool enabled = 1;</code>
@@ -698,7 +714,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True if the API is enabled
+     * True when this API is turned on in the server configuration. An enabled API can still be
+     * briefly not ready while the server is starting up - see `ready`.
      * </pre>
      *
      * <code>bool enabled = 1;</code>
@@ -714,7 +731,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True if the API is enabled
+     * True when this API is turned on in the server configuration. An enabled API can still be
+     * briefly not ready while the server is starting up - see `ready`.
      * </pre>
      *
      * <code>bool enabled = 1;</code>
@@ -730,7 +748,8 @@ private static final long serialVersionUID = 0L;
     private boolean ready_ ;
     /**
      * <pre>
-     * API readiness status
+     * True when the API has finished initialization and is actually able to serve requests.
+     * Always false when `enabled` is false.
      * </pre>
      *
      * <code>bool ready = 2;</code>
@@ -742,7 +761,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * API readiness status
+     * True when the API has finished initialization and is actually able to serve requests.
+     * Always false when `enabled` is false.
      * </pre>
      *
      * <code>bool ready = 2;</code>
@@ -758,7 +778,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * API readiness status
+     * True when the API has finished initialization and is actually able to serve requests.
+     * Always false when `enabled` is false.
      * </pre>
      *
      * <code>bool ready = 2;</code>
@@ -781,7 +802,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of base url of the web API
+     * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+     * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+     * name is singular.
      * </pre>
      *
      * <code>repeated string baseUrl = 3;</code>
@@ -794,7 +817,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of base url of the web API
+     * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+     * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+     * name is singular.
      * </pre>
      *
      * <code>repeated string baseUrl = 3;</code>
@@ -805,7 +830,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of base url of the web API
+     * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+     * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+     * name is singular.
      * </pre>
      *
      * <code>repeated string baseUrl = 3;</code>
@@ -817,7 +844,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of base url of the web API
+     * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+     * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+     * name is singular.
      * </pre>
      *
      * <code>repeated string baseUrl = 3;</code>
@@ -830,7 +859,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of base url of the web API
+     * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+     * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+     * name is singular.
      * </pre>
      *
      * <code>repeated string baseUrl = 3;</code>
@@ -849,7 +880,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of base url of the web API
+     * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+     * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+     * name is singular.
      * </pre>
      *
      * <code>repeated string baseUrl = 3;</code>
@@ -867,7 +900,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of base url of the web API
+     * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+     * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+     * name is singular.
      * </pre>
      *
      * <code>repeated string baseUrl = 3;</code>
@@ -885,7 +920,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of base url of the web API
+     * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+     * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+     * name is singular.
      * </pre>
      *
      * <code>repeated string baseUrl = 3;</code>
@@ -900,7 +937,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of base url of the web API
+     * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+     * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+     * name is singular.
      * </pre>
      *
      * <code>repeated string baseUrl = 3;</code>
@@ -932,8 +971,9 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -947,8 +987,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -962,8 +1003,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -977,8 +1019,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -999,8 +1042,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1018,8 +1062,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1039,8 +1084,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1061,8 +1107,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1080,8 +1127,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1099,8 +1147,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1119,8 +1168,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1137,8 +1187,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1155,8 +1206,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1167,8 +1219,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1182,8 +1235,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1198,8 +1252,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1210,8 +1265,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -1223,8 +1279,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * list of specific endpoints of particular API
-     * currently only system API provides list of endpoints
+     * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+     * endpoint and giving its URL(s). Currently only the system API populates this list; every
+     * other API reports it empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcApiStatusOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcApiStatusOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcApiStatusOrBuilder extends
 
   /**
    * <pre>
-   * True if the API is enabled
+   * True when this API is turned on in the server configuration. An enabled API can still be
+   * briefly not ready while the server is starting up - see `ready`.
    * </pre>
    *
    * <code>bool enabled = 1;</code>
@@ -43,7 +44,8 @@ public interface GrpcApiStatusOrBuilder extends
 
   /**
    * <pre>
-   * API readiness status
+   * True when the API has finished initialization and is actually able to serve requests.
+   * Always false when `enabled` is false.
    * </pre>
    *
    * <code>bool ready = 2;</code>
@@ -53,7 +55,9 @@ public interface GrpcApiStatusOrBuilder extends
 
   /**
    * <pre>
-   * list of base url of the web API
+   * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+   * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+   * name is singular.
    * </pre>
    *
    * <code>repeated string baseUrl = 3;</code>
@@ -63,7 +67,9 @@ public interface GrpcApiStatusOrBuilder extends
       getBaseUrlList();
   /**
    * <pre>
-   * list of base url of the web API
+   * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+   * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+   * name is singular.
    * </pre>
    *
    * <code>repeated string baseUrl = 3;</code>
@@ -72,7 +78,9 @@ public interface GrpcApiStatusOrBuilder extends
   int getBaseUrlCount();
   /**
    * <pre>
-   * list of base url of the web API
+   * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+   * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+   * name is singular.
    * </pre>
    *
    * <code>repeated string baseUrl = 3;</code>
@@ -82,7 +90,9 @@ public interface GrpcApiStatusOrBuilder extends
   java.lang.String getBaseUrl(int index);
   /**
    * <pre>
-   * list of base url of the web API
+   * Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+   * `exposeOn` override if set), so this commonly holds more than one URL even though the field
+   * name is singular.
    * </pre>
    *
    * <code>repeated string baseUrl = 3;</code>
@@ -94,8 +104,9 @@ public interface GrpcApiStatusOrBuilder extends
 
   /**
    * <pre>
-   * list of specific endpoints of particular API
-   * currently only system API provides list of endpoints
+   * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+   * endpoint and giving its URL(s). Currently only the system API populates this list; every
+   * other API reports it empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -104,8 +115,9 @@ public interface GrpcApiStatusOrBuilder extends
       getEndpointsList();
   /**
    * <pre>
-   * list of specific endpoints of particular API
-   * currently only system API provides list of endpoints
+   * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+   * endpoint and giving its URL(s). Currently only the system API populates this list; every
+   * other API reports it empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -113,8 +125,9 @@ public interface GrpcApiStatusOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEndpoint getEndpoints(int index);
   /**
    * <pre>
-   * list of specific endpoints of particular API
-   * currently only system API provides list of endpoints
+   * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+   * endpoint and giving its URL(s). Currently only the system API populates this list; every
+   * other API reports it empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -122,8 +135,9 @@ public interface GrpcApiStatusOrBuilder extends
   int getEndpointsCount();
   /**
    * <pre>
-   * list of specific endpoints of particular API
-   * currently only system API provides list of endpoints
+   * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+   * endpoint and giving its URL(s). Currently only the system API populates this list; every
+   * other API reports it empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>
@@ -132,8 +146,9 @@ public interface GrpcApiStatusOrBuilder extends
       getEndpointsOrBuilderList();
   /**
    * <pre>
-   * list of specific endpoints of particular API
-   * currently only system API provides list of endpoints
+   * Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+   * endpoint and giving its URL(s). Currently only the system API populates this list; every
+   * other API reports it empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEndpoint endpoints = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcApplyMutationWithProgressResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcApplyMutationWithProgressResponse.java
@@ -29,7 +29,10 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to apply mutation on engine level.
+ * Streamed progress report for any of evitaDB's long-running catalog-lifecycle operations that support progress
+ * tracking (apply mutation, rename, replace, make mutable/immutable/alive, duplicate, activate, deactivate - see
+ * the `*WithProgress` RPCs on `EvitaService`). One or more intermediate messages are streamed as the operation
+ * advances, followed by exactly one final message with `progressInPercent` set to 100.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcApplyMutationWithProgressResponse}
@@ -71,7 +74,8 @@ private static final long serialVersionUID = 0L;
   private int progressInPercent_ = 0;
   /**
    * <pre>
-   * The progress of the go live operation in percents.
+   * Progress of the tracked operation (percent, 0-100). Intermediate updates are throttled (only sent on an
+   * increase, at most once per second); the final message of the stream always carries 100.
    * </pre>
    *
    * <code>int32 progressInPercent = 1;</code>
@@ -86,7 +90,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value catalogVersion_;
   /**
    * <pre>
-   * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+   * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+   * unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -98,7 +104,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+   * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+   * unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -110,7 +118,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+   * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+   * unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -124,7 +134,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value catalogSchemaVersion_;
   /**
    * <pre>
-   * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+   * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+   * purely engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -136,7 +148,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+   * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+   * purely engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -148,7 +162,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+   * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+   * purely engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -349,7 +365,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to apply mutation on engine level.
+   * Streamed progress report for any of evitaDB's long-running catalog-lifecycle operations that support progress
+   * tracking (apply mutation, rename, replace, make mutable/immutable/alive, duplicate, activate, deactivate - see
+   * the `*WithProgress` RPCs on `EvitaService`). One or more intermediate messages are streamed as the operation
+   * advances, followed by exactly one final message with `progressInPercent` set to 100.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcApplyMutationWithProgressResponse}
@@ -573,7 +592,8 @@ private static final long serialVersionUID = 0L;
     private int progressInPercent_ ;
     /**
      * <pre>
-     * The progress of the go live operation in percents.
+     * Progress of the tracked operation (percent, 0-100). Intermediate updates are throttled (only sent on an
+     * increase, at most once per second); the final message of the stream always carries 100.
      * </pre>
      *
      * <code>int32 progressInPercent = 1;</code>
@@ -585,7 +605,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The progress of the go live operation in percents.
+     * Progress of the tracked operation (percent, 0-100). Intermediate updates are throttled (only sent on an
+     * increase, at most once per second); the final message of the stream always carries 100.
      * </pre>
      *
      * <code>int32 progressInPercent = 1;</code>
@@ -601,7 +622,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The progress of the go live operation in percents.
+     * Progress of the tracked operation (percent, 0-100). Intermediate updates are throttled (only sent on an
+     * increase, at most once per second); the final message of the stream always carries 100.
      * </pre>
      *
      * <code>int32 progressInPercent = 1;</code>
@@ -619,7 +641,9 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> catalogVersionBuilder_;
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+     * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+     * unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -630,7 +654,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+     * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+     * unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -645,7 +671,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+     * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+     * unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -665,7 +693,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+     * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+     * unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -683,7 +713,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+     * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+     * unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -708,7 +740,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+     * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+     * unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -725,7 +759,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+     * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+     * unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -737,7 +773,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+     * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+     * unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -752,7 +790,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+     * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+     * unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -776,7 +816,9 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> catalogSchemaVersionBuilder_;
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+     * purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -787,7 +829,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+     * purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -802,7 +846,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+     * purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -822,7 +868,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+     * purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -840,7 +888,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+     * purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -865,7 +915,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+     * purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -882,7 +934,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+     * purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -894,7 +948,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+     * purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -909,7 +965,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+     * purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcApplyMutationWithProgressResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcApplyMutationWithProgressResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcApplyMutationWithProgressResponseOrBuilder extends
 
   /**
    * <pre>
-   * The progress of the go live operation in percents.
+   * Progress of the tracked operation (percent, 0-100). Intermediate updates are throttled (only sent on an
+   * increase, at most once per second); the final message of the stream always carries 100.
    * </pre>
    *
    * <code>int32 progressInPercent = 1;</code>
@@ -43,7 +44,9 @@ public interface GrpcApplyMutationWithProgressResponseOrBuilder extends
 
   /**
    * <pre>
-   * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+   * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+   * unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -52,7 +55,9 @@ public interface GrpcApplyMutationWithProgressResponseOrBuilder extends
   boolean hasCatalogVersion();
   /**
    * <pre>
-   * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+   * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+   * unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -61,7 +66,9 @@ public interface GrpcApplyMutationWithProgressResponseOrBuilder extends
   com.google.protobuf.Int64Value getCatalogVersion();
   /**
    * <pre>
-   * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+   * if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+   * unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 2;</code>
@@ -70,7 +77,9 @@ public interface GrpcApplyMutationWithProgressResponseOrBuilder extends
 
   /**
    * <pre>
-   * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+   * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+   * purely engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -79,7 +88,9 @@ public interface GrpcApplyMutationWithProgressResponseOrBuilder extends
   boolean hasCatalogSchemaVersion();
   /**
    * <pre>
-   * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+   * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+   * purely engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>
@@ -88,7 +99,9 @@ public interface GrpcApplyMutationWithProgressResponseOrBuilder extends
   com.google.protobuf.Int32Value getCatalogSchemaVersion();
   /**
    * <pre>
-   * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+   * and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+   * purely engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value catalogSchemaVersion = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcArchiveEntityRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcArchiveEntityRequest.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request for deleting an entity that should return the archived entity with required richness.
+ * Request for archiving a single entity by primary key and returning it fetched in the richness described
+ * by `require`.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcArchiveEntityRequest}
@@ -87,7 +88,7 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object entityType_ = "";
   /**
    * <pre>
-   * Entity type of the entity to be archived.
+   * Entity type (collection name) the entity to archive belongs to.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -108,7 +109,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Entity type of the entity to be archived.
+   * Entity type (collection name) the entity to archive belongs to.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -133,7 +134,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value primaryKey_;
   /**
    * <pre>
-   * Primary key of the entity to be archived.
+   * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -145,7 +148,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Primary key of the entity to be archived.
+   * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -157,7 +162,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Primary key of the entity to be archived.
+   * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -172,7 +179,10 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object require_ = "";
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+   * back after it is archived. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -193,7 +203,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+   * back after it is archived. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -219,7 +232,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcQueryParam> positionalQueryParams_;
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -230,7 +244,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -242,7 +257,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -253,7 +269,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -264,7 +281,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -303,7 +321,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -324,7 +343,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -335,7 +355,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -353,7 +374,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -589,7 +611,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * Request for deleting an entity that should return the archived entity with required richness.
+   * Request for archiving a single entity by primary key and returning it fetched in the richness described
+   * by `require`.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcArchiveEntityRequest}
@@ -905,7 +928,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     private java.lang.Object entityType_ = "";
     /**
      * <pre>
-     * Entity type of the entity to be archived.
+     * Entity type (collection name) the entity to archive belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -925,7 +948,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Entity type of the entity to be archived.
+     * Entity type (collection name) the entity to archive belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -946,7 +969,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Entity type of the entity to be archived.
+     * Entity type (collection name) the entity to archive belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -963,7 +986,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Entity type of the entity to be archived.
+     * Entity type (collection name) the entity to archive belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -977,7 +1000,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Entity type of the entity to be archived.
+     * Entity type (collection name) the entity to archive belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -999,7 +1022,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> primaryKeyBuilder_;
     /**
      * <pre>
-     * Primary key of the entity to be archived.
+     * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1010,7 +1035,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be archived.
+     * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1025,7 +1052,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be archived.
+     * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1045,7 +1074,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be archived.
+     * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1063,7 +1094,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be archived.
+     * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1088,7 +1121,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be archived.
+     * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1105,7 +1140,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be archived.
+     * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1117,7 +1154,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be archived.
+     * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1132,7 +1171,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be archived.
+     * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1154,7 +1195,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     private java.lang.Object require_ = "";
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back after it is archived. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1174,7 +1218,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back after it is archived. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1195,7 +1242,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back after it is archived. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1212,7 +1262,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back after it is archived. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1226,7 +1279,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back after it is archived. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1257,7 +1313,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
 
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1271,7 +1328,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1285,7 +1343,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1299,7 +1358,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1320,7 +1380,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1338,7 +1399,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1358,7 +1420,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1379,7 +1442,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1397,7 +1461,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1415,7 +1480,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1434,7 +1500,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1451,7 +1518,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1468,7 +1536,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1479,7 +1548,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1493,7 +1563,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1508,7 +1579,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1519,7 +1591,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1531,7 +1604,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1592,7 +1666,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1613,7 +1688,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1624,7 +1700,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1641,7 +1718,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1663,7 +1741,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1686,7 +1765,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1703,7 +1783,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1722,7 +1803,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcArchiveEntityRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcArchiveEntityRequestOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * Entity type of the entity to be archived.
+   * Entity type (collection name) the entity to archive belongs to.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
   java.lang.String getEntityType();
   /**
    * <pre>
-   * Entity type of the entity to be archived.
+   * Entity type (collection name) the entity to archive belongs to.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -53,7 +53,9 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * Primary key of the entity to be archived.
+   * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -62,7 +64,9 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
   boolean hasPrimaryKey();
   /**
    * <pre>
-   * Primary key of the entity to be archived.
+   * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -71,7 +75,9 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
   com.google.protobuf.Int32Value getPrimaryKey();
   /**
    * <pre>
-   * Primary key of the entity to be archived.
+   * Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -80,7 +86,10 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+   * back after it is archived. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -89,7 +98,10 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
   java.lang.String getRequire();
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+   * back after it is archived. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -100,7 +112,8 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -109,7 +122,8 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
       getPositionalQueryParamsList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -117,7 +131,8 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcQueryParam getPositionalQueryParams(int index);
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -125,7 +140,8 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
   int getPositionalQueryParamsCount();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -134,7 +150,8 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
       getPositionalQueryParamsOrBuilderList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -144,7 +161,8 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -152,7 +170,8 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
   int getNamedQueryParamsCount();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -167,7 +186,8 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
   getNamedQueryParams();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -176,7 +196,8 @@ public interface GrpcArchiveEntityRequestOrBuilder extends
   getNamedQueryParamsMap();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -188,7 +209,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam getNamedQueryParamsOrDefaul
 io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue);
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcArchiveEntityResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcArchiveEntityResponse.java
@@ -111,7 +111,7 @@ private static final long serialVersionUID = 0L;
   public static final int ENTITYREFERENCE_FIELD_NUMBER = 1;
   /**
    * <pre>
-   * The archived entity reference.
+   * The archived entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -123,7 +123,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The archived entity reference.
+   * The archived entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -138,7 +138,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The archived entity reference.
+   * The archived entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -154,7 +154,7 @@ private static final long serialVersionUID = 0L;
   public static final int ENTITY_FIELD_NUMBER = 2;
   /**
    * <pre>
-   * The archived entity.
+   * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -166,7 +166,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The archived entity.
+   * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -181,7 +181,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The archived entity.
+   * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -607,7 +607,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEntityReference, io.evitadb.externalApi.grpc.generated.GrpcEntityReference.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceOrBuilder> entityReferenceBuilder_;
     /**
      * <pre>
-     * The archived entity reference.
+     * The archived entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -619,7 +619,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity reference.
+     * The archived entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity reference.
+     * The archived entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -661,7 +661,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity reference.
+     * The archived entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -679,7 +679,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity reference.
+     * The archived entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -706,7 +706,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity reference.
+     * The archived entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -729,7 +729,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity reference.
+     * The archived entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -739,7 +739,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity reference.
+     * The archived entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -757,7 +757,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity reference.
+     * The archived entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -785,7 +785,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcSealedEntity, io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.Builder, io.evitadb.externalApi.grpc.generated.GrpcSealedEntityOrBuilder> entityBuilder_;
     /**
      * <pre>
-     * The archived entity.
+     * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -797,7 +797,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity.
+     * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -819,7 +819,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity.
+     * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -839,7 +839,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity.
+     * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -857,7 +857,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity.
+     * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -884,7 +884,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity.
+     * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -907,7 +907,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity.
+     * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -917,7 +917,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity.
+     * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -935,7 +935,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The archived entity.
+     * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcArchiveEntityResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcArchiveEntityResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcArchiveEntityResponseOrBuilder extends
 
   /**
    * <pre>
-   * The archived entity reference.
+   * The archived entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcArchiveEntityResponseOrBuilder extends
   boolean hasEntityReference();
   /**
    * <pre>
-   * The archived entity reference.
+   * The archived entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcArchiveEntityResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEntityReference getEntityReference();
   /**
    * <pre>
-   * The archived entity reference.
+   * The archived entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -60,7 +60,7 @@ public interface GrpcArchiveEntityResponseOrBuilder extends
 
   /**
    * <pre>
-   * The archived entity.
+   * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -69,7 +69,7 @@ public interface GrpcArchiveEntityResponseOrBuilder extends
   boolean hasEntity();
   /**
    * <pre>
-   * The archived entity.
+   * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -78,7 +78,7 @@ public interface GrpcArchiveEntityResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcSealedEntity getEntity();
   /**
    * <pre>
-   * The archived entity.
+   * The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAssociatedDataSchema.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAssociatedDataSchema.java
@@ -130,6 +130,11 @@ private static final long serialVersionUID = 0L;
   public static final int DESCRIPTION_FIELD_NUMBER = 2;
   private com.google.protobuf.StringValue description_;
   /**
+   * <pre>
+   * Contains description of the model is optional but helps authors of the schema / client API to better
+   * explain the original purpose of the model to the consumers.
+   * </pre>
+   *
    * <code>.google.protobuf.StringValue description = 2;</code>
    * @return Whether the description field is set.
    */
@@ -138,6 +143,11 @@ private static final long serialVersionUID = 0L;
     return ((bitField0_ & 0x00000001) != 0);
   }
   /**
+   * <pre>
+   * Contains description of the model is optional but helps authors of the schema / client API to better
+   * explain the original purpose of the model to the consumers.
+   * </pre>
+   *
    * <code>.google.protobuf.StringValue description = 2;</code>
    * @return The description.
    */
@@ -146,6 +156,11 @@ private static final long serialVersionUID = 0L;
     return description_ == null ? com.google.protobuf.StringValue.getDefaultInstance() : description_;
   }
   /**
+   * <pre>
+   * Contains description of the model is optional but helps authors of the schema / client API to better
+   * explain the original purpose of the model to the consumers.
+   * </pre>
+   *
    * <code>.google.protobuf.StringValue description = 2;</code>
    */
   @java.lang.Override
@@ -1037,6 +1052,11 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> descriptionBuilder_;
     /**
+     * <pre>
+     * Contains description of the model is optional but helps authors of the schema / client API to better
+     * explain the original purpose of the model to the consumers.
+     * </pre>
+     *
      * <code>.google.protobuf.StringValue description = 2;</code>
      * @return Whether the description field is set.
      */
@@ -1044,6 +1064,11 @@ private static final long serialVersionUID = 0L;
       return ((bitField0_ & 0x00000002) != 0);
     }
     /**
+     * <pre>
+     * Contains description of the model is optional but helps authors of the schema / client API to better
+     * explain the original purpose of the model to the consumers.
+     * </pre>
+     *
      * <code>.google.protobuf.StringValue description = 2;</code>
      * @return The description.
      */
@@ -1055,6 +1080,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Contains description of the model is optional but helps authors of the schema / client API to better
+     * explain the original purpose of the model to the consumers.
+     * </pre>
+     *
      * <code>.google.protobuf.StringValue description = 2;</code>
      */
     public Builder setDescription(com.google.protobuf.StringValue value) {
@@ -1071,6 +1101,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Contains description of the model is optional but helps authors of the schema / client API to better
+     * explain the original purpose of the model to the consumers.
+     * </pre>
+     *
      * <code>.google.protobuf.StringValue description = 2;</code>
      */
     public Builder setDescription(
@@ -1085,6 +1120,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Contains description of the model is optional but helps authors of the schema / client API to better
+     * explain the original purpose of the model to the consumers.
+     * </pre>
+     *
      * <code>.google.protobuf.StringValue description = 2;</code>
      */
     public Builder mergeDescription(com.google.protobuf.StringValue value) {
@@ -1106,6 +1146,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Contains description of the model is optional but helps authors of the schema / client API to better
+     * explain the original purpose of the model to the consumers.
+     * </pre>
+     *
      * <code>.google.protobuf.StringValue description = 2;</code>
      */
     public Builder clearDescription() {
@@ -1119,6 +1164,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Contains description of the model is optional but helps authors of the schema / client API to better
+     * explain the original purpose of the model to the consumers.
+     * </pre>
+     *
      * <code>.google.protobuf.StringValue description = 2;</code>
      */
     public com.google.protobuf.StringValue.Builder getDescriptionBuilder() {
@@ -1127,6 +1177,11 @@ private static final long serialVersionUID = 0L;
       return getDescriptionFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Contains description of the model is optional but helps authors of the schema / client API to better
+     * explain the original purpose of the model to the consumers.
+     * </pre>
+     *
      * <code>.google.protobuf.StringValue description = 2;</code>
      */
     public com.google.protobuf.StringValueOrBuilder getDescriptionOrBuilder() {
@@ -1138,6 +1193,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Contains description of the model is optional but helps authors of the schema / client API to better
+     * explain the original purpose of the model to the consumers.
+     * </pre>
+     *
      * <code>.google.protobuf.StringValue description = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAssociatedDataSchemaOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAssociatedDataSchemaOrBuilder.java
@@ -54,16 +54,31 @@ public interface GrpcAssociatedDataSchemaOrBuilder extends
       getNameBytes();
 
   /**
+   * <pre>
+   * Contains description of the model is optional but helps authors of the schema / client API to better
+   * explain the original purpose of the model to the consumers.
+   * </pre>
+   *
    * <code>.google.protobuf.StringValue description = 2;</code>
    * @return Whether the description field is set.
    */
   boolean hasDescription();
   /**
+   * <pre>
+   * Contains description of the model is optional but helps authors of the schema / client API to better
+   * explain the original purpose of the model to the consumers.
+   * </pre>
+   *
    * <code>.google.protobuf.StringValue description = 2;</code>
    * @return The description.
    */
   com.google.protobuf.StringValue getDescription();
   /**
+   * <pre>
+   * Contains description of the model is optional but helps authors of the schema / client API to better
+   * explain the original purpose of the model to the consumers.
+   * </pre>
+   *
    * <code>.google.protobuf.StringValue description = 2;</code>
    */
   com.google.protobuf.StringValueOrBuilder getDescriptionOrBuilder();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeInheritanceBehavior.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeInheritanceBehavior.java
@@ -39,7 +39,7 @@ public enum GrpcAttributeInheritanceBehavior
   /**
    * <pre>
    **
-   * Inherit all attributes by default except those listed in the {&#64;link #getAttributeInheritanceFilter()} array.
+   * Inherit all attributes by default except those listed in the attribute inheritance filter array.
    * </pre>
    *
    * <code>INHERIT_ALL_EXCEPT = 0;</code>
@@ -48,7 +48,7 @@ public enum GrpcAttributeInheritanceBehavior
   /**
    * <pre>
    **
-   * Do not inherit any attributes by default except those listed in the {&#64;link #getAttributeInheritanceFilter()} array.
+   * Do not inherit any attributes by default except those listed in the attribute inheritance filter array.
    * </pre>
    *
    * <code>INHERIT_ONLY_SPECIFIED = 1;</code>
@@ -60,7 +60,7 @@ public enum GrpcAttributeInheritanceBehavior
   /**
    * <pre>
    **
-   * Inherit all attributes by default except those listed in the {&#64;link #getAttributeInheritanceFilter()} array.
+   * Inherit all attributes by default except those listed in the attribute inheritance filter array.
    * </pre>
    *
    * <code>INHERIT_ALL_EXCEPT = 0;</code>
@@ -69,7 +69,7 @@ public enum GrpcAttributeInheritanceBehavior
   /**
    * <pre>
    **
-   * Do not inherit any attributes by default except those listed in the {&#64;link #getAttributeInheritanceFilter()} array.
+   * Do not inherit any attributes by default except those listed in the attribute inheritance filter array.
    * </pre>
    *
    * <code>INHERIT_ONLY_SPECIFIED = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeSchema.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeSchema.java
@@ -301,8 +301,8 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -320,8 +320,8 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -417,7 +417,7 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * Representative flag marks the attribute as one of the most important attributes in the entity, or when used
-   * on reference level in the {&#64;link ReferenceSchemaContract} it marks attributes distinguishing duplicated
+   * on a reference-level attribute schema, it marks attributes distinguishing duplicated
    * references to the same entity and is a key attribute for creating distinct indexes for such references.
    *
    * In overall, representative attributes should be used in developer tools along with the entity's primary key to
@@ -684,8 +684,8 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -700,8 +700,8 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -717,8 +717,8 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -733,8 +733,8 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -749,8 +749,8 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -2686,8 +2686,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -2705,8 +2705,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -2728,8 +2728,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -2749,8 +2749,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -2775,8 +2775,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -3017,7 +3017,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * Representative flag marks the attribute as one of the most important attributes in the entity, or when used
-     * on reference level in the {&#64;link ReferenceSchemaContract} it marks attributes distinguishing duplicated
+     * on a reference-level attribute schema, it marks attributes distinguishing duplicated
      * references to the same entity and is a key attribute for creating distinct indexes for such references.
      *
      * In overall, representative attributes should be used in developer tools along with the entity's primary key to
@@ -3036,7 +3036,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * Representative flag marks the attribute as one of the most important attributes in the entity, or when used
-     * on reference level in the {&#64;link ReferenceSchemaContract} it marks attributes distinguishing duplicated
+     * on a reference-level attribute schema, it marks attributes distinguishing duplicated
      * references to the same entity and is a key attribute for creating distinct indexes for such references.
      *
      * In overall, representative attributes should be used in developer tools along with the entity's primary key to
@@ -3059,7 +3059,7 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * Representative flag marks the attribute as one of the most important attributes in the entity, or when used
-     * on reference level in the {&#64;link ReferenceSchemaContract} it marks attributes distinguishing duplicated
+     * on a reference-level attribute schema, it marks attributes distinguishing duplicated
      * references to the same entity and is a key attribute for creating distinct indexes for such references.
      *
      * In overall, representative attributes should be used in developer tools along with the entity's primary key to
@@ -4130,8 +4130,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4149,8 +4149,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4168,8 +4168,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4187,8 +4187,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4213,8 +4213,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4236,8 +4236,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4261,8 +4261,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4287,8 +4287,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4310,8 +4310,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4333,8 +4333,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4357,8 +4357,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4379,8 +4379,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4401,8 +4401,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4417,8 +4417,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4436,8 +4436,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4456,8 +4456,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4472,8 +4472,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.
@@ -4489,8 +4489,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-     * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-     * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+     * entity having certain value of this attribute in the entire catalog.
+     * The type of the unique attribute must implement the `Comparable` interface.
      *
      * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
      * better to have this ensured by the database engine.

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeSchemaOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeSchemaOrBuilder.java
@@ -174,8 +174,8 @@ public interface GrpcAttributeSchemaOrBuilder extends
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -191,8 +191,8 @@ public interface GrpcAttributeSchemaOrBuilder extends
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -263,7 +263,7 @@ public interface GrpcAttributeSchemaOrBuilder extends
   /**
    * <pre>
    * Representative flag marks the attribute as one of the most important attributes in the entity, or when used
-   * on reference level in the {&#64;link ReferenceSchemaContract} it marks attributes distinguishing duplicated
+   * on a reference-level attribute schema, it marks attributes distinguishing duplicated
    * references to the same entity and is a key attribute for creating distinct indexes for such references.
    *
    * In overall, representative attributes should be used in developer tools along with the entity's primary key to
@@ -462,8 +462,8 @@ public interface GrpcAttributeSchemaOrBuilder extends
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -476,8 +476,8 @@ public interface GrpcAttributeSchemaOrBuilder extends
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -489,8 +489,8 @@ public interface GrpcAttributeSchemaOrBuilder extends
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -502,8 +502,8 @@ public interface GrpcAttributeSchemaOrBuilder extends
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.
@@ -516,8 +516,8 @@ public interface GrpcAttributeSchemaOrBuilder extends
   /**
    * <pre>
    * When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-   * entity having certain value of this attribute in entire {&#64;link CatalogContract}.
-   * {&#64;link AttributeSchemaContract#getType() Type} of the unique attribute must implement {&#64;link Comparable} interface.
+   * entity having certain value of this attribute in the entire catalog.
+   * The type of the unique attribute must implement the `Comparable` interface.
    *
    * As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
    * better to have this ensured by the database engine.

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeSpecialValueArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeSpecialValueArray.java
@@ -81,7 +81,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * Value that supports storing an AttributeSpecialValue array.
+   * The individual AttributeSpecialValue values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -94,7 +94,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an AttributeSpecialValue array.
+   * The individual AttributeSpecialValue values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an AttributeSpecialValue array.
+   * The individual AttributeSpecialValue values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -119,7 +119,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an AttributeSpecialValue array.
+   * The individual AttributeSpecialValue values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -132,7 +132,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an AttributeSpecialValue array.
+   * The individual AttributeSpecialValue values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -524,7 +524,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an AttributeSpecialValue array.
+     * The individual AttributeSpecialValue values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -536,7 +536,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an AttributeSpecialValue array.
+     * The individual AttributeSpecialValue values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -547,7 +547,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an AttributeSpecialValue array.
+     * The individual AttributeSpecialValue values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -559,7 +559,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an AttributeSpecialValue array.
+     * The individual AttributeSpecialValue values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -579,7 +579,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an AttributeSpecialValue array.
+     * The individual AttributeSpecialValue values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -597,7 +597,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an AttributeSpecialValue array.
+     * The individual AttributeSpecialValue values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -615,7 +615,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an AttributeSpecialValue array.
+     * The individual AttributeSpecialValue values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -629,7 +629,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an AttributeSpecialValue array.
+     * The individual AttributeSpecialValue values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an AttributeSpecialValue array.
+     * The individual AttributeSpecialValue values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -653,7 +653,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an AttributeSpecialValue array.
+     * The individual AttributeSpecialValue values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -670,7 +670,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an AttributeSpecialValue array.
+     * The individual AttributeSpecialValue values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -685,7 +685,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an AttributeSpecialValue array.
+     * The individual AttributeSpecialValue values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeSpecialValueArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeSpecialValueArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcAttributeSpecialValueArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing an AttributeSpecialValue array.
+   * The individual AttributeSpecialValue values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcAttributeSpecialValueArrayOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue> getValueList();
   /**
    * <pre>
-   * Value that supports storing an AttributeSpecialValue array.
+   * The individual AttributeSpecialValue values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcAttributeSpecialValueArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing an AttributeSpecialValue array.
+   * The individual AttributeSpecialValue values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -61,7 +61,7 @@ public interface GrpcAttributeSpecialValueArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue getValue(int index);
   /**
    * <pre>
-   * Value that supports storing an AttributeSpecialValue array.
+   * The individual AttributeSpecialValue values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>
@@ -71,7 +71,7 @@ public interface GrpcAttributeSpecialValueArrayOrBuilder extends
   getValueValueList();
   /**
    * <pre>
-   * Value that supports storing an AttributeSpecialValue array.
+   * The individual AttributeSpecialValue values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeUniquenessType.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeUniquenessType.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * This enum represents the uniqueness type of an {&#64;link AttributeSchema}. It is used to determine whether the attribute
+ * This enum represents the uniqueness type of an `AttributeSchema`. It is used to determine whether the attribute
  * value must be unique among all the entity attributes of this type or whether it must be unique only among attributes
  * of the same locale.
  * </pre>
@@ -56,7 +56,7 @@ public enum GrpcAttributeUniquenessType
   UNIQUE_WITHIN_COLLECTION(1),
   /**
    * <pre>
-   * The localized attribute value must be unique among all values of the same {&#64;link Locale} among all the entities
+   * The localized attribute value must be unique among all values of the same `Locale` among all the entities
    * using of the same collection.
    * </pre>
    *
@@ -84,7 +84,7 @@ public enum GrpcAttributeUniquenessType
   public static final int UNIQUE_WITHIN_COLLECTION_VALUE = 1;
   /**
    * <pre>
-   * The localized attribute value must be unique among all values of the same {&#64;link Locale} among all the entities
+   * The localized attribute value must be unique among all values of the same `Locale` among all the entities
    * using of the same collection.
    * </pre>
    *

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBackupCatalogRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBackupCatalogRequest.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to a catalog backup request.
+ * Request to back up a catalog and stream the backup file to the client.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcBackupCatalogRequest}
@@ -71,7 +71,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment_;
   /**
    * <pre>
-   * The moment in time to which the catalog should be backed up. Might be null for current time.
+   * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+   * (subject to being overridden by `catalogVersion`, see below).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -83,7 +84,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The moment in time to which the catalog should be backed up. Might be null for current time.
+   * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+   * (subject to being overridden by `catalogVersion`, see below).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -95,7 +97,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The moment in time to which the catalog should be backed up. Might be null for current time.
+   * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+   * (subject to being overridden by `catalogVersion`, see below).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -125,8 +128,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value catalogVersion_;
   /**
    * <pre>
-   * precise catalog version to create backup for, or null to create backup for the latest version,
-   * when set not null, the pastMoment parameter is ignored
+   * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+   * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+   * ignored regardless of whether it is also set.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -138,8 +142,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * precise catalog version to create backup for, or null to create backup for the latest version,
-   * when set not null, the pastMoment parameter is ignored
+   * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+   * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+   * ignored regardless of whether it is also set.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -151,8 +156,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * precise catalog version to create backup for, or null to create backup for the latest version,
-   * when set not null, the pastMoment parameter is ignored
+   * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+   * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+   * ignored regardless of whether it is also set.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -354,7 +360,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to a catalog backup request.
+   * Request to back up a catalog and stream the backup file to the client.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcBackupCatalogRequest}
@@ -580,7 +586,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> pastMomentBuilder_;
     /**
      * <pre>
-     * The moment in time to which the catalog should be backed up. Might be null for current time.
+     * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+     * (subject to being overridden by `catalogVersion`, see below).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -591,7 +598,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The moment in time to which the catalog should be backed up. Might be null for current time.
+     * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+     * (subject to being overridden by `catalogVersion`, see below).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -606,7 +614,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The moment in time to which the catalog should be backed up. Might be null for current time.
+     * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+     * (subject to being overridden by `catalogVersion`, see below).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -626,7 +635,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The moment in time to which the catalog should be backed up. Might be null for current time.
+     * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+     * (subject to being overridden by `catalogVersion`, see below).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -644,7 +654,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The moment in time to which the catalog should be backed up. Might be null for current time.
+     * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+     * (subject to being overridden by `catalogVersion`, see below).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -669,7 +680,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The moment in time to which the catalog should be backed up. Might be null for current time.
+     * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+     * (subject to being overridden by `catalogVersion`, see below).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -686,7 +698,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The moment in time to which the catalog should be backed up. Might be null for current time.
+     * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+     * (subject to being overridden by `catalogVersion`, see below).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -698,7 +711,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The moment in time to which the catalog should be backed up. Might be null for current time.
+     * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+     * (subject to being overridden by `catalogVersion`, see below).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -713,7 +727,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The moment in time to which the catalog should be backed up. Might be null for current time.
+     * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+     * (subject to being overridden by `catalogVersion`, see below).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -784,8 +799,9 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> catalogVersionBuilder_;
     /**
      * <pre>
-     * precise catalog version to create backup for, or null to create backup for the latest version,
-     * when set not null, the pastMoment parameter is ignored
+     * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+     * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+     * ignored regardless of whether it is also set.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -796,8 +812,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * precise catalog version to create backup for, or null to create backup for the latest version,
-     * when set not null, the pastMoment parameter is ignored
+     * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+     * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+     * ignored regardless of whether it is also set.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -812,8 +829,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * precise catalog version to create backup for, or null to create backup for the latest version,
-     * when set not null, the pastMoment parameter is ignored
+     * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+     * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+     * ignored regardless of whether it is also set.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -833,8 +851,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * precise catalog version to create backup for, or null to create backup for the latest version,
-     * when set not null, the pastMoment parameter is ignored
+     * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+     * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+     * ignored regardless of whether it is also set.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -852,8 +871,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * precise catalog version to create backup for, or null to create backup for the latest version,
-     * when set not null, the pastMoment parameter is ignored
+     * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+     * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+     * ignored regardless of whether it is also set.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -878,8 +898,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * precise catalog version to create backup for, or null to create backup for the latest version,
-     * when set not null, the pastMoment parameter is ignored
+     * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+     * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+     * ignored regardless of whether it is also set.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -896,8 +917,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * precise catalog version to create backup for, or null to create backup for the latest version,
-     * when set not null, the pastMoment parameter is ignored
+     * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+     * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+     * ignored regardless of whether it is also set.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -909,8 +931,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * precise catalog version to create backup for, or null to create backup for the latest version,
-     * when set not null, the pastMoment parameter is ignored
+     * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+     * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+     * ignored regardless of whether it is also set.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -925,8 +948,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * precise catalog version to create backup for, or null to create backup for the latest version,
-     * when set not null, the pastMoment parameter is ignored
+     * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+     * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+     * ignored regardless of whether it is also set.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBackupCatalogRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBackupCatalogRequestOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcBackupCatalogRequestOrBuilder extends
 
   /**
    * <pre>
-   * The moment in time to which the catalog should be backed up. Might be null for current time.
+   * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+   * (subject to being overridden by `catalogVersion`, see below).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcBackupCatalogRequestOrBuilder extends
   boolean hasPastMoment();
   /**
    * <pre>
-   * The moment in time to which the catalog should be backed up. Might be null for current time.
+   * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+   * (subject to being overridden by `catalogVersion`, see below).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcBackupCatalogRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getPastMoment();
   /**
    * <pre>
-   * The moment in time to which the catalog should be backed up. Might be null for current time.
+   * The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+   * (subject to being overridden by `catalogVersion`, see below).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime pastMoment = 1;</code>
@@ -71,8 +74,9 @@ public interface GrpcBackupCatalogRequestOrBuilder extends
 
   /**
    * <pre>
-   * precise catalog version to create backup for, or null to create backup for the latest version,
-   * when set not null, the pastMoment parameter is ignored
+   * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+   * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+   * ignored regardless of whether it is also set.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -81,8 +85,9 @@ public interface GrpcBackupCatalogRequestOrBuilder extends
   boolean hasCatalogVersion();
   /**
    * <pre>
-   * precise catalog version to create backup for, or null to create backup for the latest version,
-   * when set not null, the pastMoment parameter is ignored
+   * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+   * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+   * ignored regardless of whether it is also set.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>
@@ -91,8 +96,9 @@ public interface GrpcBackupCatalogRequestOrBuilder extends
   com.google.protobuf.Int64Value getCatalogVersion();
   /**
    * <pre>
-   * precise catalog version to create backup for, or null to create backup for the latest version,
-   * when set not null, the pastMoment parameter is ignored
+   * Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+   * `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+   * ignored regardless of whether it is also set.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBackupCatalogResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBackupCatalogResponse.java
@@ -71,7 +71,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus_;
   /**
    * <pre>
-   * the task that is used to backup the catalog and getting its progress
+   * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+   * finished, retrieve the resulting backup file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -83,7 +84,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the task that is used to backup the catalog and getting its progress
+   * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+   * finished, retrieve the resulting backup file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -95,7 +97,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the task that is used to backup the catalog and getting its progress
+   * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+   * finished, retrieve the resulting backup file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -461,7 +464,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcTaskStatus, io.evitadb.externalApi.grpc.generated.GrpcTaskStatus.Builder, io.evitadb.externalApi.grpc.generated.GrpcTaskStatusOrBuilder> taskStatusBuilder_;
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -472,7 +476,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -487,7 +492,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -507,7 +513,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -525,7 +532,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -550,7 +558,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -567,7 +576,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -579,7 +589,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -594,7 +605,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBackupCatalogResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBackupCatalogResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcBackupCatalogResponseOrBuilder extends
 
   /**
    * <pre>
-   * the task that is used to backup the catalog and getting its progress
+   * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+   * finished, retrieve the resulting backup file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcBackupCatalogResponseOrBuilder extends
   boolean hasTaskStatus();
   /**
    * <pre>
-   * the task that is used to backup the catalog and getting its progress
+   * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+   * finished, retrieve the resulting backup file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcBackupCatalogResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTaskStatus getTaskStatus();
   /**
    * <pre>
-   * the task that is used to backup the catalog and getting its progress
+   * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+   * finished, retrieve the resulting backup file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimal.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimal.java
@@ -72,7 +72,10 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object valueString_ = "";
   /**
    * <pre>
-   * The string serialized value.
+   * The decimal value serialized as a string in the canonical form produced by
+   * `BigDecimal#toString()`, with the exponent marker lower-cased and its `+` sign stripped
+   * (e.g. `2.5e8` rather than `2.5E+8`). Preserves the original scale so the value round-trips
+   * exactly.
    * </pre>
    *
    * <code>string valueString = 1;</code>
@@ -93,7 +96,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string serialized value.
+   * The decimal value serialized as a string in the canonical form produced by
+   * `BigDecimal#toString()`, with the exponent marker lower-cased and its `+` sign stripped
+   * (e.g. `2.5e8` rather than `2.5E+8`). Preserves the original scale so the value round-trips
+   * exactly.
    * </pre>
    *
    * <code>string valueString = 1;</code>
@@ -447,7 +453,10 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object valueString_ = "";
     /**
      * <pre>
-     * The string serialized value.
+     * The decimal value serialized as a string in the canonical form produced by
+     * `BigDecimal#toString()`, with the exponent marker lower-cased and its `+` sign stripped
+     * (e.g. `2.5e8` rather than `2.5E+8`). Preserves the original scale so the value round-trips
+     * exactly.
      * </pre>
      *
      * <code>string valueString = 1;</code>
@@ -467,7 +476,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string serialized value.
+     * The decimal value serialized as a string in the canonical form produced by
+     * `BigDecimal#toString()`, with the exponent marker lower-cased and its `+` sign stripped
+     * (e.g. `2.5e8` rather than `2.5E+8`). Preserves the original scale so the value round-trips
+     * exactly.
      * </pre>
      *
      * <code>string valueString = 1;</code>
@@ -488,7 +500,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string serialized value.
+     * The decimal value serialized as a string in the canonical form produced by
+     * `BigDecimal#toString()`, with the exponent marker lower-cased and its `+` sign stripped
+     * (e.g. `2.5e8` rather than `2.5E+8`). Preserves the original scale so the value round-trips
+     * exactly.
      * </pre>
      *
      * <code>string valueString = 1;</code>
@@ -505,7 +520,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string serialized value.
+     * The decimal value serialized as a string in the canonical form produced by
+     * `BigDecimal#toString()`, with the exponent marker lower-cased and its `+` sign stripped
+     * (e.g. `2.5e8` rather than `2.5E+8`). Preserves the original scale so the value round-trips
+     * exactly.
      * </pre>
      *
      * <code>string valueString = 1;</code>
@@ -519,7 +537,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string serialized value.
+     * The decimal value serialized as a string in the canonical form produced by
+     * `BigDecimal#toString()`, with the exponent marker lower-cased and its `+` sign stripped
+     * (e.g. `2.5e8` rather than `2.5E+8`). Preserves the original scale so the value round-trips
+     * exactly.
      * </pre>
      *
      * <code>string valueString = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalArray.java
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcBigDecimal> value_;
   /**
    * <pre>
-   * Value that supports storing a BigDecimal array.
+   * The individual BigDecimal elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -83,7 +83,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a BigDecimal array.
+   * The individual BigDecimal elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -95,7 +95,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a BigDecimal array.
+   * The individual BigDecimal elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a BigDecimal array.
+   * The individual BigDecimal elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -117,7 +117,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a BigDecimal array.
+   * The individual BigDecimal elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -534,7 +534,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -548,7 +548,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -583,7 +583,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -601,7 +601,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -621,7 +621,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -642,7 +642,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -660,7 +660,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -678,7 +678,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -697,7 +697,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -714,7 +714,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -731,7 +731,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -742,7 +742,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -756,7 +756,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -771,7 +771,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -782,7 +782,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -794,7 +794,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimal array.
+     * The individual BigDecimal elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcBigDecimalArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a BigDecimal array.
+   * The individual BigDecimal elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcBigDecimalArrayOrBuilder extends
       getValueList();
   /**
    * <pre>
-   * Value that supports storing a BigDecimal array.
+   * The individual BigDecimal elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -50,7 +50,7 @@ public interface GrpcBigDecimalArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimal getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a BigDecimal array.
+   * The individual BigDecimal elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -58,7 +58,7 @@ public interface GrpcBigDecimalArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a BigDecimal array.
+   * The individual BigDecimal elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>
@@ -67,7 +67,7 @@ public interface GrpcBigDecimalArrayOrBuilder extends
       getValueOrBuilderList();
   /**
    * <pre>
-   * Value that supports storing a BigDecimal array.
+   * The individual BigDecimal elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimal value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalNumberRange.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalNumberRange.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Representation of BigDecimalNumberRange structures with optional from and to values.
+ * Representation of BigDecimalNumberRange structures. At least one of `from`/`to` should be set;
+ * if both are absent, the range decodes to the degenerate range `[0,0]` rather than being
+ * unbounded in both directions.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange}
@@ -71,7 +73,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from_;
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -83,7 +86,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -95,7 +99,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -109,7 +114,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to_;
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -121,7 +127,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -133,7 +140,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -147,7 +155,9 @@ private static final long serialVersionUID = 0L;
   private int decimalPlacesToCompare_ = 0;
   /**
    * <pre>
-   * The number of decimal places to compare.
+   * The number of fractional digits retained (rounded half-up) when comparing values against this
+   * range: both bounds and the compared value are scaled to this precision first, so digits beyond
+   * it are ignored for range-membership comparisons.
    * </pre>
    *
    * <code>int32 decimalPlacesToCompare = 3;</code>
@@ -349,7 +359,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Representation of BigDecimalNumberRange structures with optional from and to values.
+   * Representation of BigDecimalNumberRange structures. At least one of `from`/`to` should be set;
+   * if both are absent, the range decodes to the degenerate range `[0,0]` rather than being
+   * unbounded in both directions.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange}
@@ -575,7 +587,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBigDecimal, io.evitadb.externalApi.grpc.generated.GrpcBigDecimal.Builder, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalOrBuilder> fromBuilder_;
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -586,7 +599,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -601,7 +615,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -621,7 +636,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -639,7 +655,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -664,7 +681,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -681,7 +699,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -693,7 +712,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -708,7 +728,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -732,7 +753,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBigDecimal, io.evitadb.externalApi.grpc.generated.GrpcBigDecimal.Builder, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalOrBuilder> toBuilder_;
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -743,7 +765,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -758,7 +781,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -778,7 +802,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -796,7 +821,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -821,7 +847,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -838,7 +865,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -850,7 +878,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -865,7 +894,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -887,7 +917,9 @@ private static final long serialVersionUID = 0L;
     private int decimalPlacesToCompare_ ;
     /**
      * <pre>
-     * The number of decimal places to compare.
+     * The number of fractional digits retained (rounded half-up) when comparing values against this
+     * range: both bounds and the compared value are scaled to this precision first, so digits beyond
+     * it are ignored for range-membership comparisons.
      * </pre>
      *
      * <code>int32 decimalPlacesToCompare = 3;</code>
@@ -899,7 +931,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The number of decimal places to compare.
+     * The number of fractional digits retained (rounded half-up) when comparing values against this
+     * range: both bounds and the compared value are scaled to this precision first, so digits beyond
+     * it are ignored for range-membership comparisons.
      * </pre>
      *
      * <code>int32 decimalPlacesToCompare = 3;</code>
@@ -915,7 +949,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The number of decimal places to compare.
+     * The number of fractional digits retained (rounded half-up) when comparing values against this
+     * range: both bounds and the compared value are scaled to this precision first, so digits beyond
+     * it are ignored for range-membership comparisons.
      * </pre>
      *
      * <code>int32 decimalPlacesToCompare = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalNumberRangeArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalNumberRangeArray.java
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange> value_;
   /**
    * <pre>
-   * Value that supports storing a BigDecimalNumberRange array.
+   * The individual BigDecimalNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -83,7 +83,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a BigDecimalNumberRange array.
+   * The individual BigDecimalNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -95,7 +95,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a BigDecimalNumberRange array.
+   * The individual BigDecimalNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a BigDecimalNumberRange array.
+   * The individual BigDecimalNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -117,7 +117,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a BigDecimalNumberRange array.
+   * The individual BigDecimalNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -534,7 +534,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -548,7 +548,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -583,7 +583,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -601,7 +601,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -621,7 +621,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -642,7 +642,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -660,7 +660,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -678,7 +678,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -697,7 +697,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -714,7 +714,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -731,7 +731,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -742,7 +742,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -756,7 +756,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -771,7 +771,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -782,7 +782,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -794,7 +794,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a BigDecimalNumberRange array.
+     * The individual BigDecimalNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalNumberRangeArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalNumberRangeArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcBigDecimalNumberRangeArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a BigDecimalNumberRange array.
+   * The individual BigDecimalNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcBigDecimalNumberRangeArrayOrBuilder extends
       getValueList();
   /**
    * <pre>
-   * Value that supports storing a BigDecimalNumberRange array.
+   * The individual BigDecimalNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -50,7 +50,7 @@ public interface GrpcBigDecimalNumberRangeArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a BigDecimalNumberRange array.
+   * The individual BigDecimalNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -58,7 +58,7 @@ public interface GrpcBigDecimalNumberRangeArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a BigDecimalNumberRange array.
+   * The individual BigDecimalNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>
@@ -67,7 +67,7 @@ public interface GrpcBigDecimalNumberRangeArrayOrBuilder extends
       getValueOrBuilderList();
   /**
    * <pre>
-   * Value that supports storing a BigDecimalNumberRange array.
+   * The individual BigDecimalNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalNumberRangeOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalNumberRangeOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcBigDecimalNumberRangeOrBuilder extends
 
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcBigDecimalNumberRangeOrBuilder extends
   boolean hasFrom();
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcBigDecimalNumberRangeOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimal getFrom();
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal from = 1;</code>
@@ -60,7 +63,8 @@ public interface GrpcBigDecimalNumberRangeOrBuilder extends
 
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -69,7 +73,8 @@ public interface GrpcBigDecimalNumberRangeOrBuilder extends
   boolean hasTo();
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -78,7 +83,8 @@ public interface GrpcBigDecimalNumberRangeOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimal getTo();
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal to = 2;</code>
@@ -87,7 +93,9 @@ public interface GrpcBigDecimalNumberRangeOrBuilder extends
 
   /**
    * <pre>
-   * The number of decimal places to compare.
+   * The number of fractional digits retained (rounded half-up) when comparing values against this
+   * range: both bounds and the compared value are scaled to this precision first, so digits beyond
+   * it are ignored for range-membership comparisons.
    * </pre>
    *
    * <code>int32 decimalPlacesToCompare = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBigDecimalOrBuilder.java
@@ -33,7 +33,10 @@ public interface GrpcBigDecimalOrBuilder extends
 
   /**
    * <pre>
-   * The string serialized value.
+   * The decimal value serialized as a string in the canonical form produced by
+   * `BigDecimal#toString()`, with the exponent marker lower-cased and its `+` sign stripped
+   * (e.g. `2.5e8` rather than `2.5E+8`). Preserves the original scale so the value round-trips
+   * exactly.
    * </pre>
    *
    * <code>string valueString = 1;</code>
@@ -42,7 +45,10 @@ public interface GrpcBigDecimalOrBuilder extends
   java.lang.String getValueString();
   /**
    * <pre>
-   * The string serialized value.
+   * The decimal value serialized as a string in the canonical form produced by
+   * `BigDecimal#toString()`, with the exponent marker lower-cased and its `+` sign stripped
+   * (e.g. `2.5e8` rather than `2.5E+8`). Preserves the original scale so the value round-trips
+   * exactly.
    * </pre>
    *
    * <code>string valueString = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBooleanArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBooleanArray.java
@@ -73,7 +73,7 @@ private static final long serialVersionUID = 0L;
       emptyBooleanList();
   /**
    * <pre>
-   * Value that supports storing a boolean array.
+   * The individual boolean elements, in their original order.
    * </pre>
    *
    * <code>repeated bool value = 1;</code>
@@ -86,7 +86,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a boolean array.
+   * The individual boolean elements, in their original order.
    * </pre>
    *
    * <code>repeated bool value = 1;</code>
@@ -97,7 +97,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a boolean array.
+   * The individual boolean elements, in their original order.
    * </pre>
    *
    * <code>repeated bool value = 1;</code>
@@ -488,7 +488,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a boolean array.
+     * The individual boolean elements, in their original order.
      * </pre>
      *
      * <code>repeated bool value = 1;</code>
@@ -501,7 +501,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a boolean array.
+     * The individual boolean elements, in their original order.
      * </pre>
      *
      * <code>repeated bool value = 1;</code>
@@ -512,7 +512,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a boolean array.
+     * The individual boolean elements, in their original order.
      * </pre>
      *
      * <code>repeated bool value = 1;</code>
@@ -524,7 +524,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a boolean array.
+     * The individual boolean elements, in their original order.
      * </pre>
      *
      * <code>repeated bool value = 1;</code>
@@ -543,7 +543,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a boolean array.
+     * The individual boolean elements, in their original order.
      * </pre>
      *
      * <code>repeated bool value = 1;</code>
@@ -560,7 +560,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a boolean array.
+     * The individual boolean elements, in their original order.
      * </pre>
      *
      * <code>repeated bool value = 1;</code>
@@ -578,7 +578,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a boolean array.
+     * The individual boolean elements, in their original order.
      * </pre>
      *
      * <code>repeated bool value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBooleanArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcBooleanArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcBooleanArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a boolean array.
+   * The individual boolean elements, in their original order.
    * </pre>
    *
    * <code>repeated bool value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcBooleanArrayOrBuilder extends
   java.util.List<java.lang.Boolean> getValueList();
   /**
    * <pre>
-   * Value that supports storing a boolean array.
+   * The individual boolean elements, in their original order.
    * </pre>
    *
    * <code>repeated bool value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcBooleanArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a boolean array.
+   * The individual boolean elements, in their original order.
    * </pre>
    *
    * <code>repeated bool value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCancelTaskRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCancelTaskRequest.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to get cancel task status by id
+ * Request to cancel a task by id
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcCancelTaskRequest}
@@ -269,7 +269,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to get cancel task status by id
+   * Request to cancel a task by id
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcCancelTaskRequest}

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCancelTaskResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCancelTaskResponse.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to get cancel task status by id
+ * Response to a cancel task request.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcCancelTaskResponse}
@@ -70,7 +70,8 @@ private static final long serialVersionUID = 0L;
   private boolean success_ = false;
   /**
    * <pre>
-   * true if the task was found and canceled
+   * True if a task with the given id existed and was successfully canceled; false if no such task
+   * exists, or the task could no longer be canceled (e.g. it had already finished).
    * </pre>
    *
    * <code>bool success = 1;</code>
@@ -241,7 +242,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to get cancel task status by id
+   * Response to a cancel task request.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcCancelTaskResponse}
@@ -414,7 +415,8 @@ private static final long serialVersionUID = 0L;
     private boolean success_ ;
     /**
      * <pre>
-     * true if the task was found and canceled
+     * True if a task with the given id existed and was successfully canceled; false if no such task
+     * exists, or the task could no longer be canceled (e.g. it had already finished).
      * </pre>
      *
      * <code>bool success = 1;</code>
@@ -426,7 +428,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * true if the task was found and canceled
+     * True if a task with the given id existed and was successfully canceled; false if no such task
+     * exists, or the task could no longer be canceled (e.g. it had already finished).
      * </pre>
      *
      * <code>bool success = 1;</code>
@@ -442,7 +445,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * true if the task was found and canceled
+     * True if a task with the given id existed and was successfully canceled; false if no such task
+     * exists, or the task could no longer be canceled (e.g. it had already finished).
      * </pre>
      *
      * <code>bool success = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCancelTaskResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCancelTaskResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcCancelTaskResponseOrBuilder extends
 
   /**
    * <pre>
-   * true if the task was found and canceled
+   * True if a task with the given id existed and was successfully canceled; false if no such task
+   * exists, or the task could no longer be canceled (e.g. it had already finished).
    * </pre>
    *
    * <code>bool success = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCatalogSchema.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCatalogSchema.java
@@ -28,6 +28,13 @@
 package io.evitadb.externalApi.grpc.generated;
 
 /**
+ * <pre>
+ * Represents the schema of a single catalog - the top-level container that groups related entity collections
+ * together (analogous to a database / schema in a relational system). Holds the catalog name, its schema version,
+ * optional description, evolution mode settings, catalog-wide (global) attributes shared across entity types,
+ * name variants and the conflict resolution policy inherited by entity schemas that don't override it.
+ * </pre>
+ *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema}
  */
 public final class GrpcCatalogSchema extends
@@ -765,6 +772,13 @@ io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema defaultValue) {
     return builder;
   }
   /**
+   * <pre>
+   * Represents the schema of a single catalog - the top-level container that groups related entity collections
+   * together (analogous to a database / schema in a relational system). Holds the catalog name, its schema version,
+   * optional description, evolution mode settings, catalog-wide (global) attributes shared across entity types,
+   * name variants and the conflict resolution policy inherited by entity schemas that don't override it.
+   * </pre>
+   *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema}
    */
   public static final class Builder extends

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCatalogState.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCatalogState.java
@@ -82,7 +82,7 @@ public enum GrpcCatalogState
   INACTIVE(4),
   /**
    * <pre>
-   * State signalizing that evitaDB engine is transitioning catalog from {&#64;link #WARMING_UP} to {&#64;link #ALIVE} state.
+   * State signalizing that evitaDB engine is transitioning catalog from `WARMING_UP` to `ALIVE` state.
    * Until the transition is fully completed, the catalog is not able to serve any requests.
    * </pre>
    *
@@ -102,7 +102,7 @@ public enum GrpcCatalogState
   /**
    * <pre>
    * State signalizing that evitaDB engine is deactivating the catalog. When the operation is completed, the catalog
-   * is moved to {&#64;link #INACTIVE} state.
+   * is moved to `INACTIVE` state.
    * </pre>
    *
    * <code>BEING_DEACTIVATED = 7;</code>
@@ -212,7 +212,7 @@ public enum GrpcCatalogState
   public static final int INACTIVE_VALUE = 4;
   /**
    * <pre>
-   * State signalizing that evitaDB engine is transitioning catalog from {&#64;link #WARMING_UP} to {&#64;link #ALIVE} state.
+   * State signalizing that evitaDB engine is transitioning catalog from `WARMING_UP` to `ALIVE` state.
    * Until the transition is fully completed, the catalog is not able to serve any requests.
    * </pre>
    *
@@ -232,7 +232,7 @@ public enum GrpcCatalogState
   /**
    * <pre>
    * State signalizing that evitaDB engine is deactivating the catalog. When the operation is completed, the catalog
-   * is moved to {&#64;link #INACTIVE} state.
+   * is moved to `INACTIVE` state.
    * </pre>
    *
    * <code>BEING_DEACTIVATED = 7;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCatalogStatistics.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCatalogStatistics.java
@@ -74,7 +74,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId_;
   /**
    * <pre>
-   * name of the catalog
+   * unique identifier of the catalog
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -86,7 +86,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * name of the catalog
+   * unique identifier of the catalog
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -98,7 +98,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * name of the catalog
+   * unique identifier of the catalog
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -113,7 +113,7 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object catalogName_ = "";
   /**
    * <pre>
-   * name of the catalog
+   * The catalog's unique name, used to address it via the API.
    * </pre>
    *
    * <code>string catalogName = 2;</code>
@@ -134,7 +134,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * name of the catalog
+   * The catalog's unique name, used to address it via the API.
    * </pre>
    *
    * <code>string catalogName = 2;</code>
@@ -160,11 +160,12 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * true if the catalog is corrupted (other data will be not available)
+   * deprecated in favor of `catalogState` (compare against `CORRUPTED`)
    * </pre>
    *
    * <code>bool corrupted = 3 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics.corrupted is deprecated.
-   *     See GrpcEvitaDataTypes.proto;l=413
+   *     See GrpcEvitaDataTypes.proto;l=493
    * @return The corrupted.
    */
   @java.lang.Override
@@ -176,7 +177,8 @@ private static final long serialVersionUID = 0L;
   private int catalogState_ = 0;
   /**
    * <pre>
-   * current state of the catalog, null for corrupted catalog
+   * Current lifecycle state of the catalog. Reflects `CORRUPTED` when the catalog failed to load
+   * consistently, or `UNKNOWN_CATALOG_STATE` if the state could not be determined.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 4;</code>
@@ -187,7 +189,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * current state of the catalog, null for corrupted catalog
+   * Current lifecycle state of the catalog. Reflects `CORRUPTED` when the catalog failed to load
+   * consistently, or `UNKNOWN_CATALOG_STATE` if the state could not be determined.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 4;</code>
@@ -992,7 +995,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcUuid, io.evitadb.externalApi.grpc.generated.GrpcUuid.Builder, io.evitadb.externalApi.grpc.generated.GrpcUuidOrBuilder> catalogIdBuilder_;
     /**
      * <pre>
-     * name of the catalog
+     * unique identifier of the catalog
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -1003,7 +1006,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * name of the catalog
+     * unique identifier of the catalog
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -1018,7 +1021,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * name of the catalog
+     * unique identifier of the catalog
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -1038,7 +1041,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * name of the catalog
+     * unique identifier of the catalog
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -1056,7 +1059,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * name of the catalog
+     * unique identifier of the catalog
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -1081,7 +1084,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * name of the catalog
+     * unique identifier of the catalog
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -1098,7 +1101,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * name of the catalog
+     * unique identifier of the catalog
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -1110,7 +1113,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * name of the catalog
+     * unique identifier of the catalog
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -1125,7 +1128,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * name of the catalog
+     * unique identifier of the catalog
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -1147,7 +1150,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object catalogName_ = "";
     /**
      * <pre>
-     * name of the catalog
+     * The catalog's unique name, used to address it via the API.
      * </pre>
      *
      * <code>string catalogName = 2;</code>
@@ -1167,7 +1170,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * name of the catalog
+     * The catalog's unique name, used to address it via the API.
      * </pre>
      *
      * <code>string catalogName = 2;</code>
@@ -1188,7 +1191,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * name of the catalog
+     * The catalog's unique name, used to address it via the API.
      * </pre>
      *
      * <code>string catalogName = 2;</code>
@@ -1205,7 +1208,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * name of the catalog
+     * The catalog's unique name, used to address it via the API.
      * </pre>
      *
      * <code>string catalogName = 2;</code>
@@ -1219,7 +1222,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * name of the catalog
+     * The catalog's unique name, used to address it via the API.
      * </pre>
      *
      * <code>string catalogName = 2;</code>
@@ -1240,11 +1243,12 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * true if the catalog is corrupted (other data will be not available)
+     * deprecated in favor of `catalogState` (compare against `CORRUPTED`)
      * </pre>
      *
      * <code>bool corrupted = 3 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics.corrupted is deprecated.
-     *     See GrpcEvitaDataTypes.proto;l=413
+     *     See GrpcEvitaDataTypes.proto;l=493
      * @return The corrupted.
      */
     @java.lang.Override
@@ -1254,11 +1258,12 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * true if the catalog is corrupted (other data will be not available)
+     * deprecated in favor of `catalogState` (compare against `CORRUPTED`)
      * </pre>
      *
      * <code>bool corrupted = 3 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics.corrupted is deprecated.
-     *     See GrpcEvitaDataTypes.proto;l=413
+     *     See GrpcEvitaDataTypes.proto;l=493
      * @param value The corrupted to set.
      * @return This builder for chaining.
      */
@@ -1272,11 +1277,12 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * true if the catalog is corrupted (other data will be not available)
+     * deprecated in favor of `catalogState` (compare against `CORRUPTED`)
      * </pre>
      *
      * <code>bool corrupted = 3 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics.corrupted is deprecated.
-     *     See GrpcEvitaDataTypes.proto;l=413
+     *     See GrpcEvitaDataTypes.proto;l=493
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearCorrupted() {
@@ -1289,7 +1295,8 @@ private static final long serialVersionUID = 0L;
     private int catalogState_ = 0;
     /**
      * <pre>
-     * current state of the catalog, null for corrupted catalog
+     * Current lifecycle state of the catalog. Reflects `CORRUPTED` when the catalog failed to load
+     * consistently, or `UNKNOWN_CATALOG_STATE` if the state could not be determined.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 4;</code>
@@ -1300,7 +1307,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * current state of the catalog, null for corrupted catalog
+     * Current lifecycle state of the catalog. Reflects `CORRUPTED` when the catalog failed to load
+     * consistently, or `UNKNOWN_CATALOG_STATE` if the state could not be determined.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 4;</code>
@@ -1315,7 +1323,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * current state of the catalog, null for corrupted catalog
+     * Current lifecycle state of the catalog. Reflects `CORRUPTED` when the catalog failed to load
+     * consistently, or `UNKNOWN_CATALOG_STATE` if the state could not be determined.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 4;</code>
@@ -1328,7 +1337,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * current state of the catalog, null for corrupted catalog
+     * Current lifecycle state of the catalog. Reflects `CORRUPTED` when the catalog failed to load
+     * consistently, or `UNKNOWN_CATALOG_STATE` if the state could not be determined.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 4;</code>
@@ -1346,7 +1356,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * current state of the catalog, null for corrupted catalog
+     * Current lifecycle state of the catalog. Reflects `CORRUPTED` when the catalog failed to load
+     * consistently, or `UNKNOWN_CATALOG_STATE` if the state could not be determined.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCatalogStatisticsOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCatalogStatisticsOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcCatalogStatisticsOrBuilder extends
 
   /**
    * <pre>
-   * name of the catalog
+   * unique identifier of the catalog
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcCatalogStatisticsOrBuilder extends
   boolean hasCatalogId();
   /**
    * <pre>
-   * name of the catalog
+   * unique identifier of the catalog
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcCatalogStatisticsOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuid getCatalogId();
   /**
    * <pre>
-   * name of the catalog
+   * unique identifier of the catalog
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid catalogId = 1;</code>
@@ -60,7 +60,7 @@ public interface GrpcCatalogStatisticsOrBuilder extends
 
   /**
    * <pre>
-   * name of the catalog
+   * The catalog's unique name, used to address it via the API.
    * </pre>
    *
    * <code>string catalogName = 2;</code>
@@ -69,7 +69,7 @@ public interface GrpcCatalogStatisticsOrBuilder extends
   java.lang.String getCatalogName();
   /**
    * <pre>
-   * name of the catalog
+   * The catalog's unique name, used to address it via the API.
    * </pre>
    *
    * <code>string catalogName = 2;</code>
@@ -81,18 +81,20 @@ public interface GrpcCatalogStatisticsOrBuilder extends
   /**
    * <pre>
    * true if the catalog is corrupted (other data will be not available)
+   * deprecated in favor of `catalogState` (compare against `CORRUPTED`)
    * </pre>
    *
    * <code>bool corrupted = 3 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics.corrupted is deprecated.
-   *     See GrpcEvitaDataTypes.proto;l=413
+   *     See GrpcEvitaDataTypes.proto;l=493
    * @return The corrupted.
    */
   @java.lang.Deprecated boolean getCorrupted();
 
   /**
    * <pre>
-   * current state of the catalog, null for corrupted catalog
+   * Current lifecycle state of the catalog. Reflects `CORRUPTED` when the catalog failed to load
+   * consistently, or `UNKNOWN_CATALOG_STATE` if the state could not be determined.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 4;</code>
@@ -101,7 +103,8 @@ public interface GrpcCatalogStatisticsOrBuilder extends
   int getCatalogStateValue();
   /**
    * <pre>
-   * current state of the catalog, null for corrupted catalog
+   * Current lifecycle state of the catalog. Reflects `CORRUPTED` when the catalog failed to load
+   * consistently, or `UNKNOWN_CATALOG_STATE` if the state could not be determined.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCaptureCriteria.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCaptureCriteria.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Record for the criteria of the capture request allowing to limit mutations to specific area of interest an its
+ * Record for the criteria of the capture request allowing to limit mutations to specific area of interest and its
  * properties.
  * </pre>
  *
@@ -114,7 +114,9 @@ private static final long serialVersionUID = 0L;
   private int area_ = 0;
   /**
    * <pre>
-   * The area of capture - either schema or data (correlates with the site)
+   * The area of capture - SCHEMA, DATA or INFRASTRUCTURE. If `schemaSite`/`dataSite` below is set, it determines
+   * the effective area and this field is ignored; this field is only consulted when neither site is set, which
+   * is also the only way to select INFRASTRUCTURE (it has no site message of its own).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureArea area = 1;</code>
@@ -125,7 +127,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The area of capture - either schema or data (correlates with the site)
+   * The area of capture - SCHEMA, DATA or INFRASTRUCTURE. If `schemaSite`/`dataSite` below is set, it determines
+   * the effective area and this field is ignored; this field is only consulted when neither site is set, which
+   * is also the only way to select INFRASTRUCTURE (it has no site message of its own).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureArea area = 1;</code>
@@ -419,7 +423,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Record for the criteria of the capture request allowing to limit mutations to specific area of interest an its
+   * Record for the criteria of the capture request allowing to limit mutations to specific area of interest and its
    * properties.
    * </pre>
    *
@@ -657,7 +661,9 @@ private static final long serialVersionUID = 0L;
     private int area_ = 0;
     /**
      * <pre>
-     * The area of capture - either schema or data (correlates with the site)
+     * The area of capture - SCHEMA, DATA or INFRASTRUCTURE. If `schemaSite`/`dataSite` below is set, it determines
+     * the effective area and this field is ignored; this field is only consulted when neither site is set, which
+     * is also the only way to select INFRASTRUCTURE (it has no site message of its own).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureArea area = 1;</code>
@@ -668,7 +674,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The area of capture - either schema or data (correlates with the site)
+     * The area of capture - SCHEMA, DATA or INFRASTRUCTURE. If `schemaSite`/`dataSite` below is set, it determines
+     * the effective area and this field is ignored; this field is only consulted when neither site is set, which
+     * is also the only way to select INFRASTRUCTURE (it has no site message of its own).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureArea area = 1;</code>
@@ -683,7 +691,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The area of capture - either schema or data (correlates with the site)
+     * The area of capture - SCHEMA, DATA or INFRASTRUCTURE. If `schemaSite`/`dataSite` below is set, it determines
+     * the effective area and this field is ignored; this field is only consulted when neither site is set, which
+     * is also the only way to select INFRASTRUCTURE (it has no site message of its own).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureArea area = 1;</code>
@@ -696,7 +706,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The area of capture - either schema or data (correlates with the site)
+     * The area of capture - SCHEMA, DATA or INFRASTRUCTURE. If `schemaSite`/`dataSite` below is set, it determines
+     * the effective area and this field is ignored; this field is only consulted when neither site is set, which
+     * is also the only way to select INFRASTRUCTURE (it has no site message of its own).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureArea area = 1;</code>
@@ -714,7 +726,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The area of capture - either schema or data (correlates with the site)
+     * The area of capture - SCHEMA, DATA or INFRASTRUCTURE. If `schemaSite`/`dataSite` below is set, it determines
+     * the effective area and this field is ignored; this field is only consulted when neither site is set, which
+     * is also the only way to select INFRASTRUCTURE (it has no site message of its own).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureArea area = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCaptureCriteriaOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCaptureCriteriaOrBuilder.java
@@ -33,7 +33,9 @@ public interface GrpcChangeCaptureCriteriaOrBuilder extends
 
   /**
    * <pre>
-   * The area of capture - either schema or data (correlates with the site)
+   * The area of capture - SCHEMA, DATA or INFRASTRUCTURE. If `schemaSite`/`dataSite` below is set, it determines
+   * the effective area and this field is ignored; this field is only consulted when neither site is set, which
+   * is also the only way to select INFRASTRUCTURE (it has no site message of its own).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureArea area = 1;</code>
@@ -42,7 +44,9 @@ public interface GrpcChangeCaptureCriteriaOrBuilder extends
   int getAreaValue();
   /**
    * <pre>
-   * The area of capture - either schema or data (correlates with the site)
+   * The area of capture - SCHEMA, DATA or INFRASTRUCTURE. If `schemaSite`/`dataSite` below is set, it determines
+   * the effective area and this field is ignored; this field is only consulted when neither site is set, which
+   * is also the only way to select INFRASTRUCTURE (it has no site message of its own).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureArea area = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCaptureDataSite.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCaptureDataSite.java
@@ -30,6 +30,8 @@ package io.evitadb.externalApi.grpc.generated;
 /**
  * <pre>
  * Record describing the location and form of the CDC data event in the evitaDB that should be captured.
+ * Every field below is an independent, optional filter (logically ANDed together when several are set); an
+ * unset/empty field imposes no restriction on that dimension.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureDataSite}
@@ -75,7 +77,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.StringValue entityType_;
   /**
    * <pre>
-   * the name of the intercepted entity type
+   * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+   * type.
    * </pre>
    *
    * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -87,7 +90,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the intercepted entity type
+   * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+   * type.
    * </pre>
    *
    * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -99,7 +103,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the intercepted entity type
+   * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+   * type.
    * </pre>
    *
    * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -113,7 +118,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value entityPrimaryKey_;
   /**
    * <pre>
-   * the primary key of the intercepted entity
+   * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+   * within the entity type filter above.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -125,7 +131,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the primary key of the intercepted entity
+   * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+   * within the entity type filter above.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -137,7 +144,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the primary key of the intercepted entity
+   * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+   * within the entity type filter above.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -161,7 +169,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * the intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -174,7 +182,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -186,7 +194,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -199,7 +207,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -212,7 +220,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -239,7 +247,8 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -252,7 +261,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -264,7 +274,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -277,7 +288,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -290,7 +302,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -309,7 +322,8 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 5;</code>
@@ -321,7 +335,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 5;</code>
@@ -332,7 +347,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 5;</code>
@@ -344,7 +360,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 5;</code>
@@ -603,6 +620,8 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * Record describing the location and form of the CDC data event in the evitaDB that should be captured.
+   * Every field below is an independent, optional filter (logically ANDed together when several are set); an
+   * unset/empty field imposes no restriction on that dimension.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureDataSite}
@@ -910,7 +929,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> entityTypeBuilder_;
     /**
      * <pre>
-     * the name of the intercepted entity type
+     * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+     * type.
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -921,7 +941,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted entity type
+     * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+     * type.
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -936,7 +957,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted entity type
+     * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+     * type.
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -956,7 +978,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted entity type
+     * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+     * type.
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -974,7 +997,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted entity type
+     * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+     * type.
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -999,7 +1023,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted entity type
+     * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+     * type.
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -1016,7 +1041,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted entity type
+     * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+     * type.
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -1028,7 +1054,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted entity type
+     * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+     * type.
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -1043,7 +1070,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted entity type
+     * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+     * type.
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -1067,7 +1095,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> entityPrimaryKeyBuilder_;
     /**
      * <pre>
-     * the primary key of the intercepted entity
+     * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+     * within the entity type filter above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -1078,7 +1107,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the primary key of the intercepted entity
+     * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+     * within the entity type filter above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -1093,7 +1123,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the primary key of the intercepted entity
+     * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+     * within the entity type filter above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -1113,7 +1144,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the primary key of the intercepted entity
+     * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+     * within the entity type filter above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -1131,7 +1163,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the primary key of the intercepted entity
+     * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+     * within the entity type filter above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -1156,7 +1189,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the primary key of the intercepted entity
+     * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+     * within the entity type filter above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -1173,7 +1207,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the primary key of the intercepted entity
+     * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+     * within the entity type filter above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -1185,7 +1220,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the primary key of the intercepted entity
+     * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+     * within the entity type filter above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -1200,7 +1236,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the primary key of the intercepted entity
+     * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+     * within the entity type filter above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -1229,7 +1266,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -1241,7 +1278,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -1252,7 +1289,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -1264,7 +1301,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -1284,7 +1321,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -1302,7 +1339,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -1320,7 +1357,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -1334,7 +1371,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -1346,7 +1383,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -1358,7 +1395,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -1375,7 +1412,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -1390,7 +1427,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -1417,7 +1454,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -1429,7 +1467,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -1440,7 +1479,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -1452,7 +1492,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -1472,7 +1513,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -1490,7 +1532,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -1508,7 +1551,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -1522,7 +1566,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -1534,7 +1579,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -1546,7 +1592,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -1563,7 +1610,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -1578,7 +1626,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -1605,7 +1654,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 5;</code>
@@ -1618,7 +1668,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 5;</code>
@@ -1629,7 +1680,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 5;</code>
@@ -1641,7 +1693,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 5;</code>
@@ -1654,7 +1707,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 5;</code>
@@ -1673,7 +1727,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 5;</code>
@@ -1691,7 +1746,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 5;</code>
@@ -1709,7 +1765,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 5;</code>
@@ -1724,7 +1781,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCaptureDataSiteOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCaptureDataSiteOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
 
   /**
    * <pre>
-   * the name of the intercepted entity type
+   * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+   * type.
    * </pre>
    *
    * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   boolean hasEntityType();
   /**
    * <pre>
-   * the name of the intercepted entity type
+   * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+   * type.
    * </pre>
    *
    * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   com.google.protobuf.StringValue getEntityType();
   /**
    * <pre>
-   * the name of the intercepted entity type
+   * Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+   * type.
    * </pre>
    *
    * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -60,7 +63,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
 
   /**
    * <pre>
-   * the primary key of the intercepted entity
+   * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+   * within the entity type filter above.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -69,7 +73,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   boolean hasEntityPrimaryKey();
   /**
    * <pre>
-   * the primary key of the intercepted entity
+   * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+   * within the entity type filter above.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -78,7 +83,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   com.google.protobuf.Int32Value getEntityPrimaryKey();
   /**
    * <pre>
-   * the primary key of the intercepted entity
+   * Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+   * within the entity type filter above.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value entityPrimaryKey = 2;</code>
@@ -87,7 +93,7 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
 
   /**
    * <pre>
-   * the intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -96,7 +102,7 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation> getOperationList();
   /**
    * <pre>
-   * the intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -105,7 +111,7 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   int getOperationCount();
   /**
    * <pre>
-   * the intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -115,7 +121,7 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation getOperation(int index);
   /**
    * <pre>
-   * the intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -125,7 +131,7 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   getOperationValueList();
   /**
    * <pre>
-   * the intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 3;</code>
@@ -136,7 +142,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
 
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -145,7 +152,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType> getContainerTypeList();
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -154,7 +162,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   int getContainerTypeCount();
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -164,7 +173,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType getContainerType(int index);
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -174,7 +184,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   getContainerTypeValueList();
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 4;</code>
@@ -185,7 +196,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
 
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 5;</code>
@@ -195,7 +207,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
       getContainerNameList();
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 5;</code>
@@ -204,7 +217,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   int getContainerNameCount();
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 5;</code>
@@ -214,7 +228,8 @@ public interface GrpcChangeCaptureDataSiteOrBuilder extends
   java.lang.String getContainerName(int index);
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCaptureSchemaSite.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCaptureSchemaSite.java
@@ -30,6 +30,8 @@ package io.evitadb.externalApi.grpc.generated;
 /**
  * <pre>
  * Record describing the location and form of the CDC schema event in the evitaDB that should be captured.
+ * Every field below is an independent, optional filter (logically ANDed together when several are set); an
+ * unset/empty field imposes no restriction on that dimension.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureSchemaSite}
@@ -75,7 +77,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.StringValue entityType_;
   /**
    * <pre>
-   * The name of intercepted entity
+   * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+   * entity type, including catalog-level schema changes (which carry no entity type of their own).
    * </pre>
    *
    * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -87,7 +90,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The name of intercepted entity
+   * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+   * entity type, including catalog-level schema changes (which carry no entity type of their own).
    * </pre>
    *
    * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -99,7 +103,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The name of intercepted entity
+   * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+   * entity type, including catalog-level schema changes (which carry no entity type of their own).
    * </pre>
    *
    * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -123,7 +128,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * The intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -136,7 +141,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -148,7 +153,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -161,7 +166,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -174,7 +179,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -201,7 +206,8 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -214,7 +220,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -226,7 +233,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -239,7 +247,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -252,7 +261,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -271,7 +281,8 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 4;</code>
@@ -283,7 +294,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 4;</code>
@@ -294,7 +306,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 4;</code>
@@ -306,7 +319,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 4;</code>
@@ -549,6 +563,8 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * Record describing the location and form of the CDC schema event in the evitaDB that should be captured.
+   * Every field below is an independent, optional filter (logically ANDed together when several are set); an
+   * unset/empty field imposes no restriction on that dimension.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureSchemaSite}
@@ -834,7 +850,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> entityTypeBuilder_;
     /**
      * <pre>
-     * The name of intercepted entity
+     * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+     * entity type, including catalog-level schema changes (which carry no entity type of their own).
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -845,7 +862,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The name of intercepted entity
+     * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+     * entity type, including catalog-level schema changes (which carry no entity type of their own).
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -860,7 +878,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The name of intercepted entity
+     * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+     * entity type, including catalog-level schema changes (which carry no entity type of their own).
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -880,7 +899,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The name of intercepted entity
+     * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+     * entity type, including catalog-level schema changes (which carry no entity type of their own).
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -898,7 +918,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The name of intercepted entity
+     * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+     * entity type, including catalog-level schema changes (which carry no entity type of their own).
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -923,7 +944,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The name of intercepted entity
+     * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+     * entity type, including catalog-level schema changes (which carry no entity type of their own).
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -940,7 +962,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The name of intercepted entity
+     * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+     * entity type, including catalog-level schema changes (which carry no entity type of their own).
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -952,7 +975,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The name of intercepted entity
+     * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+     * entity type, including catalog-level schema changes (which carry no entity type of their own).
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -967,7 +991,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The name of intercepted entity
+     * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+     * entity type, including catalog-level schema changes (which carry no entity type of their own).
      * </pre>
      *
      * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -996,7 +1021,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -1008,7 +1033,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -1019,7 +1044,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -1031,7 +1056,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -1051,7 +1076,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -1069,7 +1094,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -1087,7 +1112,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -1101,7 +1126,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -1113,7 +1138,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -1125,7 +1150,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -1142,7 +1167,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -1157,7 +1182,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The intercepted type of operation
+     * Restricts capture to the listed operation types. If empty, matches any operation.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -1184,7 +1209,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -1196,7 +1222,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -1207,7 +1234,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -1219,7 +1247,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -1239,7 +1268,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -1257,7 +1287,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -1275,7 +1306,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -1289,7 +1321,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -1301,7 +1334,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -1313,7 +1347,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -1330,7 +1365,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -1345,7 +1381,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the intercepted container type
+     * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+     * matches any container type.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -1372,7 +1409,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 4;</code>
@@ -1385,7 +1423,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 4;</code>
@@ -1396,7 +1435,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 4;</code>
@@ -1408,7 +1448,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 4;</code>
@@ -1421,7 +1462,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 4;</code>
@@ -1440,7 +1482,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 4;</code>
@@ -1458,7 +1501,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 4;</code>
@@ -1476,7 +1520,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 4;</code>
@@ -1491,7 +1536,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name of the container (e.g. attribute name, associated data name, reference name)
+     * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+     * reference name). If empty, matches containers of any name.
      * </pre>
      *
      * <code>repeated string containerName = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCaptureSchemaSiteOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCaptureSchemaSiteOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
 
   /**
    * <pre>
-   * The name of intercepted entity
+   * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+   * entity type, including catalog-level schema changes (which carry no entity type of their own).
    * </pre>
    *
    * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
   boolean hasEntityType();
   /**
    * <pre>
-   * The name of intercepted entity
+   * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+   * entity type, including catalog-level schema changes (which carry no entity type of their own).
    * </pre>
    *
    * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
   com.google.protobuf.StringValue getEntityType();
   /**
    * <pre>
-   * The name of intercepted entity
+   * Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+   * entity type, including catalog-level schema changes (which carry no entity type of their own).
    * </pre>
    *
    * <code>.google.protobuf.StringValue entityType = 1;</code>
@@ -60,7 +63,7 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
 
   /**
    * <pre>
-   * The intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -69,7 +72,7 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation> getOperationList();
   /**
    * <pre>
-   * The intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -78,7 +81,7 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
   int getOperationCount();
   /**
    * <pre>
-   * The intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -88,7 +91,7 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation getOperation(int index);
   /**
    * <pre>
-   * The intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -98,7 +101,7 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
   getOperationValueList();
   /**
    * <pre>
-   * The intercepted type of operation
+   * Restricts capture to the listed operation types. If empty, matches any operation.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 2;</code>
@@ -109,7 +112,8 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
 
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -118,7 +122,8 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType> getContainerTypeList();
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -127,7 +132,8 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
   int getContainerTypeCount();
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -137,7 +143,8 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType getContainerType(int index);
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -147,7 +154,8 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
   getContainerTypeValueList();
   /**
    * <pre>
-   * the name of the intercepted container type
+   * Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+   * matches any container type.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContainerType containerType = 3;</code>
@@ -158,7 +166,8 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
 
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 4;</code>
@@ -168,7 +177,8 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
       getContainerNameList();
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 4;</code>
@@ -177,7 +187,8 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
   int getContainerNameCount();
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 4;</code>
@@ -187,7 +198,8 @@ public interface GrpcChangeCaptureSchemaSiteOrBuilder extends
   java.lang.String getContainerName(int index);
   /**
    * <pre>
-   * the name of the container (e.g. attribute name, associated data name, reference name)
+   * Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+   * reference name). If empty, matches containers of any name.
    * </pre>
    *
    * <code>repeated string containerName = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCatalogCapture.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCatalogCapture.java
@@ -119,7 +119,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value version_;
   /**
    * <pre>
-   * the version of the catalog where the operation was performed
+   * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+   * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -131,7 +132,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the version of the catalog where the operation was performed
+   * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+   * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -143,7 +145,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the version of the catalog where the operation was performed
+   * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+   * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -157,7 +160,16 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value index_;
   /**
    * <pre>
-   * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+   * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+   * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+   * descending, so the same physical record gets the same index regardless of direction - but indices are
+   * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+   * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+   * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+   * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+   * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+   * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+   * #1349 for the full analysis.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -169,7 +181,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+   * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+   * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+   * descending, so the same physical record gets the same index regardless of direction - but indices are
+   * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+   * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+   * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+   * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+   * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+   * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+   * #1349 for the full analysis.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -181,7 +202,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+   * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+   * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+   * descending, so the same physical record gets the same index regardless of direction - but indices are
+   * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+   * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+   * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+   * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+   * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+   * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+   * #1349 for the full analysis.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -303,7 +333,8 @@ private static final long serialVersionUID = 0L;
   private int operation_ = 0;
   /**
    * <pre>
-   * the operation that was performed
+   * The kind of change that produced this capture. Together with `area`, it determines which arm of `body` (if
+   * present) carries the payload - see the `body` oneof comment for the mapping.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 6;</code>
@@ -314,7 +345,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the operation that was performed
+   * The kind of change that produced this capture. Together with `area`, it determines which arm of `body` (if
+   * present) carries the payload - see the `body` oneof comment for the mapping.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 6;</code>
@@ -327,6 +359,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int SCHEMAMUTATION_FIELD_NUMBER = 7;
   /**
+   * <pre>
+   * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
    * @return Whether the schemaMutation field is set.
    */
@@ -335,6 +371,10 @@ private static final long serialVersionUID = 0L;
     return bodyCase_ == 7;
   }
   /**
+   * <pre>
+   * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
    * @return The schemaMutation.
    */
@@ -346,6 +386,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
    */
   @java.lang.Override
@@ -358,6 +402,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int ENTITYMUTATION_FIELD_NUMBER = 8;
   /**
+   * <pre>
+   * Set for the top-level DATA area entity mutation. See the `body` comment above.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
    * @return Whether the entityMutation field is set.
    */
@@ -366,6 +414,10 @@ private static final long serialVersionUID = 0L;
     return bodyCase_ == 8;
   }
   /**
+   * <pre>
+   * Set for the top-level DATA area entity mutation. See the `body` comment above.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
    * @return The entityMutation.
    */
@@ -377,6 +429,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcEntityMutation.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Set for the top-level DATA area entity mutation. See the `body` comment above.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
    */
   @java.lang.Override
@@ -389,6 +445,11 @@ private static final long serialVersionUID = 0L;
 
   public static final int LOCALMUTATION_FIELD_NUMBER = 9;
   /**
+   * <pre>
+   * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+   * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
    * @return Whether the localMutation field is set.
    */
@@ -397,6 +458,11 @@ private static final long serialVersionUID = 0L;
     return bodyCase_ == 9;
   }
   /**
+   * <pre>
+   * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+   * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
    * @return The localMutation.
    */
@@ -408,6 +474,11 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcLocalMutation.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+   * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
    */
   @java.lang.Override
@@ -420,6 +491,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int INFRASTRUCTUREMUTATION_FIELD_NUMBER = 10;
   /**
+   * <pre>
+   * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
    * @return Whether the infrastructureMutation field is set.
    */
@@ -428,6 +503,10 @@ private static final long serialVersionUID = 0L;
     return bodyCase_ == 10;
   }
   /**
+   * <pre>
+   * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
    * @return The infrastructureMutation.
    */
@@ -439,6 +518,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
    */
   @java.lang.Override
@@ -1208,7 +1291,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> versionBuilder_;
     /**
      * <pre>
-     * the version of the catalog where the operation was performed
+     * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+     * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -1219,7 +1303,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the version of the catalog where the operation was performed
+     * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+     * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -1234,7 +1319,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the version of the catalog where the operation was performed
+     * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+     * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -1254,7 +1340,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the version of the catalog where the operation was performed
+     * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+     * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -1272,7 +1359,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the version of the catalog where the operation was performed
+     * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+     * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -1297,7 +1385,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the version of the catalog where the operation was performed
+     * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+     * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -1314,7 +1403,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the version of the catalog where the operation was performed
+     * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+     * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -1326,7 +1416,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the version of the catalog where the operation was performed
+     * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+     * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -1341,7 +1432,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the version of the catalog where the operation was performed
+     * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+     * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -1365,7 +1457,16 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> indexBuilder_;
     /**
      * <pre>
-     * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+     * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+     * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+     * descending, so the same physical record gets the same index regardless of direction - but indices are
+     * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+     * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+     * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+     * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+     * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+     * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+     * #1349 for the full analysis.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -1376,7 +1477,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+     * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+     * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+     * descending, so the same physical record gets the same index regardless of direction - but indices are
+     * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+     * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+     * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+     * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+     * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+     * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+     * #1349 for the full analysis.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -1391,7 +1501,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+     * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+     * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+     * descending, so the same physical record gets the same index regardless of direction - but indices are
+     * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+     * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+     * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+     * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+     * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+     * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+     * #1349 for the full analysis.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -1411,7 +1530,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+     * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+     * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+     * descending, so the same physical record gets the same index regardless of direction - but indices are
+     * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+     * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+     * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+     * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+     * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+     * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+     * #1349 for the full analysis.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -1429,7 +1557,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+     * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+     * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+     * descending, so the same physical record gets the same index regardless of direction - but indices are
+     * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+     * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+     * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+     * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+     * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+     * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+     * #1349 for the full analysis.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -1454,7 +1591,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+     * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+     * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+     * descending, so the same physical record gets the same index regardless of direction - but indices are
+     * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+     * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+     * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+     * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+     * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+     * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+     * #1349 for the full analysis.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -1471,7 +1617,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+     * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+     * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+     * descending, so the same physical record gets the same index regardless of direction - but indices are
+     * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+     * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+     * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+     * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+     * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+     * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+     * #1349 for the full analysis.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -1483,7 +1638,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+     * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+     * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+     * descending, so the same physical record gets the same index regardless of direction - but indices are
+     * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+     * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+     * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+     * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+     * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+     * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+     * #1349 for the full analysis.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -1498,7 +1662,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+     * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+     * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+     * descending, so the same physical record gets the same index regardless of direction - but indices are
+     * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+     * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+     * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+     * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+     * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+     * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+     * #1349 for the full analysis.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -1925,7 +2098,8 @@ private static final long serialVersionUID = 0L;
     private int operation_ = 0;
     /**
      * <pre>
-     * the operation that was performed
+     * The kind of change that produced this capture. Together with `area`, it determines which arm of `body` (if
+     * present) carries the payload - see the `body` oneof comment for the mapping.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 6;</code>
@@ -1936,7 +2110,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the operation that was performed
+     * The kind of change that produced this capture. Together with `area`, it determines which arm of `body` (if
+     * present) carries the payload - see the `body` oneof comment for the mapping.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 6;</code>
@@ -1951,7 +2126,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the operation that was performed
+     * The kind of change that produced this capture. Together with `area`, it determines which arm of `body` (if
+     * present) carries the payload - see the `body` oneof comment for the mapping.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 6;</code>
@@ -1964,7 +2140,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the operation that was performed
+     * The kind of change that produced this capture. Together with `area`, it determines which arm of `body` (if
+     * present) carries the payload - see the `body` oneof comment for the mapping.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 6;</code>
@@ -1982,7 +2159,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the operation that was performed
+     * The kind of change that produced this capture. Together with `area`, it determines which arm of `body` (if
+     * present) carries the payload - see the `body` oneof comment for the mapping.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 6;</code>
@@ -1998,6 +2176,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation, io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutationOrBuilder> schemaMutationBuilder_;
     /**
+     * <pre>
+     * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
      * @return Whether the schemaMutation field is set.
      */
@@ -2006,6 +2188,10 @@ private static final long serialVersionUID = 0L;
       return bodyCase_ == 7;
     }
     /**
+     * <pre>
+     * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
      * @return The schemaMutation.
      */
@@ -2024,6 +2210,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
      */
     public Builder setSchemaMutation(io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation value) {
@@ -2040,6 +2230,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
      */
     public Builder setSchemaMutation(
@@ -2054,6 +2248,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
      */
     public Builder mergeSchemaMutation(io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation value) {
@@ -2077,6 +2275,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
      */
     public Builder clearSchemaMutation() {
@@ -2096,12 +2298,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation.Builder getSchemaMutationBuilder() {
       return getSchemaMutationFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
      */
     @java.lang.Override
@@ -2116,6 +2326,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -2140,6 +2354,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcEntityMutation, io.evitadb.externalApi.grpc.generated.GrpcEntityMutation.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntityMutationOrBuilder> entityMutationBuilder_;
     /**
+     * <pre>
+     * Set for the top-level DATA area entity mutation. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
      * @return Whether the entityMutation field is set.
      */
@@ -2148,6 +2366,10 @@ private static final long serialVersionUID = 0L;
       return bodyCase_ == 8;
     }
     /**
+     * <pre>
+     * Set for the top-level DATA area entity mutation. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
      * @return The entityMutation.
      */
@@ -2166,6 +2388,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Set for the top-level DATA area entity mutation. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
      */
     public Builder setEntityMutation(io.evitadb.externalApi.grpc.generated.GrpcEntityMutation value) {
@@ -2182,6 +2408,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for the top-level DATA area entity mutation. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
      */
     public Builder setEntityMutation(
@@ -2196,6 +2426,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for the top-level DATA area entity mutation. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
      */
     public Builder mergeEntityMutation(io.evitadb.externalApi.grpc.generated.GrpcEntityMutation value) {
@@ -2219,6 +2453,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for the top-level DATA area entity mutation. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
      */
     public Builder clearEntityMutation() {
@@ -2238,12 +2476,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for the top-level DATA area entity mutation. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcEntityMutation.Builder getEntityMutationBuilder() {
       return getEntityMutationFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Set for the top-level DATA area entity mutation. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
      */
     @java.lang.Override
@@ -2258,6 +2504,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Set for the top-level DATA area entity mutation. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -2282,6 +2532,11 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcLocalMutation, io.evitadb.externalApi.grpc.generated.GrpcLocalMutation.Builder, io.evitadb.externalApi.grpc.generated.GrpcLocalMutationOrBuilder> localMutationBuilder_;
     /**
+     * <pre>
+     * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+     * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
      * @return Whether the localMutation field is set.
      */
@@ -2290,6 +2545,11 @@ private static final long serialVersionUID = 0L;
       return bodyCase_ == 9;
     }
     /**
+     * <pre>
+     * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+     * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
      * @return The localMutation.
      */
@@ -2308,6 +2568,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+     * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
      */
     public Builder setLocalMutation(io.evitadb.externalApi.grpc.generated.GrpcLocalMutation value) {
@@ -2324,6 +2589,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+     * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
      */
     public Builder setLocalMutation(
@@ -2338,6 +2608,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+     * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
      */
     public Builder mergeLocalMutation(io.evitadb.externalApi.grpc.generated.GrpcLocalMutation value) {
@@ -2361,6 +2636,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+     * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
      */
     public Builder clearLocalMutation() {
@@ -2380,12 +2660,22 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+     * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcLocalMutation.Builder getLocalMutationBuilder() {
       return getLocalMutationFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+     * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
      */
     @java.lang.Override
@@ -2400,6 +2690,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+     * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -2424,6 +2719,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation, io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation.Builder, io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutationOrBuilder> infrastructureMutationBuilder_;
     /**
+     * <pre>
+     * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
      * @return Whether the infrastructureMutation field is set.
      */
@@ -2432,6 +2731,10 @@ private static final long serialVersionUID = 0L;
       return bodyCase_ == 10;
     }
     /**
+     * <pre>
+     * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
      * @return The infrastructureMutation.
      */
@@ -2450,6 +2753,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
      */
     public Builder setInfrastructureMutation(io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation value) {
@@ -2466,6 +2773,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
      */
     public Builder setInfrastructureMutation(
@@ -2480,6 +2791,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
      */
     public Builder mergeInfrastructureMutation(io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation value) {
@@ -2503,6 +2818,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
      */
     public Builder clearInfrastructureMutation() {
@@ -2522,12 +2841,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation.Builder getInfrastructureMutationBuilder() {
       return getInfrastructureMutationFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
      */
     @java.lang.Override
@@ -2542,6 +2869,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCatalogCaptureOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcChangeCatalogCaptureOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcChangeCatalogCaptureOrBuilder extends
 
   /**
    * <pre>
-   * the version of the catalog where the operation was performed
+   * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+   * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcChangeCatalogCaptureOrBuilder extends
   boolean hasVersion();
   /**
    * <pre>
-   * the version of the catalog where the operation was performed
+   * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+   * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcChangeCatalogCaptureOrBuilder extends
   com.google.protobuf.Int64Value getVersion();
   /**
    * <pre>
-   * the version of the catalog where the operation was performed
+   * The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+   * forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value version = 1;</code>
@@ -60,7 +63,16 @@ public interface GrpcChangeCatalogCaptureOrBuilder extends
 
   /**
    * <pre>
-   * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+   * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+   * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+   * descending, so the same physical record gets the same index regardless of direction - but indices are
+   * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+   * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+   * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+   * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+   * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+   * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+   * #1349 for the full analysis.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -69,7 +81,16 @@ public interface GrpcChangeCatalogCaptureOrBuilder extends
   boolean hasIndex();
   /**
    * <pre>
-   * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+   * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+   * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+   * descending, so the same physical record gets the same index regardless of direction - but indices are
+   * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+   * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+   * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+   * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+   * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+   * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+   * #1349 for the full analysis.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -78,7 +99,16 @@ public interface GrpcChangeCatalogCaptureOrBuilder extends
   com.google.protobuf.Int32Value getIndex();
   /**
    * <pre>
-   * the index of the event within the enclosed transaction, index 0 is the transaction lead event
+   * A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+   * counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+   * descending, so the same physical record gets the same index regardless of direction - but indices are
+   * therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+   * index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+   * index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+   * `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+   * local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+   * filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+   * #1349 for the full analysis.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value index = 2;</code>
@@ -166,7 +196,8 @@ public interface GrpcChangeCatalogCaptureOrBuilder extends
 
   /**
    * <pre>
-   * the operation that was performed
+   * The kind of change that produced this capture. Together with `area`, it determines which arm of `body` (if
+   * present) carries the payload - see the `body` oneof comment for the mapping.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 6;</code>
@@ -175,7 +206,8 @@ public interface GrpcChangeCatalogCaptureOrBuilder extends
   int getOperationValue();
   /**
    * <pre>
-   * the operation that was performed
+   * The kind of change that produced this capture. Together with `area`, it determines which arm of `body` (if
+   * present) carries the payload - see the `body` oneof comment for the mapping.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation operation = 6;</code>
@@ -184,61 +216,112 @@ public interface GrpcChangeCatalogCaptureOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureOperation getOperation();
 
   /**
+   * <pre>
+   * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
    * @return Whether the schemaMutation field is set.
    */
   boolean hasSchemaMutation();
   /**
+   * <pre>
+   * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
    * @return The schemaMutation.
    */
   io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation getSchemaMutation();
   /**
+   * <pre>
+   * Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutation schemaMutation = 7;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaMutationOrBuilder getSchemaMutationOrBuilder();
 
   /**
+   * <pre>
+   * Set for the top-level DATA area entity mutation. See the `body` comment above.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
    * @return Whether the entityMutation field is set.
    */
   boolean hasEntityMutation();
   /**
+   * <pre>
+   * Set for the top-level DATA area entity mutation. See the `body` comment above.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
    * @return The entityMutation.
    */
   io.evitadb.externalApi.grpc.generated.GrpcEntityMutation getEntityMutation();
   /**
+   * <pre>
+   * Set for the top-level DATA area entity mutation. See the `body` comment above.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 8;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcEntityMutationOrBuilder getEntityMutationOrBuilder();
 
   /**
+   * <pre>
+   * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+   * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
    * @return Whether the localMutation field is set.
    */
   boolean hasLocalMutation();
   /**
+   * <pre>
+   * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+   * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
    * @return The localMutation.
    */
   io.evitadb.externalApi.grpc.generated.GrpcLocalMutation getLocalMutation();
   /**
+   * <pre>
+   * Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+   * comment above and the `index` field comment for how it shares its parent's `(version, index)`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocalMutation localMutation = 9;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcLocalMutationOrBuilder getLocalMutationOrBuilder();
 
   /**
+   * <pre>
+   * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
    * @return Whether the infrastructureMutation field is set.
    */
   boolean hasInfrastructureMutation();
   /**
+   * <pre>
+   * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
    * @return The infrastructureMutation.
    */
   io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation getInfrastructureMutation();
   /**
+   * <pre>
+   * Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutation infrastructureMutation = 10;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcInfrastructureMutationOrBuilder getInfrastructureMutationOrBuilder();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCloseRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCloseRequest.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response for Close request that commits or rollbacks the changes in the session.
+ * Request for Close, which commits or rollbacks the changes in the session and terminates it.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcCloseRequest}
@@ -338,7 +338,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response for Close request that commits or rollbacks the changes in the session.
+   * Request for Close, which commits or rollbacks the changes in the session and terminates it.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcCloseRequest}

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCommitBehavior.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCommitBehavior.java
@@ -52,7 +52,7 @@ public enum GrpcCommitBehavior
    * Changes performed in the transaction are passed to evitaDB server, checked for conflicts and if no conflict
    * is found, they are written to Write Ahead Log (WAL) and transaction waits until the WAL is persisted on disk
    * (fsynced). After that the transaction is marked as completed and commit is finished. This behaviour is
-   * slower than {&#64;link #NO_WAIT} but guarantees that the changes are persisted on disk and durable. The server
+   * slower than `WAIT_FOR_CONFLICT_RESOLUTION` but guarantees that the changes are persisted on disk and durable. The server
    * may decide to fsync changes from multiple transactions at once, so the transaction may wait longer than
    * necessary. This behaviour still does not guarantee that the changes will be visible immediately after
    * the commit - because they still need to be propagated to indexes in order new data can be found by queries.
@@ -94,7 +94,7 @@ public enum GrpcCommitBehavior
    * Changes performed in the transaction are passed to evitaDB server, checked for conflicts and if no conflict
    * is found, they are written to Write Ahead Log (WAL) and transaction waits until the WAL is persisted on disk
    * (fsynced). After that the transaction is marked as completed and commit is finished. This behaviour is
-   * slower than {&#64;link #NO_WAIT} but guarantees that the changes are persisted on disk and durable. The server
+   * slower than `WAIT_FOR_CONFLICT_RESOLUTION` but guarantees that the changes are persisted on disk and durable. The server
    * may decide to fsync changes from multiple transactions at once, so the transaction may wait longer than
    * necessary. This behaviour still does not guarantee that the changes will be visible immediately after
    * the commit - because they still need to be propagated to indexes in order new data can be found by queries.

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCurrency.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCurrency.java
@@ -72,7 +72,8 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object code_ = "";
   /**
    * <pre>
-   * The currency code of the currency.
+   * ISO 4217 three-letter currency code (e.g. `USD`, `EUR`), resolved via
+   * `Currency#getInstance(String)`.
    * </pre>
    *
    * <code>string code = 1;</code>
@@ -93,7 +94,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The currency code of the currency.
+   * ISO 4217 three-letter currency code (e.g. `USD`, `EUR`), resolved via
+   * `Currency#getInstance(String)`.
    * </pre>
    *
    * <code>string code = 1;</code>
@@ -447,7 +449,8 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object code_ = "";
     /**
      * <pre>
-     * The currency code of the currency.
+     * ISO 4217 three-letter currency code (e.g. `USD`, `EUR`), resolved via
+     * `Currency#getInstance(String)`.
      * </pre>
      *
      * <code>string code = 1;</code>
@@ -467,7 +470,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency code of the currency.
+     * ISO 4217 three-letter currency code (e.g. `USD`, `EUR`), resolved via
+     * `Currency#getInstance(String)`.
      * </pre>
      *
      * <code>string code = 1;</code>
@@ -488,7 +492,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency code of the currency.
+     * ISO 4217 three-letter currency code (e.g. `USD`, `EUR`), resolved via
+     * `Currency#getInstance(String)`.
      * </pre>
      *
      * <code>string code = 1;</code>
@@ -505,7 +510,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency code of the currency.
+     * ISO 4217 three-letter currency code (e.g. `USD`, `EUR`), resolved via
+     * `Currency#getInstance(String)`.
      * </pre>
      *
      * <code>string code = 1;</code>
@@ -519,7 +525,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency code of the currency.
+     * ISO 4217 three-letter currency code (e.g. `USD`, `EUR`), resolved via
+     * `Currency#getInstance(String)`.
      * </pre>
      *
      * <code>string code = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCurrencyArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCurrencyArray.java
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcCurrency> value_;
   /**
    * <pre>
-   * Value that supports storing a Currency array.
+   * The individual Currency elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -83,7 +83,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Currency array.
+   * The individual Currency elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -95,7 +95,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Currency array.
+   * The individual Currency elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Currency array.
+   * The individual Currency elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -117,7 +117,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Currency array.
+   * The individual Currency elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -534,7 +534,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -548,7 +548,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -583,7 +583,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -601,7 +601,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -621,7 +621,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -642,7 +642,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -660,7 +660,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -678,7 +678,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -697,7 +697,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -714,7 +714,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -731,7 +731,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -742,7 +742,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -756,7 +756,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -771,7 +771,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -782,7 +782,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -794,7 +794,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Currency array.
+     * The individual Currency elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCurrencyArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCurrencyArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcCurrencyArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a Currency array.
+   * The individual Currency elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcCurrencyArrayOrBuilder extends
       getValueList();
   /**
    * <pre>
-   * Value that supports storing a Currency array.
+   * The individual Currency elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -50,7 +50,7 @@ public interface GrpcCurrencyArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcCurrency getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a Currency array.
+   * The individual Currency elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -58,7 +58,7 @@ public interface GrpcCurrencyArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a Currency array.
+   * The individual Currency elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>
@@ -67,7 +67,7 @@ public interface GrpcCurrencyArrayOrBuilder extends
       getValueOrBuilderList();
   /**
    * <pre>
-   * Value that supports storing a Currency array.
+   * The individual Currency elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCurrencyOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCurrencyOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcCurrencyOrBuilder extends
 
   /**
    * <pre>
-   * The currency code of the currency.
+   * ISO 4217 three-letter currency code (e.g. `USD`, `EUR`), resolved via
+   * `Currency#getInstance(String)`.
    * </pre>
    *
    * <code>string code = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcCurrencyOrBuilder extends
   java.lang.String getCode();
   /**
    * <pre>
-   * The currency code of the currency.
+   * ISO 4217 three-letter currency code (e.g. `USD`, `EUR`), resolved via
+   * `Currency#getInstance(String)`.
    * </pre>
    *
    * <code>string code = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDataChunk.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDataChunk.java
@@ -29,8 +29,10 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Structure that represents a data chunk of entities. Only one of the entity fields should be set in one response.
- * That is decided by require block in a query, so as the pagination method used.
+ * A page or strip of entities, in one of three representations (references, full sealed entities, or
+ * binary entities) depending on what the query's `require` block asked for. Only one representation is
+ * populated per response and only one of the two pagination descriptors below is set, matching whichever
+ * paging requirement (`page()`/`strip()`) the query used.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDataChunk}
@@ -117,7 +119,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcEntityReference> entityReferences_;
   /**
    * <pre>
-   * Collection of entity references.
+   * Entity references (type + primary key only, no content). Populated when the query's `require` block
+   * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -128,7 +131,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of entity references.
+   * Entity references (type + primary key only, no content). Populated when the query's `require` block
+   * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -140,7 +144,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of entity references.
+   * Entity references (type + primary key only, no content). Populated when the query's `require` block
+   * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -151,7 +156,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of entity references.
+   * Entity references (type + primary key only, no content). Populated when the query's `require` block
+   * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -162,7 +168,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of entity references.
+   * Entity references (type + primary key only, no content). Populated when the query's `require` block
+   * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -178,7 +185,9 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcSealedEntity> sealedEntities_;
   /**
    * <pre>
-   * Collection of sealed entities.
+   * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+   * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+   * are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -189,7 +198,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of sealed entities.
+   * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+   * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+   * are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -201,7 +212,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of sealed entities.
+   * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+   * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+   * are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -212,7 +225,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of sealed entities.
+   * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+   * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+   * are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -223,7 +238,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of sealed entities.
+   * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+   * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+   * are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -239,7 +256,9 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity> binaryEntities_;
   /**
    * <pre>
-   * Collection of binary entities.
+   * Fully fetched entities in the server's binary storage format, for clients that decode entities
+   * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+   * storage format; `entityReferences`/`sealedEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -250,7 +269,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of binary entities.
+   * Fully fetched entities in the server's binary storage format, for clients that decode entities
+   * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+   * storage format; `entityReferences`/`sealedEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -262,7 +283,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of binary entities.
+   * Fully fetched entities in the server's binary storage format, for clients that decode entities
+   * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+   * storage format; `entityReferences`/`sealedEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -273,7 +296,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of binary entities.
+   * Fully fetched entities in the server's binary storage format, for clients that decode entities
+   * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+   * storage format; `entityReferences`/`sealedEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -284,7 +309,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of binary entities.
+   * Fully fetched entities in the server's binary storage format, for clients that decode entities
+   * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+   * storage format; `entityReferences`/`sealedEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -298,7 +325,7 @@ private static final long serialVersionUID = 0L;
   public static final int PAGINATEDLIST_FIELD_NUMBER = 4;
   /**
    * <pre>
-   * The paginated list.
+   * Set when the query used page-based paging (`page()`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -310,7 +337,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The paginated list.
+   * Set when the query used page-based paging (`page()`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -325,7 +352,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The paginated list.
+   * Set when the query used page-based paging (`page()`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -341,7 +368,7 @@ private static final long serialVersionUID = 0L;
   public static final int STRIPLIST_FIELD_NUMBER = 5;
   /**
    * <pre>
-   * The strip list.
+   * Set when the query used strip/offset-based paging (`strip()`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -353,7 +380,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The strip list.
+   * Set when the query used strip/offset-based paging (`strip()`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -368,7 +395,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The strip list.
+   * Set when the query used strip/offset-based paging (`strip()`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -385,7 +412,7 @@ private static final long serialVersionUID = 0L;
   private int totalRecordCount_ = 0;
   /**
    * <pre>
-   * The total number of records.
+   * Total number of records matching the query across all pages/strips, not just this chunk's size.
    * </pre>
    *
    * <code>int32 totalRecordCount = 6;</code>
@@ -400,7 +427,7 @@ private static final long serialVersionUID = 0L;
   private boolean isFirst_ = false;
   /**
    * <pre>
-   * True, if this is the first page.
+   * True if this chunk is the first page/strip of the result set.
    * </pre>
    *
    * <code>bool isFirst = 7;</code>
@@ -415,7 +442,7 @@ private static final long serialVersionUID = 0L;
   private boolean isLast_ = false;
   /**
    * <pre>
-   * True, if this is the last page.
+   * True if this chunk is the last page/strip of the result set.
    * </pre>
    *
    * <code>bool isLast = 8;</code>
@@ -430,7 +457,7 @@ private static final long serialVersionUID = 0L;
   private boolean hasPrevious_ = false;
   /**
    * <pre>
-   * True, if there is a previous page.
+   * True if a preceding page/strip exists.
    * </pre>
    *
    * <code>bool hasPrevious = 9;</code>
@@ -445,7 +472,7 @@ private static final long serialVersionUID = 0L;
   private boolean hasNext_ = false;
   /**
    * <pre>
-   * True, if there is a next page.
+   * True if a following page/strip exists.
    * </pre>
    *
    * <code>bool hasNext = 10;</code>
@@ -460,7 +487,7 @@ private static final long serialVersionUID = 0L;
   private boolean isSinglePage_ = false;
   /**
    * <pre>
-   * True, if this is a single page.
+   * True if the entire result set fits within this single chunk.
    * </pre>
    *
    * <code>bool isSinglePage = 11;</code>
@@ -475,7 +502,7 @@ private static final long serialVersionUID = 0L;
   private boolean isEmpty_ = false;
   /**
    * <pre>
-   * True, if this is an empty page.
+   * True if this chunk (and the entire result set) contains no records.
    * </pre>
    *
    * <code>bool isEmpty = 12;</code>
@@ -795,8 +822,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Structure that represents a data chunk of entities. Only one of the entity fields should be set in one response.
-   * That is decided by require block in a query, so as the pagination method used.
+   * A page or strip of entities, in one of three representations (references, full sealed entities, or
+   * binary entities) depending on what the query's `require` block asked for. Only one representation is
+   * populated per response and only one of the two pagination descriptors below is set, matching whichever
+   * paging requirement (`page()`/`strip()`) the query used.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDataChunk}
@@ -1285,7 +1314,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1299,7 +1329,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1313,7 +1344,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1327,7 +1359,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1348,7 +1381,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1366,7 +1400,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1386,7 +1421,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1407,7 +1443,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1425,7 +1462,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1443,7 +1481,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1462,7 +1501,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1479,7 +1519,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1496,7 +1537,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1507,7 +1549,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1521,7 +1564,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1536,7 +1580,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1547,7 +1592,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1559,7 +1605,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of entity references.
+     * Entity references (type + primary key only, no content). Populated when the query's `require` block
+     * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -1597,7 +1644,9 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1611,7 +1660,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1625,7 +1676,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1639,7 +1692,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1660,7 +1715,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1678,7 +1735,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1698,7 +1757,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1719,7 +1780,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1737,7 +1800,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1755,7 +1820,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1774,7 +1841,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1791,7 +1860,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1808,7 +1879,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1819,7 +1892,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1833,7 +1908,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1848,7 +1925,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1859,7 +1938,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1871,7 +1952,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of sealed entities.
+     * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+     * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+     * are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -1909,7 +1992,9 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -1923,7 +2008,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -1937,7 +2024,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -1951,7 +2040,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -1972,7 +2063,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -1990,7 +2083,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2010,7 +2105,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2031,7 +2128,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2049,7 +2148,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2067,7 +2168,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2086,7 +2189,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2103,7 +2208,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2120,7 +2227,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2131,7 +2240,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2145,7 +2256,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2160,7 +2273,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2171,7 +2286,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2183,7 +2300,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of binary entities.
+     * Fully fetched entities in the server's binary storage format, for clients that decode entities
+     * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+     * storage format; `entityReferences`/`sealedEntities` are then both empty.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -2211,7 +2330,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcPaginatedList, io.evitadb.externalApi.grpc.generated.GrpcPaginatedList.Builder, io.evitadb.externalApi.grpc.generated.GrpcPaginatedListOrBuilder> paginatedListBuilder_;
     /**
      * <pre>
-     * The paginated list.
+     * Set when the query used page-based paging (`page()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -2223,7 +2342,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The paginated list.
+     * Set when the query used page-based paging (`page()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -2245,7 +2364,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The paginated list.
+     * Set when the query used page-based paging (`page()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -2265,7 +2384,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The paginated list.
+     * Set when the query used page-based paging (`page()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -2283,7 +2402,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The paginated list.
+     * Set when the query used page-based paging (`page()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -2310,7 +2429,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The paginated list.
+     * Set when the query used page-based paging (`page()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -2333,7 +2452,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The paginated list.
+     * Set when the query used page-based paging (`page()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -2343,7 +2462,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The paginated list.
+     * Set when the query used page-based paging (`page()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -2361,7 +2480,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The paginated list.
+     * Set when the query used page-based paging (`page()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -2389,7 +2508,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcStripList, io.evitadb.externalApi.grpc.generated.GrpcStripList.Builder, io.evitadb.externalApi.grpc.generated.GrpcStripListOrBuilder> stripListBuilder_;
     /**
      * <pre>
-     * The strip list.
+     * Set when the query used strip/offset-based paging (`strip()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -2401,7 +2520,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The strip list.
+     * Set when the query used strip/offset-based paging (`strip()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -2423,7 +2542,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The strip list.
+     * Set when the query used strip/offset-based paging (`strip()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -2443,7 +2562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The strip list.
+     * Set when the query used strip/offset-based paging (`strip()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -2461,7 +2580,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The strip list.
+     * Set when the query used strip/offset-based paging (`strip()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -2488,7 +2607,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The strip list.
+     * Set when the query used strip/offset-based paging (`strip()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -2511,7 +2630,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The strip list.
+     * Set when the query used strip/offset-based paging (`strip()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -2521,7 +2640,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The strip list.
+     * Set when the query used strip/offset-based paging (`strip()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -2539,7 +2658,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The strip list.
+     * Set when the query used strip/offset-based paging (`strip()`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -2566,7 +2685,7 @@ private static final long serialVersionUID = 0L;
     private int totalRecordCount_ ;
     /**
      * <pre>
-     * The total number of records.
+     * Total number of records matching the query across all pages/strips, not just this chunk's size.
      * </pre>
      *
      * <code>int32 totalRecordCount = 6;</code>
@@ -2578,7 +2697,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The total number of records.
+     * Total number of records matching the query across all pages/strips, not just this chunk's size.
      * </pre>
      *
      * <code>int32 totalRecordCount = 6;</code>
@@ -2594,7 +2713,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The total number of records.
+     * Total number of records matching the query across all pages/strips, not just this chunk's size.
      * </pre>
      *
      * <code>int32 totalRecordCount = 6;</code>
@@ -2610,7 +2729,7 @@ private static final long serialVersionUID = 0L;
     private boolean isFirst_ ;
     /**
      * <pre>
-     * True, if this is the first page.
+     * True if this chunk is the first page/strip of the result set.
      * </pre>
      *
      * <code>bool isFirst = 7;</code>
@@ -2622,7 +2741,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True, if this is the first page.
+     * True if this chunk is the first page/strip of the result set.
      * </pre>
      *
      * <code>bool isFirst = 7;</code>
@@ -2638,7 +2757,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True, if this is the first page.
+     * True if this chunk is the first page/strip of the result set.
      * </pre>
      *
      * <code>bool isFirst = 7;</code>
@@ -2654,7 +2773,7 @@ private static final long serialVersionUID = 0L;
     private boolean isLast_ ;
     /**
      * <pre>
-     * True, if this is the last page.
+     * True if this chunk is the last page/strip of the result set.
      * </pre>
      *
      * <code>bool isLast = 8;</code>
@@ -2666,7 +2785,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True, if this is the last page.
+     * True if this chunk is the last page/strip of the result set.
      * </pre>
      *
      * <code>bool isLast = 8;</code>
@@ -2682,7 +2801,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True, if this is the last page.
+     * True if this chunk is the last page/strip of the result set.
      * </pre>
      *
      * <code>bool isLast = 8;</code>
@@ -2698,7 +2817,7 @@ private static final long serialVersionUID = 0L;
     private boolean hasPrevious_ ;
     /**
      * <pre>
-     * True, if there is a previous page.
+     * True if a preceding page/strip exists.
      * </pre>
      *
      * <code>bool hasPrevious = 9;</code>
@@ -2710,7 +2829,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True, if there is a previous page.
+     * True if a preceding page/strip exists.
      * </pre>
      *
      * <code>bool hasPrevious = 9;</code>
@@ -2726,7 +2845,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True, if there is a previous page.
+     * True if a preceding page/strip exists.
      * </pre>
      *
      * <code>bool hasPrevious = 9;</code>
@@ -2742,7 +2861,7 @@ private static final long serialVersionUID = 0L;
     private boolean hasNext_ ;
     /**
      * <pre>
-     * True, if there is a next page.
+     * True if a following page/strip exists.
      * </pre>
      *
      * <code>bool hasNext = 10;</code>
@@ -2754,7 +2873,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True, if there is a next page.
+     * True if a following page/strip exists.
      * </pre>
      *
      * <code>bool hasNext = 10;</code>
@@ -2770,7 +2889,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True, if there is a next page.
+     * True if a following page/strip exists.
      * </pre>
      *
      * <code>bool hasNext = 10;</code>
@@ -2786,7 +2905,7 @@ private static final long serialVersionUID = 0L;
     private boolean isSinglePage_ ;
     /**
      * <pre>
-     * True, if this is a single page.
+     * True if the entire result set fits within this single chunk.
      * </pre>
      *
      * <code>bool isSinglePage = 11;</code>
@@ -2798,7 +2917,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True, if this is a single page.
+     * True if the entire result set fits within this single chunk.
      * </pre>
      *
      * <code>bool isSinglePage = 11;</code>
@@ -2814,7 +2933,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True, if this is a single page.
+     * True if the entire result set fits within this single chunk.
      * </pre>
      *
      * <code>bool isSinglePage = 11;</code>
@@ -2830,7 +2949,7 @@ private static final long serialVersionUID = 0L;
     private boolean isEmpty_ ;
     /**
      * <pre>
-     * True, if this is an empty page.
+     * True if this chunk (and the entire result set) contains no records.
      * </pre>
      *
      * <code>bool isEmpty = 12;</code>
@@ -2842,7 +2961,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True, if this is an empty page.
+     * True if this chunk (and the entire result set) contains no records.
      * </pre>
      *
      * <code>bool isEmpty = 12;</code>
@@ -2858,7 +2977,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * True, if this is an empty page.
+     * True if this chunk (and the entire result set) contains no records.
      * </pre>
      *
      * <code>bool isEmpty = 12;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDataChunkOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDataChunkOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcDataChunkOrBuilder extends
 
   /**
    * <pre>
-   * Collection of entity references.
+   * Entity references (type + primary key only, no content). Populated when the query's `require` block
+   * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcDataChunkOrBuilder extends
       getEntityReferencesList();
   /**
    * <pre>
-   * Collection of entity references.
+   * Entity references (type + primary key only, no content). Populated when the query's `require` block
+   * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -50,7 +52,8 @@ public interface GrpcDataChunkOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEntityReference getEntityReferences(int index);
   /**
    * <pre>
-   * Collection of entity references.
+   * Entity references (type + primary key only, no content). Populated when the query's `require` block
+   * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -58,7 +61,8 @@ public interface GrpcDataChunkOrBuilder extends
   int getEntityReferencesCount();
   /**
    * <pre>
-   * Collection of entity references.
+   * Entity references (type + primary key only, no content). Populated when the query's `require` block
+   * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -67,7 +71,8 @@ public interface GrpcDataChunkOrBuilder extends
       getEntityReferencesOrBuilderList();
   /**
    * <pre>
-   * Collection of entity references.
+   * Entity references (type + primary key only, no content). Populated when the query's `require` block
+   * has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
@@ -77,7 +82,9 @@ public interface GrpcDataChunkOrBuilder extends
 
   /**
    * <pre>
-   * Collection of sealed entities.
+   * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+   * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+   * are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -86,7 +93,9 @@ public interface GrpcDataChunkOrBuilder extends
       getSealedEntitiesList();
   /**
    * <pre>
-   * Collection of sealed entities.
+   * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+   * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+   * are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -94,7 +103,9 @@ public interface GrpcDataChunkOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcSealedEntity getSealedEntities(int index);
   /**
    * <pre>
-   * Collection of sealed entities.
+   * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+   * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+   * are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -102,7 +113,9 @@ public interface GrpcDataChunkOrBuilder extends
   int getSealedEntitiesCount();
   /**
    * <pre>
-   * Collection of sealed entities.
+   * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+   * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+   * are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -111,7 +124,9 @@ public interface GrpcDataChunkOrBuilder extends
       getSealedEntitiesOrBuilderList();
   /**
    * <pre>
-   * Collection of sealed entities.
+   * Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+   * requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+   * are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
@@ -121,7 +136,9 @@ public interface GrpcDataChunkOrBuilder extends
 
   /**
    * <pre>
-   * Collection of binary entities.
+   * Fully fetched entities in the server's binary storage format, for clients that decode entities
+   * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+   * storage format; `entityReferences`/`sealedEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -130,7 +147,9 @@ public interface GrpcDataChunkOrBuilder extends
       getBinaryEntitiesList();
   /**
    * <pre>
-   * Collection of binary entities.
+   * Fully fetched entities in the server's binary storage format, for clients that decode entities
+   * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+   * storage format; `entityReferences`/`sealedEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -138,7 +157,9 @@ public interface GrpcDataChunkOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity getBinaryEntities(int index);
   /**
    * <pre>
-   * Collection of binary entities.
+   * Fully fetched entities in the server's binary storage format, for clients that decode entities
+   * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+   * storage format; `entityReferences`/`sealedEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -146,7 +167,9 @@ public interface GrpcDataChunkOrBuilder extends
   int getBinaryEntitiesCount();
   /**
    * <pre>
-   * Collection of binary entities.
+   * Fully fetched entities in the server's binary storage format, for clients that decode entities
+   * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+   * storage format; `entityReferences`/`sealedEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -155,7 +178,9 @@ public interface GrpcDataChunkOrBuilder extends
       getBinaryEntitiesOrBuilderList();
   /**
    * <pre>
-   * Collection of binary entities.
+   * Fully fetched entities in the server's binary storage format, for clients that decode entities
+   * themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+   * storage format; `entityReferences`/`sealedEntities` are then both empty.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
@@ -165,7 +190,7 @@ public interface GrpcDataChunkOrBuilder extends
 
   /**
    * <pre>
-   * The paginated list.
+   * Set when the query used page-based paging (`page()`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -174,7 +199,7 @@ public interface GrpcDataChunkOrBuilder extends
   boolean hasPaginatedList();
   /**
    * <pre>
-   * The paginated list.
+   * Set when the query used page-based paging (`page()`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -183,7 +208,7 @@ public interface GrpcDataChunkOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcPaginatedList getPaginatedList();
   /**
    * <pre>
-   * The paginated list.
+   * Set when the query used page-based paging (`page()`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPaginatedList paginatedList = 4;</code>
@@ -192,7 +217,7 @@ public interface GrpcDataChunkOrBuilder extends
 
   /**
    * <pre>
-   * The strip list.
+   * Set when the query used strip/offset-based paging (`strip()`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -201,7 +226,7 @@ public interface GrpcDataChunkOrBuilder extends
   boolean hasStripList();
   /**
    * <pre>
-   * The strip list.
+   * Set when the query used strip/offset-based paging (`strip()`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -210,7 +235,7 @@ public interface GrpcDataChunkOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcStripList getStripList();
   /**
    * <pre>
-   * The strip list.
+   * Set when the query used strip/offset-based paging (`strip()`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStripList stripList = 5;</code>
@@ -219,7 +244,7 @@ public interface GrpcDataChunkOrBuilder extends
 
   /**
    * <pre>
-   * The total number of records.
+   * Total number of records matching the query across all pages/strips, not just this chunk's size.
    * </pre>
    *
    * <code>int32 totalRecordCount = 6;</code>
@@ -229,7 +254,7 @@ public interface GrpcDataChunkOrBuilder extends
 
   /**
    * <pre>
-   * True, if this is the first page.
+   * True if this chunk is the first page/strip of the result set.
    * </pre>
    *
    * <code>bool isFirst = 7;</code>
@@ -239,7 +264,7 @@ public interface GrpcDataChunkOrBuilder extends
 
   /**
    * <pre>
-   * True, if this is the last page.
+   * True if this chunk is the last page/strip of the result set.
    * </pre>
    *
    * <code>bool isLast = 8;</code>
@@ -249,7 +274,7 @@ public interface GrpcDataChunkOrBuilder extends
 
   /**
    * <pre>
-   * True, if there is a previous page.
+   * True if a preceding page/strip exists.
    * </pre>
    *
    * <code>bool hasPrevious = 9;</code>
@@ -259,7 +284,7 @@ public interface GrpcDataChunkOrBuilder extends
 
   /**
    * <pre>
-   * True, if there is a next page.
+   * True if a following page/strip exists.
    * </pre>
    *
    * <code>bool hasNext = 10;</code>
@@ -269,7 +294,7 @@ public interface GrpcDataChunkOrBuilder extends
 
   /**
    * <pre>
-   * True, if this is a single page.
+   * True if the entire result set fits within this single chunk.
    * </pre>
    *
    * <code>bool isSinglePage = 11;</code>
@@ -279,7 +304,7 @@ public interface GrpcDataChunkOrBuilder extends
 
   /**
    * <pre>
-   * True, if this is an empty page.
+   * True if this chunk (and the entire result set) contains no records.
    * </pre>
    *
    * <code>bool isEmpty = 12;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDataItem.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDataItem.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Structure that holds a complex object. It can be either a map or an array of values.
+ * Structure that holds one node of a complex (structured) associated data value's recursive tree.
+ * A node is either a leaf primitive value, an array of child nodes, or a map of named child nodes.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDataItem}
@@ -113,7 +114,7 @@ private static final long serialVersionUID = 0L;
   public static final int PRIMITIVEVALUE_FIELD_NUMBER = 1;
   /**
    * <pre>
-   * Primitive value.
+   * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -125,7 +126,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Primitive value.
+   * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -140,7 +141,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Primitive value.
+   * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -156,7 +157,7 @@ private static final long serialVersionUID = 0L;
   public static final int ARRAYVALUE_FIELD_NUMBER = 4;
   /**
    * <pre>
-   * The array of values.
+   * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -168,7 +169,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The array of values.
+   * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -183,7 +184,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The array of values.
+   * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -199,7 +200,7 @@ private static final long serialVersionUID = 0L;
   public static final int MAPVALUE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   * The map of values.
+   * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -211,7 +212,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The map of values.
+   * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -226,7 +227,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The map of values.
+   * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -441,7 +442,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Structure that holds a complex object. It can be either a map or an array of values.
+   * Structure that holds one node of a complex (structured) associated data value's recursive tree.
+   * A node is either a leaf primitive value, an array of child nodes, or a map of named child nodes.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDataItem}
@@ -685,7 +687,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEvitaValue, io.evitadb.externalApi.grpc.generated.GrpcEvitaValue.Builder, io.evitadb.externalApi.grpc.generated.GrpcEvitaValueOrBuilder> primitiveValueBuilder_;
     /**
      * <pre>
-     * Primitive value.
+     * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -697,7 +699,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -719,7 +721,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -739,7 +741,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -757,7 +759,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -784,7 +786,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -807,7 +809,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -817,7 +819,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -835,7 +837,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -863,7 +865,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcDataItemArray, io.evitadb.externalApi.grpc.generated.GrpcDataItemArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcDataItemArrayOrBuilder> arrayValueBuilder_;
     /**
      * <pre>
-     * The array of values.
+     * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -875,7 +877,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -897,7 +899,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -917,7 +919,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -935,7 +937,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -962,7 +964,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -985,7 +987,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -995,7 +997,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -1013,7 +1015,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -1041,7 +1043,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.DataItemMap, io.evitadb.externalApi.grpc.generated.DataItemMap.Builder, io.evitadb.externalApi.grpc.generated.DataItemMapOrBuilder> mapValueBuilder_;
     /**
      * <pre>
-     * The map of values.
+     * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -1053,7 +1055,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The map of values.
+     * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -1075,7 +1077,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The map of values.
+     * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -1095,7 +1097,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The map of values.
+     * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -1113,7 +1115,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The map of values.
+     * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -1140,7 +1142,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The map of values.
+     * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -1163,7 +1165,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The map of values.
+     * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -1173,7 +1175,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The map of values.
+     * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -1191,7 +1193,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The map of values.
+     * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDataItemArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDataItemArray.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Structure that holds a array of values stored inside array of the complex object.
+ * Structure that holds an array-typed node of a complex associated data value's tree.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDataItemArray}
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcDataItem> children_;
   /**
    * <pre>
-   * The stored array of values.
+   * The ordered child nodes of this array node, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -83,7 +83,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The stored array of values.
+   * The ordered child nodes of this array node, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -95,7 +95,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The stored array of values.
+   * The ordered child nodes of this array node, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The stored array of values.
+   * The ordered child nodes of this array node, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -117,7 +117,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The stored array of values.
+   * The ordered child nodes of this array node, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -289,7 +289,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Structure that holds a array of values stored inside array of the complex object.
+   * Structure that holds an array-typed node of a complex associated data value's tree.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDataItemArray}
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -534,7 +534,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -548,7 +548,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -583,7 +583,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -601,7 +601,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -621,7 +621,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -642,7 +642,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -660,7 +660,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -678,7 +678,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -697,7 +697,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -714,7 +714,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -731,7 +731,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -742,7 +742,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -756,7 +756,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -771,7 +771,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -782,7 +782,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -794,7 +794,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The stored array of values.
+     * The ordered child nodes of this array node, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDataItemArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDataItemArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcDataItemArrayOrBuilder extends
 
   /**
    * <pre>
-   * The stored array of values.
+   * The ordered child nodes of this array node, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcDataItemArrayOrBuilder extends
       getChildrenList();
   /**
    * <pre>
-   * The stored array of values.
+   * The ordered child nodes of this array node, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -50,7 +50,7 @@ public interface GrpcDataItemArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcDataItem getChildren(int index);
   /**
    * <pre>
-   * The stored array of values.
+   * The ordered child nodes of this array node, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -58,7 +58,7 @@ public interface GrpcDataItemArrayOrBuilder extends
   int getChildrenCount();
   /**
    * <pre>
-   * The stored array of values.
+   * The ordered child nodes of this array node, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>
@@ -67,7 +67,7 @@ public interface GrpcDataItemArrayOrBuilder extends
       getChildrenOrBuilderList();
   /**
    * <pre>
-   * The stored array of values.
+   * The ordered child nodes of this array node, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDataItem children = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDataItemOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDataItemOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcDataItemOrBuilder extends
 
   /**
    * <pre>
-   * Primitive value.
+   * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcDataItemOrBuilder extends
   boolean hasPrimitiveValue();
   /**
    * <pre>
-   * Primitive value.
+   * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcDataItemOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEvitaValue getPrimitiveValue();
   /**
    * <pre>
-   * Primitive value.
+   * Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -60,7 +60,7 @@ public interface GrpcDataItemOrBuilder extends
 
   /**
    * <pre>
-   * The array of values.
+   * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -69,7 +69,7 @@ public interface GrpcDataItemOrBuilder extends
   boolean hasArrayValue();
   /**
    * <pre>
-   * The array of values.
+   * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -78,7 +78,7 @@ public interface GrpcDataItemOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcDataItemArray getArrayValue();
   /**
    * <pre>
-   * The array of values.
+   * Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItemArray arrayValue = 4;</code>
@@ -87,7 +87,7 @@ public interface GrpcDataItemOrBuilder extends
 
   /**
    * <pre>
-   * The map of values.
+   * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -96,7 +96,7 @@ public interface GrpcDataItemOrBuilder extends
   boolean hasMapValue();
   /**
    * <pre>
-   * The map of values.
+   * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>
@@ -105,7 +105,7 @@ public interface GrpcDataItemOrBuilder extends
   io.evitadb.externalApi.grpc.generated.DataItemMap getMapValue();
   /**
    * <pre>
-   * The map of values.
+   * Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.DataItemMap mapValue = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDateTimeRange.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDateTimeRange.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Representation of DateTimeRange structures with optional from and to values.
+ * Representation of DateTimeRange structures. At least one of `from`/`to` should be set; if both
+ * are absent, the range decodes to a degenerate range anchored at the Unix epoch
+ * (1970-01-01T00:00:00Z) rather than being unbounded in both directions.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange}
@@ -71,7 +73,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from_;
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+   * unbounded below (open start).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -83,7 +86,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+   * unbounded below (open start).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -95,7 +99,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+   * unbounded below (open start).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -109,7 +114,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to_;
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+   * unbounded above (open end).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -121,7 +127,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+   * unbounded above (open end).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -133,7 +140,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+   * unbounded above (open end).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -323,7 +331,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Representation of DateTimeRange structures with optional from and to values.
+   * Representation of DateTimeRange structures. At least one of `from`/`to` should be set; if both
+   * are absent, the range decodes to a degenerate range anchored at the Unix epoch
+   * (1970-01-01T00:00:00Z) rather than being unbounded in both directions.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange}
@@ -537,7 +547,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> fromBuilder_;
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+     * unbounded below (open start).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -548,7 +559,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+     * unbounded below (open start).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -563,7 +575,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+     * unbounded below (open start).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -583,7 +596,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+     * unbounded below (open start).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -601,7 +615,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+     * unbounded below (open start).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -626,7 +641,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+     * unbounded below (open start).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -643,7 +659,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+     * unbounded below (open start).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -655,7 +672,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+     * unbounded below (open start).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -670,7 +688,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+     * unbounded below (open start).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -694,7 +713,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> toBuilder_;
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+     * unbounded above (open end).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -705,7 +725,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+     * unbounded above (open end).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -720,7 +741,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+     * unbounded above (open end).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -740,7 +762,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+     * unbounded above (open end).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -758,7 +781,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+     * unbounded above (open end).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -783,7 +807,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+     * unbounded above (open end).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -800,7 +825,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+     * unbounded above (open end).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -812,7 +838,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+     * unbounded above (open end).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -827,7 +854,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+     * unbounded above (open end).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDateTimeRangeArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDateTimeRangeArray.java
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange> value_;
   /**
    * <pre>
-   * Value that supports storing a DateTimeRange array.
+   * The individual DateTimeRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -83,7 +83,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a DateTimeRange array.
+   * The individual DateTimeRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -95,7 +95,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a DateTimeRange array.
+   * The individual DateTimeRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a DateTimeRange array.
+   * The individual DateTimeRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -117,7 +117,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a DateTimeRange array.
+   * The individual DateTimeRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -534,7 +534,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -548,7 +548,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -583,7 +583,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -601,7 +601,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -621,7 +621,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -642,7 +642,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -660,7 +660,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -678,7 +678,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -697,7 +697,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -714,7 +714,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -731,7 +731,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -742,7 +742,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -756,7 +756,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -771,7 +771,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -782,7 +782,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -794,7 +794,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a DateTimeRange array.
+     * The individual DateTimeRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDateTimeRangeArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDateTimeRangeArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcDateTimeRangeArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a DateTimeRange array.
+   * The individual DateTimeRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcDateTimeRangeArrayOrBuilder extends
       getValueList();
   /**
    * <pre>
-   * Value that supports storing a DateTimeRange array.
+   * The individual DateTimeRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -50,7 +50,7 @@ public interface GrpcDateTimeRangeArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a DateTimeRange array.
+   * The individual DateTimeRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -58,7 +58,7 @@ public interface GrpcDateTimeRangeArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a DateTimeRange array.
+   * The individual DateTimeRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>
@@ -67,7 +67,7 @@ public interface GrpcDateTimeRangeArrayOrBuilder extends
       getValueOrBuilderList();
   /**
    * <pre>
-   * Value that supports storing a DateTimeRange array.
+   * The individual DateTimeRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDateTimeRangeOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDateTimeRangeOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcDateTimeRangeOrBuilder extends
 
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+   * unbounded below (open start).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcDateTimeRangeOrBuilder extends
   boolean hasFrom();
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+   * unbounded below (open start).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcDateTimeRangeOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getFrom();
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+   * unbounded below (open start).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime from = 1;</code>
@@ -60,7 +63,8 @@ public interface GrpcDateTimeRangeOrBuilder extends
 
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+   * unbounded above (open end).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -69,7 +73,8 @@ public interface GrpcDateTimeRangeOrBuilder extends
   boolean hasTo();
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+   * unbounded above (open end).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>
@@ -78,7 +83,8 @@ public interface GrpcDateTimeRangeOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getTo();
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+   * unbounded above (open end).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime to = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntitiesRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntitiesRequest.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request for deleting a collection of entities specified by a query.
+ * Request for deleting all entities matched by a query. Beware: without a `page()`/`strip()` requirement
+ * in the query's `require` block to bound the result, at most 20 entities are deleted (the engine's
+ * default page size) - add an explicit `page()`/`strip()` requirement to remove more.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDeleteEntitiesRequest}
@@ -85,7 +87,9 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object query_ = "";
   /**
    * <pre>
-   * The string part of the parametrised query.
+   * The string part of the parametrised query. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string query = 1;</code>
@@ -106,7 +110,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string part of the parametrised query.
+   * The string part of the parametrised query. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string query = 1;</code>
@@ -132,7 +138,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcQueryParam> positionalQueryParams_;
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -143,7 +150,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -155,7 +163,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -166,7 +175,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -177,7 +187,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -216,7 +227,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -237,7 +249,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -248,7 +261,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -266,7 +280,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -476,7 +491,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * Request for deleting a collection of entities specified by a query.
+   * Request for deleting all entities matched by a query. Beware: without a `page()`/`strip()` requirement
+   * in the query's `require` block to bound the result, at most 20 entities are deleted (the engine's
+   * default page size) - add an explicit `page()`/`strip()` requirement to remove more.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDeleteEntitiesRequest}
@@ -748,7 +765,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     private java.lang.Object query_ = "";
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The string part of the parametrised query. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -768,7 +787,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The string part of the parametrised query. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -789,7 +810,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The string part of the parametrised query. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -806,7 +829,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The string part of the parametrised query. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -820,7 +845,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The string part of the parametrised query. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -851,7 +878,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
 
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -865,7 +893,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -879,7 +908,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -893,7 +923,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -914,7 +945,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -932,7 +964,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -952,7 +985,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -973,7 +1007,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -991,7 +1026,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1009,7 +1045,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1028,7 +1065,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1045,7 +1083,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1062,7 +1101,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1073,7 +1113,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1087,7 +1128,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1102,7 +1144,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1113,7 +1156,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1125,7 +1169,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1186,7 +1231,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1207,7 +1253,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1218,7 +1265,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1235,7 +1283,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1257,7 +1306,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1280,7 +1330,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1297,7 +1348,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1316,7 +1368,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntitiesRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntitiesRequestOrBuilder.java
@@ -33,7 +33,9 @@ public interface GrpcDeleteEntitiesRequestOrBuilder extends
 
   /**
    * <pre>
-   * The string part of the parametrised query.
+   * The string part of the parametrised query. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string query = 1;</code>
@@ -42,7 +44,9 @@ public interface GrpcDeleteEntitiesRequestOrBuilder extends
   java.lang.String getQuery();
   /**
    * <pre>
-   * The string part of the parametrised query.
+   * The string part of the parametrised query. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string query = 1;</code>
@@ -53,7 +57,8 @@ public interface GrpcDeleteEntitiesRequestOrBuilder extends
 
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -62,7 +67,8 @@ public interface GrpcDeleteEntitiesRequestOrBuilder extends
       getPositionalQueryParamsList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -70,7 +76,8 @@ public interface GrpcDeleteEntitiesRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcQueryParam getPositionalQueryParams(int index);
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -78,7 +85,8 @@ public interface GrpcDeleteEntitiesRequestOrBuilder extends
   int getPositionalQueryParamsCount();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -87,7 +95,8 @@ public interface GrpcDeleteEntitiesRequestOrBuilder extends
       getPositionalQueryParamsOrBuilderList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -97,7 +106,8 @@ public interface GrpcDeleteEntitiesRequestOrBuilder extends
 
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -105,7 +115,8 @@ public interface GrpcDeleteEntitiesRequestOrBuilder extends
   int getNamedQueryParamsCount();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -120,7 +131,8 @@ public interface GrpcDeleteEntitiesRequestOrBuilder extends
   getNamedQueryParams();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -129,7 +141,8 @@ public interface GrpcDeleteEntitiesRequestOrBuilder extends
   getNamedQueryParamsMap();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -141,7 +154,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam getNamedQueryParamsOrDefaul
 io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue);
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntitiesResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntitiesResponse.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to DeleteEntities request that deletes all entities that match the sent query..
+ * Response to DeleteEntities request that deletes all entities matched by the sent query.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDeleteEntitiesResponse}
@@ -71,7 +71,7 @@ private static final long serialVersionUID = 0L;
   private int deletedEntities_ = 0;
   /**
    * <pre>
-   * Count of deleted entities.
+   * Total number of entities deleted.
    * </pre>
    *
    * <code>int32 deletedEntities = 1;</code>
@@ -87,7 +87,9 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcSealedEntity> deletedEntityBodies_;
   /**
    * <pre>
-   * The deleted entity bodies.
+   * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+   * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+   * `entityFetch` requirement.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -98,7 +100,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The deleted entity bodies.
+   * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+   * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+   * `entityFetch` requirement.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -110,7 +114,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The deleted entity bodies.
+   * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+   * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+   * `entityFetch` requirement.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -121,7 +127,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The deleted entity bodies.
+   * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+   * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+   * `entityFetch` requirement.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -132,7 +140,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The deleted entity bodies.
+   * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+   * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+   * `entityFetch` requirement.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -315,7 +325,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to DeleteEntities request that deletes all entities that match the sent query..
+   * Response to DeleteEntities request that deletes all entities matched by the sent query.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDeleteEntitiesResponse}
@@ -547,7 +557,7 @@ private static final long serialVersionUID = 0L;
     private int deletedEntities_ ;
     /**
      * <pre>
-     * Count of deleted entities.
+     * Total number of entities deleted.
      * </pre>
      *
      * <code>int32 deletedEntities = 1;</code>
@@ -559,7 +569,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Count of deleted entities.
+     * Total number of entities deleted.
      * </pre>
      *
      * <code>int32 deletedEntities = 1;</code>
@@ -575,7 +585,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Count of deleted entities.
+     * Total number of entities deleted.
      * </pre>
      *
      * <code>int32 deletedEntities = 1;</code>
@@ -602,7 +612,9 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -616,7 +628,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -630,7 +644,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -644,7 +660,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -665,7 +683,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -683,7 +703,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -703,7 +725,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -724,7 +748,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -742,7 +768,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -760,7 +788,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -779,7 +809,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -796,7 +828,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -813,7 +847,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -824,7 +860,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -838,7 +876,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -853,7 +893,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -864,7 +906,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -876,7 +920,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity bodies.
+     * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+     * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+     * `entityFetch` requirement.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntitiesResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntitiesResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcDeleteEntitiesResponseOrBuilder extends
 
   /**
    * <pre>
-   * Count of deleted entities.
+   * Total number of entities deleted.
    * </pre>
    *
    * <code>int32 deletedEntities = 1;</code>
@@ -43,7 +43,9 @@ public interface GrpcDeleteEntitiesResponseOrBuilder extends
 
   /**
    * <pre>
-   * The deleted entity bodies.
+   * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+   * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+   * `entityFetch` requirement.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -52,7 +54,9 @@ public interface GrpcDeleteEntitiesResponseOrBuilder extends
       getDeletedEntityBodiesList();
   /**
    * <pre>
-   * The deleted entity bodies.
+   * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+   * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+   * `entityFetch` requirement.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -60,7 +64,9 @@ public interface GrpcDeleteEntitiesResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcSealedEntity getDeletedEntityBodies(int index);
   /**
    * <pre>
-   * The deleted entity bodies.
+   * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+   * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+   * `entityFetch` requirement.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -68,7 +74,9 @@ public interface GrpcDeleteEntitiesResponseOrBuilder extends
   int getDeletedEntityBodiesCount();
   /**
    * <pre>
-   * The deleted entity bodies.
+   * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+   * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+   * `entityFetch` requirement.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>
@@ -77,7 +85,9 @@ public interface GrpcDeleteEntitiesResponseOrBuilder extends
       getDeletedEntityBodiesOrBuilderList();
   /**
    * <pre>
-   * The deleted entity bodies.
+   * The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+   * `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+   * `entityFetch` requirement.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedEntityBodies = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntityAndItsHierarchyResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntityAndItsHierarchyResponse.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to DeleteEntity request when hierarchy has been specified in filter.
+ * Response to DeleteEntityAndItsHierarchy, which removes a hierarchical root entity together with every
+ * entity of the same type that transitively references it as a parent.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDeleteEntityAndItsHierarchyResponse}
@@ -113,7 +114,7 @@ private static final long serialVersionUID = 0L;
   private int deletedEntities_ = 0;
   /**
    * <pre>
-   * Count of deleted entities.
+   * Total number of entities deleted (the root plus its whole nested hierarchy).
    * </pre>
    *
    * <code>int32 deletedEntities = 1;</code>
@@ -127,7 +128,8 @@ private static final long serialVersionUID = 0L;
   public static final int DELETEDROOTENTITYREFERENCE_FIELD_NUMBER = 2;
   /**
    * <pre>
-   * The deleted root entity reference.
+   * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+   * server - see the message-level comment above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -139,7 +141,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The deleted root entity reference.
+   * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+   * server - see the message-level comment above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -154,7 +157,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The deleted root entity reference.
+   * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+   * server - see the message-level comment above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -170,7 +174,8 @@ private static final long serialVersionUID = 0L;
   public static final int DELETEDROOTENTITY_FIELD_NUMBER = 3;
   /**
    * <pre>
-   * The deleted root entity.
+   * The deleted root entity, fully fetched (as it was immediately before deletion) per
+   * `GrpcDeleteEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -182,7 +187,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The deleted root entity.
+   * The deleted root entity, fully fetched (as it was immediately before deletion) per
+   * `GrpcDeleteEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -197,7 +203,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The deleted root entity.
+   * The deleted root entity, fully fetched (as it was immediately before deletion) per
+   * `GrpcDeleteEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -216,7 +223,8 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   * Deleted entity primary keys.
+   * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+   * own primary key.
    * </pre>
    *
    * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>
@@ -229,7 +237,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Deleted entity primary keys.
+   * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+   * own primary key.
    * </pre>
    *
    * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>
@@ -240,7 +249,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Deleted entity primary keys.
+   * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+   * own primary key.
    * </pre>
    *
    * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>
@@ -478,7 +488,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to DeleteEntity request when hierarchy has been specified in filter.
+   * Response to DeleteEntityAndItsHierarchy, which removes a hierarchical root entity together with every
+   * entity of the same type that transitively references it as a parent.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDeleteEntityAndItsHierarchyResponse}
@@ -747,7 +758,7 @@ private static final long serialVersionUID = 0L;
     private int deletedEntities_ ;
     /**
      * <pre>
-     * Count of deleted entities.
+     * Total number of entities deleted (the root plus its whole nested hierarchy).
      * </pre>
      *
      * <code>int32 deletedEntities = 1;</code>
@@ -759,7 +770,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Count of deleted entities.
+     * Total number of entities deleted (the root plus its whole nested hierarchy).
      * </pre>
      *
      * <code>int32 deletedEntities = 1;</code>
@@ -775,7 +786,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Count of deleted entities.
+     * Total number of entities deleted (the root plus its whole nested hierarchy).
      * </pre>
      *
      * <code>int32 deletedEntities = 1;</code>
@@ -792,7 +803,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEntityReference, io.evitadb.externalApi.grpc.generated.GrpcEntityReference.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceOrBuilder> deletedRootEntityReferenceBuilder_;
     /**
      * <pre>
-     * The deleted root entity reference.
+     * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+     * server - see the message-level comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -804,7 +816,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity reference.
+     * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+     * server - see the message-level comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -826,7 +839,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity reference.
+     * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+     * server - see the message-level comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -846,7 +860,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity reference.
+     * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+     * server - see the message-level comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -864,7 +879,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity reference.
+     * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+     * server - see the message-level comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -891,7 +907,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity reference.
+     * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+     * server - see the message-level comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -914,7 +931,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity reference.
+     * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+     * server - see the message-level comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -924,7 +942,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity reference.
+     * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+     * server - see the message-level comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -942,7 +961,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity reference.
+     * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+     * server - see the message-level comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -970,7 +990,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcSealedEntity, io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.Builder, io.evitadb.externalApi.grpc.generated.GrpcSealedEntityOrBuilder> deletedRootEntityBuilder_;
     /**
      * <pre>
-     * The deleted root entity.
+     * The deleted root entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -982,7 +1003,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity.
+     * The deleted root entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -1004,7 +1026,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity.
+     * The deleted root entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -1024,7 +1047,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity.
+     * The deleted root entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -1042,7 +1066,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity.
+     * The deleted root entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -1069,7 +1094,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity.
+     * The deleted root entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -1092,7 +1118,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity.
+     * The deleted root entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -1102,7 +1129,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity.
+     * The deleted root entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -1120,7 +1148,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted root entity.
+     * The deleted root entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -1153,7 +1182,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Deleted entity primary keys.
+     * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+     * own primary key.
      * </pre>
      *
      * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>
@@ -1166,7 +1196,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Deleted entity primary keys.
+     * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+     * own primary key.
      * </pre>
      *
      * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>
@@ -1177,7 +1208,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Deleted entity primary keys.
+     * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+     * own primary key.
      * </pre>
      *
      * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>
@@ -1189,7 +1221,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Deleted entity primary keys.
+     * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+     * own primary key.
      * </pre>
      *
      * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>
@@ -1208,7 +1241,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Deleted entity primary keys.
+     * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+     * own primary key.
      * </pre>
      *
      * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>
@@ -1225,7 +1259,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Deleted entity primary keys.
+     * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+     * own primary key.
      * </pre>
      *
      * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>
@@ -1243,7 +1278,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Deleted entity primary keys.
+     * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+     * own primary key.
      * </pre>
      *
      * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntityAndItsHierarchyResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntityAndItsHierarchyResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcDeleteEntityAndItsHierarchyResponseOrBuilder extends
 
   /**
    * <pre>
-   * Count of deleted entities.
+   * Total number of entities deleted (the root plus its whole nested hierarchy).
    * </pre>
    *
    * <code>int32 deletedEntities = 1;</code>
@@ -43,7 +43,8 @@ public interface GrpcDeleteEntityAndItsHierarchyResponseOrBuilder extends
 
   /**
    * <pre>
-   * The deleted root entity reference.
+   * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+   * server - see the message-level comment above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -52,7 +53,8 @@ public interface GrpcDeleteEntityAndItsHierarchyResponseOrBuilder extends
   boolean hasDeletedRootEntityReference();
   /**
    * <pre>
-   * The deleted root entity reference.
+   * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+   * server - see the message-level comment above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -61,7 +63,8 @@ public interface GrpcDeleteEntityAndItsHierarchyResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEntityReference getDeletedRootEntityReference();
   /**
    * <pre>
-   * The deleted root entity reference.
+   * The deleted root entity as a reference (type + primary key only). Currently never populated by the
+   * server - see the message-level comment above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference deletedRootEntityReference = 2;</code>
@@ -70,7 +73,8 @@ public interface GrpcDeleteEntityAndItsHierarchyResponseOrBuilder extends
 
   /**
    * <pre>
-   * The deleted root entity.
+   * The deleted root entity, fully fetched (as it was immediately before deletion) per
+   * `GrpcDeleteEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -79,7 +83,8 @@ public interface GrpcDeleteEntityAndItsHierarchyResponseOrBuilder extends
   boolean hasDeletedRootEntity();
   /**
    * <pre>
-   * The deleted root entity.
+   * The deleted root entity, fully fetched (as it was immediately before deletion) per
+   * `GrpcDeleteEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -88,7 +93,8 @@ public interface GrpcDeleteEntityAndItsHierarchyResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcSealedEntity getDeletedRootEntity();
   /**
    * <pre>
-   * The deleted root entity.
+   * The deleted root entity, fully fetched (as it was immediately before deletion) per
+   * `GrpcDeleteEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity deletedRootEntity = 3;</code>
@@ -97,7 +103,8 @@ public interface GrpcDeleteEntityAndItsHierarchyResponseOrBuilder extends
 
   /**
    * <pre>
-   * Deleted entity primary keys.
+   * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+   * own primary key.
    * </pre>
    *
    * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>
@@ -106,7 +113,8 @@ public interface GrpcDeleteEntityAndItsHierarchyResponseOrBuilder extends
   java.util.List<java.lang.Integer> getDeletedEntityPrimaryKeysList();
   /**
    * <pre>
-   * Deleted entity primary keys.
+   * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+   * own primary key.
    * </pre>
    *
    * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>
@@ -115,7 +123,8 @@ public interface GrpcDeleteEntityAndItsHierarchyResponseOrBuilder extends
   int getDeletedEntityPrimaryKeysCount();
   /**
    * <pre>
-   * Deleted entity primary keys.
+   * Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+   * own primary key.
    * </pre>
    *
    * <code>repeated int32 deletedEntityPrimaryKeys = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntityRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntityRequest.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request for deleting an entity that should return the deleted entity with required richness.
+ * Request for deleting a single entity by primary key and returning it fetched in the richness described
+ * by `require` before deletion.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDeleteEntityRequest}
@@ -87,7 +88,7 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object entityType_ = "";
   /**
    * <pre>
-   * Entity type of the entity to be deleted.
+   * Entity type (collection name) the entity to delete belongs to.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -108,7 +109,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Entity type of the entity to be deleted.
+   * Entity type (collection name) the entity to delete belongs to.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -133,7 +134,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value primaryKey_;
   /**
    * <pre>
-   * Primary key of the entity to be deleted.
+   * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -145,7 +148,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Primary key of the entity to be deleted.
+   * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -157,7 +162,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Primary key of the entity to be deleted.
+   * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -172,7 +179,10 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object require_ = "";
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+   * back before it is deleted. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -193,7 +203,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+   * back before it is deleted. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -219,7 +232,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcQueryParam> positionalQueryParams_;
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -230,7 +244,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -242,7 +257,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -253,7 +269,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -264,7 +281,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -303,7 +321,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -324,7 +343,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -335,7 +355,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -353,7 +374,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -589,7 +611,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * Request for deleting an entity that should return the deleted entity with required richness.
+   * Request for deleting a single entity by primary key and returning it fetched in the richness described
+   * by `require` before deletion.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDeleteEntityRequest}
@@ -905,7 +928,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     private java.lang.Object entityType_ = "";
     /**
      * <pre>
-     * Entity type of the entity to be deleted.
+     * Entity type (collection name) the entity to delete belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -925,7 +948,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Entity type of the entity to be deleted.
+     * Entity type (collection name) the entity to delete belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -946,7 +969,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Entity type of the entity to be deleted.
+     * Entity type (collection name) the entity to delete belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -963,7 +986,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Entity type of the entity to be deleted.
+     * Entity type (collection name) the entity to delete belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -977,7 +1000,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Entity type of the entity to be deleted.
+     * Entity type (collection name) the entity to delete belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -999,7 +1022,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> primaryKeyBuilder_;
     /**
      * <pre>
-     * Primary key of the entity to be deleted.
+     * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1010,7 +1035,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be deleted.
+     * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1025,7 +1052,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be deleted.
+     * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1045,7 +1074,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be deleted.
+     * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1063,7 +1094,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be deleted.
+     * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1088,7 +1121,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be deleted.
+     * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1105,7 +1140,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be deleted.
+     * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1117,7 +1154,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be deleted.
+     * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1132,7 +1171,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be deleted.
+     * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1154,7 +1195,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     private java.lang.Object require_ = "";
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back before it is deleted. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1174,7 +1218,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back before it is deleted. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1195,7 +1242,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back before it is deleted. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1212,7 +1262,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back before it is deleted. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1226,7 +1279,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back before it is deleted. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1257,7 +1313,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
 
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1271,7 +1328,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1285,7 +1343,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1299,7 +1358,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1320,7 +1380,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1338,7 +1399,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1358,7 +1420,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1379,7 +1442,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1397,7 +1461,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1415,7 +1480,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1434,7 +1500,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1451,7 +1518,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1468,7 +1536,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1479,7 +1548,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1493,7 +1563,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1508,7 +1579,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1519,7 +1591,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1531,7 +1604,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1592,7 +1666,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1613,7 +1688,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1624,7 +1700,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1641,7 +1718,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1663,7 +1741,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1686,7 +1765,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1703,7 +1783,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1722,7 +1803,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntityRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntityRequestOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * Entity type of the entity to be deleted.
+   * Entity type (collection name) the entity to delete belongs to.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
   java.lang.String getEntityType();
   /**
    * <pre>
-   * Entity type of the entity to be deleted.
+   * Entity type (collection name) the entity to delete belongs to.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -53,7 +53,9 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * Primary key of the entity to be deleted.
+   * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -62,7 +64,9 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
   boolean hasPrimaryKey();
   /**
    * <pre>
-   * Primary key of the entity to be deleted.
+   * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -71,7 +75,9 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
   com.google.protobuf.Int32Value getPrimaryKey();
   /**
    * <pre>
-   * Primary key of the entity to be deleted.
+   * Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -80,7 +86,10 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+   * back before it is deleted. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -89,7 +98,10 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
   java.lang.String getRequire();
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+   * back before it is deleted. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -100,7 +112,8 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -109,7 +122,8 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
       getPositionalQueryParamsList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -117,7 +131,8 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcQueryParam getPositionalQueryParams(int index);
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -125,7 +140,8 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
   int getPositionalQueryParamsCount();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -134,7 +150,8 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
       getPositionalQueryParamsOrBuilderList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -144,7 +161,8 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -152,7 +170,8 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
   int getNamedQueryParamsCount();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -167,7 +186,8 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
   getNamedQueryParams();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -176,7 +196,8 @@ public interface GrpcDeleteEntityRequestOrBuilder extends
   getNamedQueryParamsMap();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -188,7 +209,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam getNamedQueryParamsOrDefaul
 io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue);
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntityResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntityResponse.java
@@ -111,7 +111,7 @@ private static final long serialVersionUID = 0L;
   public static final int ENTITYREFERENCE_FIELD_NUMBER = 1;
   /**
    * <pre>
-   * The deleted entity reference.
+   * The deleted entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -123,7 +123,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The deleted entity reference.
+   * The deleted entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -138,7 +138,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The deleted entity reference.
+   * The deleted entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -154,7 +154,8 @@ private static final long serialVersionUID = 0L;
   public static final int ENTITY_FIELD_NUMBER = 2;
   /**
    * <pre>
-   * The deleted entity.
+   * The deleted entity, fully fetched (as it was immediately before deletion) per
+   * `GrpcDeleteEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -166,7 +167,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The deleted entity.
+   * The deleted entity, fully fetched (as it was immediately before deletion) per
+   * `GrpcDeleteEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -181,7 +183,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The deleted entity.
+   * The deleted entity, fully fetched (as it was immediately before deletion) per
+   * `GrpcDeleteEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -607,7 +610,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEntityReference, io.evitadb.externalApi.grpc.generated.GrpcEntityReference.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceOrBuilder> entityReferenceBuilder_;
     /**
      * <pre>
-     * The deleted entity reference.
+     * The deleted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -619,7 +622,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity reference.
+     * The deleted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -641,7 +644,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity reference.
+     * The deleted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -661,7 +664,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity reference.
+     * The deleted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -679,7 +682,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity reference.
+     * The deleted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -706,7 +709,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity reference.
+     * The deleted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -729,7 +732,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity reference.
+     * The deleted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -739,7 +742,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity reference.
+     * The deleted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -757,7 +760,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity reference.
+     * The deleted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -785,7 +788,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcSealedEntity, io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.Builder, io.evitadb.externalApi.grpc.generated.GrpcSealedEntityOrBuilder> entityBuilder_;
     /**
      * <pre>
-     * The deleted entity.
+     * The deleted entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -797,7 +801,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity.
+     * The deleted entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -819,7 +824,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity.
+     * The deleted entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -839,7 +845,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity.
+     * The deleted entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -857,7 +864,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity.
+     * The deleted entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -884,7 +892,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity.
+     * The deleted entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -907,7 +916,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity.
+     * The deleted entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -917,7 +927,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity.
+     * The deleted entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -935,7 +946,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The deleted entity.
+     * The deleted entity, fully fetched (as it was immediately before deletion) per
+     * `GrpcDeleteEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntityResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteEntityResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcDeleteEntityResponseOrBuilder extends
 
   /**
    * <pre>
-   * The deleted entity reference.
+   * The deleted entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcDeleteEntityResponseOrBuilder extends
   boolean hasEntityReference();
   /**
    * <pre>
-   * The deleted entity reference.
+   * The deleted entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcDeleteEntityResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEntityReference getEntityReference();
   /**
    * <pre>
-   * The deleted entity reference.
+   * The deleted entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -60,7 +60,8 @@ public interface GrpcDeleteEntityResponseOrBuilder extends
 
   /**
    * <pre>
-   * The deleted entity.
+   * The deleted entity, fully fetched (as it was immediately before deletion) per
+   * `GrpcDeleteEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -69,7 +70,8 @@ public interface GrpcDeleteEntityResponseOrBuilder extends
   boolean hasEntity();
   /**
    * <pre>
-   * The deleted entity.
+   * The deleted entity, fully fetched (as it was immediately before deletion) per
+   * `GrpcDeleteEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -78,7 +80,8 @@ public interface GrpcDeleteEntityResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcSealedEntity getEntity();
   /**
    * <pre>
-   * The deleted entity.
+   * The deleted entity, fully fetched (as it was immediately before deletion) per
+   * `GrpcDeleteEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteFileToFetchRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteFileToFetchRequest.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to list task statuses in paginated form.
+ * Request to delete a file available for fetching, by its id.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDeleteFileToFetchRequest}
@@ -269,7 +269,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to list task statuses in paginated form.
+   * Request to delete a file available for fetching, by its id.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDeleteFileToFetchRequest}

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteFileToFetchResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteFileToFetchResponse.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to a task statuses request.
+ * Response to a file deletion request.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDeleteFileToFetchResponse}
@@ -70,7 +70,8 @@ private static final long serialVersionUID = 0L;
   private boolean success_ = false;
   /**
    * <pre>
-   * true if the file was found and deleted
+   * True if the file existed and was deleted; false if no file exists for the given id. Any other
+   * failure during deletion is reported as a gRPC error rather than `false`.
    * </pre>
    *
    * <code>bool success = 1;</code>
@@ -241,7 +242,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to a task statuses request.
+   * Response to a file deletion request.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcDeleteFileToFetchResponse}
@@ -414,7 +415,8 @@ private static final long serialVersionUID = 0L;
     private boolean success_ ;
     /**
      * <pre>
-     * true if the file was found and deleted
+     * True if the file existed and was deleted; false if no file exists for the given id. Any other
+     * failure during deletion is reported as a gRPC error rather than `false`.
      * </pre>
      *
      * <code>bool success = 1;</code>
@@ -426,7 +428,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * true if the file was found and deleted
+     * True if the file existed and was deleted; false if no file exists for the given id. Any other
+     * failure during deletion is reported as a gRPC error rather than `false`.
      * </pre>
      *
      * <code>bool success = 1;</code>
@@ -442,7 +445,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * true if the file was found and deleted
+     * True if the file existed and was deleted; false if no file exists for the given id. Any other
+     * failure during deletion is reported as a gRPC error rather than `false`.
      * </pre>
      *
      * <code>bool success = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteFileToFetchResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDeleteFileToFetchResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcDeleteFileToFetchResponseOrBuilder extends
 
   /**
    * <pre>
-   * true if the file was found and deleted
+   * True if the file existed and was deleted; false if no file exists for the given id. Any other
+   * failure during deletion is reported as a gRPC error rather than `false`.
    * </pre>
    *
    * <code>bool success = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEmptyHierarchicalEntityBehaviourArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEmptyHierarchicalEntityBehaviourArray.java
@@ -81,7 +81,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+   * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -94,7 +94,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+   * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+   * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -119,7 +119,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+   * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -132,7 +132,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+   * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -524,7 +524,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+     * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -536,7 +536,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+     * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -547,7 +547,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+     * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -559,7 +559,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+     * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -579,7 +579,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+     * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -597,7 +597,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+     * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -615,7 +615,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+     * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -629,7 +629,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+     * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+     * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -653,7 +653,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+     * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -670,7 +670,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+     * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -685,7 +685,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+     * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEmptyHierarchicalEntityBehaviourArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEmptyHierarchicalEntityBehaviourArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcEmptyHierarchicalEntityBehaviourArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+   * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcEmptyHierarchicalEntityBehaviourArrayOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour> getValueList();
   /**
    * <pre>
-   * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+   * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcEmptyHierarchicalEntityBehaviourArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+   * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -61,7 +61,7 @@ public interface GrpcEmptyHierarchicalEntityBehaviourArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour getValue(int index);
   /**
    * <pre>
-   * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+   * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>
@@ -71,7 +71,7 @@ public interface GrpcEmptyHierarchicalEntityBehaviourArrayOrBuilder extends
   getValueValueList();
   /**
    * <pre>
-   * Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+   * The individual EmptyHierarchicalEntityBehaviour values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEndpoint.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEndpoint.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Information about a system endpoint of particular purpose derived from name
+ * A named endpoint exposed by an external API, distinct from the API's own base URL(s) (see
+ * `GrpcApiStatus.endpoints`).
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcEndpoint}
@@ -74,7 +75,9 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object name_ = "";
   /**
    * <pre>
-   * logical name of the endpoint
+   * Logical name identifying what the endpoint serves. For the system API - currently the only API
+   * that populates `GrpcApiStatus.endpoints` - this is one of `serverNameUrl`,
+   * `serverCertificateUrl`, `clientCertificateUrl`, `clientPrivateKeyUrl`.
    * </pre>
    *
    * <code>string name = 1;</code>
@@ -95,7 +98,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * logical name of the endpoint
+   * Logical name identifying what the endpoint serves. For the system API - currently the only API
+   * that populates `GrpcApiStatus.endpoints` - this is one of `serverNameUrl`,
+   * `serverCertificateUrl`, `clientCertificateUrl`, `clientPrivateKeyUrl`.
    * </pre>
    *
    * <code>string name = 1;</code>
@@ -122,7 +127,8 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
-   * absolute URL of the endpoint
+   * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+   * commonly holds more than one URL even though the field name is singular.
    * </pre>
    *
    * <code>repeated string url = 2;</code>
@@ -134,7 +140,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * absolute URL of the endpoint
+   * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+   * commonly holds more than one URL even though the field name is singular.
    * </pre>
    *
    * <code>repeated string url = 2;</code>
@@ -145,7 +152,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * absolute URL of the endpoint
+   * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+   * commonly holds more than one URL even though the field name is singular.
    * </pre>
    *
    * <code>repeated string url = 2;</code>
@@ -157,7 +165,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * absolute URL of the endpoint
+   * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+   * commonly holds more than one URL even though the field name is singular.
    * </pre>
    *
    * <code>repeated string url = 2;</code>
@@ -344,7 +353,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Information about a system endpoint of particular purpose derived from name
+   * A named endpoint exposed by an external API, distinct from the API's own base URL(s) (see
+   * `GrpcApiStatus.endpoints`).
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcEndpoint}
@@ -541,7 +551,9 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object name_ = "";
     /**
      * <pre>
-     * logical name of the endpoint
+     * Logical name identifying what the endpoint serves. For the system API - currently the only API
+     * that populates `GrpcApiStatus.endpoints` - this is one of `serverNameUrl`,
+     * `serverCertificateUrl`, `clientCertificateUrl`, `clientPrivateKeyUrl`.
      * </pre>
      *
      * <code>string name = 1;</code>
@@ -561,7 +573,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * logical name of the endpoint
+     * Logical name identifying what the endpoint serves. For the system API - currently the only API
+     * that populates `GrpcApiStatus.endpoints` - this is one of `serverNameUrl`,
+     * `serverCertificateUrl`, `clientCertificateUrl`, `clientPrivateKeyUrl`.
      * </pre>
      *
      * <code>string name = 1;</code>
@@ -582,7 +596,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * logical name of the endpoint
+     * Logical name identifying what the endpoint serves. For the system API - currently the only API
+     * that populates `GrpcApiStatus.endpoints` - this is one of `serverNameUrl`,
+     * `serverCertificateUrl`, `clientCertificateUrl`, `clientPrivateKeyUrl`.
      * </pre>
      *
      * <code>string name = 1;</code>
@@ -599,7 +615,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * logical name of the endpoint
+     * Logical name identifying what the endpoint serves. For the system API - currently the only API
+     * that populates `GrpcApiStatus.endpoints` - this is one of `serverNameUrl`,
+     * `serverCertificateUrl`, `clientCertificateUrl`, `clientPrivateKeyUrl`.
      * </pre>
      *
      * <code>string name = 1;</code>
@@ -613,7 +631,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * logical name of the endpoint
+     * Logical name identifying what the endpoint serves. For the system API - currently the only API
+     * that populates `GrpcApiStatus.endpoints` - this is one of `serverNameUrl`,
+     * `serverCertificateUrl`, `clientCertificateUrl`, `clientPrivateKeyUrl`.
      * </pre>
      *
      * <code>string name = 1;</code>
@@ -640,7 +660,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * absolute URL of the endpoint
+     * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+     * commonly holds more than one URL even though the field name is singular.
      * </pre>
      *
      * <code>repeated string url = 2;</code>
@@ -653,7 +674,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * absolute URL of the endpoint
+     * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+     * commonly holds more than one URL even though the field name is singular.
      * </pre>
      *
      * <code>repeated string url = 2;</code>
@@ -664,7 +686,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * absolute URL of the endpoint
+     * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+     * commonly holds more than one URL even though the field name is singular.
      * </pre>
      *
      * <code>repeated string url = 2;</code>
@@ -676,7 +699,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * absolute URL of the endpoint
+     * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+     * commonly holds more than one URL even though the field name is singular.
      * </pre>
      *
      * <code>repeated string url = 2;</code>
@@ -689,7 +713,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * absolute URL of the endpoint
+     * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+     * commonly holds more than one URL even though the field name is singular.
      * </pre>
      *
      * <code>repeated string url = 2;</code>
@@ -708,7 +733,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * absolute URL of the endpoint
+     * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+     * commonly holds more than one URL even though the field name is singular.
      * </pre>
      *
      * <code>repeated string url = 2;</code>
@@ -726,7 +752,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * absolute URL of the endpoint
+     * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+     * commonly holds more than one URL even though the field name is singular.
      * </pre>
      *
      * <code>repeated string url = 2;</code>
@@ -744,7 +771,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * absolute URL of the endpoint
+     * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+     * commonly holds more than one URL even though the field name is singular.
      * </pre>
      *
      * <code>repeated string url = 2;</code>
@@ -759,7 +787,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * absolute URL of the endpoint
+     * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+     * commonly holds more than one URL even though the field name is singular.
      * </pre>
      *
      * <code>repeated string url = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEndpointOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEndpointOrBuilder.java
@@ -33,7 +33,9 @@ public interface GrpcEndpointOrBuilder extends
 
   /**
    * <pre>
-   * logical name of the endpoint
+   * Logical name identifying what the endpoint serves. For the system API - currently the only API
+   * that populates `GrpcApiStatus.endpoints` - this is one of `serverNameUrl`,
+   * `serverCertificateUrl`, `clientCertificateUrl`, `clientPrivateKeyUrl`.
    * </pre>
    *
    * <code>string name = 1;</code>
@@ -42,7 +44,9 @@ public interface GrpcEndpointOrBuilder extends
   java.lang.String getName();
   /**
    * <pre>
-   * logical name of the endpoint
+   * Logical name identifying what the endpoint serves. For the system API - currently the only API
+   * that populates `GrpcApiStatus.endpoints` - this is one of `serverNameUrl`,
+   * `serverCertificateUrl`, `clientCertificateUrl`, `clientPrivateKeyUrl`.
    * </pre>
    *
    * <code>string name = 1;</code>
@@ -53,7 +57,8 @@ public interface GrpcEndpointOrBuilder extends
 
   /**
    * <pre>
-   * absolute URL of the endpoint
+   * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+   * commonly holds more than one URL even though the field name is singular.
    * </pre>
    *
    * <code>repeated string url = 2;</code>
@@ -63,7 +68,8 @@ public interface GrpcEndpointOrBuilder extends
       getUrlList();
   /**
    * <pre>
-   * absolute URL of the endpoint
+   * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+   * commonly holds more than one URL even though the field name is singular.
    * </pre>
    *
    * <code>repeated string url = 2;</code>
@@ -72,7 +78,8 @@ public interface GrpcEndpointOrBuilder extends
   int getUrlCount();
   /**
    * <pre>
-   * absolute URL of the endpoint
+   * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+   * commonly holds more than one URL even though the field name is singular.
    * </pre>
    *
    * <code>repeated string url = 2;</code>
@@ -82,7 +89,8 @@ public interface GrpcEndpointOrBuilder extends
   java.lang.String getUrl(int index);
   /**
    * <pre>
-   * absolute URL of the endpoint
+   * Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+   * commonly holds more than one URL even though the field name is singular.
    * </pre>
    *
    * <code>repeated string url = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityCollectionChanges.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityCollectionChanges.java
@@ -71,6 +71,10 @@ private static final long serialVersionUID = 0L;
   @SuppressWarnings("serial")
   private volatile java.lang.Object entityName_ = "";
   /**
+   * <pre>
+   * The name (entity type) of the entity collection these counts apply to.
+   * </pre>
+   *
    * <code>string entityName = 1;</code>
    * @return The entityName.
    */
@@ -88,6 +92,10 @@ private static final long serialVersionUID = 0L;
     }
   }
   /**
+   * <pre>
+   * The name (entity type) of the entity collection these counts apply to.
+   * </pre>
+   *
    * <code>string entityName = 1;</code>
    * @return The bytes for entityName.
    */
@@ -552,6 +560,10 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object entityName_ = "";
     /**
+     * <pre>
+     * The name (entity type) of the entity collection these counts apply to.
+     * </pre>
+     *
      * <code>string entityName = 1;</code>
      * @return The entityName.
      */
@@ -568,6 +580,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * The name (entity type) of the entity collection these counts apply to.
+     * </pre>
+     *
      * <code>string entityName = 1;</code>
      * @return The bytes for entityName.
      */
@@ -585,6 +601,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * The name (entity type) of the entity collection these counts apply to.
+     * </pre>
+     *
      * <code>string entityName = 1;</code>
      * @param value The entityName to set.
      * @return This builder for chaining.
@@ -598,6 +618,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * The name (entity type) of the entity collection these counts apply to.
+     * </pre>
+     *
      * <code>string entityName = 1;</code>
      * @return This builder for chaining.
      */
@@ -608,6 +632,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * The name (entity type) of the entity collection these counts apply to.
+     * </pre>
+     *
      * <code>string entityName = 1;</code>
      * @param value The bytes for entityName to set.
      * @return This builder for chaining.

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityCollectionChangesOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityCollectionChangesOrBuilder.java
@@ -32,11 +32,19 @@ public interface GrpcEntityCollectionChangesOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   * <pre>
+   * The name (entity type) of the entity collection these counts apply to.
+   * </pre>
+   *
    * <code>string entityName = 1;</code>
    * @return The entityName.
    */
   java.lang.String getEntityName();
   /**
+   * <pre>
+   * The name (entity type) of the entity collection these counts apply to.
+   * </pre>
+   *
    * <code>string entityName = 1;</code>
    * @return The bytes for entityName.
    */

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityCollectionSizeRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityCollectionSizeRequest.java
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object entityType_ = "";
   /**
    * <pre>
-   * The entity type of the collection - (count of entities stored).
+   * The entity type (collection name) whose size (count of entities stored) should be returned.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -93,7 +93,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The entity type of the collection - (count of entities stored).
+   * The entity type (collection name) whose size (count of entities stored) should be returned.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -447,7 +447,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object entityType_ = "";
     /**
      * <pre>
-     * The entity type of the collection - (count of entities stored).
+     * The entity type (collection name) whose size (count of entities stored) should be returned.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -467,7 +467,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The entity type of the collection - (count of entities stored).
+     * The entity type (collection name) whose size (count of entities stored) should be returned.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -488,7 +488,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The entity type of the collection - (count of entities stored).
+     * The entity type (collection name) whose size (count of entities stored) should be returned.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -505,7 +505,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The entity type of the collection - (count of entities stored).
+     * The entity type (collection name) whose size (count of entities stored) should be returned.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -519,7 +519,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The entity type of the collection - (count of entities stored).
+     * The entity type (collection name) whose size (count of entities stored) should be returned.
      * </pre>
      *
      * <code>string entityType = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityCollectionSizeRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityCollectionSizeRequestOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcEntityCollectionSizeRequestOrBuilder extends
 
   /**
    * <pre>
-   * The entity type of the collection - (count of entities stored).
+   * The entity type (collection name) whose size (count of entities stored) should be returned.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcEntityCollectionSizeRequestOrBuilder extends
   java.lang.String getEntityType();
   /**
    * <pre>
-   * The entity type of the collection - (count of entities stored).
+   * The entity type (collection name) whose size (count of entities stored) should be returned.
    * </pre>
    *
    * <code>string entityType = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityRequest.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request for acquiring an entity.
+ * Request for acquiring a single entity by primary key, in the richness described by `require`.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcEntityRequest}
@@ -86,7 +86,7 @@ private static final long serialVersionUID = 0L;
   private int primaryKey_ = 0;
   /**
    * <pre>
-   * The primary key of the entity.
+   * The primary key of the entity to fetch.
    * </pre>
    *
    * <code>int32 primaryKey = 1;</code>
@@ -102,7 +102,7 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object entityType_ = "";
   /**
    * <pre>
-   * The entity type of the entity.
+   * The entity type (collection name) the primary key belongs to.
    * </pre>
    *
    * <code>string entityType = 2;</code>
@@ -123,7 +123,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The entity type of the entity.
+   * The entity type (collection name) the primary key belongs to.
    * </pre>
    *
    * <code>string entityType = 2;</code>
@@ -149,7 +149,11 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object require_ = "";
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`),
+   * parsed on the server. Parameter values are not embedded in this string but supplied separately via
+   * `positionalQueryParams`/`namedQueryParams` below. A `?` placeholder in this string is a positional
+   * parameter, an `&#64;name` placeholder is a named parameter - see `positionalQueryParams`/`namedQueryParams`
+   * below for the full binding contract, which applies identically here.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -170,7 +174,11 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`),
+   * parsed on the server. Parameter values are not embedded in this string but supplied separately via
+   * `positionalQueryParams`/`namedQueryParams` below. A `?` placeholder in this string is a positional
+   * parameter, an `&#64;name` placeholder is a named parameter - see `positionalQueryParams`/`namedQueryParams`
+   * below for the full binding contract, which applies identically here.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -196,7 +204,10 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcQueryParam> positionalQueryParams_;
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+   * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+   * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+   * "Missing argument of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -207,7 +218,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+   * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+   * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+   * "Missing argument of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -219,7 +233,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+   * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+   * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+   * "Missing argument of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -230,7 +247,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+   * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+   * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+   * "Missing argument of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -241,7 +261,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+   * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+   * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+   * "Missing argument of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -280,7 +303,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+   * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+   * with "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -301,7 +326,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+   * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+   * with "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -312,7 +339,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+   * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+   * with "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -330,7 +359,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+   * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+   * with "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -361,7 +392,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
           };
   /**
    * <pre>
-   * The set of scopes to search for the entity.
+   * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+   * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -374,7 +406,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * The set of scopes to search for the entity.
+   * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+   * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -386,7 +419,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * The set of scopes to search for the entity.
+   * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+   * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -399,7 +433,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * The set of scopes to search for the entity.
+   * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+   * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -412,7 +447,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * The set of scopes to search for the entity.
+   * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+   * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -664,7 +700,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * Request for acquiring an entity.
+   * Request for acquiring a single entity by primary key, in the richness described by `require`.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcEntityRequest}
@@ -996,7 +1032,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     private int primaryKey_ ;
     /**
      * <pre>
-     * The primary key of the entity.
+     * The primary key of the entity to fetch.
      * </pre>
      *
      * <code>int32 primaryKey = 1;</code>
@@ -1008,7 +1044,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The primary key of the entity.
+     * The primary key of the entity to fetch.
      * </pre>
      *
      * <code>int32 primaryKey = 1;</code>
@@ -1024,7 +1060,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The primary key of the entity.
+     * The primary key of the entity to fetch.
      * </pre>
      *
      * <code>int32 primaryKey = 1;</code>
@@ -1040,7 +1076,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     private java.lang.Object entityType_ = "";
     /**
      * <pre>
-     * The entity type of the entity.
+     * The entity type (collection name) the primary key belongs to.
      * </pre>
      *
      * <code>string entityType = 2;</code>
@@ -1060,7 +1096,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The entity type of the entity.
+     * The entity type (collection name) the primary key belongs to.
      * </pre>
      *
      * <code>string entityType = 2;</code>
@@ -1081,7 +1117,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The entity type of the entity.
+     * The entity type (collection name) the primary key belongs to.
      * </pre>
      *
      * <code>string entityType = 2;</code>
@@ -1098,7 +1134,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The entity type of the entity.
+     * The entity type (collection name) the primary key belongs to.
      * </pre>
      *
      * <code>string entityType = 2;</code>
@@ -1112,7 +1148,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The entity type of the entity.
+     * The entity type (collection name) the primary key belongs to.
      * </pre>
      *
      * <code>string entityType = 2;</code>
@@ -1132,7 +1168,11 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     private java.lang.Object require_ = "";
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`),
+     * parsed on the server. Parameter values are not embedded in this string but supplied separately via
+     * `positionalQueryParams`/`namedQueryParams` below. A `?` placeholder in this string is a positional
+     * parameter, an `&#64;name` placeholder is a named parameter - see `positionalQueryParams`/`namedQueryParams`
+     * below for the full binding contract, which applies identically here.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1152,7 +1192,11 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`),
+     * parsed on the server. Parameter values are not embedded in this string but supplied separately via
+     * `positionalQueryParams`/`namedQueryParams` below. A `?` placeholder in this string is a positional
+     * parameter, an `&#64;name` placeholder is a named parameter - see `positionalQueryParams`/`namedQueryParams`
+     * below for the full binding contract, which applies identically here.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1173,7 +1217,11 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`),
+     * parsed on the server. Parameter values are not embedded in this string but supplied separately via
+     * `positionalQueryParams`/`namedQueryParams` below. A `?` placeholder in this string is a positional
+     * parameter, an `&#64;name` placeholder is a named parameter - see `positionalQueryParams`/`namedQueryParams`
+     * below for the full binding contract, which applies identically here.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1190,7 +1238,11 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`),
+     * parsed on the server. Parameter values are not embedded in this string but supplied separately via
+     * `positionalQueryParams`/`namedQueryParams` below. A `?` placeholder in this string is a positional
+     * parameter, an `&#64;name` placeholder is a named parameter - see `positionalQueryParams`/`namedQueryParams`
+     * below for the full binding contract, which applies identically here.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1204,7 +1256,11 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`),
+     * parsed on the server. Parameter values are not embedded in this string but supplied separately via
+     * `positionalQueryParams`/`namedQueryParams` below. A `?` placeholder in this string is a positional
+     * parameter, an `&#64;name` placeholder is a named parameter - see `positionalQueryParams`/`namedQueryParams`
+     * below for the full binding contract, which applies identically here.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1235,7 +1291,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
 
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1249,7 +1308,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1263,7 +1325,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1277,7 +1342,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1298,7 +1366,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1316,7 +1387,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1336,7 +1410,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1357,7 +1434,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1375,7 +1455,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1393,7 +1476,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1412,7 +1498,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1429,7 +1518,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1446,7 +1538,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1457,7 +1552,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1471,7 +1569,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1486,7 +1587,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1497,7 +1601,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1509,7 +1616,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+     * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+     * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+     * "Missing argument of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1570,7 +1680,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+     * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+     * with "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1591,7 +1703,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+     * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+     * with "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1602,7 +1716,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+     * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+     * with "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1619,7 +1735,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+     * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+     * with "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1641,7 +1759,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+     * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+     * with "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1664,7 +1784,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+     * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+     * with "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1681,7 +1803,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+     * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+     * with "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1700,7 +1824,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+     * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+     * with "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1730,7 +1856,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The set of scopes to search for the entity.
+     * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+     * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -1742,7 +1869,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The set of scopes to search for the entity.
+     * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+     * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -1753,7 +1881,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The set of scopes to search for the entity.
+     * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+     * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -1765,7 +1894,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The set of scopes to search for the entity.
+     * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+     * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -1785,7 +1915,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The set of scopes to search for the entity.
+     * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+     * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -1803,7 +1934,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The set of scopes to search for the entity.
+     * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+     * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -1821,7 +1953,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The set of scopes to search for the entity.
+     * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+     * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -1835,7 +1968,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The set of scopes to search for the entity.
+     * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+     * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -1847,7 +1981,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The set of scopes to search for the entity.
+     * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+     * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -1859,7 +1994,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The set of scopes to search for the entity.
+     * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+     * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -1876,7 +2012,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The set of scopes to search for the entity.
+     * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+     * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -1891,7 +2028,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The set of scopes to search for the entity.
+     * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+     * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityRequestOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The primary key of the entity.
+   * The primary key of the entity to fetch.
    * </pre>
    *
    * <code>int32 primaryKey = 1;</code>
@@ -43,7 +43,7 @@ public interface GrpcEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The entity type of the entity.
+   * The entity type (collection name) the primary key belongs to.
    * </pre>
    *
    * <code>string entityType = 2;</code>
@@ -52,7 +52,7 @@ public interface GrpcEntityRequestOrBuilder extends
   java.lang.String getEntityType();
   /**
    * <pre>
-   * The entity type of the entity.
+   * The entity type (collection name) the primary key belongs to.
    * </pre>
    *
    * <code>string entityType = 2;</code>
@@ -63,7 +63,11 @@ public interface GrpcEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`),
+   * parsed on the server. Parameter values are not embedded in this string but supplied separately via
+   * `positionalQueryParams`/`namedQueryParams` below. A `?` placeholder in this string is a positional
+   * parameter, an `&#64;name` placeholder is a named parameter - see `positionalQueryParams`/`namedQueryParams`
+   * below for the full binding contract, which applies identically here.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -72,7 +76,11 @@ public interface GrpcEntityRequestOrBuilder extends
   java.lang.String getRequire();
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`),
+   * parsed on the server. Parameter values are not embedded in this string but supplied separately via
+   * `positionalQueryParams`/`namedQueryParams` below. A `?` placeholder in this string is a positional
+   * parameter, an `&#64;name` placeholder is a named parameter - see `positionalQueryParams`/`namedQueryParams`
+   * below for the full binding contract, which applies identically here.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -83,7 +91,10 @@ public interface GrpcEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+   * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+   * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+   * "Missing argument of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -92,7 +103,10 @@ public interface GrpcEntityRequestOrBuilder extends
       getPositionalQueryParamsList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+   * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+   * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+   * "Missing argument of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -100,7 +114,10 @@ public interface GrpcEntityRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcQueryParam getPositionalQueryParams(int index);
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+   * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+   * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+   * "Missing argument of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -108,7 +125,10 @@ public interface GrpcEntityRequestOrBuilder extends
   int getPositionalQueryParamsCount();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+   * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+   * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+   * "Missing argument of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -117,7 +137,10 @@ public interface GrpcEntityRequestOrBuilder extends
       getPositionalQueryParamsOrBuilderList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+   * the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+   * so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+   * "Missing argument of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -127,7 +150,9 @@ public interface GrpcEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+   * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+   * with "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -135,7 +160,9 @@ public interface GrpcEntityRequestOrBuilder extends
   int getNamedQueryParamsCount();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+   * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+   * with "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -150,7 +177,9 @@ public interface GrpcEntityRequestOrBuilder extends
   getNamedQueryParams();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+   * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+   * with "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -159,7 +188,9 @@ public interface GrpcEntityRequestOrBuilder extends
   getNamedQueryParamsMap();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+   * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+   * with "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -171,7 +202,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam getNamedQueryParamsOrDefaul
 io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue);
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by the name used after `&#64;` in the
+   * string (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request
+   * with "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -181,7 +214,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue);
 
   /**
    * <pre>
-   * The set of scopes to search for the entity.
+   * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+   * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -190,7 +224,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue);
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcEntityScope> getScopesList();
   /**
    * <pre>
-   * The set of scopes to search for the entity.
+   * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+   * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -199,7 +234,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue);
   int getScopesCount();
   /**
    * <pre>
-   * The set of scopes to search for the entity.
+   * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+   * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -209,7 +245,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue);
   io.evitadb.externalApi.grpc.generated.GrpcEntityScope getScopes(int index);
   /**
    * <pre>
-   * The set of scopes to search for the entity.
+   * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+   * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>
@@ -219,7 +256,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue);
   getScopesValueList();
   /**
    * <pre>
-   * The set of scopes to search for the entity.
+   * Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+   * `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope scopes = 6;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityResponse.java
@@ -71,7 +71,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity_;
   /**
    * <pre>
-   * The found entity.
+   * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+   * `entityType` within the requested `scopes`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -83,7 +84,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The found entity.
+   * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+   * `entityType` within the requested `scopes`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -95,7 +97,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The found entity.
+   * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+   * `entityType` within the requested `scopes`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -461,7 +464,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcSealedEntity, io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.Builder, io.evitadb.externalApi.grpc.generated.GrpcSealedEntityOrBuilder> entityBuilder_;
     /**
      * <pre>
-     * The found entity.
+     * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+     * `entityType` within the requested `scopes`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -472,7 +476,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The found entity.
+     * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+     * `entityType` within the requested `scopes`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -487,7 +492,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The found entity.
+     * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+     * `entityType` within the requested `scopes`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -507,7 +513,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The found entity.
+     * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+     * `entityType` within the requested `scopes`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -525,7 +532,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The found entity.
+     * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+     * `entityType` within the requested `scopes`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -550,7 +558,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The found entity.
+     * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+     * `entityType` within the requested `scopes`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -567,7 +576,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The found entity.
+     * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+     * `entityType` within the requested `scopes`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -579,7 +589,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The found entity.
+     * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+     * `entityType` within the requested `scopes`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -594,7 +605,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The found entity.
+     * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+     * `entityType` within the requested `scopes`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcEntityResponseOrBuilder extends
 
   /**
    * <pre>
-   * The found entity.
+   * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+   * `entityType` within the requested `scopes`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcEntityResponseOrBuilder extends
   boolean hasEntity();
   /**
    * <pre>
-   * The found entity.
+   * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+   * `entityType` within the requested `scopes`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcEntityResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcSealedEntity getEntity();
   /**
    * <pre>
-   * The found entity.
+   * The found entity. Unset (not an error) if no entity with the requested primary key exists in
+   * `entityType` within the requested `scopes`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntitySchema.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntitySchema.java
@@ -287,7 +287,7 @@ private static final long serialVersionUID = 0L;
    * Each entity must be part of at most single hierarchy (tree).
    *
    * Hierarchy can limit returned entities by using filtering constraints. It's also used for
-   * computation of extra data - such as `hierarchyParentsOfSelf`. It can also invert type of returned entities in case extra result
+   * computation of extra data - such as the `parents` requirement. It can also invert type of returned entities in case extra result
    * `hierarchyOfSelf` is requested.
    * </pre>
    *
@@ -1254,7 +1254,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -1272,7 +1272,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -1289,7 +1289,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -1307,7 +1307,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -1325,7 +1325,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -3131,7 +3131,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * Each entity must be part of at most single hierarchy (tree).
      *
      * Hierarchy can limit returned entities by using filtering constraints. It's also used for
-     * computation of extra data - such as `hierarchyParentsOfSelf`. It can also invert type of returned entities in case extra result
+     * computation of extra data - such as the `parents` requirement. It can also invert type of returned entities in case extra result
      * `hierarchyOfSelf` is requested.
      * </pre>
      *
@@ -3152,7 +3152,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * Each entity must be part of at most single hierarchy (tree).
      *
      * Hierarchy can limit returned entities by using filtering constraints. It's also used for
-     * computation of extra data - such as `hierarchyParentsOfSelf`. It can also invert type of returned entities in case extra result
+     * computation of extra data - such as the `parents` requirement. It can also invert type of returned entities in case extra result
      * `hierarchyOfSelf` is requested.
      * </pre>
      *
@@ -3177,7 +3177,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * Each entity must be part of at most single hierarchy (tree).
      *
      * Hierarchy can limit returned entities by using filtering constraints. It's also used for
-     * computation of extra data - such as `hierarchyParentsOfSelf`. It can also invert type of returned entities in case extra result
+     * computation of extra data - such as the `parents` requirement. It can also invert type of returned entities in case extra result
      * `hierarchyOfSelf` is requested.
      * </pre>
      *
@@ -5759,7 +5759,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -5776,7 +5776,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -5792,7 +5792,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -5809,7 +5809,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -5834,7 +5834,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -5857,7 +5857,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -5880,7 +5880,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -5899,7 +5899,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -5916,7 +5916,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -5933,7 +5933,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -5955,7 +5955,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -5975,7 +5975,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntitySchemaOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntitySchemaOrBuilder.java
@@ -154,7 +154,7 @@ public interface GrpcEntitySchemaOrBuilder extends
    * Each entity must be part of at most single hierarchy (tree).
    *
    * Hierarchy can limit returned entities by using filtering constraints. It's also used for
-   * computation of extra data - such as `hierarchyParentsOfSelf`. It can also invert type of returned entities in case extra result
+   * computation of extra data - such as the `parents` requirement. It can also invert type of returned entities in case extra result
    * `hierarchyOfSelf` is requested.
    * </pre>
    *
@@ -859,7 +859,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -873,7 +873,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -887,7 +887,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -902,7 +902,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>
@@ -917,7 +917,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope priceIndexedInScopes = 18;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityScopeArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityScopeArray.java
@@ -81,7 +81,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * Value that supports storing a Scope array.
+   * The individual Scope values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -94,7 +94,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Scope array.
+   * The individual Scope values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Scope array.
+   * The individual Scope values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -119,7 +119,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Scope array.
+   * The individual Scope values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -132,7 +132,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Scope array.
+   * The individual Scope values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -524,7 +524,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Scope array.
+     * The individual Scope values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -536,7 +536,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Scope array.
+     * The individual Scope values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -547,7 +547,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Scope array.
+     * The individual Scope values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -559,7 +559,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Scope array.
+     * The individual Scope values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -579,7 +579,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Scope array.
+     * The individual Scope values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -597,7 +597,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Scope array.
+     * The individual Scope values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -615,7 +615,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Scope array.
+     * The individual Scope values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -629,7 +629,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Scope array.
+     * The individual Scope values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Scope array.
+     * The individual Scope values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -653,7 +653,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Scope array.
+     * The individual Scope values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -670,7 +670,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Scope array.
+     * The individual Scope values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -685,7 +685,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Scope array.
+     * The individual Scope values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityScopeArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityScopeArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcEntityScopeArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a Scope array.
+   * The individual Scope values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcEntityScopeArrayOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcEntityScope> getValueList();
   /**
    * <pre>
-   * Value that supports storing a Scope array.
+   * The individual Scope values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcEntityScopeArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a Scope array.
+   * The individual Scope values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -61,7 +61,7 @@ public interface GrpcEntityScopeArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEntityScope getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a Scope array.
+   * The individual Scope values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>
@@ -71,7 +71,7 @@ public interface GrpcEntityScopeArrayOrBuilder extends
   getValueValueList();
   /**
    * <pre>
-   * Value that supports storing a Scope array.
+   * The individual Scope values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityTypesResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityTypesResponse.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request for acquiring the list of all entity types.
+ * Response to GetAllEntityTypes request.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcEntityTypesResponse}
@@ -74,7 +74,7 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
-   * The list of all entity types.
+   * Names of all entity collections (entity types) defined in the catalog.
    * </pre>
    *
    * <code>repeated string entityTypes = 1;</code>
@@ -86,7 +86,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of all entity types.
+   * Names of all entity collections (entity types) defined in the catalog.
    * </pre>
    *
    * <code>repeated string entityTypes = 1;</code>
@@ -97,7 +97,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of all entity types.
+   * Names of all entity collections (entity types) defined in the catalog.
    * </pre>
    *
    * <code>repeated string entityTypes = 1;</code>
@@ -109,7 +109,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of all entity types.
+   * Names of all entity collections (entity types) defined in the catalog.
    * </pre>
    *
    * <code>repeated string entityTypes = 1;</code>
@@ -286,7 +286,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request for acquiring the list of all entity types.
+   * Response to GetAllEntityTypes request.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcEntityTypesResponse}
@@ -476,7 +476,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of all entity types.
+     * Names of all entity collections (entity types) defined in the catalog.
      * </pre>
      *
      * <code>repeated string entityTypes = 1;</code>
@@ -489,7 +489,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of all entity types.
+     * Names of all entity collections (entity types) defined in the catalog.
      * </pre>
      *
      * <code>repeated string entityTypes = 1;</code>
@@ -500,7 +500,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of all entity types.
+     * Names of all entity collections (entity types) defined in the catalog.
      * </pre>
      *
      * <code>repeated string entityTypes = 1;</code>
@@ -512,7 +512,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of all entity types.
+     * Names of all entity collections (entity types) defined in the catalog.
      * </pre>
      *
      * <code>repeated string entityTypes = 1;</code>
@@ -525,7 +525,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of all entity types.
+     * Names of all entity collections (entity types) defined in the catalog.
      * </pre>
      *
      * <code>repeated string entityTypes = 1;</code>
@@ -544,7 +544,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of all entity types.
+     * Names of all entity collections (entity types) defined in the catalog.
      * </pre>
      *
      * <code>repeated string entityTypes = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of all entity types.
+     * Names of all entity collections (entity types) defined in the catalog.
      * </pre>
      *
      * <code>repeated string entityTypes = 1;</code>
@@ -580,7 +580,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of all entity types.
+     * Names of all entity collections (entity types) defined in the catalog.
      * </pre>
      *
      * <code>repeated string entityTypes = 1;</code>
@@ -595,7 +595,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of all entity types.
+     * Names of all entity collections (entity types) defined in the catalog.
      * </pre>
      *
      * <code>repeated string entityTypes = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityTypesResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityTypesResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcEntityTypesResponseOrBuilder extends
 
   /**
    * <pre>
-   * The list of all entity types.
+   * Names of all entity collections (entity types) defined in the catalog.
    * </pre>
    *
    * <code>repeated string entityTypes = 1;</code>
@@ -43,7 +43,7 @@ public interface GrpcEntityTypesResponseOrBuilder extends
       getEntityTypesList();
   /**
    * <pre>
-   * The list of all entity types.
+   * Names of all entity collections (entity types) defined in the catalog.
    * </pre>
    *
    * <code>repeated string entityTypes = 1;</code>
@@ -52,7 +52,7 @@ public interface GrpcEntityTypesResponseOrBuilder extends
   int getEntityTypesCount();
   /**
    * <pre>
-   * The list of all entity types.
+   * Names of all entity collections (entity types) defined in the catalog.
    * </pre>
    *
    * <code>repeated string entityTypes = 1;</code>
@@ -62,7 +62,7 @@ public interface GrpcEntityTypesResponseOrBuilder extends
   java.lang.String getEntityTypes(int index);
   /**
    * <pre>
-   * The list of all entity types.
+   * Names of all entity collections (entity types) defined in the catalog.
    * </pre>
    *
    * <code>repeated string entityTypes = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaAssociatedDataDataType.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaAssociatedDataDataType.java
@@ -67,6 +67,11 @@ private static final long serialVersionUID = 0L;
   }
 
   /**
+   * <pre>
+   * Enumerates the value types evitaDB supports for associated data (both scalar and array variants) - a subset
+   * of the general query data types plus `ComplexDataObject` for arbitrary nested structures.
+   * </pre>
+   *
    * Protobuf enum {@code io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataDataType.GrpcEvitaDataType}
    */
   public enum GrpcEvitaDataType

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaAssociatedDataValue.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaAssociatedDataValue.java
@@ -29,8 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Structure that holds AssociatedData value. Might be one of the supported data types or a JSON string that will be
- * internally converted into ComplexDataObject.
+ * Structure that holds a single associated-data value, which is either one of the primitive/array
+ * Evita data types (wrapped by `GrpcEvitaValue`) or a complex (structured) object.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue}
@@ -116,7 +116,8 @@ private static final long serialVersionUID = 0L;
   public static final int PRIMITIVEVALUE_FIELD_NUMBER = 1;
   /**
    * <pre>
-   * Primitive value.
+   * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+   * is not a complex/structured object.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -128,7 +129,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Primitive value.
+   * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+   * is not a complex/structured object.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -143,7 +145,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Primitive value.
+   * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+   * is not a complex/structured object.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -159,12 +162,15 @@ private static final long serialVersionUID = 0L;
   public static final int JSONVALUE_FIELD_NUMBER = 2;
   /**
    * <pre>
-   * JSON string value, this old approach led to data type loss and is deprecated.
+   * JSON-encoded `ComplexDataObject` value.
+   * deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+   * TOBEDONE #538: remove once no client older than 2025.4 remains in use
+   * (https://github.com/FgForrest/evitaDB/issues/538)
    * </pre>
    *
    * <code>string jsonValue = 2 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue.jsonValue is deprecated.
-   *     See GrpcEvitaDataTypes.proto;l=310
+   *     See GrpcEvitaDataTypes.proto;l=372
    * @return Whether the jsonValue field is set.
    */
   @java.lang.Deprecated public boolean hasJsonValue() {
@@ -172,12 +178,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * JSON string value, this old approach led to data type loss and is deprecated.
+   * JSON-encoded `ComplexDataObject` value.
+   * deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+   * TOBEDONE #538: remove once no client older than 2025.4 remains in use
+   * (https://github.com/FgForrest/evitaDB/issues/538)
    * </pre>
    *
    * <code>string jsonValue = 2 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue.jsonValue is deprecated.
-   *     See GrpcEvitaDataTypes.proto;l=310
+   *     See GrpcEvitaDataTypes.proto;l=372
    * @return The jsonValue.
    */
   @java.lang.Deprecated public java.lang.String getJsonValue() {
@@ -199,12 +208,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * JSON string value, this old approach led to data type loss and is deprecated.
+   * JSON-encoded `ComplexDataObject` value.
+   * deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+   * TOBEDONE #538: remove once no client older than 2025.4 remains in use
+   * (https://github.com/FgForrest/evitaDB/issues/538)
    * </pre>
    *
    * <code>string jsonValue = 2 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue.jsonValue is deprecated.
-   *     See GrpcEvitaDataTypes.proto;l=310
+   *     See GrpcEvitaDataTypes.proto;l=372
    * @return The bytes for jsonValue.
    */
   @java.lang.Deprecated public com.google.protobuf.ByteString
@@ -229,7 +241,8 @@ private static final long serialVersionUID = 0L;
   public static final int ROOT_FIELD_NUMBER = 4;
   /**
    * <pre>
-   * The array of values.
+   * The root node of a complex (structured) object's tree, recursively described by
+   * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -241,7 +254,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The array of values.
+   * The root node of a complex (structured) object's tree, recursively described by
+   * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -256,7 +270,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The array of values.
+   * The root node of a complex (structured) object's tree, recursively described by
+   * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -273,7 +288,8 @@ private static final long serialVersionUID = 0L;
   private int type_ = 0;
   /**
    * <pre>
-   * The type of the stored value.
+   * The concrete Evita data type of the stored value, including `COMPLEX_DATA_OBJECT` when the
+   * value is a structured object described via `root` (or the deprecated `jsonValue`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataDataType.GrpcEvitaDataType type = 100;</code>
@@ -284,7 +300,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The type of the stored value.
+   * The concrete Evita data type of the stored value, including `COMPLEX_DATA_OBJECT` when the
+   * value is a structured object described via `root` (or the deprecated `jsonValue`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataDataType.GrpcEvitaDataType type = 100;</code>
@@ -299,8 +316,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value version_;
   /**
    * <pre>
-   * Contains version of this value and gets increased with any entity type update. Allows to execute
-   *			optimistic locking i.e. avoiding parallel modifications.
+   * Version of this associated data value; increases on every update to enable optimistic locking
+   * (concurrent-modification detection). May be null if this value is nested within a larger
+   * complex object.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -312,8 +330,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Contains version of this value and gets increased with any entity type update. Allows to execute
-   *			optimistic locking i.e. avoiding parallel modifications.
+   * Version of this associated data value; increases on every update to enable optimistic locking
+   * (concurrent-modification detection). May be null if this value is nested within a larger
+   * complex object.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -325,8 +344,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Contains version of this value and gets increased with any entity type update. Allows to execute
-   *			optimistic locking i.e. avoiding parallel modifications.
+   * Version of this associated data value; increases on every update to enable optimistic locking
+   * (concurrent-modification detection). May be null if this value is nested within a larger
+   * complex object.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -563,8 +583,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Structure that holds AssociatedData value. Might be one of the supported data types or a JSON string that will be
-   * internally converted into ComplexDataObject.
+   * Structure that holds a single associated-data value, which is either one of the primitive/array
+   * Evita data types (wrapped by `GrpcEvitaValue`) or a complex (structured) object.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue}
@@ -843,7 +863,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEvitaValue, io.evitadb.externalApi.grpc.generated.GrpcEvitaValue.Builder, io.evitadb.externalApi.grpc.generated.GrpcEvitaValueOrBuilder> primitiveValueBuilder_;
     /**
      * <pre>
-     * Primitive value.
+     * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+     * is not a complex/structured object.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -855,7 +876,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+     * is not a complex/structured object.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -877,7 +899,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+     * is not a complex/structured object.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -897,7 +920,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+     * is not a complex/structured object.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -915,7 +939,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+     * is not a complex/structured object.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -942,7 +967,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+     * is not a complex/structured object.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -965,7 +991,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+     * is not a complex/structured object.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -975,7 +1002,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+     * is not a complex/structured object.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -993,7 +1021,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Primitive value.
+     * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+     * is not a complex/structured object.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -1019,12 +1048,15 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * JSON string value, this old approach led to data type loss and is deprecated.
+     * JSON-encoded `ComplexDataObject` value.
+     * deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+     * TOBEDONE #538: remove once no client older than 2025.4 remains in use
+     * (https://github.com/FgForrest/evitaDB/issues/538)
      * </pre>
      *
      * <code>string jsonValue = 2 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue.jsonValue is deprecated.
-     *     See GrpcEvitaDataTypes.proto;l=310
+     *     See GrpcEvitaDataTypes.proto;l=372
      * @return Whether the jsonValue field is set.
      */
     @java.lang.Override
@@ -1033,12 +1065,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * JSON string value, this old approach led to data type loss and is deprecated.
+     * JSON-encoded `ComplexDataObject` value.
+     * deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+     * TOBEDONE #538: remove once no client older than 2025.4 remains in use
+     * (https://github.com/FgForrest/evitaDB/issues/538)
      * </pre>
      *
      * <code>string jsonValue = 2 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue.jsonValue is deprecated.
-     *     See GrpcEvitaDataTypes.proto;l=310
+     *     See GrpcEvitaDataTypes.proto;l=372
      * @return The jsonValue.
      */
     @java.lang.Override
@@ -1061,12 +1096,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * JSON string value, this old approach led to data type loss and is deprecated.
+     * JSON-encoded `ComplexDataObject` value.
+     * deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+     * TOBEDONE #538: remove once no client older than 2025.4 remains in use
+     * (https://github.com/FgForrest/evitaDB/issues/538)
      * </pre>
      *
      * <code>string jsonValue = 2 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue.jsonValue is deprecated.
-     *     See GrpcEvitaDataTypes.proto;l=310
+     *     See GrpcEvitaDataTypes.proto;l=372
      * @return The bytes for jsonValue.
      */
     @java.lang.Override
@@ -1090,12 +1128,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * JSON string value, this old approach led to data type loss and is deprecated.
+     * JSON-encoded `ComplexDataObject` value.
+     * deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+     * TOBEDONE #538: remove once no client older than 2025.4 remains in use
+     * (https://github.com/FgForrest/evitaDB/issues/538)
      * </pre>
      *
      * <code>string jsonValue = 2 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue.jsonValue is deprecated.
-     *     See GrpcEvitaDataTypes.proto;l=310
+     *     See GrpcEvitaDataTypes.proto;l=372
      * @param value The jsonValue to set.
      * @return This builder for chaining.
      */
@@ -1109,12 +1150,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * JSON string value, this old approach led to data type loss and is deprecated.
+     * JSON-encoded `ComplexDataObject` value.
+     * deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+     * TOBEDONE #538: remove once no client older than 2025.4 remains in use
+     * (https://github.com/FgForrest/evitaDB/issues/538)
      * </pre>
      *
      * <code>string jsonValue = 2 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue.jsonValue is deprecated.
-     *     See GrpcEvitaDataTypes.proto;l=310
+     *     See GrpcEvitaDataTypes.proto;l=372
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearJsonValue() {
@@ -1127,12 +1171,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * JSON string value, this old approach led to data type loss and is deprecated.
+     * JSON-encoded `ComplexDataObject` value.
+     * deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+     * TOBEDONE #538: remove once no client older than 2025.4 remains in use
+     * (https://github.com/FgForrest/evitaDB/issues/538)
      * </pre>
      *
      * <code>string jsonValue = 2 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue.jsonValue is deprecated.
-     *     See GrpcEvitaDataTypes.proto;l=310
+     *     See GrpcEvitaDataTypes.proto;l=372
      * @param value The bytes for jsonValue to set.
      * @return This builder for chaining.
      */
@@ -1150,7 +1197,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcDataItem, io.evitadb.externalApi.grpc.generated.GrpcDataItem.Builder, io.evitadb.externalApi.grpc.generated.GrpcDataItemOrBuilder> rootBuilder_;
     /**
      * <pre>
-     * The array of values.
+     * The root node of a complex (structured) object's tree, recursively described by
+     * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -1162,7 +1210,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * The root node of a complex (structured) object's tree, recursively described by
+     * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -1184,7 +1233,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * The root node of a complex (structured) object's tree, recursively described by
+     * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -1204,7 +1254,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * The root node of a complex (structured) object's tree, recursively described by
+     * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -1222,7 +1273,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * The root node of a complex (structured) object's tree, recursively described by
+     * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -1249,7 +1301,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * The root node of a complex (structured) object's tree, recursively described by
+     * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -1272,7 +1325,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * The root node of a complex (structured) object's tree, recursively described by
+     * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -1282,7 +1336,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * The root node of a complex (structured) object's tree, recursively described by
+     * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -1300,7 +1355,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The array of values.
+     * The root node of a complex (structured) object's tree, recursively described by
+     * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -1327,7 +1383,8 @@ private static final long serialVersionUID = 0L;
     private int type_ = 0;
     /**
      * <pre>
-     * The type of the stored value.
+     * The concrete Evita data type of the stored value, including `COMPLEX_DATA_OBJECT` when the
+     * value is a structured object described via `root` (or the deprecated `jsonValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataDataType.GrpcEvitaDataType type = 100;</code>
@@ -1338,7 +1395,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the stored value.
+     * The concrete Evita data type of the stored value, including `COMPLEX_DATA_OBJECT` when the
+     * value is a structured object described via `root` (or the deprecated `jsonValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataDataType.GrpcEvitaDataType type = 100;</code>
@@ -1353,7 +1411,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the stored value.
+     * The concrete Evita data type of the stored value, including `COMPLEX_DATA_OBJECT` when the
+     * value is a structured object described via `root` (or the deprecated `jsonValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataDataType.GrpcEvitaDataType type = 100;</code>
@@ -1366,7 +1425,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the stored value.
+     * The concrete Evita data type of the stored value, including `COMPLEX_DATA_OBJECT` when the
+     * value is a structured object described via `root` (or the deprecated `jsonValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataDataType.GrpcEvitaDataType type = 100;</code>
@@ -1384,7 +1444,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the stored value.
+     * The concrete Evita data type of the stored value, including `COMPLEX_DATA_OBJECT` when the
+     * value is a structured object described via `root` (or the deprecated `jsonValue`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataDataType.GrpcEvitaDataType type = 100;</code>
@@ -1402,8 +1463,9 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> versionBuilder_;
     /**
      * <pre>
-     * Contains version of this value and gets increased with any entity type update. Allows to execute
-     *			optimistic locking i.e. avoiding parallel modifications.
+     * Version of this associated data value; increases on every update to enable optimistic locking
+     * (concurrent-modification detection). May be null if this value is nested within a larger
+     * complex object.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -1414,8 +1476,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains version of this value and gets increased with any entity type update. Allows to execute
-     *			optimistic locking i.e. avoiding parallel modifications.
+     * Version of this associated data value; increases on every update to enable optimistic locking
+     * (concurrent-modification detection). May be null if this value is nested within a larger
+     * complex object.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -1430,8 +1493,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains version of this value and gets increased with any entity type update. Allows to execute
-     *			optimistic locking i.e. avoiding parallel modifications.
+     * Version of this associated data value; increases on every update to enable optimistic locking
+     * (concurrent-modification detection). May be null if this value is nested within a larger
+     * complex object.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -1451,8 +1515,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains version of this value and gets increased with any entity type update. Allows to execute
-     *			optimistic locking i.e. avoiding parallel modifications.
+     * Version of this associated data value; increases on every update to enable optimistic locking
+     * (concurrent-modification detection). May be null if this value is nested within a larger
+     * complex object.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -1470,8 +1535,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains version of this value and gets increased with any entity type update. Allows to execute
-     *			optimistic locking i.e. avoiding parallel modifications.
+     * Version of this associated data value; increases on every update to enable optimistic locking
+     * (concurrent-modification detection). May be null if this value is nested within a larger
+     * complex object.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -1496,8 +1562,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains version of this value and gets increased with any entity type update. Allows to execute
-     *			optimistic locking i.e. avoiding parallel modifications.
+     * Version of this associated data value; increases on every update to enable optimistic locking
+     * (concurrent-modification detection). May be null if this value is nested within a larger
+     * complex object.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -1514,8 +1581,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains version of this value and gets increased with any entity type update. Allows to execute
-     *			optimistic locking i.e. avoiding parallel modifications.
+     * Version of this associated data value; increases on every update to enable optimistic locking
+     * (concurrent-modification detection). May be null if this value is nested within a larger
+     * complex object.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -1527,8 +1595,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains version of this value and gets increased with any entity type update. Allows to execute
-     *			optimistic locking i.e. avoiding parallel modifications.
+     * Version of this associated data value; increases on every update to enable optimistic locking
+     * (concurrent-modification detection). May be null if this value is nested within a larger
+     * complex object.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -1543,8 +1612,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains version of this value and gets increased with any entity type update. Allows to execute
-     *			optimistic locking i.e. avoiding parallel modifications.
+     * Version of this associated data value; increases on every update to enable optimistic locking
+     * (concurrent-modification detection). May be null if this value is nested within a larger
+     * complex object.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value version = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaAssociatedDataValueOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaAssociatedDataValueOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcEvitaAssociatedDataValueOrBuilder extends
 
   /**
    * <pre>
-   * Primitive value.
+   * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+   * is not a complex/structured object.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcEvitaAssociatedDataValueOrBuilder extends
   boolean hasPrimitiveValue();
   /**
    * <pre>
-   * Primitive value.
+   * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+   * is not a complex/structured object.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcEvitaAssociatedDataValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEvitaValue getPrimitiveValue();
   /**
    * <pre>
-   * Primitive value.
+   * A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+   * is not a complex/structured object.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaValue primitiveValue = 1;</code>
@@ -60,34 +63,43 @@ public interface GrpcEvitaAssociatedDataValueOrBuilder extends
 
   /**
    * <pre>
-   * JSON string value, this old approach led to data type loss and is deprecated.
+   * JSON-encoded `ComplexDataObject` value.
+   * deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+   * TOBEDONE #538: remove once no client older than 2025.4 remains in use
+   * (https://github.com/FgForrest/evitaDB/issues/538)
    * </pre>
    *
    * <code>string jsonValue = 2 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue.jsonValue is deprecated.
-   *     See GrpcEvitaDataTypes.proto;l=310
+   *     See GrpcEvitaDataTypes.proto;l=372
    * @return Whether the jsonValue field is set.
    */
   @java.lang.Deprecated boolean hasJsonValue();
   /**
    * <pre>
-   * JSON string value, this old approach led to data type loss and is deprecated.
+   * JSON-encoded `ComplexDataObject` value.
+   * deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+   * TOBEDONE #538: remove once no client older than 2025.4 remains in use
+   * (https://github.com/FgForrest/evitaDB/issues/538)
    * </pre>
    *
    * <code>string jsonValue = 2 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue.jsonValue is deprecated.
-   *     See GrpcEvitaDataTypes.proto;l=310
+   *     See GrpcEvitaDataTypes.proto;l=372
    * @return The jsonValue.
    */
   @java.lang.Deprecated java.lang.String getJsonValue();
   /**
    * <pre>
-   * JSON string value, this old approach led to data type loss and is deprecated.
+   * JSON-encoded `ComplexDataObject` value.
+   * deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+   * TOBEDONE #538: remove once no client older than 2025.4 remains in use
+   * (https://github.com/FgForrest/evitaDB/issues/538)
    * </pre>
    *
    * <code>string jsonValue = 2 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataValue.jsonValue is deprecated.
-   *     See GrpcEvitaDataTypes.proto;l=310
+   *     See GrpcEvitaDataTypes.proto;l=372
    * @return The bytes for jsonValue.
    */
   @java.lang.Deprecated com.google.protobuf.ByteString
@@ -95,7 +107,8 @@ public interface GrpcEvitaAssociatedDataValueOrBuilder extends
 
   /**
    * <pre>
-   * The array of values.
+   * The root node of a complex (structured) object's tree, recursively described by
+   * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -104,7 +117,8 @@ public interface GrpcEvitaAssociatedDataValueOrBuilder extends
   boolean hasRoot();
   /**
    * <pre>
-   * The array of values.
+   * The root node of a complex (structured) object's tree, recursively described by
+   * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -113,7 +127,8 @@ public interface GrpcEvitaAssociatedDataValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcDataItem getRoot();
   /**
    * <pre>
-   * The array of values.
+   * The root node of a complex (structured) object's tree, recursively described by
+   * `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataItem root = 4;</code>
@@ -122,7 +137,8 @@ public interface GrpcEvitaAssociatedDataValueOrBuilder extends
 
   /**
    * <pre>
-   * The type of the stored value.
+   * The concrete Evita data type of the stored value, including `COMPLEX_DATA_OBJECT` when the
+   * value is a structured object described via `root` (or the deprecated `jsonValue`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataDataType.GrpcEvitaDataType type = 100;</code>
@@ -131,7 +147,8 @@ public interface GrpcEvitaAssociatedDataValueOrBuilder extends
   int getTypeValue();
   /**
    * <pre>
-   * The type of the stored value.
+   * The concrete Evita data type of the stored value, including `COMPLEX_DATA_OBJECT` when the
+   * value is a structured object described via `root` (or the deprecated `jsonValue`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaAssociatedDataDataType.GrpcEvitaDataType type = 100;</code>
@@ -141,8 +158,9 @@ public interface GrpcEvitaAssociatedDataValueOrBuilder extends
 
   /**
    * <pre>
-   * Contains version of this value and gets increased with any entity type update. Allows to execute
-   *			optimistic locking i.e. avoiding parallel modifications.
+   * Version of this associated data value; increases on every update to enable optimistic locking
+   * (concurrent-modification detection). May be null if this value is nested within a larger
+   * complex object.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -151,8 +169,9 @@ public interface GrpcEvitaAssociatedDataValueOrBuilder extends
   boolean hasVersion();
   /**
    * <pre>
-   * Contains version of this value and gets increased with any entity type update. Allows to execute
-   *			optimistic locking i.e. avoiding parallel modifications.
+   * Version of this associated data value; increases on every update to enable optimistic locking
+   * (concurrent-modification detection). May be null if this value is nested within a larger
+   * complex object.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value version = 3;</code>
@@ -161,8 +180,9 @@ public interface GrpcEvitaAssociatedDataValueOrBuilder extends
   com.google.protobuf.Int32Value getVersion();
   /**
    * <pre>
-   * Contains version of this value and gets increased with any entity type update. Allows to execute
-   *			optimistic locking i.e. avoiding parallel modifications.
+   * Version of this associated data value; increases on every update to enable optimistic locking
+   * (concurrent-modification detection). May be null if this value is nested within a larger
+   * complex object.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value version = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaCatalogStatisticsResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaCatalogStatisticsResponse.java
@@ -72,7 +72,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics> catalogStatistics_;
   /**
    * <pre>
-   * Collection of catalog statistics for all catalogs
+   * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+   * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -83,7 +84,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of catalog statistics for all catalogs
+   * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+   * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -95,7 +97,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of catalog statistics for all catalogs
+   * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+   * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -106,7 +109,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of catalog statistics for all catalogs
+   * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+   * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -117,7 +121,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of catalog statistics for all catalogs
+   * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+   * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -520,7 +525,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -534,7 +540,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -548,7 +555,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -562,7 +570,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -583,7 +592,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -601,7 +611,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -621,7 +632,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -642,7 +654,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -660,7 +673,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -678,7 +692,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -697,7 +712,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -714,7 +730,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -731,7 +748,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -742,7 +760,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -756,7 +775,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -771,7 +791,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -782,7 +803,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -794,7 +816,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of catalog statistics for all catalogs
+     * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+     * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaCatalogStatisticsResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaCatalogStatisticsResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcEvitaCatalogStatisticsResponseOrBuilder extends
 
   /**
    * <pre>
-   * Collection of catalog statistics for all catalogs
+   * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+   * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcEvitaCatalogStatisticsResponseOrBuilder extends
       getCatalogStatisticsList();
   /**
    * <pre>
-   * Collection of catalog statistics for all catalogs
+   * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+   * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -50,7 +52,8 @@ public interface GrpcEvitaCatalogStatisticsResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics getCatalogStatistics(int index);
   /**
    * <pre>
-   * Collection of catalog statistics for all catalogs
+   * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+   * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -58,7 +61,8 @@ public interface GrpcEvitaCatalogStatisticsResponseOrBuilder extends
   int getCatalogStatisticsCount();
   /**
    * <pre>
-   * Collection of catalog statistics for all catalogs
+   * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+   * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>
@@ -67,7 +71,8 @@ public interface GrpcEvitaCatalogStatisticsResponseOrBuilder extends
       getCatalogStatisticsOrBuilderList();
   /**
    * <pre>
-   * Collection of catalog statistics for all catalogs
+   * Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+   * `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCatalogStatistics catalogStatistics = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaConfigurationResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaConfigurationResponse.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to an evitaDB configuration request.
+ * Response to an evitaDB configuration request. This RPC (and therefore this response) is
+ * unavailable while the engine runs in read-only mode - see GrpcEvitaEngineSettingsResponse for
+ * the smaller, always-available subset of configuration.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcEvitaConfigurationResponse}
@@ -272,7 +274,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to an evitaDB configuration request.
+   * Response to an evitaDB configuration request. This RPC (and therefore this response) is
+   * unavailable while the engine runs in read-only mode - see GrpcEvitaEngineSettingsResponse for
+   * the smaller, always-available subset of configuration.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcEvitaConfigurationResponse}

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaServerStatusResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaServerStatusResponse.java
@@ -276,7 +276,8 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * Health problems
+   * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+   * means no problems were detected.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -289,7 +290,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Health problems
+   * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+   * means no problems were detected.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -301,7 +303,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Health problems
+   * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+   * means no problems were detected.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -314,7 +317,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Health problems
+   * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+   * means no problems were detected.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -327,7 +331,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Health problems
+   * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+   * means no problems were detected.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -394,7 +399,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Information about all available APIs
+   * Status keyed by API code, for every external API registered on the classpath - including ones
+   * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+   * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+   * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -415,7 +423,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Information about all available APIs
+   * Status keyed by API code, for every external API registered on the classpath - including ones
+   * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+   * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+   * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -426,7 +437,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Information about all available APIs
+   * Status keyed by API code, for every external API registered on the classpath - including ones
+   * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+   * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+   * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -444,7 +458,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
   }
   /**
    * <pre>
-   * Information about all available APIs
+   * Status keyed by API code, for every external API registered on the classpath - including ones
+   * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+   * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+   * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -510,7 +527,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
   private long engineVersion_ = 0L;
   /**
    * <pre>
-   * The version of the current evitaDB server engine state (change in engine state).
+   * Monotonically increasing version number of the engine's own state, distinct from any single
+   * catalog's version - incremented once for each committed engine-level change (e.g. a catalog
+   * being created, removed, renamed, or having its format upgraded or read-only mode toggled).
+   * Ordinary data mutations within a catalog do not advance it.
    * </pre>
    *
    * <code>int64 engineVersion = 13;</code>
@@ -1794,7 +1814,8 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Health problems
+     * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+     * means no problems were detected.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -1806,7 +1827,8 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Health problems
+     * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+     * means no problems were detected.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -1817,7 +1839,8 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Health problems
+     * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+     * means no problems were detected.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -1829,7 +1852,8 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Health problems
+     * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+     * means no problems were detected.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -1849,7 +1873,8 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Health problems
+     * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+     * means no problems were detected.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -1867,7 +1892,8 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Health problems
+     * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+     * means no problems were detected.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -1885,7 +1911,8 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Health problems
+     * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+     * means no problems were detected.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -1899,7 +1926,8 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Health problems
+     * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+     * means no problems were detected.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -1911,7 +1939,8 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Health problems
+     * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+     * means no problems were detected.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -1923,7 +1952,8 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Health problems
+     * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+     * means no problems were detected.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -1940,7 +1970,8 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Health problems
+     * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+     * means no problems were detected.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -1955,7 +1986,8 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Health problems
+     * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+     * means no problems were detected.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -2082,7 +2114,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Information about all available APIs
+     * Status keyed by API code, for every external API registered on the classpath - including ones
+     * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+     * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+     * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -2103,7 +2138,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Information about all available APIs
+     * Status keyed by API code, for every external API registered on the classpath - including ones
+     * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+     * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+     * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -2114,7 +2152,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Information about all available APIs
+     * Status keyed by API code, for every external API registered on the classpath - including ones
+     * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+     * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+     * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -2131,7 +2172,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Information about all available APIs
+     * Status keyed by API code, for every external API registered on the classpath - including ones
+     * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+     * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+     * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -2153,7 +2197,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Information about all available APIs
+     * Status keyed by API code, for every external API registered on the classpath - including ones
+     * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+     * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+     * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -2176,7 +2223,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Information about all available APIs
+     * Status keyed by API code, for every external API registered on the classpath - including ones
+     * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+     * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+     * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -2193,7 +2243,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Information about all available APIs
+     * Status keyed by API code, for every external API registered on the classpath - including ones
+     * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+     * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+     * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -2212,7 +2265,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * Information about all available APIs
+     * Status keyed by API code, for every external API registered on the classpath - including ones
+     * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+     * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+     * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -2367,7 +2423,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     private long engineVersion_ ;
     /**
      * <pre>
-     * The version of the current evitaDB server engine state (change in engine state).
+     * Monotonically increasing version number of the engine's own state, distinct from any single
+     * catalog's version - incremented once for each committed engine-level change (e.g. a catalog
+     * being created, removed, renamed, or having its format upgraded or read-only mode toggled).
+     * Ordinary data mutations within a catalog do not advance it.
      * </pre>
      *
      * <code>int64 engineVersion = 13;</code>
@@ -2379,7 +2438,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * The version of the current evitaDB server engine state (change in engine state).
+     * Monotonically increasing version number of the engine's own state, distinct from any single
+     * catalog's version - incremented once for each committed engine-level change (e.g. a catalog
+     * being created, removed, renamed, or having its format upgraded or read-only mode toggled).
+     * Ordinary data mutations within a catalog do not advance it.
      * </pre>
      *
      * <code>int64 engineVersion = 13;</code>
@@ -2395,7 +2457,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue) {
     }
     /**
      * <pre>
-     * The version of the current evitaDB server engine state (change in engine state).
+     * Monotonically increasing version number of the engine's own state, distinct from any single
+     * catalog's version - incremented once for each committed engine-level change (e.g. a catalog
+     * being created, removed, renamed, or having its format upgraded or read-only mode toggled).
+     * Ordinary data mutations within a catalog do not advance it.
      * </pre>
      *
      * <code>int64 engineVersion = 13;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaServerStatusResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaServerStatusResponseOrBuilder.java
@@ -132,7 +132,8 @@ public interface GrpcEvitaServerStatusResponseOrBuilder extends
 
   /**
    * <pre>
-   * Health problems
+   * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+   * means no problems were detected.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -141,7 +142,8 @@ public interface GrpcEvitaServerStatusResponseOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcHealthProblem> getHealthProblemsList();
   /**
    * <pre>
-   * Health problems
+   * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+   * means no problems were detected.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -150,7 +152,8 @@ public interface GrpcEvitaServerStatusResponseOrBuilder extends
   int getHealthProblemsCount();
   /**
    * <pre>
-   * Health problems
+   * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+   * means no problems were detected.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -160,7 +163,8 @@ public interface GrpcEvitaServerStatusResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcHealthProblem getHealthProblems(int index);
   /**
    * <pre>
-   * Health problems
+   * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+   * means no problems were detected.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -170,7 +174,8 @@ public interface GrpcEvitaServerStatusResponseOrBuilder extends
   getHealthProblemsValueList();
   /**
    * <pre>
-   * Health problems
+   * Health problems currently detected by any of the server's health probes, deduplicated. Empty
+   * means no problems were detected.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHealthProblem healthProblems = 7;</code>
@@ -200,7 +205,10 @@ public interface GrpcEvitaServerStatusResponseOrBuilder extends
 
   /**
    * <pre>
-   * Information about all available APIs
+   * Status keyed by API code, for every external API registered on the classpath - including ones
+   * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+   * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+   * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -208,7 +216,10 @@ public interface GrpcEvitaServerStatusResponseOrBuilder extends
   int getApiCount();
   /**
    * <pre>
-   * Information about all available APIs
+   * Status keyed by API code, for every external API registered on the classpath - including ones
+   * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+   * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+   * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -223,7 +234,10 @@ public interface GrpcEvitaServerStatusResponseOrBuilder extends
   getApi();
   /**
    * <pre>
-   * Information about all available APIs
+   * Status keyed by API code, for every external API registered on the classpath - including ones
+   * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+   * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+   * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -232,7 +246,10 @@ public interface GrpcEvitaServerStatusResponseOrBuilder extends
   getApiMap();
   /**
    * <pre>
-   * Information about all available APIs
+   * Status keyed by API code, for every external API registered on the classpath - including ones
+   * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+   * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+   * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -244,7 +261,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus getApiOrDefault(
 io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue);
   /**
    * <pre>
-   * Information about all available APIs
+   * Status keyed by API code, for every external API registered on the classpath - including ones
+   * that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+   * case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+   * enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcApiStatus&gt; api = 9;</code>
@@ -284,7 +304,10 @@ io.evitadb.externalApi.grpc.generated.GrpcApiStatus defaultValue);
 
   /**
    * <pre>
-   * The version of the current evitaDB server engine state (change in engine state).
+   * Monotonically increasing version number of the engine's own state, distinct from any single
+   * catalog's version - incremented once for each committed engine-level change (e.g. a catalog
+   * being created, removed, renamed, or having its format upgraded or read-only mode toggled).
+   * Ordinary data mutations within a catalog do not advance it.
    * </pre>
    *
    * <code>int64 engineVersion = 13;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionRequest.java
@@ -119,7 +119,10 @@ private static final long serialVersionUID = 0L;
   private int commitBehavior_ = 0;
   /**
    * <pre>
-   * Commit behaviour
+   * Default commit behaviour applied when the session is closed implicitly via `close()` - determines how far a
+   * transaction must be durably persisted before the close is considered complete. Can be overridden per call by
+   * closing the session explicitly with a specific behaviour instead. See `GrpcCommitBehavior` for the available
+   * durability/performance trade-offs.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehavior = 2;</code>
@@ -130,7 +133,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Commit behaviour
+   * Default commit behaviour applied when the session is closed implicitly via `close()` - determines how far a
+   * transaction must be durably persisted before the close is considered complete. Can be overridden per call by
+   * closing the session explicitly with a specific behaviour instead. See `GrpcCommitBehavior` for the available
+   * durability/performance trade-offs.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehavior = 2;</code>
@@ -627,7 +633,10 @@ private static final long serialVersionUID = 0L;
     private int commitBehavior_ = 0;
     /**
      * <pre>
-     * Commit behaviour
+     * Default commit behaviour applied when the session is closed implicitly via `close()` - determines how far a
+     * transaction must be durably persisted before the close is considered complete. Can be overridden per call by
+     * closing the session explicitly with a specific behaviour instead. See `GrpcCommitBehavior` for the available
+     * durability/performance trade-offs.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehavior = 2;</code>
@@ -638,7 +647,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Commit behaviour
+     * Default commit behaviour applied when the session is closed implicitly via `close()` - determines how far a
+     * transaction must be durably persisted before the close is considered complete. Can be overridden per call by
+     * closing the session explicitly with a specific behaviour instead. See `GrpcCommitBehavior` for the available
+     * durability/performance trade-offs.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehavior = 2;</code>
@@ -653,7 +665,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Commit behaviour
+     * Default commit behaviour applied when the session is closed implicitly via `close()` - determines how far a
+     * transaction must be durably persisted before the close is considered complete. Can be overridden per call by
+     * closing the session explicitly with a specific behaviour instead. See `GrpcCommitBehavior` for the available
+     * durability/performance trade-offs.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehavior = 2;</code>
@@ -666,7 +681,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Commit behaviour
+     * Default commit behaviour applied when the session is closed implicitly via `close()` - determines how far a
+     * transaction must be durably persisted before the close is considered complete. Can be overridden per call by
+     * closing the session explicitly with a specific behaviour instead. See `GrpcCommitBehavior` for the available
+     * durability/performance trade-offs.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehavior = 2;</code>
@@ -684,7 +702,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Commit behaviour
+     * Default commit behaviour applied when the session is closed implicitly via `close()` - determines how far a
+     * transaction must be durably persisted before the close is considered complete. Can be overridden per call by
+     * closing the session explicitly with a specific behaviour instead. See `GrpcCommitBehavior` for the available
+     * durability/performance trade-offs.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehavior = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionRequestOrBuilder.java
@@ -53,7 +53,10 @@ public interface GrpcEvitaSessionRequestOrBuilder extends
 
   /**
    * <pre>
-   * Commit behaviour
+   * Default commit behaviour applied when the session is closed implicitly via `close()` - determines how far a
+   * transaction must be durably persisted before the close is considered complete. Can be overridden per call by
+   * closing the session explicitly with a specific behaviour instead. See `GrpcCommitBehavior` for the available
+   * durability/performance trade-offs.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehavior = 2;</code>
@@ -62,7 +65,10 @@ public interface GrpcEvitaSessionRequestOrBuilder extends
   int getCommitBehaviorValue();
   /**
    * <pre>
-   * Commit behaviour
+   * Default commit behaviour applied when the session is closed implicitly via `close()` - determines how far a
+   * transaction must be durably persisted before the close is considered complete. Can be overridden per call by
+   * closing the session explicitly with a specific behaviour instead. See `GrpcCommitBehavior` for the available
+   * durability/performance trade-offs.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehavior = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionResponse.java
@@ -122,7 +122,8 @@ private static final long serialVersionUID = 0L;
   private int sessionType_ = 0;
   /**
    * <pre>
-   * Type of the created session.
+   * Type of the created session - read-only vs. read-write, and whether fetched entities are returned in binary
+   * form for the Java driver (`BINARY_*` variants). See `GrpcSessionType`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSessionType sessionType = 2;</code>
@@ -133,7 +134,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Type of the created session.
+   * Type of the created session - read-only vs. read-write, and whether fetched entities are returned in binary
+   * form for the Java driver (`BINARY_*` variants). See `GrpcSessionType`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSessionType sessionType = 2;</code>
@@ -148,7 +150,8 @@ private static final long serialVersionUID = 0L;
   private int commitBehaviour_ = 0;
   /**
    * <pre>
-   * Commit behaviour
+   * Effective commit behaviour of the created session, applied when the session is closed implicitly via
+   * `close()`. See `GrpcCommitBehavior` for the available durability/performance trade-offs.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehaviour = 3;</code>
@@ -159,7 +162,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Commit behaviour
+   * Effective commit behaviour of the created session, applied when the session is closed implicitly via
+   * `close()`. See `GrpcCommitBehavior` for the available durability/performance trade-offs.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehaviour = 3;</code>
@@ -758,7 +762,8 @@ private static final long serialVersionUID = 0L;
     private int sessionType_ = 0;
     /**
      * <pre>
-     * Type of the created session.
+     * Type of the created session - read-only vs. read-write, and whether fetched entities are returned in binary
+     * form for the Java driver (`BINARY_*` variants). See `GrpcSessionType`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSessionType sessionType = 2;</code>
@@ -769,7 +774,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Type of the created session.
+     * Type of the created session - read-only vs. read-write, and whether fetched entities are returned in binary
+     * form for the Java driver (`BINARY_*` variants). See `GrpcSessionType`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSessionType sessionType = 2;</code>
@@ -784,7 +790,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Type of the created session.
+     * Type of the created session - read-only vs. read-write, and whether fetched entities are returned in binary
+     * form for the Java driver (`BINARY_*` variants). See `GrpcSessionType`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSessionType sessionType = 2;</code>
@@ -797,7 +804,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Type of the created session.
+     * Type of the created session - read-only vs. read-write, and whether fetched entities are returned in binary
+     * form for the Java driver (`BINARY_*` variants). See `GrpcSessionType`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSessionType sessionType = 2;</code>
@@ -815,7 +823,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Type of the created session.
+     * Type of the created session - read-only vs. read-write, and whether fetched entities are returned in binary
+     * form for the Java driver (`BINARY_*` variants). See `GrpcSessionType`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSessionType sessionType = 2;</code>
@@ -831,7 +840,8 @@ private static final long serialVersionUID = 0L;
     private int commitBehaviour_ = 0;
     /**
      * <pre>
-     * Commit behaviour
+     * Effective commit behaviour of the created session, applied when the session is closed implicitly via
+     * `close()`. See `GrpcCommitBehavior` for the available durability/performance trade-offs.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehaviour = 3;</code>
@@ -842,7 +852,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Commit behaviour
+     * Effective commit behaviour of the created session, applied when the session is closed implicitly via
+     * `close()`. See `GrpcCommitBehavior` for the available durability/performance trade-offs.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehaviour = 3;</code>
@@ -857,7 +868,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Commit behaviour
+     * Effective commit behaviour of the created session, applied when the session is closed implicitly via
+     * `close()`. See `GrpcCommitBehavior` for the available durability/performance trade-offs.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehaviour = 3;</code>
@@ -870,7 +882,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Commit behaviour
+     * Effective commit behaviour of the created session, applied when the session is closed implicitly via
+     * `close()`. See `GrpcCommitBehavior` for the available durability/performance trade-offs.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehaviour = 3;</code>
@@ -888,7 +901,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Commit behaviour
+     * Effective commit behaviour of the created session, applied when the session is closed implicitly via
+     * `close()`. See `GrpcCommitBehavior` for the available durability/performance trade-offs.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehaviour = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionResponseOrBuilder.java
@@ -53,7 +53,8 @@ public interface GrpcEvitaSessionResponseOrBuilder extends
 
   /**
    * <pre>
-   * Type of the created session.
+   * Type of the created session - read-only vs. read-write, and whether fetched entities are returned in binary
+   * form for the Java driver (`BINARY_*` variants). See `GrpcSessionType`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSessionType sessionType = 2;</code>
@@ -62,7 +63,8 @@ public interface GrpcEvitaSessionResponseOrBuilder extends
   int getSessionTypeValue();
   /**
    * <pre>
-   * Type of the created session.
+   * Type of the created session - read-only vs. read-write, and whether fetched entities are returned in binary
+   * form for the Java driver (`BINARY_*` variants). See `GrpcSessionType`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSessionType sessionType = 2;</code>
@@ -72,7 +74,8 @@ public interface GrpcEvitaSessionResponseOrBuilder extends
 
   /**
    * <pre>
-   * Commit behaviour
+   * Effective commit behaviour of the created session, applied when the session is closed implicitly via
+   * `close()`. See `GrpcCommitBehavior` for the available durability/performance trade-offs.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehaviour = 3;</code>
@@ -81,7 +84,8 @@ public interface GrpcEvitaSessionResponseOrBuilder extends
   int getCommitBehaviourValue();
   /**
    * <pre>
-   * Commit behaviour
+   * Effective commit behaviour of the created session, applied when the session is closed implicitly via
+   * `close()`. See `GrpcCommitBehavior` for the available durability/performance trade-offs.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCommitBehavior commitBehaviour = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaTrafficRecordingServiceGrpc.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaTrafficRecordingServiceGrpc.java
@@ -26,6 +26,11 @@ package io.evitadb.externalApi.grpc.generated;
 import static io.grpc.MethodDescriptor.generateFullMethodName;
 
 /**
+ * <pre>
+ * This service contains RPCs that could be called by gRPC clients on evitaDB's catalog by usage of a before created
+ * session. Main purpose of this service is to provide a way to query and manage recorded traffic (queries, mutations,
+ * session lifecycle events) captured for diagnostics.
+ * </pre>
  */
 @io.grpc.stub.annotations.GrpcGenerated
 public final class GrpcEvitaTrafficRecordingServiceGrpc {
@@ -343,6 +348,11 @@ public final class GrpcEvitaTrafficRecordingServiceGrpc {
   }
 
   /**
+   * <pre>
+   * This service contains RPCs that could be called by gRPC clients on evitaDB's catalog by usage of a before created
+   * session. Main purpose of this service is to provide a way to query and manage recorded traffic (queries, mutations,
+   * session lifecycle events) captured for diagnostics.
+   * </pre>
    */
   public interface AsyncService {
 
@@ -404,7 +414,8 @@ public final class GrpcEvitaTrafficRecordingServiceGrpc {
 
     /**
      * <pre>
-     * Procedure that starts the traffic recording for the given criteria and settings
+     * Procedure that starts the traffic recording for the given criteria and settings. Fails if a recording is
+     * already in progress - only one recording may run at a time.
      * </pre>
      */
     default void startTrafficRecording(io.evitadb.externalApi.grpc.generated.GrpcStartTrafficRecordingRequest request,
@@ -436,6 +447,11 @@ public final class GrpcEvitaTrafficRecordingServiceGrpc {
 
   /**
    * Base class for the server implementation of the service GrpcEvitaTrafficRecordingService.
+   * <pre>
+   * This service contains RPCs that could be called by gRPC clients on evitaDB's catalog by usage of a before created
+   * session. Main purpose of this service is to provide a way to query and manage recorded traffic (queries, mutations,
+   * session lifecycle events) captured for diagnostics.
+   * </pre>
    */
   public static abstract class GrpcEvitaTrafficRecordingServiceImplBase
       implements io.grpc.BindableService, AsyncService {
@@ -447,6 +463,11 @@ public final class GrpcEvitaTrafficRecordingServiceGrpc {
 
   /**
    * A stub to allow clients to do asynchronous rpc calls to service GrpcEvitaTrafficRecordingService.
+   * <pre>
+   * This service contains RPCs that could be called by gRPC clients on evitaDB's catalog by usage of a before created
+   * session. Main purpose of this service is to provide a way to query and manage recorded traffic (queries, mutations,
+   * session lifecycle events) captured for diagnostics.
+   * </pre>
    */
   public static final class GrpcEvitaTrafficRecordingServiceStub
       extends io.grpc.stub.AbstractAsyncStub<GrpcEvitaTrafficRecordingServiceStub> {
@@ -524,7 +545,8 @@ public final class GrpcEvitaTrafficRecordingServiceGrpc {
 
     /**
      * <pre>
-     * Procedure that starts the traffic recording for the given criteria and settings
+     * Procedure that starts the traffic recording for the given criteria and settings. Fails if a recording is
+     * already in progress - only one recording may run at a time.
      * </pre>
      */
     public void startTrafficRecording(io.evitadb.externalApi.grpc.generated.GrpcStartTrafficRecordingRequest request,
@@ -559,6 +581,11 @@ public final class GrpcEvitaTrafficRecordingServiceGrpc {
 
   /**
    * A stub to allow clients to do synchronous rpc calls to service GrpcEvitaTrafficRecordingService.
+   * <pre>
+   * This service contains RPCs that could be called by gRPC clients on evitaDB's catalog by usage of a before created
+   * session. Main purpose of this service is to provide a way to query and manage recorded traffic (queries, mutations,
+   * session lifecycle events) captured for diagnostics.
+   * </pre>
    */
   public static final class GrpcEvitaTrafficRecordingServiceBlockingV2Stub
       extends io.grpc.stub.AbstractBlockingStub<GrpcEvitaTrafficRecordingServiceBlockingV2Stub> {
@@ -633,7 +660,8 @@ public final class GrpcEvitaTrafficRecordingServiceGrpc {
 
     /**
      * <pre>
-     * Procedure that starts the traffic recording for the given criteria and settings
+     * Procedure that starts the traffic recording for the given criteria and settings. Fails if a recording is
+     * already in progress - only one recording may run at a time.
      * </pre>
      */
     public io.evitadb.externalApi.grpc.generated.GetTrafficRecordingStatusResponse startTrafficRecording(io.evitadb.externalApi.grpc.generated.GrpcStartTrafficRecordingRequest request) throws io.grpc.StatusException {
@@ -665,6 +693,11 @@ public final class GrpcEvitaTrafficRecordingServiceGrpc {
 
   /**
    * A stub to allow clients to do limited synchronous rpc calls to service GrpcEvitaTrafficRecordingService.
+   * <pre>
+   * This service contains RPCs that could be called by gRPC clients on evitaDB's catalog by usage of a before created
+   * session. Main purpose of this service is to provide a way to query and manage recorded traffic (queries, mutations,
+   * session lifecycle events) captured for diagnostics.
+   * </pre>
    */
   public static final class GrpcEvitaTrafficRecordingServiceBlockingStub
       extends io.grpc.stub.AbstractBlockingStub<GrpcEvitaTrafficRecordingServiceBlockingStub> {
@@ -738,7 +771,8 @@ public final class GrpcEvitaTrafficRecordingServiceGrpc {
 
     /**
      * <pre>
-     * Procedure that starts the traffic recording for the given criteria and settings
+     * Procedure that starts the traffic recording for the given criteria and settings. Fails if a recording is
+     * already in progress - only one recording may run at a time.
      * </pre>
      */
     public io.evitadb.externalApi.grpc.generated.GetTrafficRecordingStatusResponse startTrafficRecording(io.evitadb.externalApi.grpc.generated.GrpcStartTrafficRecordingRequest request) {
@@ -770,6 +804,11 @@ public final class GrpcEvitaTrafficRecordingServiceGrpc {
 
   /**
    * A stub to allow clients to do ListenableFuture-style rpc calls to service GrpcEvitaTrafficRecordingService.
+   * <pre>
+   * This service contains RPCs that could be called by gRPC clients on evitaDB's catalog by usage of a before created
+   * session. Main purpose of this service is to provide a way to query and manage recorded traffic (queries, mutations,
+   * session lifecycle events) captured for diagnostics.
+   * </pre>
    */
   public static final class GrpcEvitaTrafficRecordingServiceFutureStub
       extends io.grpc.stub.AbstractFutureStub<GrpcEvitaTrafficRecordingServiceFutureStub> {
@@ -834,7 +873,8 @@ public final class GrpcEvitaTrafficRecordingServiceGrpc {
 
     /**
      * <pre>
-     * Procedure that starts the traffic recording for the given criteria and settings
+     * Procedure that starts the traffic recording for the given criteria and settings. Fails if a recording is
+     * already in progress - only one recording may run at a time.
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<io.evitadb.externalApi.grpc.generated.GetTrafficRecordingStatusResponse> startTrafficRecording(

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaValue.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaValue.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Structure that holds one of the supported data type values, its type and version of stored value.
+ * Structure that holds a single attribute/default-value value together with its declared Evita
+ * data type and optimistic-locking version.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcEvitaValue}
@@ -163,7 +164,8 @@ private static final long serialVersionUID = 0L;
   public static final int STRINGVALUE_FIELD_NUMBER = 1;
   /**
    * <pre>
-   * String value.
+   * String value (Java `String`). Also carries a `Character` value, as a single-character
+   * string, when `type` is `CHARACTER`.
    * </pre>
    *
    * <code>string stringValue = 1;</code>
@@ -174,7 +176,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * String value.
+   * String value (Java `String`). Also carries a `Character` value, as a single-character
+   * string, when `type` is `CHARACTER`.
    * </pre>
    *
    * <code>string stringValue = 1;</code>
@@ -199,7 +202,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * String value.
+   * String value (Java `String`). Also carries a `Character` value, as a single-character
+   * string, when `type` is `CHARACTER`.
    * </pre>
    *
    * <code>string stringValue = 1;</code>
@@ -227,7 +231,8 @@ private static final long serialVersionUID = 0L;
   public static final int INTEGERVALUE_FIELD_NUMBER = 2;
   /**
    * <pre>
-   * Integer value.
+   * Integer value (Java `int`). Also carries `Byte` and `Short` values, widened to int32, when
+   * `type` is `BYTE` or `SHORT`.
    * </pre>
    *
    * <code>int32 integerValue = 2;</code>
@@ -239,7 +244,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Integer value.
+   * Integer value (Java `int`). Also carries `Byte` and `Short` values, widened to int32, when
+   * `type` is `BYTE` or `SHORT`.
    * </pre>
    *
    * <code>int32 integerValue = 2;</code>
@@ -256,7 +262,7 @@ private static final long serialVersionUID = 0L;
   public static final int LONGVALUE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   * Long value.
+   * Long value (Java `long`).
    * </pre>
    *
    * <code>int64 longValue = 3;</code>
@@ -268,7 +274,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Long value.
+   * Long value (Java `long`).
    * </pre>
    *
    * <code>int64 longValue = 3;</code>
@@ -285,7 +291,7 @@ private static final long serialVersionUID = 0L;
   public static final int BOOLEANVALUE_FIELD_NUMBER = 4;
   /**
    * <pre>
-   * Boolean value.
+   * Boolean value (Java `boolean`).
    * </pre>
    *
    * <code>bool booleanValue = 4;</code>
@@ -297,7 +303,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Boolean value.
+   * Boolean value (Java `boolean`).
    * </pre>
    *
    * <code>bool booleanValue = 4;</code>
@@ -314,7 +320,7 @@ private static final long serialVersionUID = 0L;
   public static final int BIGDECIMALVALUE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   * BigDecimal value.
+   * BigDecimal value (Java `BigDecimal`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -326,7 +332,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * BigDecimal value.
+   * BigDecimal value (Java `BigDecimal`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -341,7 +347,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * BigDecimal value.
+   * BigDecimal value (Java `BigDecimal`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -357,7 +363,7 @@ private static final long serialVersionUID = 0L;
   public static final int DATETIMERANGEVALUE_FIELD_NUMBER = 6;
   /**
    * <pre>
-   * DateTimeRange value.
+   * DateTimeRange value (evitaDB `DateTimeRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -369,7 +375,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * DateTimeRange value.
+   * DateTimeRange value (evitaDB `DateTimeRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -384,7 +390,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * DateTimeRange value.
+   * DateTimeRange value (evitaDB `DateTimeRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -400,7 +406,8 @@ private static final long serialVersionUID = 0L;
   public static final int INTEGERNUMBERRANGEVALUE_FIELD_NUMBER = 7;
   /**
    * <pre>
-   * IntegerNumberRange value.
+   * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+   * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -412,7 +419,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * IntegerNumberRange value.
+   * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+   * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -427,7 +435,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * IntegerNumberRange value.
+   * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+   * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -443,7 +452,7 @@ private static final long serialVersionUID = 0L;
   public static final int LONGNUMBERRANGEVALUE_FIELD_NUMBER = 8;
   /**
    * <pre>
-   * LongNumberRange value.
+   * LongNumberRange value (evitaDB `LongNumberRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -455,7 +464,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * LongNumberRange value.
+   * LongNumberRange value (evitaDB `LongNumberRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -470,7 +479,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * LongNumberRange value.
+   * LongNumberRange value (evitaDB `LongNumberRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -486,7 +495,7 @@ private static final long serialVersionUID = 0L;
   public static final int BIGDECIMALNUMBERRANGEVALUE_FIELD_NUMBER = 9;
   /**
    * <pre>
-   * BigDecimalNumberRange value.
+   * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -498,7 +507,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * BigDecimalNumberRange value.
+   * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -513,7 +522,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * BigDecimalNumberRange value.
+   * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -529,7 +538,9 @@ private static final long serialVersionUID = 0L;
   public static final int OFFSETDATETIMEVALUE_FIELD_NUMBER = 10;
   /**
    * <pre>
-   * OffsetDateTime value.
+   * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+   * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+   * respectively.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -541,7 +552,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * OffsetDateTime value.
+   * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+   * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+   * respectively.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -556,7 +569,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * OffsetDateTime value.
+   * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+   * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+   * respectively.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -572,7 +587,7 @@ private static final long serialVersionUID = 0L;
   public static final int LOCALEVALUE_FIELD_NUMBER = 11;
   /**
    * <pre>
-   * Locale value.
+   * Locale value (Java `Locale`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -584,7 +599,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Locale value.
+   * Locale value (Java `Locale`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -599,7 +614,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Locale value.
+   * Locale value (Java `Locale`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -615,7 +630,7 @@ private static final long serialVersionUID = 0L;
   public static final int CURRENCYVALUE_FIELD_NUMBER = 12;
   /**
    * <pre>
-   * Currency value.
+   * Currency value (Java `Currency`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -627,7 +642,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Currency value.
+   * Currency value (Java `Currency`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -642,7 +657,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Currency value.
+   * Currency value (Java `Currency`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -658,7 +673,7 @@ private static final long serialVersionUID = 0L;
   public static final int UUIDVALUE_FIELD_NUMBER = 13;
   /**
    * <pre>
-   * UUID value.
+   * UUID value (Java `UUID`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -670,7 +685,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * UUID value.
+   * UUID value (Java `UUID`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -685,7 +700,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * UUID value.
+   * UUID value (Java `UUID`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -701,7 +716,8 @@ private static final long serialVersionUID = 0L;
   public static final int PREDECESSORVALUE_FIELD_NUMBER = 14;
   /**
    * <pre>
-   * Predecessor value.
+   * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+   * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -713,7 +729,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Predecessor value.
+   * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+   * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -728,7 +745,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Predecessor value.
+   * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+   * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -744,7 +762,8 @@ private static final long serialVersionUID = 0L;
   public static final int STRINGARRAYVALUE_FIELD_NUMBER = 50;
   /**
    * <pre>
-   * Array of string values.
+   * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+   * single-character string, when `type` is `CHARACTER_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -756,7 +775,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of string values.
+   * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+   * single-character string, when `type` is `CHARACTER_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -771,7 +791,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of string values.
+   * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+   * single-character string, when `type` is `CHARACTER_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -787,7 +808,8 @@ private static final long serialVersionUID = 0L;
   public static final int INTEGERARRAYVALUE_FIELD_NUMBER = 51;
   /**
    * <pre>
-   * Array of integer values.
+   * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+   * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -799,7 +821,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of integer values.
+   * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+   * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -814,7 +837,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of integer values.
+   * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+   * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -830,7 +854,7 @@ private static final long serialVersionUID = 0L;
   public static final int LONGARRAYVALUE_FIELD_NUMBER = 52;
   /**
    * <pre>
-   * Array of long values.
+   * Long array value (Java `Long[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -842,7 +866,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of long values.
+   * Long array value (Java `Long[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -857,7 +881,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of long values.
+   * Long array value (Java `Long[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -873,7 +897,7 @@ private static final long serialVersionUID = 0L;
   public static final int BOOLEANARRAYVALUE_FIELD_NUMBER = 53;
   /**
    * <pre>
-   * Array of boolean values.
+   * Boolean array value (Java `Boolean[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -885,7 +909,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of boolean values.
+   * Boolean array value (Java `Boolean[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -900,7 +924,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of boolean values.
+   * Boolean array value (Java `Boolean[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -916,7 +940,7 @@ private static final long serialVersionUID = 0L;
   public static final int BIGDECIMALARRAYVALUE_FIELD_NUMBER = 54;
   /**
    * <pre>
-   * Array of BigDecimal values.
+   * BigDecimal array value (Java `BigDecimal[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -928,7 +952,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of BigDecimal values.
+   * BigDecimal array value (Java `BigDecimal[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -943,7 +967,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of BigDecimal values.
+   * BigDecimal array value (Java `BigDecimal[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -959,7 +983,7 @@ private static final long serialVersionUID = 0L;
   public static final int DATETIMERANGEARRAYVALUE_FIELD_NUMBER = 55;
   /**
    * <pre>
-   * Array of DateTimeRange values.
+   * DateTimeRange array value (evitaDB `DateTimeRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -971,7 +995,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of DateTimeRange values.
+   * DateTimeRange array value (evitaDB `DateTimeRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -986,7 +1010,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of DateTimeRange values.
+   * DateTimeRange array value (evitaDB `DateTimeRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -1002,7 +1026,9 @@ private static final long serialVersionUID = 0L;
   public static final int INTEGERNUMBERRANGEARRAYVALUE_FIELD_NUMBER = 56;
   /**
    * <pre>
-   * Array of IntegerNumberRange values.
+   * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+   * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+   * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -1014,7 +1040,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of IntegerNumberRange values.
+   * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+   * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+   * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -1029,7 +1057,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of IntegerNumberRange values.
+   * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+   * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+   * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -1045,7 +1075,7 @@ private static final long serialVersionUID = 0L;
   public static final int LONGNUMBERRANGEARRAYVALUE_FIELD_NUMBER = 57;
   /**
    * <pre>
-   * Array of LongNumberRange values.
+   * LongNumberRange array value (evitaDB `LongNumberRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -1057,7 +1087,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of LongNumberRange values.
+   * LongNumberRange array value (evitaDB `LongNumberRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -1072,7 +1102,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of LongNumberRange values.
+   * LongNumberRange array value (evitaDB `LongNumberRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -1088,7 +1118,7 @@ private static final long serialVersionUID = 0L;
   public static final int BIGDECIMALNUMBERRANGEARRAYVALUE_FIELD_NUMBER = 58;
   /**
    * <pre>
-   * Array of BigDecimalNumberRange values.
+   * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -1100,7 +1130,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of BigDecimalNumberRange values.
+   * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -1115,7 +1145,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of BigDecimalNumberRange values.
+   * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -1131,7 +1161,9 @@ private static final long serialVersionUID = 0L;
   public static final int OFFSETDATETIMEARRAYVALUE_FIELD_NUMBER = 59;
   /**
    * <pre>
-   * Array of OffsetDateTime values.
+   * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+   * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+   * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -1143,7 +1175,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of OffsetDateTime values.
+   * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+   * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+   * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -1158,7 +1192,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of OffsetDateTime values.
+   * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+   * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+   * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -1174,7 +1210,7 @@ private static final long serialVersionUID = 0L;
   public static final int LOCALEARRAYVALUE_FIELD_NUMBER = 60;
   /**
    * <pre>
-   * Array of Locale values.
+   * Locale array value (Java `Locale[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -1186,7 +1222,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of Locale values.
+   * Locale array value (Java `Locale[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -1201,7 +1237,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of Locale values.
+   * Locale array value (Java `Locale[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -1217,7 +1253,7 @@ private static final long serialVersionUID = 0L;
   public static final int CURRENCYARRAYVALUE_FIELD_NUMBER = 61;
   /**
    * <pre>
-   * Array of Currency values.
+   * Currency array value (Java `Currency[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -1229,7 +1265,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of Currency values.
+   * Currency array value (Java `Currency[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -1244,7 +1280,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of Currency values.
+   * Currency array value (Java `Currency[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -1260,7 +1296,7 @@ private static final long serialVersionUID = 0L;
   public static final int UUIDARRAYVALUE_FIELD_NUMBER = 62;
   /**
    * <pre>
-   * Array of UUID values.
+   * UUID array value (Java `UUID[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -1272,7 +1308,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of UUID values.
+   * UUID array value (Java `UUID[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -1287,7 +1323,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Array of UUID values.
+   * UUID array value (Java `UUID[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -1304,7 +1340,8 @@ private static final long serialVersionUID = 0L;
   private int type_ = 0;
   /**
    * <pre>
-   * The type of the stored value.
+   * The concrete Evita/Java data type represented by the `value` oneof above (see each arm's
+   * comment for which narrower types it also stands in for).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaDataType type = 100;</code>
@@ -1315,7 +1352,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The type of the stored value.
+   * The concrete Evita/Java data type represented by the `value` oneof above (see each arm's
+   * comment for which narrower types it also stands in for).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaDataType type = 100;</code>
@@ -1962,7 +2000,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Structure that holds one of the supported data type values, its type and version of stored value.
+   * Structure that holds a single attribute/default-value value together with its declared Evita
+   * data type and optimistic-locking version.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcEvitaValue}
@@ -2644,7 +2683,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * String value.
+     * String value (Java `String`). Also carries a `Character` value, as a single-character
+     * string, when `type` is `CHARACTER`.
      * </pre>
      *
      * <code>string stringValue = 1;</code>
@@ -2656,7 +2696,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * String value.
+     * String value (Java `String`). Also carries a `Character` value, as a single-character
+     * string, when `type` is `CHARACTER`.
      * </pre>
      *
      * <code>string stringValue = 1;</code>
@@ -2682,7 +2723,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * String value.
+     * String value (Java `String`). Also carries a `Character` value, as a single-character
+     * string, when `type` is `CHARACTER`.
      * </pre>
      *
      * <code>string stringValue = 1;</code>
@@ -2709,7 +2751,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * String value.
+     * String value (Java `String`). Also carries a `Character` value, as a single-character
+     * string, when `type` is `CHARACTER`.
      * </pre>
      *
      * <code>string stringValue = 1;</code>
@@ -2726,7 +2769,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * String value.
+     * String value (Java `String`). Also carries a `Character` value, as a single-character
+     * string, when `type` is `CHARACTER`.
      * </pre>
      *
      * <code>string stringValue = 1;</code>
@@ -2742,7 +2786,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * String value.
+     * String value (Java `String`). Also carries a `Character` value, as a single-character
+     * string, when `type` is `CHARACTER`.
      * </pre>
      *
      * <code>string stringValue = 1;</code>
@@ -2761,7 +2806,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Integer value.
+     * Integer value (Java `int`). Also carries `Byte` and `Short` values, widened to int32, when
+     * `type` is `BYTE` or `SHORT`.
      * </pre>
      *
      * <code>int32 integerValue = 2;</code>
@@ -2772,7 +2818,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Integer value.
+     * Integer value (Java `int`). Also carries `Byte` and `Short` values, widened to int32, when
+     * `type` is `BYTE` or `SHORT`.
      * </pre>
      *
      * <code>int32 integerValue = 2;</code>
@@ -2786,7 +2833,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Integer value.
+     * Integer value (Java `int`). Also carries `Byte` and `Short` values, widened to int32, when
+     * `type` is `BYTE` or `SHORT`.
      * </pre>
      *
      * <code>int32 integerValue = 2;</code>
@@ -2802,7 +2850,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Integer value.
+     * Integer value (Java `int`). Also carries `Byte` and `Short` values, widened to int32, when
+     * `type` is `BYTE` or `SHORT`.
      * </pre>
      *
      * <code>int32 integerValue = 2;</code>
@@ -2819,7 +2868,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Long value.
+     * Long value (Java `long`).
      * </pre>
      *
      * <code>int64 longValue = 3;</code>
@@ -2830,7 +2879,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Long value.
+     * Long value (Java `long`).
      * </pre>
      *
      * <code>int64 longValue = 3;</code>
@@ -2844,7 +2893,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Long value.
+     * Long value (Java `long`).
      * </pre>
      *
      * <code>int64 longValue = 3;</code>
@@ -2860,7 +2909,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Long value.
+     * Long value (Java `long`).
      * </pre>
      *
      * <code>int64 longValue = 3;</code>
@@ -2877,7 +2926,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Boolean value.
+     * Boolean value (Java `boolean`).
      * </pre>
      *
      * <code>bool booleanValue = 4;</code>
@@ -2888,7 +2937,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Boolean value.
+     * Boolean value (Java `boolean`).
      * </pre>
      *
      * <code>bool booleanValue = 4;</code>
@@ -2902,7 +2951,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Boolean value.
+     * Boolean value (Java `boolean`).
      * </pre>
      *
      * <code>bool booleanValue = 4;</code>
@@ -2918,7 +2967,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Boolean value.
+     * Boolean value (Java `boolean`).
      * </pre>
      *
      * <code>bool booleanValue = 4;</code>
@@ -2937,7 +2986,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBigDecimal, io.evitadb.externalApi.grpc.generated.GrpcBigDecimal.Builder, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalOrBuilder> bigDecimalValueBuilder_;
     /**
      * <pre>
-     * BigDecimal value.
+     * BigDecimal value (Java `BigDecimal`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -2949,7 +2998,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimal value.
+     * BigDecimal value (Java `BigDecimal`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -2971,7 +3020,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimal value.
+     * BigDecimal value (Java `BigDecimal`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -2991,7 +3040,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimal value.
+     * BigDecimal value (Java `BigDecimal`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -3009,7 +3058,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimal value.
+     * BigDecimal value (Java `BigDecimal`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -3036,7 +3085,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimal value.
+     * BigDecimal value (Java `BigDecimal`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -3059,7 +3108,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimal value.
+     * BigDecimal value (Java `BigDecimal`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -3069,7 +3118,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimal value.
+     * BigDecimal value (Java `BigDecimal`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -3087,7 +3136,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimal value.
+     * BigDecimal value (Java `BigDecimal`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -3115,7 +3164,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange, io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange.Builder, io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeOrBuilder> dateTimeRangeValueBuilder_;
     /**
      * <pre>
-     * DateTimeRange value.
+     * DateTimeRange value (evitaDB `DateTimeRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -3127,7 +3176,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * DateTimeRange value.
+     * DateTimeRange value (evitaDB `DateTimeRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -3149,7 +3198,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * DateTimeRange value.
+     * DateTimeRange value (evitaDB `DateTimeRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -3169,7 +3218,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * DateTimeRange value.
+     * DateTimeRange value (evitaDB `DateTimeRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -3187,7 +3236,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * DateTimeRange value.
+     * DateTimeRange value (evitaDB `DateTimeRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -3214,7 +3263,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * DateTimeRange value.
+     * DateTimeRange value (evitaDB `DateTimeRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -3237,7 +3286,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * DateTimeRange value.
+     * DateTimeRange value (evitaDB `DateTimeRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -3247,7 +3296,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * DateTimeRange value.
+     * DateTimeRange value (evitaDB `DateTimeRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -3265,7 +3314,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * DateTimeRange value.
+     * DateTimeRange value (evitaDB `DateTimeRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -3293,7 +3342,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange, io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange.Builder, io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeOrBuilder> integerNumberRangeValueBuilder_;
     /**
      * <pre>
-     * IntegerNumberRange value.
+     * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+     * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -3305,7 +3355,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * IntegerNumberRange value.
+     * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+     * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -3327,7 +3378,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * IntegerNumberRange value.
+     * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+     * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -3347,7 +3399,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * IntegerNumberRange value.
+     * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+     * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -3365,7 +3418,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * IntegerNumberRange value.
+     * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+     * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -3392,7 +3446,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * IntegerNumberRange value.
+     * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+     * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -3415,7 +3470,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * IntegerNumberRange value.
+     * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+     * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -3425,7 +3481,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * IntegerNumberRange value.
+     * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+     * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -3443,7 +3500,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * IntegerNumberRange value.
+     * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+     * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -3471,7 +3529,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange, io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange.Builder, io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeOrBuilder> longNumberRangeValueBuilder_;
     /**
      * <pre>
-     * LongNumberRange value.
+     * LongNumberRange value (evitaDB `LongNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -3483,7 +3541,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * LongNumberRange value.
+     * LongNumberRange value (evitaDB `LongNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -3505,7 +3563,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * LongNumberRange value.
+     * LongNumberRange value (evitaDB `LongNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -3525,7 +3583,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * LongNumberRange value.
+     * LongNumberRange value (evitaDB `LongNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -3543,7 +3601,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * LongNumberRange value.
+     * LongNumberRange value (evitaDB `LongNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -3570,7 +3628,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * LongNumberRange value.
+     * LongNumberRange value (evitaDB `LongNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -3593,7 +3651,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * LongNumberRange value.
+     * LongNumberRange value (evitaDB `LongNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -3603,7 +3661,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * LongNumberRange value.
+     * LongNumberRange value (evitaDB `LongNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -3621,7 +3679,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * LongNumberRange value.
+     * LongNumberRange value (evitaDB `LongNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -3649,7 +3707,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange.Builder, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeOrBuilder> bigDecimalNumberRangeValueBuilder_;
     /**
      * <pre>
-     * BigDecimalNumberRange value.
+     * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -3661,7 +3719,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimalNumberRange value.
+     * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -3683,7 +3741,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimalNumberRange value.
+     * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -3703,7 +3761,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimalNumberRange value.
+     * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -3721,7 +3779,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimalNumberRange value.
+     * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -3748,7 +3806,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimalNumberRange value.
+     * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -3771,7 +3829,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimalNumberRange value.
+     * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -3781,7 +3839,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimalNumberRange value.
+     * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -3799,7 +3857,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * BigDecimalNumberRange value.
+     * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -3827,7 +3885,9 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> offsetDateTimeValueBuilder_;
     /**
      * <pre>
-     * OffsetDateTime value.
+     * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+     * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+     * respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -3839,7 +3899,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * OffsetDateTime value.
+     * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+     * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+     * respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -3861,7 +3923,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * OffsetDateTime value.
+     * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+     * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+     * respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -3881,7 +3945,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * OffsetDateTime value.
+     * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+     * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+     * respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -3899,7 +3965,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * OffsetDateTime value.
+     * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+     * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+     * respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -3926,7 +3994,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * OffsetDateTime value.
+     * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+     * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+     * respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -3949,7 +4019,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * OffsetDateTime value.
+     * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+     * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+     * respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -3959,7 +4031,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * OffsetDateTime value.
+     * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+     * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+     * respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -3977,7 +4051,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * OffsetDateTime value.
+     * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+     * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+     * respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -4005,7 +4081,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcLocale, io.evitadb.externalApi.grpc.generated.GrpcLocale.Builder, io.evitadb.externalApi.grpc.generated.GrpcLocaleOrBuilder> localeValueBuilder_;
     /**
      * <pre>
-     * Locale value.
+     * Locale value (Java `Locale`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -4017,7 +4093,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Locale value.
+     * Locale value (Java `Locale`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -4039,7 +4115,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Locale value.
+     * Locale value (Java `Locale`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -4059,7 +4135,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Locale value.
+     * Locale value (Java `Locale`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -4077,7 +4153,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Locale value.
+     * Locale value (Java `Locale`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -4104,7 +4180,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Locale value.
+     * Locale value (Java `Locale`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -4127,7 +4203,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Locale value.
+     * Locale value (Java `Locale`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -4137,7 +4213,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Locale value.
+     * Locale value (Java `Locale`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -4155,7 +4231,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Locale value.
+     * Locale value (Java `Locale`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -4183,7 +4259,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcCurrency, io.evitadb.externalApi.grpc.generated.GrpcCurrency.Builder, io.evitadb.externalApi.grpc.generated.GrpcCurrencyOrBuilder> currencyValueBuilder_;
     /**
      * <pre>
-     * Currency value.
+     * Currency value (Java `Currency`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -4195,7 +4271,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Currency value.
+     * Currency value (Java `Currency`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -4217,7 +4293,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Currency value.
+     * Currency value (Java `Currency`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -4237,7 +4313,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Currency value.
+     * Currency value (Java `Currency`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -4255,7 +4331,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Currency value.
+     * Currency value (Java `Currency`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -4282,7 +4358,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Currency value.
+     * Currency value (Java `Currency`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -4305,7 +4381,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Currency value.
+     * Currency value (Java `Currency`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -4315,7 +4391,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Currency value.
+     * Currency value (Java `Currency`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -4333,7 +4409,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Currency value.
+     * Currency value (Java `Currency`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -4361,7 +4437,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcUuid, io.evitadb.externalApi.grpc.generated.GrpcUuid.Builder, io.evitadb.externalApi.grpc.generated.GrpcUuidOrBuilder> uuidValueBuilder_;
     /**
      * <pre>
-     * UUID value.
+     * UUID value (Java `UUID`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -4373,7 +4449,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * UUID value.
+     * UUID value (Java `UUID`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -4395,7 +4471,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * UUID value.
+     * UUID value (Java `UUID`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -4415,7 +4491,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * UUID value.
+     * UUID value (Java `UUID`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -4433,7 +4509,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * UUID value.
+     * UUID value (Java `UUID`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -4460,7 +4536,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * UUID value.
+     * UUID value (Java `UUID`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -4483,7 +4559,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * UUID value.
+     * UUID value (Java `UUID`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -4493,7 +4569,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * UUID value.
+     * UUID value (Java `UUID`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -4511,7 +4587,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * UUID value.
+     * UUID value (Java `UUID`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -4539,7 +4615,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcPredecessor, io.evitadb.externalApi.grpc.generated.GrpcPredecessor.Builder, io.evitadb.externalApi.grpc.generated.GrpcPredecessorOrBuilder> predecessorValueBuilder_;
     /**
      * <pre>
-     * Predecessor value.
+     * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+     * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -4551,7 +4628,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Predecessor value.
+     * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+     * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -4573,7 +4651,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Predecessor value.
+     * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+     * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -4593,7 +4672,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Predecessor value.
+     * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+     * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -4611,7 +4691,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Predecessor value.
+     * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+     * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -4638,7 +4719,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Predecessor value.
+     * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+     * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -4661,7 +4743,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Predecessor value.
+     * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+     * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -4671,7 +4754,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Predecessor value.
+     * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+     * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -4689,7 +4773,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Predecessor value.
+     * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+     * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -4717,7 +4802,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcStringArray, io.evitadb.externalApi.grpc.generated.GrpcStringArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcStringArrayOrBuilder> stringArrayValueBuilder_;
     /**
      * <pre>
-     * Array of string values.
+     * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+     * single-character string, when `type` is `CHARACTER_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -4729,7 +4815,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of string values.
+     * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+     * single-character string, when `type` is `CHARACTER_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -4751,7 +4838,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of string values.
+     * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+     * single-character string, when `type` is `CHARACTER_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -4771,7 +4859,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of string values.
+     * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+     * single-character string, when `type` is `CHARACTER_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -4789,7 +4878,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of string values.
+     * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+     * single-character string, when `type` is `CHARACTER_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -4816,7 +4906,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of string values.
+     * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+     * single-character string, when `type` is `CHARACTER_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -4839,7 +4930,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of string values.
+     * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+     * single-character string, when `type` is `CHARACTER_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -4849,7 +4941,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of string values.
+     * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+     * single-character string, when `type` is `CHARACTER_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -4867,7 +4960,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of string values.
+     * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+     * single-character string, when `type` is `CHARACTER_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -4895,7 +4989,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcIntegerArray, io.evitadb.externalApi.grpc.generated.GrpcIntegerArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcIntegerArrayOrBuilder> integerArrayValueBuilder_;
     /**
      * <pre>
-     * Array of integer values.
+     * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+     * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -4907,7 +5002,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of integer values.
+     * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+     * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -4929,7 +5025,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of integer values.
+     * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+     * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -4949,7 +5046,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of integer values.
+     * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+     * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -4967,7 +5065,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of integer values.
+     * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+     * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -4994,7 +5093,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of integer values.
+     * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+     * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -5017,7 +5117,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of integer values.
+     * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+     * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -5027,7 +5128,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of integer values.
+     * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+     * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -5045,7 +5147,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of integer values.
+     * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+     * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -5073,7 +5176,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcLongArray, io.evitadb.externalApi.grpc.generated.GrpcLongArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcLongArrayOrBuilder> longArrayValueBuilder_;
     /**
      * <pre>
-     * Array of long values.
+     * Long array value (Java `Long[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -5085,7 +5188,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of long values.
+     * Long array value (Java `Long[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -5107,7 +5210,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of long values.
+     * Long array value (Java `Long[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -5127,7 +5230,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of long values.
+     * Long array value (Java `Long[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -5145,7 +5248,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of long values.
+     * Long array value (Java `Long[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -5172,7 +5275,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of long values.
+     * Long array value (Java `Long[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -5195,7 +5298,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of long values.
+     * Long array value (Java `Long[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -5205,7 +5308,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of long values.
+     * Long array value (Java `Long[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -5223,7 +5326,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of long values.
+     * Long array value (Java `Long[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -5251,7 +5354,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBooleanArray, io.evitadb.externalApi.grpc.generated.GrpcBooleanArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcBooleanArrayOrBuilder> booleanArrayValueBuilder_;
     /**
      * <pre>
-     * Array of boolean values.
+     * Boolean array value (Java `Boolean[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -5263,7 +5366,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of boolean values.
+     * Boolean array value (Java `Boolean[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -5285,7 +5388,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of boolean values.
+     * Boolean array value (Java `Boolean[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -5305,7 +5408,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of boolean values.
+     * Boolean array value (Java `Boolean[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -5323,7 +5426,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of boolean values.
+     * Boolean array value (Java `Boolean[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -5350,7 +5453,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of boolean values.
+     * Boolean array value (Java `Boolean[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -5373,7 +5476,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of boolean values.
+     * Boolean array value (Java `Boolean[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -5383,7 +5486,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of boolean values.
+     * Boolean array value (Java `Boolean[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -5401,7 +5504,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of boolean values.
+     * Boolean array value (Java `Boolean[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -5429,7 +5532,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArrayOrBuilder> bigDecimalArrayValueBuilder_;
     /**
      * <pre>
-     * Array of BigDecimal values.
+     * BigDecimal array value (Java `BigDecimal[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -5441,7 +5544,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimal values.
+     * BigDecimal array value (Java `BigDecimal[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -5463,7 +5566,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimal values.
+     * BigDecimal array value (Java `BigDecimal[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -5483,7 +5586,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimal values.
+     * BigDecimal array value (Java `BigDecimal[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -5501,7 +5604,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimal values.
+     * BigDecimal array value (Java `BigDecimal[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -5528,7 +5631,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimal values.
+     * BigDecimal array value (Java `BigDecimal[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -5551,7 +5654,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimal values.
+     * BigDecimal array value (Java `BigDecimal[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -5561,7 +5664,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimal values.
+     * BigDecimal array value (Java `BigDecimal[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -5579,7 +5682,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimal values.
+     * BigDecimal array value (Java `BigDecimal[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -5607,7 +5710,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray, io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArrayOrBuilder> dateTimeRangeArrayValueBuilder_;
     /**
      * <pre>
-     * Array of DateTimeRange values.
+     * DateTimeRange array value (evitaDB `DateTimeRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -5619,7 +5722,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of DateTimeRange values.
+     * DateTimeRange array value (evitaDB `DateTimeRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -5641,7 +5744,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of DateTimeRange values.
+     * DateTimeRange array value (evitaDB `DateTimeRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -5661,7 +5764,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of DateTimeRange values.
+     * DateTimeRange array value (evitaDB `DateTimeRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -5679,7 +5782,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of DateTimeRange values.
+     * DateTimeRange array value (evitaDB `DateTimeRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -5706,7 +5809,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of DateTimeRange values.
+     * DateTimeRange array value (evitaDB `DateTimeRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -5729,7 +5832,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of DateTimeRange values.
+     * DateTimeRange array value (evitaDB `DateTimeRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -5739,7 +5842,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of DateTimeRange values.
+     * DateTimeRange array value (evitaDB `DateTimeRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -5757,7 +5860,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of DateTimeRange values.
+     * DateTimeRange array value (evitaDB `DateTimeRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -5785,7 +5888,9 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray, io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArrayOrBuilder> integerNumberRangeArrayValueBuilder_;
     /**
      * <pre>
-     * Array of IntegerNumberRange values.
+     * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+     * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+     * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -5797,7 +5902,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of IntegerNumberRange values.
+     * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+     * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+     * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -5819,7 +5926,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of IntegerNumberRange values.
+     * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+     * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+     * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -5839,7 +5948,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of IntegerNumberRange values.
+     * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+     * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+     * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -5857,7 +5968,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of IntegerNumberRange values.
+     * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+     * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+     * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -5884,7 +5997,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of IntegerNumberRange values.
+     * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+     * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+     * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -5907,7 +6022,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of IntegerNumberRange values.
+     * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+     * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+     * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -5917,7 +6034,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of IntegerNumberRange values.
+     * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+     * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+     * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -5935,7 +6054,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of IntegerNumberRange values.
+     * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+     * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+     * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -5963,7 +6084,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray, io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArrayOrBuilder> longNumberRangeArrayValueBuilder_;
     /**
      * <pre>
-     * Array of LongNumberRange values.
+     * LongNumberRange array value (evitaDB `LongNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -5975,7 +6096,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of LongNumberRange values.
+     * LongNumberRange array value (evitaDB `LongNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -5997,7 +6118,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of LongNumberRange values.
+     * LongNumberRange array value (evitaDB `LongNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -6017,7 +6138,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of LongNumberRange values.
+     * LongNumberRange array value (evitaDB `LongNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -6035,7 +6156,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of LongNumberRange values.
+     * LongNumberRange array value (evitaDB `LongNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -6062,7 +6183,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of LongNumberRange values.
+     * LongNumberRange array value (evitaDB `LongNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -6085,7 +6206,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of LongNumberRange values.
+     * LongNumberRange array value (evitaDB `LongNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -6095,7 +6216,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of LongNumberRange values.
+     * LongNumberRange array value (evitaDB `LongNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -6113,7 +6234,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of LongNumberRange values.
+     * LongNumberRange array value (evitaDB `LongNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -6141,7 +6262,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArrayOrBuilder> bigDecimalNumberRangeArrayValueBuilder_;
     /**
      * <pre>
-     * Array of BigDecimalNumberRange values.
+     * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -6153,7 +6274,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimalNumberRange values.
+     * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -6175,7 +6296,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimalNumberRange values.
+     * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -6195,7 +6316,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimalNumberRange values.
+     * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -6213,7 +6334,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimalNumberRange values.
+     * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -6240,7 +6361,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimalNumberRange values.
+     * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -6263,7 +6384,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimalNumberRange values.
+     * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -6273,7 +6394,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimalNumberRange values.
+     * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -6291,7 +6412,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of BigDecimalNumberRange values.
+     * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -6319,7 +6440,9 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArrayOrBuilder> offsetDateTimeArrayValueBuilder_;
     /**
      * <pre>
-     * Array of OffsetDateTime values.
+     * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+     * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+     * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -6331,7 +6454,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of OffsetDateTime values.
+     * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+     * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+     * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -6353,7 +6478,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of OffsetDateTime values.
+     * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+     * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+     * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -6373,7 +6500,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of OffsetDateTime values.
+     * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+     * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+     * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -6391,7 +6520,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of OffsetDateTime values.
+     * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+     * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+     * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -6418,7 +6549,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of OffsetDateTime values.
+     * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+     * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+     * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -6441,7 +6574,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of OffsetDateTime values.
+     * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+     * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+     * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -6451,7 +6586,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of OffsetDateTime values.
+     * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+     * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+     * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -6469,7 +6606,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of OffsetDateTime values.
+     * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+     * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+     * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -6497,7 +6636,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcLocaleArray, io.evitadb.externalApi.grpc.generated.GrpcLocaleArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcLocaleArrayOrBuilder> localeArrayValueBuilder_;
     /**
      * <pre>
-     * Array of Locale values.
+     * Locale array value (Java `Locale[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -6509,7 +6648,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Locale values.
+     * Locale array value (Java `Locale[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -6531,7 +6670,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Locale values.
+     * Locale array value (Java `Locale[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -6551,7 +6690,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Locale values.
+     * Locale array value (Java `Locale[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -6569,7 +6708,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Locale values.
+     * Locale array value (Java `Locale[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -6596,7 +6735,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Locale values.
+     * Locale array value (Java `Locale[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -6619,7 +6758,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Locale values.
+     * Locale array value (Java `Locale[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -6629,7 +6768,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Locale values.
+     * Locale array value (Java `Locale[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -6647,7 +6786,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Locale values.
+     * Locale array value (Java `Locale[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -6675,7 +6814,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray, io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcCurrencyArrayOrBuilder> currencyArrayValueBuilder_;
     /**
      * <pre>
-     * Array of Currency values.
+     * Currency array value (Java `Currency[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -6687,7 +6826,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Currency values.
+     * Currency array value (Java `Currency[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -6709,7 +6848,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Currency values.
+     * Currency array value (Java `Currency[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -6729,7 +6868,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Currency values.
+     * Currency array value (Java `Currency[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -6747,7 +6886,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Currency values.
+     * Currency array value (Java `Currency[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -6774,7 +6913,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Currency values.
+     * Currency array value (Java `Currency[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -6797,7 +6936,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Currency values.
+     * Currency array value (Java `Currency[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -6807,7 +6946,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Currency values.
+     * Currency array value (Java `Currency[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -6825,7 +6964,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of Currency values.
+     * Currency array value (Java `Currency[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -6853,7 +6992,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcUuidArray, io.evitadb.externalApi.grpc.generated.GrpcUuidArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcUuidArrayOrBuilder> uuidArrayValueBuilder_;
     /**
      * <pre>
-     * Array of UUID values.
+     * UUID array value (Java `UUID[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -6865,7 +7004,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of UUID values.
+     * UUID array value (Java `UUID[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -6887,7 +7026,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of UUID values.
+     * UUID array value (Java `UUID[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -6907,7 +7046,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of UUID values.
+     * UUID array value (Java `UUID[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -6925,7 +7064,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of UUID values.
+     * UUID array value (Java `UUID[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -6952,7 +7091,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of UUID values.
+     * UUID array value (Java `UUID[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -6975,7 +7114,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of UUID values.
+     * UUID array value (Java `UUID[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -6985,7 +7124,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of UUID values.
+     * UUID array value (Java `UUID[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -7003,7 +7142,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Array of UUID values.
+     * UUID array value (Java `UUID[]`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -7030,7 +7169,8 @@ private static final long serialVersionUID = 0L;
     private int type_ = 0;
     /**
      * <pre>
-     * The type of the stored value.
+     * The concrete Evita/Java data type represented by the `value` oneof above (see each arm's
+     * comment for which narrower types it also stands in for).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaDataType type = 100;</code>
@@ -7041,7 +7181,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the stored value.
+     * The concrete Evita/Java data type represented by the `value` oneof above (see each arm's
+     * comment for which narrower types it also stands in for).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaDataType type = 100;</code>
@@ -7056,7 +7197,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the stored value.
+     * The concrete Evita/Java data type represented by the `value` oneof above (see each arm's
+     * comment for which narrower types it also stands in for).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaDataType type = 100;</code>
@@ -7069,7 +7211,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the stored value.
+     * The concrete Evita/Java data type represented by the `value` oneof above (see each arm's
+     * comment for which narrower types it also stands in for).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaDataType type = 100;</code>
@@ -7087,7 +7230,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the stored value.
+     * The concrete Evita/Java data type represented by the `value` oneof above (see each arm's
+     * comment for which narrower types it also stands in for).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaDataType type = 100;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaValueOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaValueOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * String value.
+   * String value (Java `String`). Also carries a `Character` value, as a single-character
+   * string, when `type` is `CHARACTER`.
    * </pre>
    *
    * <code>string stringValue = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasStringValue();
   /**
    * <pre>
-   * String value.
+   * String value (Java `String`). Also carries a `Character` value, as a single-character
+   * string, when `type` is `CHARACTER`.
    * </pre>
    *
    * <code>string stringValue = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcEvitaValueOrBuilder extends
   java.lang.String getStringValue();
   /**
    * <pre>
-   * String value.
+   * String value (Java `String`). Also carries a `Character` value, as a single-character
+   * string, when `type` is `CHARACTER`.
    * </pre>
    *
    * <code>string stringValue = 1;</code>
@@ -62,7 +65,8 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Integer value.
+   * Integer value (Java `int`). Also carries `Byte` and `Short` values, widened to int32, when
+   * `type` is `BYTE` or `SHORT`.
    * </pre>
    *
    * <code>int32 integerValue = 2;</code>
@@ -71,7 +75,8 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasIntegerValue();
   /**
    * <pre>
-   * Integer value.
+   * Integer value (Java `int`). Also carries `Byte` and `Short` values, widened to int32, when
+   * `type` is `BYTE` or `SHORT`.
    * </pre>
    *
    * <code>int32 integerValue = 2;</code>
@@ -81,7 +86,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Long value.
+   * Long value (Java `long`).
    * </pre>
    *
    * <code>int64 longValue = 3;</code>
@@ -90,7 +95,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasLongValue();
   /**
    * <pre>
-   * Long value.
+   * Long value (Java `long`).
    * </pre>
    *
    * <code>int64 longValue = 3;</code>
@@ -100,7 +105,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Boolean value.
+   * Boolean value (Java `boolean`).
    * </pre>
    *
    * <code>bool booleanValue = 4;</code>
@@ -109,7 +114,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasBooleanValue();
   /**
    * <pre>
-   * Boolean value.
+   * Boolean value (Java `boolean`).
    * </pre>
    *
    * <code>bool booleanValue = 4;</code>
@@ -119,7 +124,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * BigDecimal value.
+   * BigDecimal value (Java `BigDecimal`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -128,7 +133,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasBigDecimalValue();
   /**
    * <pre>
-   * BigDecimal value.
+   * BigDecimal value (Java `BigDecimal`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -137,7 +142,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimal getBigDecimalValue();
   /**
    * <pre>
-   * BigDecimal value.
+   * BigDecimal value (Java `BigDecimal`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -146,7 +151,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * DateTimeRange value.
+   * DateTimeRange value (evitaDB `DateTimeRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -155,7 +160,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasDateTimeRangeValue();
   /**
    * <pre>
-   * DateTimeRange value.
+   * DateTimeRange value (evitaDB `DateTimeRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -164,7 +169,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange getDateTimeRangeValue();
   /**
    * <pre>
-   * DateTimeRange value.
+   * DateTimeRange value (evitaDB `DateTimeRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -173,7 +178,8 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * IntegerNumberRange value.
+   * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+   * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -182,7 +188,8 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasIntegerNumberRangeValue();
   /**
    * <pre>
-   * IntegerNumberRange value.
+   * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+   * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -191,7 +198,8 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange getIntegerNumberRangeValue();
   /**
    * <pre>
-   * IntegerNumberRange value.
+   * IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+   * `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -200,7 +208,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * LongNumberRange value.
+   * LongNumberRange value (evitaDB `LongNumberRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -209,7 +217,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasLongNumberRangeValue();
   /**
    * <pre>
-   * LongNumberRange value.
+   * LongNumberRange value (evitaDB `LongNumberRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -218,7 +226,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange getLongNumberRangeValue();
   /**
    * <pre>
-   * LongNumberRange value.
+   * LongNumberRange value (evitaDB `LongNumberRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -227,7 +235,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * BigDecimalNumberRange value.
+   * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -236,7 +244,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasBigDecimalNumberRangeValue();
   /**
    * <pre>
-   * BigDecimalNumberRange value.
+   * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -245,7 +253,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange getBigDecimalNumberRangeValue();
   /**
    * <pre>
-   * BigDecimalNumberRange value.
+   * BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -254,7 +262,9 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * OffsetDateTime value.
+   * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+   * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+   * respectively.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -263,7 +273,9 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasOffsetDateTimeValue();
   /**
    * <pre>
-   * OffsetDateTime value.
+   * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+   * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+   * respectively.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -272,7 +284,9 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getOffsetDateTimeValue();
   /**
    * <pre>
-   * OffsetDateTime value.
+   * Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+   * `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+   * respectively.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -281,7 +295,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Locale value.
+   * Locale value (Java `Locale`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -290,7 +304,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasLocaleValue();
   /**
    * <pre>
-   * Locale value.
+   * Locale value (Java `Locale`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -299,7 +313,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcLocale getLocaleValue();
   /**
    * <pre>
-   * Locale value.
+   * Locale value (Java `Locale`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -308,7 +322,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Currency value.
+   * Currency value (Java `Currency`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -317,7 +331,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasCurrencyValue();
   /**
    * <pre>
-   * Currency value.
+   * Currency value (Java `Currency`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -326,7 +340,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcCurrency getCurrencyValue();
   /**
    * <pre>
-   * Currency value.
+   * Currency value (Java `Currency`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -335,7 +349,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * UUID value.
+   * UUID value (Java `UUID`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -344,7 +358,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasUuidValue();
   /**
    * <pre>
-   * UUID value.
+   * UUID value (Java `UUID`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -353,7 +367,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuid getUuidValue();
   /**
    * <pre>
-   * UUID value.
+   * UUID value (Java `UUID`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuidValue = 13;</code>
@@ -362,7 +376,8 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Predecessor value.
+   * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+   * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -371,7 +386,8 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasPredecessorValue();
   /**
    * <pre>
-   * Predecessor value.
+   * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+   * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -380,7 +396,8 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcPredecessor getPredecessorValue();
   /**
    * <pre>
-   * Predecessor value.
+   * Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+   * value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPredecessor predecessorValue = 14;</code>
@@ -389,7 +406,8 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of string values.
+   * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+   * single-character string, when `type` is `CHARACTER_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -398,7 +416,8 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasStringArrayValue();
   /**
    * <pre>
-   * Array of string values.
+   * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+   * single-character string, when `type` is `CHARACTER_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -407,7 +426,8 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcStringArray getStringArrayValue();
   /**
    * <pre>
-   * Array of string values.
+   * String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+   * single-character string, when `type` is `CHARACTER_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 50;</code>
@@ -416,7 +436,8 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of integer values.
+   * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+   * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -425,7 +446,8 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasIntegerArrayValue();
   /**
    * <pre>
-   * Array of integer values.
+   * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+   * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -434,7 +456,8 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcIntegerArray getIntegerArrayValue();
   /**
    * <pre>
-   * Array of integer values.
+   * Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+   * `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 51;</code>
@@ -443,7 +466,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of long values.
+   * Long array value (Java `Long[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -452,7 +475,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasLongArrayValue();
   /**
    * <pre>
-   * Array of long values.
+   * Long array value (Java `Long[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -461,7 +484,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcLongArray getLongArrayValue();
   /**
    * <pre>
-   * Array of long values.
+   * Long array value (Java `Long[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 52;</code>
@@ -470,7 +493,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of boolean values.
+   * Boolean array value (Java `Boolean[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -479,7 +502,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasBooleanArrayValue();
   /**
    * <pre>
-   * Array of boolean values.
+   * Boolean array value (Java `Boolean[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -488,7 +511,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBooleanArray getBooleanArrayValue();
   /**
    * <pre>
-   * Array of boolean values.
+   * Boolean array value (Java `Boolean[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 53;</code>
@@ -497,7 +520,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of BigDecimal values.
+   * BigDecimal array value (Java `BigDecimal[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -506,7 +529,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasBigDecimalArrayValue();
   /**
    * <pre>
-   * Array of BigDecimal values.
+   * BigDecimal array value (Java `BigDecimal[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -515,7 +538,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray getBigDecimalArrayValue();
   /**
    * <pre>
-   * Array of BigDecimal values.
+   * BigDecimal array value (Java `BigDecimal[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 54;</code>
@@ -524,7 +547,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of DateTimeRange values.
+   * DateTimeRange array value (evitaDB `DateTimeRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -533,7 +556,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasDateTimeRangeArrayValue();
   /**
    * <pre>
-   * Array of DateTimeRange values.
+   * DateTimeRange array value (evitaDB `DateTimeRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -542,7 +565,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray getDateTimeRangeArrayValue();
   /**
    * <pre>
-   * Array of DateTimeRange values.
+   * DateTimeRange array value (evitaDB `DateTimeRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;</code>
@@ -551,7 +574,9 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of IntegerNumberRange values.
+   * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+   * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+   * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -560,7 +585,9 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasIntegerNumberRangeArrayValue();
   /**
    * <pre>
-   * Array of IntegerNumberRange values.
+   * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+   * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+   * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -569,7 +596,9 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray getIntegerNumberRangeArrayValue();
   /**
    * <pre>
-   * Array of IntegerNumberRange values.
+   * IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+   * `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+   * `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;</code>
@@ -578,7 +607,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of LongNumberRange values.
+   * LongNumberRange array value (evitaDB `LongNumberRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -587,7 +616,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasLongNumberRangeArrayValue();
   /**
    * <pre>
-   * Array of LongNumberRange values.
+   * LongNumberRange array value (evitaDB `LongNumberRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -596,7 +625,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray getLongNumberRangeArrayValue();
   /**
    * <pre>
-   * Array of LongNumberRange values.
+   * LongNumberRange array value (evitaDB `LongNumberRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;</code>
@@ -605,7 +634,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of BigDecimalNumberRange values.
+   * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -614,7 +643,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasBigDecimalNumberRangeArrayValue();
   /**
    * <pre>
-   * Array of BigDecimalNumberRange values.
+   * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -623,7 +652,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray getBigDecimalNumberRangeArrayValue();
   /**
    * <pre>
-   * Array of BigDecimalNumberRange values.
+   * BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;</code>
@@ -632,7 +661,9 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of OffsetDateTime values.
+   * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+   * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+   * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -641,7 +672,9 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasOffsetDateTimeArrayValue();
   /**
    * <pre>
-   * Array of OffsetDateTime values.
+   * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+   * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+   * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -650,7 +683,9 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray getOffsetDateTimeArrayValue();
   /**
    * <pre>
-   * Array of OffsetDateTime values.
+   * Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+   * `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+   * `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;</code>
@@ -659,7 +694,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of Locale values.
+   * Locale array value (Java `Locale[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -668,7 +703,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasLocaleArrayValue();
   /**
    * <pre>
-   * Array of Locale values.
+   * Locale array value (Java `Locale[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -677,7 +712,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcLocaleArray getLocaleArrayValue();
   /**
    * <pre>
-   * Array of Locale values.
+   * Locale array value (Java `Locale[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 60;</code>
@@ -686,7 +721,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of Currency values.
+   * Currency array value (Java `Currency[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -695,7 +730,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasCurrencyArrayValue();
   /**
    * <pre>
-   * Array of Currency values.
+   * Currency array value (Java `Currency[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -704,7 +739,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray getCurrencyArrayValue();
   /**
    * <pre>
-   * Array of Currency values.
+   * Currency array value (Java `Currency[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 61;</code>
@@ -713,7 +748,7 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * Array of UUID values.
+   * UUID array value (Java `UUID[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -722,7 +757,7 @@ public interface GrpcEvitaValueOrBuilder extends
   boolean hasUuidArrayValue();
   /**
    * <pre>
-   * Array of UUID values.
+   * UUID array value (Java `UUID[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -731,7 +766,7 @@ public interface GrpcEvitaValueOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuidArray getUuidArrayValue();
   /**
    * <pre>
-   * Array of UUID values.
+   * UUID array value (Java `UUID[]`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuidArray uuidArrayValue = 62;</code>
@@ -740,7 +775,8 @@ public interface GrpcEvitaValueOrBuilder extends
 
   /**
    * <pre>
-   * The type of the stored value.
+   * The concrete Evita/Java data type represented by the `value` oneof above (see each arm's
+   * comment for which narrower types it also stands in for).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaDataType type = 100;</code>
@@ -749,7 +785,8 @@ public interface GrpcEvitaValueOrBuilder extends
   int getTypeValue();
   /**
    * <pre>
-   * The type of the stored value.
+   * The concrete Evita/Java data type represented by the `value` oneof above (see each arm's
+   * comment for which narrower types it also stands in for).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEvitaDataType type = 100;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcExportTrafficRecordingRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcExportTrafficRecordingRequest.java
@@ -71,7 +71,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value chunkFileSizeInBytes_;
   /**
    * <pre>
-   * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+   * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+   * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -83,7 +84,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+   * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+   * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -95,7 +97,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+   * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+   * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -461,7 +464,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> chunkFileSizeInBytesBuilder_;
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -472,7 +476,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -487,7 +492,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -507,7 +513,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -525,7 +532,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -550,7 +558,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -567,7 +576,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -579,7 +589,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -594,7 +605,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcExportTrafficRecordingRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcExportTrafficRecordingRequestOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcExportTrafficRecordingRequestOrBuilder extends
 
   /**
    * <pre>
-   * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+   * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+   * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcExportTrafficRecordingRequestOrBuilder extends
   boolean hasChunkFileSizeInBytes();
   /**
    * <pre>
-   * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+   * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+   * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcExportTrafficRecordingRequestOrBuilder extends
   com.google.protobuf.Int64Value getChunkFileSizeInBytes();
   /**
    * <pre>
-   * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+   * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+   * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetGroupStatistics.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetGroupStatistics.java
@@ -30,7 +30,8 @@ package io.evitadb.externalApi.grpc.generated;
 /**
  * <pre>
  * This DTO contains information about single facet group and statistics of the facets that relates to it.
- * TOBEDONE: remove when FacetSummary constraint is removed
+ * deprecated in favor of `GrpcReferenceGroupStatistics`, produced by the `referenceSummary` requirement
+ * TOBEDONE: remove when FacetSummary constraint is removed (https://github.com/FgForrest/evitaDB/issues/538)
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFacetGroupStatistics}
@@ -484,7 +485,8 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * This DTO contains information about single facet group and statistics of the facets that relates to it.
-   * TOBEDONE: remove when FacetSummary constraint is removed
+   * deprecated in favor of `GrpcReferenceGroupStatistics`, produced by the `referenceSummary` requirement
+   * TOBEDONE: remove when FacetSummary constraint is removed (https://github.com/FgForrest/evitaDB/issues/538)
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFacetGroupStatistics}

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetStatisticsDepthArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetStatisticsDepthArray.java
@@ -81,7 +81,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * Value that supports storing a FacetStatisticsDepth array.
+   * The individual FacetStatisticsDepth values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -94,7 +94,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a FacetStatisticsDepth array.
+   * The individual FacetStatisticsDepth values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a FacetStatisticsDepth array.
+   * The individual FacetStatisticsDepth values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -119,7 +119,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a FacetStatisticsDepth array.
+   * The individual FacetStatisticsDepth values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -132,7 +132,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a FacetStatisticsDepth array.
+   * The individual FacetStatisticsDepth values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -524,7 +524,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a FacetStatisticsDepth array.
+     * The individual FacetStatisticsDepth values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -536,7 +536,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a FacetStatisticsDepth array.
+     * The individual FacetStatisticsDepth values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -547,7 +547,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a FacetStatisticsDepth array.
+     * The individual FacetStatisticsDepth values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -559,7 +559,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a FacetStatisticsDepth array.
+     * The individual FacetStatisticsDepth values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -579,7 +579,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a FacetStatisticsDepth array.
+     * The individual FacetStatisticsDepth values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -597,7 +597,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a FacetStatisticsDepth array.
+     * The individual FacetStatisticsDepth values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -615,7 +615,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a FacetStatisticsDepth array.
+     * The individual FacetStatisticsDepth values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -629,7 +629,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a FacetStatisticsDepth array.
+     * The individual FacetStatisticsDepth values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a FacetStatisticsDepth array.
+     * The individual FacetStatisticsDepth values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -653,7 +653,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a FacetStatisticsDepth array.
+     * The individual FacetStatisticsDepth values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -670,7 +670,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a FacetStatisticsDepth array.
+     * The individual FacetStatisticsDepth values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -685,7 +685,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a FacetStatisticsDepth array.
+     * The individual FacetStatisticsDepth values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetStatisticsDepthArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetStatisticsDepthArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcFacetStatisticsDepthArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a FacetStatisticsDepth array.
+   * The individual FacetStatisticsDepth values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcFacetStatisticsDepthArrayOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth> getValueList();
   /**
    * <pre>
-   * Value that supports storing a FacetStatisticsDepth array.
+   * The individual FacetStatisticsDepth values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcFacetStatisticsDepthArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a FacetStatisticsDepth array.
+   * The individual FacetStatisticsDepth values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -61,7 +61,7 @@ public interface GrpcFacetStatisticsDepthArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a FacetStatisticsDepth array.
+   * The individual FacetStatisticsDepth values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>
@@ -71,7 +71,7 @@ public interface GrpcFacetStatisticsDepthArrayOrBuilder extends
   getValueValueList();
   /**
    * <pre>
-   * Value that supports storing a FacetStatisticsDepth array.
+   * The individual FacetStatisticsDepth values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFetchFileRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFetchFileRequest.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to get single file by id
+ * Request to stream the contents of a single file available for fetching, by its id.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFetchFileRequest}
@@ -269,7 +269,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to get single file by id
+   * Request to stream the contents of a single file available for fetching, by its id.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFetchFileRequest}

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFetchFileResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFetchFileResponse.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to a task status request.
+ * One chunk of a file's contents, streamed back to the client. The server sends a sequence of
+ * these messages; concatenate `fileContents` from all of them, in arrival order, to reconstruct
+ * the full file.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFetchFileResponse}
@@ -71,7 +73,7 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.ByteString fileContents_ = com.google.protobuf.ByteString.EMPTY;
   /**
    * <pre>
-   * chunk of the file content
+   * One chunk of the file's binary contents.
    * </pre>
    *
    * <code>bytes fileContents = 1;</code>
@@ -86,7 +88,8 @@ private static final long serialVersionUID = 0L;
   private long totalSizeInBytes_ = 0L;
   /**
    * <pre>
-   * total size of the file
+   * Total size of the complete file (bytes); the same value is repeated on every chunk in the
+   * stream, not just the size of this chunk.
    * </pre>
    *
    * <code>int64 totalSizeInBytes = 2;</code>
@@ -268,7 +271,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to a task status request.
+   * One chunk of a file's contents, streamed back to the client. The server sends a sequence of
+   * these messages; concatenate `fileContents` from all of them, in arrival order, to reconstruct
+   * the full file.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFetchFileResponse}
@@ -453,7 +458,7 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.ByteString fileContents_ = com.google.protobuf.ByteString.EMPTY;
     /**
      * <pre>
-     * chunk of the file content
+     * One chunk of the file's binary contents.
      * </pre>
      *
      * <code>bytes fileContents = 1;</code>
@@ -465,7 +470,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * chunk of the file content
+     * One chunk of the file's binary contents.
      * </pre>
      *
      * <code>bytes fileContents = 1;</code>
@@ -481,7 +486,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * chunk of the file content
+     * One chunk of the file's binary contents.
      * </pre>
      *
      * <code>bytes fileContents = 1;</code>
@@ -497,7 +502,8 @@ private static final long serialVersionUID = 0L;
     private long totalSizeInBytes_ ;
     /**
      * <pre>
-     * total size of the file
+     * Total size of the complete file (bytes); the same value is repeated on every chunk in the
+     * stream, not just the size of this chunk.
      * </pre>
      *
      * <code>int64 totalSizeInBytes = 2;</code>
@@ -509,7 +515,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * total size of the file
+     * Total size of the complete file (bytes); the same value is repeated on every chunk in the
+     * stream, not just the size of this chunk.
      * </pre>
      *
      * <code>int64 totalSizeInBytes = 2;</code>
@@ -525,7 +532,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * total size of the file
+     * Total size of the complete file (bytes); the same value is repeated on every chunk in the
+     * stream, not just the size of this chunk.
      * </pre>
      *
      * <code>int64 totalSizeInBytes = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFetchFileResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFetchFileResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcFetchFileResponseOrBuilder extends
 
   /**
    * <pre>
-   * chunk of the file content
+   * One chunk of the file's binary contents.
    * </pre>
    *
    * <code>bytes fileContents = 1;</code>
@@ -43,7 +43,8 @@ public interface GrpcFetchFileResponseOrBuilder extends
 
   /**
    * <pre>
-   * total size of the file
+   * Total size of the complete file (bytes); the same value is repeated on every chunk in the
+   * stream, not just the size of this chunk.
    * </pre>
    *
    * <code>int64 totalSizeInBytes = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFile.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFile.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * identification of the file available for fetching
+ * Identification of a file available for fetching from the server (e.g. a backup archive or an
+ * export produced by an asynchronous task).
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFile}
@@ -73,7 +74,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcUuid fileId_;
   /**
    * <pre>
-   * Identification of the file
+   * Unique identifier of the file, used to reference it in fetch/download requests.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -85,7 +86,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Identification of the file
+   * Unique identifier of the file, used to reference it in fetch/download requests.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -97,7 +98,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Identification of the file
+   * Unique identifier of the file, used to reference it in fetch/download requests.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -112,7 +113,7 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object name_ = "";
   /**
    * <pre>
-   * File name
+   * File name, including extension.
    * </pre>
    *
    * <code>string name = 2;</code>
@@ -133,7 +134,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * File name
+   * File name, including extension.
    * </pre>
    *
    * <code>string name = 2;</code>
@@ -158,7 +159,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.StringValue description_;
   /**
    * <pre>
-   * Detailed description of the file
+   * Human-readable description of the file's purpose or contents. Unset when no description was
+   * provided.
    * </pre>
    *
    * <code>.google.protobuf.StringValue description = 3;</code>
@@ -170,7 +172,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Detailed description of the file
+   * Human-readable description of the file's purpose or contents. Unset when no description was
+   * provided.
    * </pre>
    *
    * <code>.google.protobuf.StringValue description = 3;</code>
@@ -182,7 +185,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Detailed description of the file
+   * Human-readable description of the file's purpose or contents. Unset when no description was
+   * provided.
    * </pre>
    *
    * <code>.google.protobuf.StringValue description = 3;</code>
@@ -197,7 +201,7 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object contentType_ = "";
   /**
    * <pre>
-   * Content type of the file
+   * MIME content type of the file (e.g. `application/zip`).
    * </pre>
    *
    * <code>string contentType = 4;</code>
@@ -218,7 +222,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Content type of the file
+   * MIME content type of the file (e.g. `application/zip`).
    * </pre>
    *
    * <code>string contentType = 4;</code>
@@ -243,7 +247,7 @@ private static final long serialVersionUID = 0L;
   private long totalSizeInBytes_ = 0L;
   /**
    * <pre>
-   * Size of the file in bytes
+   * Size of the file on disk (bytes).
    * </pre>
    *
    * <code>int64 totalSizeInBytes = 5;</code>
@@ -258,7 +262,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created_;
   /**
    * <pre>
-   * Date and time when the file was created
+   * Date and time when the file was created.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -270,7 +274,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Date and time when the file was created
+   * Date and time when the file was created.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -282,7 +286,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Date and time when the file was created
+   * Date and time when the file was created.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -296,7 +300,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.StringValue origin_;
   /**
    * <pre>
-   * Origin of the file (usually the taskType)
+   * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+   * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
    * </pre>
    *
    * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -308,7 +313,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Origin of the file (usually the taskType)
+   * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+   * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
    * </pre>
    *
    * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -320,7 +326,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Origin of the file (usually the taskType)
+   * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+   * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
    * </pre>
    *
    * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -574,7 +581,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * identification of the file available for fetching
+   * Identification of a file available for fetching from the server (e.g. a backup archive or an
+   * export produced by an asynchronous task).
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFile}
@@ -872,7 +880,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcUuid, io.evitadb.externalApi.grpc.generated.GrpcUuid.Builder, io.evitadb.externalApi.grpc.generated.GrpcUuidOrBuilder> fileIdBuilder_;
     /**
      * <pre>
-     * Identification of the file
+     * Unique identifier of the file, used to reference it in fetch/download requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -883,7 +891,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the file
+     * Unique identifier of the file, used to reference it in fetch/download requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -898,7 +906,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the file
+     * Unique identifier of the file, used to reference it in fetch/download requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -918,7 +926,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the file
+     * Unique identifier of the file, used to reference it in fetch/download requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -936,7 +944,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the file
+     * Unique identifier of the file, used to reference it in fetch/download requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -961,7 +969,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the file
+     * Unique identifier of the file, used to reference it in fetch/download requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -978,7 +986,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the file
+     * Unique identifier of the file, used to reference it in fetch/download requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -990,7 +998,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the file
+     * Unique identifier of the file, used to reference it in fetch/download requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -1005,7 +1013,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the file
+     * Unique identifier of the file, used to reference it in fetch/download requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -1027,7 +1035,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object name_ = "";
     /**
      * <pre>
-     * File name
+     * File name, including extension.
      * </pre>
      *
      * <code>string name = 2;</code>
@@ -1047,7 +1055,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File name
+     * File name, including extension.
      * </pre>
      *
      * <code>string name = 2;</code>
@@ -1068,7 +1076,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File name
+     * File name, including extension.
      * </pre>
      *
      * <code>string name = 2;</code>
@@ -1085,7 +1093,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File name
+     * File name, including extension.
      * </pre>
      *
      * <code>string name = 2;</code>
@@ -1099,7 +1107,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File name
+     * File name, including extension.
      * </pre>
      *
      * <code>string name = 2;</code>
@@ -1121,7 +1129,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> descriptionBuilder_;
     /**
      * <pre>
-     * Detailed description of the file
+     * Human-readable description of the file's purpose or contents. Unset when no description was
+     * provided.
      * </pre>
      *
      * <code>.google.protobuf.StringValue description = 3;</code>
@@ -1132,7 +1141,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Detailed description of the file
+     * Human-readable description of the file's purpose or contents. Unset when no description was
+     * provided.
      * </pre>
      *
      * <code>.google.protobuf.StringValue description = 3;</code>
@@ -1147,7 +1157,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Detailed description of the file
+     * Human-readable description of the file's purpose or contents. Unset when no description was
+     * provided.
      * </pre>
      *
      * <code>.google.protobuf.StringValue description = 3;</code>
@@ -1167,7 +1178,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Detailed description of the file
+     * Human-readable description of the file's purpose or contents. Unset when no description was
+     * provided.
      * </pre>
      *
      * <code>.google.protobuf.StringValue description = 3;</code>
@@ -1185,7 +1197,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Detailed description of the file
+     * Human-readable description of the file's purpose or contents. Unset when no description was
+     * provided.
      * </pre>
      *
      * <code>.google.protobuf.StringValue description = 3;</code>
@@ -1210,7 +1223,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Detailed description of the file
+     * Human-readable description of the file's purpose or contents. Unset when no description was
+     * provided.
      * </pre>
      *
      * <code>.google.protobuf.StringValue description = 3;</code>
@@ -1227,7 +1241,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Detailed description of the file
+     * Human-readable description of the file's purpose or contents. Unset when no description was
+     * provided.
      * </pre>
      *
      * <code>.google.protobuf.StringValue description = 3;</code>
@@ -1239,7 +1254,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Detailed description of the file
+     * Human-readable description of the file's purpose or contents. Unset when no description was
+     * provided.
      * </pre>
      *
      * <code>.google.protobuf.StringValue description = 3;</code>
@@ -1254,7 +1270,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Detailed description of the file
+     * Human-readable description of the file's purpose or contents. Unset when no description was
+     * provided.
      * </pre>
      *
      * <code>.google.protobuf.StringValue description = 3;</code>
@@ -1276,7 +1293,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object contentType_ = "";
     /**
      * <pre>
-     * Content type of the file
+     * MIME content type of the file (e.g. `application/zip`).
      * </pre>
      *
      * <code>string contentType = 4;</code>
@@ -1296,7 +1313,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Content type of the file
+     * MIME content type of the file (e.g. `application/zip`).
      * </pre>
      *
      * <code>string contentType = 4;</code>
@@ -1317,7 +1334,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Content type of the file
+     * MIME content type of the file (e.g. `application/zip`).
      * </pre>
      *
      * <code>string contentType = 4;</code>
@@ -1334,7 +1351,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Content type of the file
+     * MIME content type of the file (e.g. `application/zip`).
      * </pre>
      *
      * <code>string contentType = 4;</code>
@@ -1348,7 +1365,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Content type of the file
+     * MIME content type of the file (e.g. `application/zip`).
      * </pre>
      *
      * <code>string contentType = 4;</code>
@@ -1368,7 +1385,7 @@ private static final long serialVersionUID = 0L;
     private long totalSizeInBytes_ ;
     /**
      * <pre>
-     * Size of the file in bytes
+     * Size of the file on disk (bytes).
      * </pre>
      *
      * <code>int64 totalSizeInBytes = 5;</code>
@@ -1380,7 +1397,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Size of the file in bytes
+     * Size of the file on disk (bytes).
      * </pre>
      *
      * <code>int64 totalSizeInBytes = 5;</code>
@@ -1396,7 +1413,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Size of the file in bytes
+     * Size of the file on disk (bytes).
      * </pre>
      *
      * <code>int64 totalSizeInBytes = 5;</code>
@@ -1414,7 +1431,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> createdBuilder_;
     /**
      * <pre>
-     * Date and time when the file was created
+     * Date and time when the file was created.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -1425,7 +1442,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the file was created
+     * Date and time when the file was created.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -1440,7 +1457,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the file was created
+     * Date and time when the file was created.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -1460,7 +1477,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the file was created
+     * Date and time when the file was created.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -1478,7 +1495,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the file was created
+     * Date and time when the file was created.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -1503,7 +1520,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the file was created
+     * Date and time when the file was created.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -1520,7 +1537,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the file was created
+     * Date and time when the file was created.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -1532,7 +1549,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the file was created
+     * Date and time when the file was created.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -1547,7 +1564,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the file was created
+     * Date and time when the file was created.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -1571,7 +1588,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> originBuilder_;
     /**
      * <pre>
-     * Origin of the file (usually the taskType)
+     * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+     * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
      * </pre>
      *
      * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -1582,7 +1600,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Origin of the file (usually the taskType)
+     * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+     * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
      * </pre>
      *
      * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -1597,7 +1616,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Origin of the file (usually the taskType)
+     * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+     * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
      * </pre>
      *
      * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -1617,7 +1637,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Origin of the file (usually the taskType)
+     * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+     * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
      * </pre>
      *
      * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -1635,7 +1656,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Origin of the file (usually the taskType)
+     * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+     * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
      * </pre>
      *
      * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -1660,7 +1682,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Origin of the file (usually the taskType)
+     * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+     * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
      * </pre>
      *
      * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -1677,7 +1700,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Origin of the file (usually the taskType)
+     * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+     * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
      * </pre>
      *
      * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -1689,7 +1713,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Origin of the file (usually the taskType)
+     * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+     * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
      * </pre>
      *
      * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -1704,7 +1729,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Origin of the file (usually the taskType)
+     * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+     * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
      * </pre>
      *
      * <code>.google.protobuf.StringValue origin = 7;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFileOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFileOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcFileOrBuilder extends
 
   /**
    * <pre>
-   * Identification of the file
+   * Unique identifier of the file, used to reference it in fetch/download requests.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcFileOrBuilder extends
   boolean hasFileId();
   /**
    * <pre>
-   * Identification of the file
+   * Unique identifier of the file, used to reference it in fetch/download requests.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcFileOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuid getFileId();
   /**
    * <pre>
-   * Identification of the file
+   * Unique identifier of the file, used to reference it in fetch/download requests.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 1;</code>
@@ -60,7 +60,7 @@ public interface GrpcFileOrBuilder extends
 
   /**
    * <pre>
-   * File name
+   * File name, including extension.
    * </pre>
    *
    * <code>string name = 2;</code>
@@ -69,7 +69,7 @@ public interface GrpcFileOrBuilder extends
   java.lang.String getName();
   /**
    * <pre>
-   * File name
+   * File name, including extension.
    * </pre>
    *
    * <code>string name = 2;</code>
@@ -80,7 +80,8 @@ public interface GrpcFileOrBuilder extends
 
   /**
    * <pre>
-   * Detailed description of the file
+   * Human-readable description of the file's purpose or contents. Unset when no description was
+   * provided.
    * </pre>
    *
    * <code>.google.protobuf.StringValue description = 3;</code>
@@ -89,7 +90,8 @@ public interface GrpcFileOrBuilder extends
   boolean hasDescription();
   /**
    * <pre>
-   * Detailed description of the file
+   * Human-readable description of the file's purpose or contents. Unset when no description was
+   * provided.
    * </pre>
    *
    * <code>.google.protobuf.StringValue description = 3;</code>
@@ -98,7 +100,8 @@ public interface GrpcFileOrBuilder extends
   com.google.protobuf.StringValue getDescription();
   /**
    * <pre>
-   * Detailed description of the file
+   * Human-readable description of the file's purpose or contents. Unset when no description was
+   * provided.
    * </pre>
    *
    * <code>.google.protobuf.StringValue description = 3;</code>
@@ -107,7 +110,7 @@ public interface GrpcFileOrBuilder extends
 
   /**
    * <pre>
-   * Content type of the file
+   * MIME content type of the file (e.g. `application/zip`).
    * </pre>
    *
    * <code>string contentType = 4;</code>
@@ -116,7 +119,7 @@ public interface GrpcFileOrBuilder extends
   java.lang.String getContentType();
   /**
    * <pre>
-   * Content type of the file
+   * MIME content type of the file (e.g. `application/zip`).
    * </pre>
    *
    * <code>string contentType = 4;</code>
@@ -127,7 +130,7 @@ public interface GrpcFileOrBuilder extends
 
   /**
    * <pre>
-   * Size of the file in bytes
+   * Size of the file on disk (bytes).
    * </pre>
    *
    * <code>int64 totalSizeInBytes = 5;</code>
@@ -137,7 +140,7 @@ public interface GrpcFileOrBuilder extends
 
   /**
    * <pre>
-   * Date and time when the file was created
+   * Date and time when the file was created.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -146,7 +149,7 @@ public interface GrpcFileOrBuilder extends
   boolean hasCreated();
   /**
    * <pre>
-   * Date and time when the file was created
+   * Date and time when the file was created.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -155,7 +158,7 @@ public interface GrpcFileOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getCreated();
   /**
    * <pre>
-   * Date and time when the file was created
+   * Date and time when the file was created.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 6;</code>
@@ -164,7 +167,8 @@ public interface GrpcFileOrBuilder extends
 
   /**
    * <pre>
-   * Origin of the file (usually the taskType)
+   * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+   * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
    * </pre>
    *
    * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -173,7 +177,8 @@ public interface GrpcFileOrBuilder extends
   boolean hasOrigin();
   /**
    * <pre>
-   * Origin of the file (usually the taskType)
+   * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+   * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
    * </pre>
    *
    * <code>.google.protobuf.StringValue origin = 7;</code>
@@ -182,7 +187,8 @@ public interface GrpcFileOrBuilder extends
   com.google.protobuf.StringValue getOrigin();
   /**
    * <pre>
-   * Origin of the file (usually the taskType)
+   * Comma-separated identifiers of what produced the file — usually the `taskType` (see
+   * `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
    * </pre>
    *
    * <code>.google.protobuf.StringValue origin = 7;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFileToFetchRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFileToFetchRequest.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to list task statuses in paginated form.
+ * Request to get a single file available for fetching, by its id.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFileToFetchRequest}
@@ -269,7 +269,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to list task statuses in paginated form.
+   * Request to get a single file available for fetching, by its id.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFileToFetchRequest}

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFileToFetchResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFileToFetchResponse.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to a task statuses request.
+ * Response to a request for a single file available for fetching. If no file exists for the given
+ * id, the call fails with an error instead of returning this message.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFileToFetchResponse}
@@ -71,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch_;
   /**
    * <pre>
-   * File to fetch.
+   * Descriptor of the requested file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -83,7 +84,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * File to fetch.
+   * Descriptor of the requested file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -95,7 +96,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * File to fetch.
+   * Descriptor of the requested file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -269,7 +270,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to a task statuses request.
+   * Response to a request for a single file available for fetching. If no file exists for the given
+   * id, the call fails with an error instead of returning this message.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFileToFetchResponse}
@@ -461,7 +463,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcFile, io.evitadb.externalApi.grpc.generated.GrpcFile.Builder, io.evitadb.externalApi.grpc.generated.GrpcFileOrBuilder> fileToFetchBuilder_;
     /**
      * <pre>
-     * File to fetch.
+     * Descriptor of the requested file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -472,7 +474,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File to fetch.
+     * Descriptor of the requested file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -487,7 +489,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File to fetch.
+     * Descriptor of the requested file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -507,7 +509,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File to fetch.
+     * Descriptor of the requested file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -525,7 +527,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File to fetch.
+     * Descriptor of the requested file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -550,7 +552,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File to fetch.
+     * Descriptor of the requested file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -567,7 +569,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File to fetch.
+     * Descriptor of the requested file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -579,7 +581,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File to fetch.
+     * Descriptor of the requested file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -594,7 +596,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File to fetch.
+     * Descriptor of the requested file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFileToFetchResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFileToFetchResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcFileToFetchResponseOrBuilder extends
 
   /**
    * <pre>
-   * File to fetch.
+   * Descriptor of the requested file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcFileToFetchResponseOrBuilder extends
   boolean hasFileToFetch();
   /**
    * <pre>
-   * File to fetch.
+   * Descriptor of the requested file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcFileToFetchResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcFile getFileToFetch();
   /**
    * <pre>
-   * File to fetch.
+   * Descriptor of the requested file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile fileToFetch = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFilesToFetchRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFilesToFetchRequest.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to list files to fetch in paginated form.
+ * Request to list files available for fetching, in paginated form.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFilesToFetchRequest}
@@ -71,7 +71,8 @@ private static final long serialVersionUID = 0L;
   private int pageNumber_ = 0;
   /**
    * <pre>
-   * Page number of the task statuses to be listed.
+   * Page number of the files to be listed. Page-based paging: 1-indexed, page 1 is the first page
+   * (see `io.evitadb.dataType.PaginatedList#getPageNumber`).
    * </pre>
    *
    * <code>int32 pageNumber = 1;</code>
@@ -86,7 +87,7 @@ private static final long serialVersionUID = 0L;
   private int pageSize_ = 0;
   /**
    * <pre>
-   * Number of task statuses per page.
+   * Number of files per page. No server-side maximum is enforced.
    * </pre>
    *
    * <code>int32 pageSize = 2;</code>
@@ -102,8 +103,9 @@ private static final long serialVersionUID = 0L;
   private java.util.List<com.google.protobuf.StringValue> origin_;
   /**
    * <pre>
-   * Optional origin of the files (derived from taskType), passing non-null value
-   * in this argument filters the returned files to only those that are related to the specified origin
+   * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+   * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+   * values. Empty (the default) means no filtering - files of all origins are returned.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -114,8 +116,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional origin of the files (derived from taskType), passing non-null value
-   * in this argument filters the returned files to only those that are related to the specified origin
+   * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+   * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+   * values. Empty (the default) means no filtering - files of all origins are returned.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -127,8 +130,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional origin of the files (derived from taskType), passing non-null value
-   * in this argument filters the returned files to only those that are related to the specified origin
+   * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+   * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+   * values. Empty (the default) means no filtering - files of all origins are returned.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -139,8 +143,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional origin of the files (derived from taskType), passing non-null value
-   * in this argument filters the returned files to only those that are related to the specified origin
+   * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+   * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+   * values. Empty (the default) means no filtering - files of all origins are returned.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -151,8 +156,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional origin of the files (derived from taskType), passing non-null value
-   * in this argument filters the returned files to only those that are related to the specified origin
+   * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+   * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+   * values. Empty (the default) means no filtering - files of all origins are returned.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -346,7 +352,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to list files to fetch in paginated form.
+   * Request to list files available for fetching, in paginated form.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFilesToFetchRequest}
@@ -590,7 +596,8 @@ private static final long serialVersionUID = 0L;
     private int pageNumber_ ;
     /**
      * <pre>
-     * Page number of the task statuses to be listed.
+     * Page number of the files to be listed. Page-based paging: 1-indexed, page 1 is the first page
+     * (see `io.evitadb.dataType.PaginatedList#getPageNumber`).
      * </pre>
      *
      * <code>int32 pageNumber = 1;</code>
@@ -602,7 +609,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Page number of the task statuses to be listed.
+     * Page number of the files to be listed. Page-based paging: 1-indexed, page 1 is the first page
+     * (see `io.evitadb.dataType.PaginatedList#getPageNumber`).
      * </pre>
      *
      * <code>int32 pageNumber = 1;</code>
@@ -618,7 +626,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Page number of the task statuses to be listed.
+     * Page number of the files to be listed. Page-based paging: 1-indexed, page 1 is the first page
+     * (see `io.evitadb.dataType.PaginatedList#getPageNumber`).
      * </pre>
      *
      * <code>int32 pageNumber = 1;</code>
@@ -634,7 +643,7 @@ private static final long serialVersionUID = 0L;
     private int pageSize_ ;
     /**
      * <pre>
-     * Number of task statuses per page.
+     * Number of files per page. No server-side maximum is enforced.
      * </pre>
      *
      * <code>int32 pageSize = 2;</code>
@@ -646,7 +655,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Number of task statuses per page.
+     * Number of files per page. No server-side maximum is enforced.
      * </pre>
      *
      * <code>int32 pageSize = 2;</code>
@@ -662,7 +671,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Number of task statuses per page.
+     * Number of files per page. No server-side maximum is enforced.
      * </pre>
      *
      * <code>int32 pageSize = 2;</code>
@@ -689,8 +698,9 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -704,8 +714,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -719,8 +730,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -734,8 +746,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -756,8 +769,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -775,8 +789,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -796,8 +811,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -818,8 +834,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -837,8 +854,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -856,8 +874,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -876,8 +895,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -894,8 +914,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -912,8 +933,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -924,8 +946,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -939,8 +962,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -955,8 +979,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -967,8 +992,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -980,8 +1006,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional origin of the files (derived from taskType), passing non-null value
-     * in this argument filters the returned files to only those that are related to the specified origin
+     * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+     * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+     * values. Empty (the default) means no filtering - files of all origins are returned.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue origin = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFilesToFetchRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFilesToFetchRequestOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcFilesToFetchRequestOrBuilder extends
 
   /**
    * <pre>
-   * Page number of the task statuses to be listed.
+   * Page number of the files to be listed. Page-based paging: 1-indexed, page 1 is the first page
+   * (see `io.evitadb.dataType.PaginatedList#getPageNumber`).
    * </pre>
    *
    * <code>int32 pageNumber = 1;</code>
@@ -43,7 +44,7 @@ public interface GrpcFilesToFetchRequestOrBuilder extends
 
   /**
    * <pre>
-   * Number of task statuses per page.
+   * Number of files per page. No server-side maximum is enforced.
    * </pre>
    *
    * <code>int32 pageSize = 2;</code>
@@ -53,8 +54,9 @@ public interface GrpcFilesToFetchRequestOrBuilder extends
 
   /**
    * <pre>
-   * Optional origin of the files (derived from taskType), passing non-null value
-   * in this argument filters the returned files to only those that are related to the specified origin
+   * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+   * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+   * values. Empty (the default) means no filtering - files of all origins are returned.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -63,8 +65,9 @@ public interface GrpcFilesToFetchRequestOrBuilder extends
       getOriginList();
   /**
    * <pre>
-   * Optional origin of the files (derived from taskType), passing non-null value
-   * in this argument filters the returned files to only those that are related to the specified origin
+   * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+   * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+   * values. Empty (the default) means no filtering - files of all origins are returned.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -72,8 +75,9 @@ public interface GrpcFilesToFetchRequestOrBuilder extends
   com.google.protobuf.StringValue getOrigin(int index);
   /**
    * <pre>
-   * Optional origin of the files (derived from taskType), passing non-null value
-   * in this argument filters the returned files to only those that are related to the specified origin
+   * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+   * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+   * values. Empty (the default) means no filtering - files of all origins are returned.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -81,8 +85,9 @@ public interface GrpcFilesToFetchRequestOrBuilder extends
   int getOriginCount();
   /**
    * <pre>
-   * Optional origin of the files (derived from taskType), passing non-null value
-   * in this argument filters the returned files to only those that are related to the specified origin
+   * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+   * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+   * values. Empty (the default) means no filtering - files of all origins are returned.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue origin = 3;</code>
@@ -91,8 +96,9 @@ public interface GrpcFilesToFetchRequestOrBuilder extends
       getOriginOrBuilderList();
   /**
    * <pre>
-   * Optional origin of the files (derived from taskType), passing non-null value
-   * in this argument filters the returned files to only those that are related to the specified origin
+   * File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+   * produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+   * values. Empty (the default) means no filtering - files of all origins are returned.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue origin = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFilesToFetchResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFilesToFetchResponse.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to a get files to fetch request.
+ * Response to a request to list files available for fetching.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFilesToFetchResponse}
@@ -71,7 +71,7 @@ private static final long serialVersionUID = 0L;
   private int pageSize_ = 0;
   /**
    * <pre>
-   * The size of the page.
+   * The page size that was actually applied (echoes the request's `pageSize`).
    * </pre>
    *
    * <code>int32 pageSize = 1;</code>
@@ -86,7 +86,8 @@ private static final long serialVersionUID = 0L;
   private int pageNumber_ = 0;
   /**
    * <pre>
-   * The number of the page.
+   * The page number that was actually applied (echoes the request's `pageNumber`); 1-indexed, see
+   * `GrpcFilesToFetchRequest.pageNumber` for the paging model.
    * </pre>
    *
    * <code>int32 pageNumber = 2;</code>
@@ -102,7 +103,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcFile> filesToFetch_;
   /**
    * <pre>
-   * Collection of files to fetch.
+   * Files on this page, matching the origin filter from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -113,7 +114,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of files to fetch.
+   * Files on this page, matching the origin filter from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -125,7 +126,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of files to fetch.
+   * Files on this page, matching the origin filter from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -136,7 +137,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of files to fetch.
+   * Files on this page, matching the origin filter from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -147,7 +148,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of files to fetch.
+   * Files on this page, matching the origin filter from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -162,7 +163,8 @@ private static final long serialVersionUID = 0L;
   private int totalNumberOfRecords_ = 0;
   /**
    * <pre>
-   * Total number of files to fetch.
+   * Total number of files matching the request's origin filter across all pages, not just this
+   * one.
    * </pre>
    *
    * <code>int32 totalNumberOfRecords = 4;</code>
@@ -367,7 +369,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to a get files to fetch request.
+   * Response to a request to list files available for fetching.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFilesToFetchResponse}
@@ -623,7 +625,7 @@ private static final long serialVersionUID = 0L;
     private int pageSize_ ;
     /**
      * <pre>
-     * The size of the page.
+     * The page size that was actually applied (echoes the request's `pageSize`).
      * </pre>
      *
      * <code>int32 pageSize = 1;</code>
@@ -635,7 +637,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page.
+     * The page size that was actually applied (echoes the request's `pageSize`).
      * </pre>
      *
      * <code>int32 pageSize = 1;</code>
@@ -651,7 +653,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page.
+     * The page size that was actually applied (echoes the request's `pageSize`).
      * </pre>
      *
      * <code>int32 pageSize = 1;</code>
@@ -667,7 +669,8 @@ private static final long serialVersionUID = 0L;
     private int pageNumber_ ;
     /**
      * <pre>
-     * The number of the page.
+     * The page number that was actually applied (echoes the request's `pageNumber`); 1-indexed, see
+     * `GrpcFilesToFetchRequest.pageNumber` for the paging model.
      * </pre>
      *
      * <code>int32 pageNumber = 2;</code>
@@ -679,7 +682,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The number of the page.
+     * The page number that was actually applied (echoes the request's `pageNumber`); 1-indexed, see
+     * `GrpcFilesToFetchRequest.pageNumber` for the paging model.
      * </pre>
      *
      * <code>int32 pageNumber = 2;</code>
@@ -695,7 +699,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The number of the page.
+     * The page number that was actually applied (echoes the request's `pageNumber`); 1-indexed, see
+     * `GrpcFilesToFetchRequest.pageNumber` for the paging model.
      * </pre>
      *
      * <code>int32 pageNumber = 2;</code>
@@ -722,7 +727,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -736,7 +741,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -750,7 +755,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -764,7 +769,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -785,7 +790,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -803,7 +808,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -823,7 +828,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -844,7 +849,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -862,7 +867,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -880,7 +885,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -899,7 +904,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -916,7 +921,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -933,7 +938,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -944,7 +949,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -958,7 +963,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -973,7 +978,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -984,7 +989,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -996,7 +1001,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of files to fetch.
+     * Files on this page, matching the origin filter from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -1023,7 +1028,8 @@ private static final long serialVersionUID = 0L;
     private int totalNumberOfRecords_ ;
     /**
      * <pre>
-     * Total number of files to fetch.
+     * Total number of files matching the request's origin filter across all pages, not just this
+     * one.
      * </pre>
      *
      * <code>int32 totalNumberOfRecords = 4;</code>
@@ -1035,7 +1041,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Total number of files to fetch.
+     * Total number of files matching the request's origin filter across all pages, not just this
+     * one.
      * </pre>
      *
      * <code>int32 totalNumberOfRecords = 4;</code>
@@ -1051,7 +1058,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Total number of files to fetch.
+     * Total number of files matching the request's origin filter across all pages, not just this
+     * one.
      * </pre>
      *
      * <code>int32 totalNumberOfRecords = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFilesToFetchResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFilesToFetchResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcFilesToFetchResponseOrBuilder extends
 
   /**
    * <pre>
-   * The size of the page.
+   * The page size that was actually applied (echoes the request's `pageSize`).
    * </pre>
    *
    * <code>int32 pageSize = 1;</code>
@@ -43,7 +43,8 @@ public interface GrpcFilesToFetchResponseOrBuilder extends
 
   /**
    * <pre>
-   * The number of the page.
+   * The page number that was actually applied (echoes the request's `pageNumber`); 1-indexed, see
+   * `GrpcFilesToFetchRequest.pageNumber` for the paging model.
    * </pre>
    *
    * <code>int32 pageNumber = 2;</code>
@@ -53,7 +54,7 @@ public interface GrpcFilesToFetchResponseOrBuilder extends
 
   /**
    * <pre>
-   * Collection of files to fetch.
+   * Files on this page, matching the origin filter from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -62,7 +63,7 @@ public interface GrpcFilesToFetchResponseOrBuilder extends
       getFilesToFetchList();
   /**
    * <pre>
-   * Collection of files to fetch.
+   * Files on this page, matching the origin filter from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -70,7 +71,7 @@ public interface GrpcFilesToFetchResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcFile getFilesToFetch(int index);
   /**
    * <pre>
-   * Collection of files to fetch.
+   * Files on this page, matching the origin filter from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -78,7 +79,7 @@ public interface GrpcFilesToFetchResponseOrBuilder extends
   int getFilesToFetchCount();
   /**
    * <pre>
-   * Collection of files to fetch.
+   * Files on this page, matching the origin filter from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -87,7 +88,7 @@ public interface GrpcFilesToFetchResponseOrBuilder extends
       getFilesToFetchOrBuilderList();
   /**
    * <pre>
-   * Collection of files to fetch.
+   * Files on this page, matching the origin filter from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcFile filesToFetch = 3;</code>
@@ -97,7 +98,8 @@ public interface GrpcFilesToFetchResponseOrBuilder extends
 
   /**
    * <pre>
-   * Total number of files to fetch.
+   * Total number of files matching the request's origin filter across all pages, not just this
+   * one.
    * </pre>
    *
    * <code>int32 totalNumberOfRecords = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFullBackupCatalogResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFullBackupCatalogResponse.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to a catalog full backup request.
+ * Response to a catalog full backup request (a backup that includes the entire catalog history, not just
+ * the current state).
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFullBackupCatalogResponse}
@@ -71,7 +72,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus_;
   /**
    * <pre>
-   * the task that is used to backup the catalog and getting its progress
+   * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+   * finished, retrieve the resulting backup file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -83,7 +85,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the task that is used to backup the catalog and getting its progress
+   * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+   * finished, retrieve the resulting backup file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -95,7 +98,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the task that is used to backup the catalog and getting its progress
+   * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+   * finished, retrieve the resulting backup file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -269,7 +273,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to a catalog full backup request.
+   * Response to a catalog full backup request (a backup that includes the entire catalog history, not just
+   * the current state).
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcFullBackupCatalogResponse}
@@ -461,7 +466,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcTaskStatus, io.evitadb.externalApi.grpc.generated.GrpcTaskStatus.Builder, io.evitadb.externalApi.grpc.generated.GrpcTaskStatusOrBuilder> taskStatusBuilder_;
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -472,7 +478,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -487,7 +494,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -507,7 +515,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -525,7 +534,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -550,7 +560,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -567,7 +578,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -579,7 +591,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -594,7 +607,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to backup the catalog and getting its progress
+     * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+     * finished, retrieve the resulting backup file.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFullBackupCatalogResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFullBackupCatalogResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcFullBackupCatalogResponseOrBuilder extends
 
   /**
    * <pre>
-   * the task that is used to backup the catalog and getting its progress
+   * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+   * finished, retrieve the resulting backup file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcFullBackupCatalogResponseOrBuilder extends
   boolean hasTaskStatus();
   /**
    * <pre>
-   * the task that is used to backup the catalog and getting its progress
+   * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+   * finished, retrieve the resulting backup file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcFullBackupCatalogResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTaskStatus getTaskStatus();
   /**
    * <pre>
-   * the task that is used to backup the catalog and getting its progress
+   * Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+   * finished, retrieve the resulting backup file.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGetCatalogStateResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGetCatalogStateResponse.java
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private int catalogState_ = 0;
   /**
    * <pre>
-   * State of the catalog.
+   * State of the catalog. Unset if no catalog with the requested name exists.
    * </pre>
    *
    * <code>optional .io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 1;</code>
@@ -83,7 +83,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * State of the catalog.
+   * State of the catalog. Unset if no catalog with the requested name exists.
    * </pre>
    *
    * <code>optional .io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 1;</code>
@@ -94,7 +94,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * State of the catalog.
+   * State of the catalog. Unset if no catalog with the requested name exists.
    * </pre>
    *
    * <code>optional .io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 1;</code>
@@ -444,7 +444,7 @@ private static final long serialVersionUID = 0L;
     private int catalogState_ = 0;
     /**
      * <pre>
-     * State of the catalog.
+     * State of the catalog. Unset if no catalog with the requested name exists.
      * </pre>
      *
      * <code>optional .io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 1;</code>
@@ -455,7 +455,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * State of the catalog.
+     * State of the catalog. Unset if no catalog with the requested name exists.
      * </pre>
      *
      * <code>optional .io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 1;</code>
@@ -466,7 +466,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * State of the catalog.
+     * State of the catalog. Unset if no catalog with the requested name exists.
      * </pre>
      *
      * <code>optional .io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 1;</code>
@@ -481,7 +481,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * State of the catalog.
+     * State of the catalog. Unset if no catalog with the requested name exists.
      * </pre>
      *
      * <code>optional .io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 1;</code>
@@ -494,7 +494,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * State of the catalog.
+     * State of the catalog. Unset if no catalog with the requested name exists.
      * </pre>
      *
      * <code>optional .io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 1;</code>
@@ -512,7 +512,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * State of the catalog.
+     * State of the catalog. Unset if no catalog with the requested name exists.
      * </pre>
      *
      * <code>optional .io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGetCatalogStateResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGetCatalogStateResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcGetCatalogStateResponseOrBuilder extends
 
   /**
    * <pre>
-   * State of the catalog.
+   * State of the catalog. Unset if no catalog with the requested name exists.
    * </pre>
    *
    * <code>optional .io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcGetCatalogStateResponseOrBuilder extends
   boolean hasCatalogState();
   /**
    * <pre>
-   * State of the catalog.
+   * State of the catalog. Unset if no catalog with the requested name exists.
    * </pre>
    *
    * <code>optional .io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcGetCatalogStateResponseOrBuilder extends
   int getCatalogStateValue();
   /**
    * <pre>
-   * State of the catalog.
+   * State of the catalog. Unset if no catalog with the requested name exists.
    * </pre>
    *
    * <code>optional .io.evitadb.externalApi.grpc.generated.GrpcCatalogState catalogState = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGetProgressResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGetProgressResponse.java
@@ -72,7 +72,10 @@ private static final long serialVersionUID = 0L;
   private boolean found_ = false;
   /**
    * <pre>
-   * contains information whether the progress was found or not
+   * True when a mutation progress was being tracked for `catalogName` at the moment this call was received. If
+   * `false`, none of the fields below carry information - either no mutation is currently in flight for this
+   * catalog, or a previously tracked one already finished (and its progress entry was cleared) before this call
+   * arrived; the call must be made while the operation is still running in order to observe it.
    * </pre>
    *
    * <code>bool found = 1;</code>
@@ -87,7 +90,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value progressInPercent_;
   /**
    * <pre>
-   * The progress of the top-level engine mutation in percents.
+   * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+   * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
    * </pre>
    *
    * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -99,7 +103,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The progress of the top-level engine mutation in percents.
+   * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+   * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
    * </pre>
    *
    * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -111,7 +116,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The progress of the top-level engine mutation in percents.
+   * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+   * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
    * </pre>
    *
    * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -126,7 +132,7 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object catalogName_ = "";
   /**
    * <pre>
-   * Contains catalog name copied from the request (if the progress is related to a catalog)
+   * Catalog name copied from the request. Empty when `found` is `false`.
    * </pre>
    *
    * <code>string catalogName = 3;</code>
@@ -147,7 +153,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Contains catalog name copied from the request (if the progress is related to a catalog)
+   * Catalog name copied from the request. Empty when `found` is `false`.
    * </pre>
    *
    * <code>string catalogName = 3;</code>
@@ -172,7 +178,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value catalogVersion_;
   /**
    * <pre>
-   * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+   * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+   * engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -184,7 +192,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+   * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+   * engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -196,7 +206,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+   * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+   * engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -210,7 +222,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value catalogSchemaVersion_;
   /**
    * <pre>
-   * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog schema version reached by the operation. Set only on the final streamed message
+   * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+   * catalog rather than being purely engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -222,7 +236,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog schema version reached by the operation. Set only on the final streamed message
+   * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+   * catalog rather than being purely engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -234,7 +250,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog schema version reached by the operation. Set only on the final streamed message
+   * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+   * catalog rather than being purely engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -722,7 +740,10 @@ private static final long serialVersionUID = 0L;
     private boolean found_ ;
     /**
      * <pre>
-     * contains information whether the progress was found or not
+     * True when a mutation progress was being tracked for `catalogName` at the moment this call was received. If
+     * `false`, none of the fields below carry information - either no mutation is currently in flight for this
+     * catalog, or a previously tracked one already finished (and its progress entry was cleared) before this call
+     * arrived; the call must be made while the operation is still running in order to observe it.
      * </pre>
      *
      * <code>bool found = 1;</code>
@@ -734,7 +755,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * contains information whether the progress was found or not
+     * True when a mutation progress was being tracked for `catalogName` at the moment this call was received. If
+     * `false`, none of the fields below carry information - either no mutation is currently in flight for this
+     * catalog, or a previously tracked one already finished (and its progress entry was cleared) before this call
+     * arrived; the call must be made while the operation is still running in order to observe it.
      * </pre>
      *
      * <code>bool found = 1;</code>
@@ -750,7 +774,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * contains information whether the progress was found or not
+     * True when a mutation progress was being tracked for `catalogName` at the moment this call was received. If
+     * `false`, none of the fields below carry information - either no mutation is currently in flight for this
+     * catalog, or a previously tracked one already finished (and its progress entry was cleared) before this call
+     * arrived; the call must be made while the operation is still running in order to observe it.
      * </pre>
      *
      * <code>bool found = 1;</code>
@@ -768,7 +795,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> progressInPercentBuilder_;
     /**
      * <pre>
-     * The progress of the top-level engine mutation in percents.
+     * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+     * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
      * </pre>
      *
      * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -779,7 +807,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The progress of the top-level engine mutation in percents.
+     * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+     * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
      * </pre>
      *
      * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -794,7 +823,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The progress of the top-level engine mutation in percents.
+     * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+     * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
      * </pre>
      *
      * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -814,7 +844,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The progress of the top-level engine mutation in percents.
+     * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+     * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
      * </pre>
      *
      * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -832,7 +863,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The progress of the top-level engine mutation in percents.
+     * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+     * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
      * </pre>
      *
      * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -857,7 +889,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The progress of the top-level engine mutation in percents.
+     * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+     * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
      * </pre>
      *
      * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -874,7 +907,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The progress of the top-level engine mutation in percents.
+     * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+     * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
      * </pre>
      *
      * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -886,7 +920,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The progress of the top-level engine mutation in percents.
+     * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+     * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
      * </pre>
      *
      * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -901,7 +936,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The progress of the top-level engine mutation in percents.
+     * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+     * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
      * </pre>
      *
      * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -923,7 +959,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object catalogName_ = "";
     /**
      * <pre>
-     * Contains catalog name copied from the request (if the progress is related to a catalog)
+     * Catalog name copied from the request. Empty when `found` is `false`.
      * </pre>
      *
      * <code>string catalogName = 3;</code>
@@ -943,7 +979,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog name copied from the request (if the progress is related to a catalog)
+     * Catalog name copied from the request. Empty when `found` is `false`.
      * </pre>
      *
      * <code>string catalogName = 3;</code>
@@ -964,7 +1000,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog name copied from the request (if the progress is related to a catalog)
+     * Catalog name copied from the request. Empty when `found` is `false`.
      * </pre>
      *
      * <code>string catalogName = 3;</code>
@@ -981,7 +1017,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog name copied from the request (if the progress is related to a catalog)
+     * Catalog name copied from the request. Empty when `found` is `false`.
      * </pre>
      *
      * <code>string catalogName = 3;</code>
@@ -995,7 +1031,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog name copied from the request (if the progress is related to a catalog)
+     * Catalog name copied from the request. Empty when `found` is `false`.
      * </pre>
      *
      * <code>string catalogName = 3;</code>
@@ -1017,7 +1053,9 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> catalogVersionBuilder_;
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+     * engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -1028,7 +1066,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+     * engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -1043,7 +1083,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+     * engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -1063,7 +1105,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+     * engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -1081,7 +1125,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+     * engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -1106,7 +1152,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+     * engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -1123,7 +1171,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+     * engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -1135,7 +1185,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+     * engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -1150,7 +1202,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+     * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+     * engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -1174,7 +1228,9 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> catalogSchemaVersionBuilder_;
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final streamed message
+     * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+     * catalog rather than being purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -1185,7 +1241,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final streamed message
+     * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+     * catalog rather than being purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -1200,7 +1258,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final streamed message
+     * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+     * catalog rather than being purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -1220,7 +1280,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final streamed message
+     * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+     * catalog rather than being purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -1238,7 +1300,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final streamed message
+     * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+     * catalog rather than being purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -1263,7 +1327,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final streamed message
+     * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+     * catalog rather than being purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -1280,7 +1346,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final streamed message
+     * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+     * catalog rather than being purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -1292,7 +1360,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final streamed message
+     * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+     * catalog rather than being purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -1307,7 +1377,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+     * Catalog schema version reached by the operation. Set only on the final streamed message
+     * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+     * catalog rather than being purely engine-level); unset on every intermediate update.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGetProgressResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGetProgressResponseOrBuilder.java
@@ -33,7 +33,10 @@ public interface GrpcGetProgressResponseOrBuilder extends
 
   /**
    * <pre>
-   * contains information whether the progress was found or not
+   * True when a mutation progress was being tracked for `catalogName` at the moment this call was received. If
+   * `false`, none of the fields below carry information - either no mutation is currently in flight for this
+   * catalog, or a previously tracked one already finished (and its progress entry was cleared) before this call
+   * arrived; the call must be made while the operation is still running in order to observe it.
    * </pre>
    *
    * <code>bool found = 1;</code>
@@ -43,7 +46,8 @@ public interface GrpcGetProgressResponseOrBuilder extends
 
   /**
    * <pre>
-   * The progress of the top-level engine mutation in percents.
+   * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+   * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
    * </pre>
    *
    * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -52,7 +56,8 @@ public interface GrpcGetProgressResponseOrBuilder extends
   boolean hasProgressInPercent();
   /**
    * <pre>
-   * The progress of the top-level engine mutation in percents.
+   * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+   * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
    * </pre>
    *
    * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -61,7 +66,8 @@ public interface GrpcGetProgressResponseOrBuilder extends
   com.google.protobuf.Int32Value getProgressInPercent();
   /**
    * <pre>
-   * The progress of the top-level engine mutation in percents.
+   * Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+   * message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
    * </pre>
    *
    * <code>.google.protobuf.Int32Value progressInPercent = 2;</code>
@@ -70,7 +76,7 @@ public interface GrpcGetProgressResponseOrBuilder extends
 
   /**
    * <pre>
-   * Contains catalog name copied from the request (if the progress is related to a catalog)
+   * Catalog name copied from the request. Empty when `found` is `false`.
    * </pre>
    *
    * <code>string catalogName = 3;</code>
@@ -79,7 +85,7 @@ public interface GrpcGetProgressResponseOrBuilder extends
   java.lang.String getCatalogName();
   /**
    * <pre>
-   * Contains catalog name copied from the request (if the progress is related to a catalog)
+   * Catalog name copied from the request. Empty when `found` is `false`.
    * </pre>
    *
    * <code>string catalogName = 3;</code>
@@ -90,7 +96,9 @@ public interface GrpcGetProgressResponseOrBuilder extends
 
   /**
    * <pre>
-   * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+   * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+   * engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -99,7 +107,9 @@ public interface GrpcGetProgressResponseOrBuilder extends
   boolean hasCatalogVersion();
   /**
    * <pre>
-   * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+   * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+   * engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -108,7 +118,9 @@ public interface GrpcGetProgressResponseOrBuilder extends
   com.google.protobuf.Int64Value getCatalogVersion();
   /**
    * <pre>
-   * Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+   * and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+   * engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value catalogVersion = 4;</code>
@@ -117,7 +129,9 @@ public interface GrpcGetProgressResponseOrBuilder extends
 
   /**
    * <pre>
-   * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog schema version reached by the operation. Set only on the final streamed message
+   * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+   * catalog rather than being purely engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -126,7 +140,9 @@ public interface GrpcGetProgressResponseOrBuilder extends
   boolean hasCatalogSchemaVersion();
   /**
    * <pre>
-   * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog schema version reached by the operation. Set only on the final streamed message
+   * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+   * catalog rather than being purely engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>
@@ -135,7 +151,9 @@ public interface GrpcGetProgressResponseOrBuilder extends
   com.google.protobuf.Int32Value getCatalogSchemaVersion();
   /**
    * <pre>
-   * Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+   * Catalog schema version reached by the operation. Set only on the final streamed message
+   * (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+   * catalog rather than being purely engine-level); unset on every intermediate update.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value catalogSchemaVersion = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGlobalAttributeSchema.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGlobalAttributeSchema.java
@@ -93,6 +93,11 @@ private static final long serialVersionUID = 0L;
   @SuppressWarnings("serial")
   private volatile java.lang.Object name_ = "";
   /**
+   * <pre>
+   * Contains unique name of the attribute. Case-sensitive. Distinguishes one attribute from another within
+   * a single entity type or, for global attributes, within the entire catalog.
+   * </pre>
+   *
    * <code>string name = 1;</code>
    * @return The name.
    */
@@ -110,6 +115,11 @@ private static final long serialVersionUID = 0L;
     }
   }
   /**
+   * <pre>
+   * Contains unique name of the attribute. Case-sensitive. Distinguishes one attribute from another within
+   * a single entity type or, for global attributes, within the entire catalog.
+   * </pre>
+   *
    * <code>string name = 1;</code>
    * @return The bytes for name.
    */
@@ -218,7 +228,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeUniquenessType unique = 4 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.unique is deprecated.
-   *     See GrpcCatalogSchema.proto;l=67
+   *     See GrpcCatalogSchema.proto;l=73
    * @return The enum numeric value on the wire for unique.
    */
   @java.lang.Override @java.lang.Deprecated public int getUniqueValue() {
@@ -236,7 +246,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeUniquenessType unique = 4 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.unique is deprecated.
-   *     See GrpcCatalogSchema.proto;l=67
+   *     See GrpcCatalogSchema.proto;l=73
    * @return The unique.
    */
   @java.lang.Override @java.lang.Deprecated public io.evitadb.externalApi.grpc.generated.GrpcAttributeUniquenessType getUnique() {
@@ -259,7 +269,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>bool filterable = 5 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.filterable is deprecated.
-   *     See GrpcCatalogSchema.proto;l=75
+   *     See GrpcCatalogSchema.proto;l=81
    * @return The filterable.
    */
   @java.lang.Override
@@ -279,7 +289,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>bool sortable = 6 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.sortable is deprecated.
-   *     See GrpcCatalogSchema.proto;l=80
+   *     See GrpcCatalogSchema.proto;l=86
    * @return The sortable.
    */
   @java.lang.Override
@@ -411,8 +421,8 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * Determines how many fractional places are important when entities are compared during filtering or sorting. It is
-   * significant to know that all values of this attribute will be converted to {&#64;link java.lang.Integer}, so the attribute
-   * number must not ever exceed maximum limits of {&#64;link java.lang.Integer} type when scaling the number by the power
+   * significant to know that all values of this attribute will be converted to `Integer`, so the attribute
+   * number must not ever exceed maximum limits of `Integer` type when scaling the number by the power
    * of ten using `indexedDecimalPlaces` as exponent.
    * </pre>
    *
@@ -438,7 +448,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeUniquenessType uniqueGlobally = 13 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.uniqueGlobally is deprecated.
-   *     See GrpcCatalogSchema.proto;l=109
+   *     See GrpcCatalogSchema.proto;l=115
    * @return The enum numeric value on the wire for uniqueGlobally.
    */
   @java.lang.Override @java.lang.Deprecated public int getUniqueGloballyValue() {
@@ -456,7 +466,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeUniquenessType uniqueGlobally = 13 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.uniqueGlobally is deprecated.
-   *     See GrpcCatalogSchema.proto;l=109
+   *     See GrpcCatalogSchema.proto;l=115
    * @return The uniqueGlobally.
    */
   @java.lang.Override @java.lang.Deprecated public io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeUniquenessType getUniqueGlobally() {
@@ -1930,6 +1940,11 @@ private static final long serialVersionUID = 0L;
 
     private java.lang.Object name_ = "";
     /**
+     * <pre>
+     * Contains unique name of the attribute. Case-sensitive. Distinguishes one attribute from another within
+     * a single entity type or, for global attributes, within the entire catalog.
+     * </pre>
+     *
      * <code>string name = 1;</code>
      * @return The name.
      */
@@ -1946,6 +1961,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Contains unique name of the attribute. Case-sensitive. Distinguishes one attribute from another within
+     * a single entity type or, for global attributes, within the entire catalog.
+     * </pre>
+     *
      * <code>string name = 1;</code>
      * @return The bytes for name.
      */
@@ -1963,6 +1983,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Contains unique name of the attribute. Case-sensitive. Distinguishes one attribute from another within
+     * a single entity type or, for global attributes, within the entire catalog.
+     * </pre>
+     *
      * <code>string name = 1;</code>
      * @param value The name to set.
      * @return This builder for chaining.
@@ -1976,6 +2001,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Contains unique name of the attribute. Case-sensitive. Distinguishes one attribute from another within
+     * a single entity type or, for global attributes, within the entire catalog.
+     * </pre>
+     *
      * <code>string name = 1;</code>
      * @return This builder for chaining.
      */
@@ -1986,6 +2016,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Contains unique name of the attribute. Case-sensitive. Distinguishes one attribute from another within
+     * a single entity type or, for global attributes, within the entire catalog.
+     * </pre>
+     *
      * <code>string name = 1;</code>
      * @param value The bytes for name to set.
      * @return This builder for chaining.
@@ -2327,7 +2362,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeUniquenessType unique = 4 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.unique is deprecated.
-     *     See GrpcCatalogSchema.proto;l=67
+     *     See GrpcCatalogSchema.proto;l=73
      * @return The enum numeric value on the wire for unique.
      */
     @java.lang.Override @java.lang.Deprecated public int getUniqueValue() {
@@ -2345,7 +2380,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeUniquenessType unique = 4 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.unique is deprecated.
-     *     See GrpcCatalogSchema.proto;l=67
+     *     See GrpcCatalogSchema.proto;l=73
      * @param value The enum numeric value on the wire for unique to set.
      * @return This builder for chaining.
      */
@@ -2367,7 +2402,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeUniquenessType unique = 4 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.unique is deprecated.
-     *     See GrpcCatalogSchema.proto;l=67
+     *     See GrpcCatalogSchema.proto;l=73
      * @return The unique.
      */
     @java.lang.Override
@@ -2387,7 +2422,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeUniquenessType unique = 4 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.unique is deprecated.
-     *     See GrpcCatalogSchema.proto;l=67
+     *     See GrpcCatalogSchema.proto;l=73
      * @param value The unique to set.
      * @return This builder for chaining.
      */
@@ -2412,7 +2447,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeUniquenessType unique = 4 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.unique is deprecated.
-     *     See GrpcCatalogSchema.proto;l=67
+     *     See GrpcCatalogSchema.proto;l=73
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearUnique() {
@@ -2436,7 +2471,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>bool filterable = 5 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.filterable is deprecated.
-     *     See GrpcCatalogSchema.proto;l=75
+     *     See GrpcCatalogSchema.proto;l=81
      * @return The filterable.
      */
     @java.lang.Override
@@ -2456,7 +2491,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>bool filterable = 5 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.filterable is deprecated.
-     *     See GrpcCatalogSchema.proto;l=75
+     *     See GrpcCatalogSchema.proto;l=81
      * @param value The filterable to set.
      * @return This builder for chaining.
      */
@@ -2480,7 +2515,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>bool filterable = 5 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.filterable is deprecated.
-     *     See GrpcCatalogSchema.proto;l=75
+     *     See GrpcCatalogSchema.proto;l=81
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearFilterable() {
@@ -2501,7 +2536,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>bool sortable = 6 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.sortable is deprecated.
-     *     See GrpcCatalogSchema.proto;l=80
+     *     See GrpcCatalogSchema.proto;l=86
      * @return The sortable.
      */
     @java.lang.Override
@@ -2518,7 +2553,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>bool sortable = 6 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.sortable is deprecated.
-     *     See GrpcCatalogSchema.proto;l=80
+     *     See GrpcCatalogSchema.proto;l=86
      * @param value The sortable to set.
      * @return This builder for chaining.
      */
@@ -2539,7 +2574,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>bool sortable = 6 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.sortable is deprecated.
-     *     See GrpcCatalogSchema.proto;l=80
+     *     See GrpcCatalogSchema.proto;l=86
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearSortable() {
@@ -2944,8 +2979,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * Determines how many fractional places are important when entities are compared during filtering or sorting. It is
-     * significant to know that all values of this attribute will be converted to {&#64;link java.lang.Integer}, so the attribute
-     * number must not ever exceed maximum limits of {&#64;link java.lang.Integer} type when scaling the number by the power
+     * significant to know that all values of this attribute will be converted to `Integer`, so the attribute
+     * number must not ever exceed maximum limits of `Integer` type when scaling the number by the power
      * of ten using `indexedDecimalPlaces` as exponent.
      * </pre>
      *
@@ -2959,8 +2994,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * Determines how many fractional places are important when entities are compared during filtering or sorting. It is
-     * significant to know that all values of this attribute will be converted to {&#64;link java.lang.Integer}, so the attribute
-     * number must not ever exceed maximum limits of {&#64;link java.lang.Integer} type when scaling the number by the power
+     * significant to know that all values of this attribute will be converted to `Integer`, so the attribute
+     * number must not ever exceed maximum limits of `Integer` type when scaling the number by the power
      * of ten using `indexedDecimalPlaces` as exponent.
      * </pre>
      *
@@ -2978,8 +3013,8 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * Determines how many fractional places are important when entities are compared during filtering or sorting. It is
-     * significant to know that all values of this attribute will be converted to {&#64;link java.lang.Integer}, so the attribute
-     * number must not ever exceed maximum limits of {&#64;link java.lang.Integer} type when scaling the number by the power
+     * significant to know that all values of this attribute will be converted to `Integer`, so the attribute
+     * number must not ever exceed maximum limits of `Integer` type when scaling the number by the power
      * of ten using `indexedDecimalPlaces` as exponent.
      * </pre>
      *
@@ -3006,7 +3041,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeUniquenessType uniqueGlobally = 13 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.uniqueGlobally is deprecated.
-     *     See GrpcCatalogSchema.proto;l=109
+     *     See GrpcCatalogSchema.proto;l=115
      * @return The enum numeric value on the wire for uniqueGlobally.
      */
     @java.lang.Override @java.lang.Deprecated public int getUniqueGloballyValue() {
@@ -3024,7 +3059,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeUniquenessType uniqueGlobally = 13 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.uniqueGlobally is deprecated.
-     *     See GrpcCatalogSchema.proto;l=109
+     *     See GrpcCatalogSchema.proto;l=115
      * @param value The enum numeric value on the wire for uniqueGlobally to set.
      * @return This builder for chaining.
      */
@@ -3046,7 +3081,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeUniquenessType uniqueGlobally = 13 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.uniqueGlobally is deprecated.
-     *     See GrpcCatalogSchema.proto;l=109
+     *     See GrpcCatalogSchema.proto;l=115
      * @return The uniqueGlobally.
      */
     @java.lang.Override
@@ -3066,7 +3101,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeUniquenessType uniqueGlobally = 13 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.uniqueGlobally is deprecated.
-     *     See GrpcCatalogSchema.proto;l=109
+     *     See GrpcCatalogSchema.proto;l=115
      * @param value The uniqueGlobally to set.
      * @return This builder for chaining.
      */
@@ -3091,7 +3126,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeUniquenessType uniqueGlobally = 13 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.uniqueGlobally is deprecated.
-     *     See GrpcCatalogSchema.proto;l=109
+     *     See GrpcCatalogSchema.proto;l=115
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearUniqueGlobally() {

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGlobalAttributeSchemaOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGlobalAttributeSchemaOrBuilder.java
@@ -32,11 +32,21 @@ public interface GrpcGlobalAttributeSchemaOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   * <pre>
+   * Contains unique name of the attribute. Case-sensitive. Distinguishes one attribute from another within
+   * a single entity type or, for global attributes, within the entire catalog.
+   * </pre>
+   *
    * <code>string name = 1;</code>
    * @return The name.
    */
   java.lang.String getName();
   /**
+   * <pre>
+   * Contains unique name of the attribute. Case-sensitive. Distinguishes one attribute from another within
+   * a single entity type or, for global attributes, within the entire catalog.
+   * </pre>
+   *
    * <code>string name = 1;</code>
    * @return The bytes for name.
    */
@@ -109,7 +119,7 @@ public interface GrpcGlobalAttributeSchemaOrBuilder extends
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeUniquenessType unique = 4 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.unique is deprecated.
-   *     See GrpcCatalogSchema.proto;l=67
+   *     See GrpcCatalogSchema.proto;l=73
    * @return The enum numeric value on the wire for unique.
    */
   @java.lang.Deprecated int getUniqueValue();
@@ -125,7 +135,7 @@ public interface GrpcGlobalAttributeSchemaOrBuilder extends
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeUniquenessType unique = 4 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.unique is deprecated.
-   *     See GrpcCatalogSchema.proto;l=67
+   *     See GrpcCatalogSchema.proto;l=73
    * @return The unique.
    */
   @java.lang.Deprecated io.evitadb.externalApi.grpc.generated.GrpcAttributeUniquenessType getUnique();
@@ -143,7 +153,7 @@ public interface GrpcGlobalAttributeSchemaOrBuilder extends
    *
    * <code>bool filterable = 5 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.filterable is deprecated.
-   *     See GrpcCatalogSchema.proto;l=75
+   *     See GrpcCatalogSchema.proto;l=81
    * @return The filterable.
    */
   @java.lang.Deprecated boolean getFilterable();
@@ -158,7 +168,7 @@ public interface GrpcGlobalAttributeSchemaOrBuilder extends
    *
    * <code>bool sortable = 6 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.sortable is deprecated.
-   *     See GrpcCatalogSchema.proto;l=80
+   *     See GrpcCatalogSchema.proto;l=86
    * @return The sortable.
    */
   @java.lang.Deprecated boolean getSortable();
@@ -252,8 +262,8 @@ public interface GrpcGlobalAttributeSchemaOrBuilder extends
   /**
    * <pre>
    * Determines how many fractional places are important when entities are compared during filtering or sorting. It is
-   * significant to know that all values of this attribute will be converted to {&#64;link java.lang.Integer}, so the attribute
-   * number must not ever exceed maximum limits of {&#64;link java.lang.Integer} type when scaling the number by the power
+   * significant to know that all values of this attribute will be converted to `Integer`, so the attribute
+   * number must not ever exceed maximum limits of `Integer` type when scaling the number by the power
    * of ten using `indexedDecimalPlaces` as exponent.
    * </pre>
    *
@@ -274,7 +284,7 @@ public interface GrpcGlobalAttributeSchemaOrBuilder extends
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeUniquenessType uniqueGlobally = 13 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.uniqueGlobally is deprecated.
-   *     See GrpcCatalogSchema.proto;l=109
+   *     See GrpcCatalogSchema.proto;l=115
    * @return The enum numeric value on the wire for uniqueGlobally.
    */
   @java.lang.Deprecated int getUniqueGloballyValue();
@@ -290,7 +300,7 @@ public interface GrpcGlobalAttributeSchemaOrBuilder extends
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeUniquenessType uniqueGlobally = 13 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeSchema.uniqueGlobally is deprecated.
-   *     See GrpcCatalogSchema.proto;l=109
+   *     See GrpcCatalogSchema.proto;l=115
    * @return The uniqueGlobally.
    */
   @java.lang.Deprecated io.evitadb.externalApi.grpc.generated.GrpcGlobalAttributeUniquenessType getUniqueGlobally();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGlobalAttributeUniquenessType.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGlobalAttributeUniquenessType.java
@@ -29,8 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * This enum represents the uniqueness type of an {&#64;link GlobalAttributeSchema}. It is used to determine whether
- * the attribute value must be unique among all the entities using this {&#64;link GlobalAttributeSchema} or whether it
+ * This enum represents the uniqueness type of a `GlobalAttributeSchema`. It is used to determine whether
+ * the attribute value must be unique among all the entities using this `GlobalAttributeSchema` or whether it
  * must be unique only among entities of the same locale.
  * </pre>
  *
@@ -49,7 +49,7 @@ public enum GrpcGlobalAttributeUniquenessType
   /**
    * <pre>
    * The attribute value (either localized or non-localized) must be unique among all values among all the entities
-   * using this {&#64;link GlobalAttributeSchema} in the entire catalog.
+   * using this `GlobalAttributeSchema` in the entire catalog.
    * </pre>
    *
    * <code>UNIQUE_WITHIN_CATALOG = 1;</code>
@@ -57,8 +57,8 @@ public enum GrpcGlobalAttributeUniquenessType
   UNIQUE_WITHIN_CATALOG(1),
   /**
    * <pre>
-   * The localized attribute value must be unique among all values of the same {&#64;link Locale} among all the entities
-   * using this {&#64;link GlobalAttributeSchema} in the entire catalog.
+   * The localized attribute value must be unique among all values of the same `Locale` among all the entities
+   * using this `GlobalAttributeSchema` in the entire catalog.
    * </pre>
    *
    * <code>UNIQUE_WITHIN_CATALOG_LOCALE = 2;</code>
@@ -78,7 +78,7 @@ public enum GrpcGlobalAttributeUniquenessType
   /**
    * <pre>
    * The attribute value (either localized or non-localized) must be unique among all values among all the entities
-   * using this {&#64;link GlobalAttributeSchema} in the entire catalog.
+   * using this `GlobalAttributeSchema` in the entire catalog.
    * </pre>
    *
    * <code>UNIQUE_WITHIN_CATALOG = 1;</code>
@@ -86,8 +86,8 @@ public enum GrpcGlobalAttributeUniquenessType
   public static final int UNIQUE_WITHIN_CATALOG_VALUE = 1;
   /**
    * <pre>
-   * The localized attribute value must be unique among all values of the same {&#64;link Locale} among all the entities
-   * using this {&#64;link GlobalAttributeSchema} in the entire catalog.
+   * The localized attribute value must be unique among all values of the same `Locale` among all the entities
+   * using this `GlobalAttributeSchema` in the entire catalog.
    * </pre>
    *
    * <code>UNIQUE_WITHIN_CATALOG_LOCALE = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGoLiveAndCloseWithProgressResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGoLiveAndCloseWithProgressResponse.java
@@ -28,6 +28,14 @@
 package io.evitadb.externalApi.grpc.generated;
 
 /**
+ * <pre>
+ * One message of the GoLiveAndCloseWithProgress stream. Intermediate messages report only
+ * `progressInPercent` (throttled to at most once per second, and only when the percentage has
+ * increased); `catalogVersion`/`catalogSchemaVersion` are left at their zero default on those messages
+ * since they are not yet meaningful. The final message always carries `progressInPercent == 100` together
+ * with a populated `catalogVersion`/`catalogSchemaVersion`, and ends the stream.
+ * </pre>
+ *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseWithProgressResponse}
  */
 public final class GrpcGoLiveAndCloseWithProgressResponse extends
@@ -66,7 +74,8 @@ private static final long serialVersionUID = 0L;
   private long catalogVersion_ = 0L;
   /**
    * <pre>
-   * Contains next catalog version
+   * Contains next catalog version. Only populated on the final message (`progressInPercent == 100`); left
+   * at its default (`0`) on intermediate progress-only messages.
    * </pre>
    *
    * <code>int64 catalogVersion = 1;</code>
@@ -83,7 +92,8 @@ private static final long serialVersionUID = 0L;
    * <pre>
    * Contains the version of the catalog schema that will be valid at the moment of closing the session.
    * If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
-   * version (i.e. the one that is returned in the response) becomes visible.
+   * version (i.e. the one that is returned in the response) becomes visible. Only populated on the final
+   * message (`progressInPercent == 100`); left at its default (`0`) on intermediate progress-only messages.
    * </pre>
    *
    * <code>int32 catalogSchemaVersion = 2;</code>
@@ -98,7 +108,8 @@ private static final long serialVersionUID = 0L;
   private int progressInPercent_ = 0;
   /**
    * <pre>
-   * The progress of the go live operation in percents.
+   * Progress of the go-live operation, 0-100. Monotonically increasing across messages; the final message
+   * in the stream always carries 100.
    * </pre>
    *
    * <code>int32 progressInPercent = 3;</code>
@@ -290,6 +301,14 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
+   * <pre>
+   * One message of the GoLiveAndCloseWithProgress stream. Intermediate messages report only
+   * `progressInPercent` (throttled to at most once per second, and only when the percentage has
+   * increased); `catalogVersion`/`catalogSchemaVersion` are left at their zero default on those messages
+   * since they are not yet meaningful. The final message always carries `progressInPercent == 100` together
+   * with a populated `catalogVersion`/`catalogSchemaVersion`, and ends the stream.
+   * </pre>
+   *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseWithProgressResponse}
    */
   public static final class Builder extends
@@ -484,7 +503,8 @@ private static final long serialVersionUID = 0L;
     private long catalogVersion_ ;
     /**
      * <pre>
-     * Contains next catalog version
+     * Contains next catalog version. Only populated on the final message (`progressInPercent == 100`); left
+     * at its default (`0`) on intermediate progress-only messages.
      * </pre>
      *
      * <code>int64 catalogVersion = 1;</code>
@@ -496,7 +516,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains next catalog version
+     * Contains next catalog version. Only populated on the final message (`progressInPercent == 100`); left
+     * at its default (`0`) on intermediate progress-only messages.
      * </pre>
      *
      * <code>int64 catalogVersion = 1;</code>
@@ -512,7 +533,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Contains next catalog version
+     * Contains next catalog version. Only populated on the final message (`progressInPercent == 100`); left
+     * at its default (`0`) on intermediate progress-only messages.
      * </pre>
      *
      * <code>int64 catalogVersion = 1;</code>
@@ -530,7 +552,8 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * Contains the version of the catalog schema that will be valid at the moment of closing the session.
      * If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
-     * version (i.e. the one that is returned in the response) becomes visible.
+     * version (i.e. the one that is returned in the response) becomes visible. Only populated on the final
+     * message (`progressInPercent == 100`); left at its default (`0`) on intermediate progress-only messages.
      * </pre>
      *
      * <code>int32 catalogSchemaVersion = 2;</code>
@@ -544,7 +567,8 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * Contains the version of the catalog schema that will be valid at the moment of closing the session.
      * If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
-     * version (i.e. the one that is returned in the response) becomes visible.
+     * version (i.e. the one that is returned in the response) becomes visible. Only populated on the final
+     * message (`progressInPercent == 100`); left at its default (`0`) on intermediate progress-only messages.
      * </pre>
      *
      * <code>int32 catalogSchemaVersion = 2;</code>
@@ -562,7 +586,8 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * Contains the version of the catalog schema that will be valid at the moment of closing the session.
      * If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
-     * version (i.e. the one that is returned in the response) becomes visible.
+     * version (i.e. the one that is returned in the response) becomes visible. Only populated on the final
+     * message (`progressInPercent == 100`); left at its default (`0`) on intermediate progress-only messages.
      * </pre>
      *
      * <code>int32 catalogSchemaVersion = 2;</code>
@@ -578,7 +603,8 @@ private static final long serialVersionUID = 0L;
     private int progressInPercent_ ;
     /**
      * <pre>
-     * The progress of the go live operation in percents.
+     * Progress of the go-live operation, 0-100. Monotonically increasing across messages; the final message
+     * in the stream always carries 100.
      * </pre>
      *
      * <code>int32 progressInPercent = 3;</code>
@@ -590,7 +616,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The progress of the go live operation in percents.
+     * Progress of the go-live operation, 0-100. Monotonically increasing across messages; the final message
+     * in the stream always carries 100.
      * </pre>
      *
      * <code>int32 progressInPercent = 3;</code>
@@ -606,7 +633,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The progress of the go live operation in percents.
+     * Progress of the go-live operation, 0-100. Monotonically increasing across messages; the final message
+     * in the stream always carries 100.
      * </pre>
      *
      * <code>int32 progressInPercent = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGoLiveAndCloseWithProgressResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGoLiveAndCloseWithProgressResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcGoLiveAndCloseWithProgressResponseOrBuilder extends
 
   /**
    * <pre>
-   * Contains next catalog version
+   * Contains next catalog version. Only populated on the final message (`progressInPercent == 100`); left
+   * at its default (`0`) on intermediate progress-only messages.
    * </pre>
    *
    * <code>int64 catalogVersion = 1;</code>
@@ -45,7 +46,8 @@ public interface GrpcGoLiveAndCloseWithProgressResponseOrBuilder extends
    * <pre>
    * Contains the version of the catalog schema that will be valid at the moment of closing the session.
    * If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
-   * version (i.e. the one that is returned in the response) becomes visible.
+   * version (i.e. the one that is returned in the response) becomes visible. Only populated on the final
+   * message (`progressInPercent == 100`); left at its default (`0`) on intermediate progress-only messages.
    * </pre>
    *
    * <code>int32 catalogSchemaVersion = 2;</code>
@@ -55,7 +57,8 @@ public interface GrpcGoLiveAndCloseWithProgressResponseOrBuilder extends
 
   /**
    * <pre>
-   * The progress of the go live operation in percents.
+   * Progress of the go-live operation, 0-100. Monotonically increasing across messages; the final message
+   * in the stream always carries 100.
    * </pre>
    *
    * <code>int32 progressInPercent = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcHistogramBehaviorTypeArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcHistogramBehaviorTypeArray.java
@@ -81,7 +81,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * Value that supports storing a HistogramBehavior array.
+   * The individual HistogramBehavior values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -94,7 +94,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a HistogramBehavior array.
+   * The individual HistogramBehavior values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a HistogramBehavior array.
+   * The individual HistogramBehavior values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -119,7 +119,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a HistogramBehavior array.
+   * The individual HistogramBehavior values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -132,7 +132,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a HistogramBehavior array.
+   * The individual HistogramBehavior values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -524,7 +524,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a HistogramBehavior array.
+     * The individual HistogramBehavior values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -536,7 +536,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a HistogramBehavior array.
+     * The individual HistogramBehavior values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -547,7 +547,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a HistogramBehavior array.
+     * The individual HistogramBehavior values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -559,7 +559,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a HistogramBehavior array.
+     * The individual HistogramBehavior values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -579,7 +579,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a HistogramBehavior array.
+     * The individual HistogramBehavior values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -597,7 +597,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a HistogramBehavior array.
+     * The individual HistogramBehavior values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -615,7 +615,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a HistogramBehavior array.
+     * The individual HistogramBehavior values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -629,7 +629,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a HistogramBehavior array.
+     * The individual HistogramBehavior values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a HistogramBehavior array.
+     * The individual HistogramBehavior values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -653,7 +653,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a HistogramBehavior array.
+     * The individual HistogramBehavior values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -670,7 +670,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a HistogramBehavior array.
+     * The individual HistogramBehavior values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -685,7 +685,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a HistogramBehavior array.
+     * The individual HistogramBehavior values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcHistogramBehaviorTypeArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcHistogramBehaviorTypeArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcHistogramBehaviorTypeArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a HistogramBehavior array.
+   * The individual HistogramBehavior values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcHistogramBehaviorTypeArrayOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior> getValueList();
   /**
    * <pre>
-   * Value that supports storing a HistogramBehavior array.
+   * The individual HistogramBehavior values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcHistogramBehaviorTypeArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a HistogramBehavior array.
+   * The individual HistogramBehavior values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -61,7 +61,7 @@ public interface GrpcHistogramBehaviorTypeArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a HistogramBehavior array.
+   * The individual HistogramBehavior values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>
@@ -71,7 +71,7 @@ public interface GrpcHistogramBehaviorTypeArrayOrBuilder extends
   getValueValueList();
   /**
    * <pre>
-   * Value that supports storing a HistogramBehavior array.
+   * The individual HistogramBehavior values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcIntegerArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcIntegerArray.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Wrapper for representing an array of integers.
+ * Wrapper for representing an array of integers. Also used to carry Byte and Short arrays,
+ * narrowed/widened to int32 on the wire; which Java array type applies is determined by the
+ * accompanying GrpcEvitaDataType (BYTE_ARRAY, SHORT_ARRAY or INTEGER_ARRAY).
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcIntegerArray}
@@ -73,7 +75,7 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   * Value that supports storing an integer array.
+   * The individual integer elements, in their original order.
    * </pre>
    *
    * <code>repeated int32 value = 1;</code>
@@ -86,7 +88,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an integer array.
+   * The individual integer elements, in their original order.
    * </pre>
    *
    * <code>repeated int32 value = 1;</code>
@@ -97,7 +99,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an integer array.
+   * The individual integer elements, in their original order.
    * </pre>
    *
    * <code>repeated int32 value = 1;</code>
@@ -285,7 +287,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Wrapper for representing an array of integers.
+   * Wrapper for representing an array of integers. Also used to carry Byte and Short arrays,
+   * narrowed/widened to int32 on the wire; which Java array type applies is determined by the
+   * accompanying GrpcEvitaDataType (BYTE_ARRAY, SHORT_ARRAY or INTEGER_ARRAY).
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcIntegerArray}
@@ -484,7 +488,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an integer array.
+     * The individual integer elements, in their original order.
      * </pre>
      *
      * <code>repeated int32 value = 1;</code>
@@ -497,7 +501,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an integer array.
+     * The individual integer elements, in their original order.
      * </pre>
      *
      * <code>repeated int32 value = 1;</code>
@@ -508,7 +512,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an integer array.
+     * The individual integer elements, in their original order.
      * </pre>
      *
      * <code>repeated int32 value = 1;</code>
@@ -520,7 +524,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an integer array.
+     * The individual integer elements, in their original order.
      * </pre>
      *
      * <code>repeated int32 value = 1;</code>
@@ -539,7 +543,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an integer array.
+     * The individual integer elements, in their original order.
      * </pre>
      *
      * <code>repeated int32 value = 1;</code>
@@ -556,7 +560,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an integer array.
+     * The individual integer elements, in their original order.
      * </pre>
      *
      * <code>repeated int32 value = 1;</code>
@@ -574,7 +578,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an integer array.
+     * The individual integer elements, in their original order.
      * </pre>
      *
      * <code>repeated int32 value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcIntegerArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcIntegerArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcIntegerArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing an integer array.
+   * The individual integer elements, in their original order.
    * </pre>
    *
    * <code>repeated int32 value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcIntegerArrayOrBuilder extends
   java.util.List<java.lang.Integer> getValueList();
   /**
    * <pre>
-   * Value that supports storing an integer array.
+   * The individual integer elements, in their original order.
    * </pre>
    *
    * <code>repeated int32 value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcIntegerArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing an integer array.
+   * The individual integer elements, in their original order.
    * </pre>
    *
    * <code>repeated int32 value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcIntegerNumberRange.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcIntegerNumberRange.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Representation of IntegerNumberRange structures with optional from and to values.
+ * Representation of IntegerNumberRange structures. At least one of `from`/`to` should be set; if
+ * both are absent, the range decodes to the degenerate range `[0,0]` rather than being unbounded
+ * in both directions.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange}
@@ -71,7 +73,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value from_;
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -83,7 +86,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -95,7 +99,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -109,7 +114,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value to_;
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -121,7 +127,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -133,7 +140,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -323,7 +331,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Representation of IntegerNumberRange structures with optional from and to values.
+   * Representation of IntegerNumberRange structures. At least one of `from`/`to` should be set; if
+   * both are absent, the range decodes to the degenerate range `[0,0]` rather than being unbounded
+   * in both directions.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange}
@@ -537,7 +547,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> fromBuilder_;
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -548,7 +559,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -563,7 +575,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -583,7 +596,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -601,7 +615,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -626,7 +641,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -643,7 +659,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -655,7 +672,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -670,7 +688,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -694,7 +713,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> toBuilder_;
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -705,7 +725,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -720,7 +741,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -740,7 +762,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -758,7 +781,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -783,7 +807,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -800,7 +825,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -812,7 +838,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -827,7 +854,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value to = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcIntegerNumberRangeArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcIntegerNumberRangeArray.java
@@ -29,7 +29,10 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Wrapper for representing an array of IntegerNumberRanges.
+ * Wrapper for representing an array of IntegerNumberRanges. Also used to carry ByteNumberRange
+ * and ShortNumberRange arrays; which Java array type applies is determined by the accompanying
+ * GrpcEvitaDataType (BYTE_NUMBER_RANGE_ARRAY, SHORT_NUMBER_RANGE_ARRAY or
+ * INTEGER_NUMBER_RANGE_ARRAY).
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray}
@@ -72,7 +75,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange> value_;
   /**
    * <pre>
-   * Value that supports storing an IntegerNumberRange array.
+   * The individual IntegerNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -83,7 +86,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an IntegerNumberRange array.
+   * The individual IntegerNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -95,7 +98,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an IntegerNumberRange array.
+   * The individual IntegerNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -106,7 +109,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an IntegerNumberRange array.
+   * The individual IntegerNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -117,7 +120,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an IntegerNumberRange array.
+   * The individual IntegerNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -289,7 +292,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Wrapper for representing an array of IntegerNumberRanges.
+   * Wrapper for representing an array of IntegerNumberRanges. Also used to carry ByteNumberRange
+   * and ShortNumberRange arrays; which Java array type applies is determined by the accompanying
+   * GrpcEvitaDataType (BYTE_NUMBER_RANGE_ARRAY, SHORT_NUMBER_RANGE_ARRAY or
+   * INTEGER_NUMBER_RANGE_ARRAY).
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray}
@@ -520,7 +526,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -534,7 +540,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -548,7 +554,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -562,7 +568,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -583,7 +589,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -601,7 +607,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -621,7 +627,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -642,7 +648,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -660,7 +666,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -678,7 +684,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -697,7 +703,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -714,7 +720,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -731,7 +737,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -742,7 +748,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -756,7 +762,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -771,7 +777,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -782,7 +788,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -794,7 +800,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an IntegerNumberRange array.
+     * The individual IntegerNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcIntegerNumberRangeArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcIntegerNumberRangeArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcIntegerNumberRangeArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing an IntegerNumberRange array.
+   * The individual IntegerNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcIntegerNumberRangeArrayOrBuilder extends
       getValueList();
   /**
    * <pre>
-   * Value that supports storing an IntegerNumberRange array.
+   * The individual IntegerNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -50,7 +50,7 @@ public interface GrpcIntegerNumberRangeArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange getValue(int index);
   /**
    * <pre>
-   * Value that supports storing an IntegerNumberRange array.
+   * The individual IntegerNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -58,7 +58,7 @@ public interface GrpcIntegerNumberRangeArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing an IntegerNumberRange array.
+   * The individual IntegerNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>
@@ -67,7 +67,7 @@ public interface GrpcIntegerNumberRangeArrayOrBuilder extends
       getValueOrBuilderList();
   /**
    * <pre>
-   * Value that supports storing an IntegerNumberRange array.
+   * The individual IntegerNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcIntegerNumberRangeOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcIntegerNumberRangeOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcIntegerNumberRangeOrBuilder extends
 
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcIntegerNumberRangeOrBuilder extends
   boolean hasFrom();
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcIntegerNumberRangeOrBuilder extends
   com.google.protobuf.Int32Value getFrom();
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value from = 1;</code>
@@ -60,7 +63,8 @@ public interface GrpcIntegerNumberRangeOrBuilder extends
 
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -69,7 +73,8 @@ public interface GrpcIntegerNumberRangeOrBuilder extends
   boolean hasTo();
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value to = 2;</code>
@@ -78,7 +83,8 @@ public interface GrpcIntegerNumberRangeOrBuilder extends
   com.google.protobuf.Int32Value getTo();
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value to = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLocale.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLocale.java
@@ -72,7 +72,8 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object languageTag_ = "";
   /**
    * <pre>
-   * The language tag of the locale.
+   * IETF BCP 47 language tag (e.g. `en-US`, `cs-CZ`), resolved server-side via
+   * `Locale#forLanguageTag(String)`.
    * </pre>
    *
    * <code>string languageTag = 1;</code>
@@ -93,7 +94,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The language tag of the locale.
+   * IETF BCP 47 language tag (e.g. `en-US`, `cs-CZ`), resolved server-side via
+   * `Locale#forLanguageTag(String)`.
    * </pre>
    *
    * <code>string languageTag = 1;</code>
@@ -447,7 +449,8 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object languageTag_ = "";
     /**
      * <pre>
-     * The language tag of the locale.
+     * IETF BCP 47 language tag (e.g. `en-US`, `cs-CZ`), resolved server-side via
+     * `Locale#forLanguageTag(String)`.
      * </pre>
      *
      * <code>string languageTag = 1;</code>
@@ -467,7 +470,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The language tag of the locale.
+     * IETF BCP 47 language tag (e.g. `en-US`, `cs-CZ`), resolved server-side via
+     * `Locale#forLanguageTag(String)`.
      * </pre>
      *
      * <code>string languageTag = 1;</code>
@@ -488,7 +492,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The language tag of the locale.
+     * IETF BCP 47 language tag (e.g. `en-US`, `cs-CZ`), resolved server-side via
+     * `Locale#forLanguageTag(String)`.
      * </pre>
      *
      * <code>string languageTag = 1;</code>
@@ -505,7 +510,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The language tag of the locale.
+     * IETF BCP 47 language tag (e.g. `en-US`, `cs-CZ`), resolved server-side via
+     * `Locale#forLanguageTag(String)`.
      * </pre>
      *
      * <code>string languageTag = 1;</code>
@@ -519,7 +525,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The language tag of the locale.
+     * IETF BCP 47 language tag (e.g. `en-US`, `cs-CZ`), resolved server-side via
+     * `Locale#forLanguageTag(String)`.
      * </pre>
      *
      * <code>string languageTag = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLocaleArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLocaleArray.java
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcLocale> value_;
   /**
    * <pre>
-   * Value that supports storing a Locale array.
+   * The individual Locale elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -83,7 +83,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Locale array.
+   * The individual Locale elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -95,7 +95,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Locale array.
+   * The individual Locale elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Locale array.
+   * The individual Locale elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -117,7 +117,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Locale array.
+   * The individual Locale elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -534,7 +534,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -548,7 +548,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -583,7 +583,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -601,7 +601,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -621,7 +621,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -642,7 +642,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -660,7 +660,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -678,7 +678,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -697,7 +697,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -714,7 +714,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -731,7 +731,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -742,7 +742,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -756,7 +756,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -771,7 +771,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -782,7 +782,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -794,7 +794,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Locale array.
+     * The individual Locale elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLocaleArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLocaleArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcLocaleArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a Locale array.
+   * The individual Locale elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcLocaleArrayOrBuilder extends
       getValueList();
   /**
    * <pre>
-   * Value that supports storing a Locale array.
+   * The individual Locale elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -50,7 +50,7 @@ public interface GrpcLocaleArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcLocale getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a Locale array.
+   * The individual Locale elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -58,7 +58,7 @@ public interface GrpcLocaleArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a Locale array.
+   * The individual Locale elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>
@@ -67,7 +67,7 @@ public interface GrpcLocaleArrayOrBuilder extends
       getValueOrBuilderList();
   /**
    * <pre>
-   * Value that supports storing a Locale array.
+   * The individual Locale elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLocaleOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLocaleOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcLocaleOrBuilder extends
 
   /**
    * <pre>
-   * The language tag of the locale.
+   * IETF BCP 47 language tag (e.g. `en-US`, `cs-CZ`), resolved server-side via
+   * `Locale#forLanguageTag(String)`.
    * </pre>
    *
    * <code>string languageTag = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcLocaleOrBuilder extends
   java.lang.String getLanguageTag();
   /**
    * <pre>
-   * The language tag of the locale.
+   * IETF BCP 47 language tag (e.g. `en-US`, `cs-CZ`), resolved server-side via
+   * `Locale#forLanguageTag(String)`.
    * </pre>
    *
    * <code>string languageTag = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLongArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLongArray.java
@@ -73,7 +73,7 @@ private static final long serialVersionUID = 0L;
       emptyLongList();
   /**
    * <pre>
-   * Value that supports storing a long array.
+   * The individual long elements, in their original order.
    * </pre>
    *
    * <code>repeated int64 value = 1;</code>
@@ -86,7 +86,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a long array.
+   * The individual long elements, in their original order.
    * </pre>
    *
    * <code>repeated int64 value = 1;</code>
@@ -97,7 +97,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a long array.
+   * The individual long elements, in their original order.
    * </pre>
    *
    * <code>repeated int64 value = 1;</code>
@@ -484,7 +484,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a long array.
+     * The individual long elements, in their original order.
      * </pre>
      *
      * <code>repeated int64 value = 1;</code>
@@ -497,7 +497,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a long array.
+     * The individual long elements, in their original order.
      * </pre>
      *
      * <code>repeated int64 value = 1;</code>
@@ -508,7 +508,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a long array.
+     * The individual long elements, in their original order.
      * </pre>
      *
      * <code>repeated int64 value = 1;</code>
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a long array.
+     * The individual long elements, in their original order.
      * </pre>
      *
      * <code>repeated int64 value = 1;</code>
@@ -539,7 +539,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a long array.
+     * The individual long elements, in their original order.
      * </pre>
      *
      * <code>repeated int64 value = 1;</code>
@@ -556,7 +556,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a long array.
+     * The individual long elements, in their original order.
      * </pre>
      *
      * <code>repeated int64 value = 1;</code>
@@ -574,7 +574,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a long array.
+     * The individual long elements, in their original order.
      * </pre>
      *
      * <code>repeated int64 value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLongArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLongArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcLongArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a long array.
+   * The individual long elements, in their original order.
    * </pre>
    *
    * <code>repeated int64 value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcLongArrayOrBuilder extends
   java.util.List<java.lang.Long> getValueList();
   /**
    * <pre>
-   * Value that supports storing a long array.
+   * The individual long elements, in their original order.
    * </pre>
    *
    * <code>repeated int64 value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcLongArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a long array.
+   * The individual long elements, in their original order.
    * </pre>
    *
    * <code>repeated int64 value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLongNumberRange.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLongNumberRange.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Representation of LongNumberRange structures with optional from and to values.
+ * Representation of LongNumberRange structures. At least one of `from`/`to` should be set; if
+ * both are absent, the range decodes to the degenerate range `[0,0]` rather than being unbounded
+ * in both directions.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange}
@@ -71,7 +73,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value from_;
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -83,7 +86,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -95,7 +99,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -109,7 +114,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value to_;
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -121,7 +127,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -133,7 +140,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -323,7 +331,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Representation of LongNumberRange structures with optional from and to values.
+   * Representation of LongNumberRange structures. At least one of `from`/`to` should be set; if
+   * both are absent, the range decodes to the degenerate range `[0,0]` rather than being unbounded
+   * in both directions.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange}
@@ -537,7 +547,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> fromBuilder_;
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -548,7 +559,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -563,7 +575,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -583,7 +596,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -601,7 +615,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -626,7 +641,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -643,7 +659,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -655,7 +672,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -670,7 +688,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The lower bound of the range.
+     * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+     * below.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -694,7 +713,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> toBuilder_;
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -705,7 +725,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -720,7 +741,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -740,7 +762,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -758,7 +781,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -783,7 +807,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -800,7 +825,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -812,7 +838,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -827,7 +854,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upper bound of the range.
+     * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+     * above.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value to = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLongNumberRangeArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLongNumberRangeArray.java
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange> value_;
   /**
    * <pre>
-   * Value that supports storing a LongNumberRange array.
+   * The individual LongNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -83,7 +83,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a LongNumberRange array.
+   * The individual LongNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -95,7 +95,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a LongNumberRange array.
+   * The individual LongNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a LongNumberRange array.
+   * The individual LongNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -117,7 +117,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a LongNumberRange array.
+   * The individual LongNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -534,7 +534,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -548,7 +548,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -583,7 +583,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -601,7 +601,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -621,7 +621,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -642,7 +642,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -660,7 +660,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -678,7 +678,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -697,7 +697,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -714,7 +714,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -731,7 +731,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -742,7 +742,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -756,7 +756,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -771,7 +771,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -782,7 +782,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -794,7 +794,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a LongNumberRange array.
+     * The individual LongNumberRange elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLongNumberRangeArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLongNumberRangeArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcLongNumberRangeArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a LongNumberRange array.
+   * The individual LongNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcLongNumberRangeArrayOrBuilder extends
       getValueList();
   /**
    * <pre>
-   * Value that supports storing a LongNumberRange array.
+   * The individual LongNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -50,7 +50,7 @@ public interface GrpcLongNumberRangeArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a LongNumberRange array.
+   * The individual LongNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -58,7 +58,7 @@ public interface GrpcLongNumberRangeArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a LongNumberRange array.
+   * The individual LongNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>
@@ -67,7 +67,7 @@ public interface GrpcLongNumberRangeArrayOrBuilder extends
       getValueOrBuilderList();
   /**
    * <pre>
-   * Value that supports storing a LongNumberRange array.
+   * The individual LongNumberRange elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLongNumberRangeOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcLongNumberRangeOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcLongNumberRangeOrBuilder extends
 
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcLongNumberRangeOrBuilder extends
   boolean hasFrom();
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcLongNumberRangeOrBuilder extends
   com.google.protobuf.Int64Value getFrom();
   /**
    * <pre>
-   * The lower bound of the range.
+   * The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+   * below.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value from = 1;</code>
@@ -60,7 +63,8 @@ public interface GrpcLongNumberRangeOrBuilder extends
 
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -69,7 +73,8 @@ public interface GrpcLongNumberRangeOrBuilder extends
   boolean hasTo();
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value to = 2;</code>
@@ -78,7 +83,8 @@ public interface GrpcLongNumberRangeOrBuilder extends
   com.google.protobuf.Int64Value getTo();
   /**
    * <pre>
-   * The upper bound of the range.
+   * The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+   * above.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value to = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcManagedReferencesBehaviour.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcManagedReferencesBehaviour.java
@@ -29,10 +29,10 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * This enumeration controls behavior of the {&#64;link ReferenceContent} related to managed entities.
- * If the target entity is not (yet) present in the database and {&#64;link ManagedReferencesBehaviour#EXISTING} is set,
+ * This enumeration controls behavior of the `ReferenceContent` related to managed entities.
+ * If the target entity is not (yet) present in the database and `EXISTING` is set,
  * the reference will not be returned as if it does not exist.
- * If {&#64;link ManagedReferencesBehaviour#ANY} is set (default behavior), the reference will be returned if defined regardless
+ * If `ANY` is set (default behavior), the reference will be returned if defined regardless
  * of its target entity existence.
  * </pre>
  *

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcNameVariant.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcNameVariant.java
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private int namingConvention_ = 0;
   /**
    * <pre>
-   * naming convention the name is in
+   * The naming convention this variant is rendered in (e.g. camelCase, kebab-case, PascalCase).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcNamingConvention namingConvention = 1;</code>
@@ -83,7 +83,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * naming convention the name is in
+   * The naming convention this variant is rendered in (e.g. camelCase, kebab-case, PascalCase).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcNamingConvention namingConvention = 1;</code>
@@ -99,7 +99,7 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object name_ = "";
   /**
    * <pre>
-   * the name in the particular naming convention
+   * The entity/attribute/reference name transformed into the given naming convention.
    * </pre>
    *
    * <code>string name = 2;</code>
@@ -120,7 +120,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the name in the particular naming convention
+   * The entity/attribute/reference name transformed into the given naming convention.
    * </pre>
    *
    * <code>string name = 2;</code>
@@ -496,7 +496,7 @@ private static final long serialVersionUID = 0L;
     private int namingConvention_ = 0;
     /**
      * <pre>
-     * naming convention the name is in
+     * The naming convention this variant is rendered in (e.g. camelCase, kebab-case, PascalCase).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcNamingConvention namingConvention = 1;</code>
@@ -507,7 +507,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * naming convention the name is in
+     * The naming convention this variant is rendered in (e.g. camelCase, kebab-case, PascalCase).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcNamingConvention namingConvention = 1;</code>
@@ -522,7 +522,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * naming convention the name is in
+     * The naming convention this variant is rendered in (e.g. camelCase, kebab-case, PascalCase).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcNamingConvention namingConvention = 1;</code>
@@ -535,7 +535,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * naming convention the name is in
+     * The naming convention this variant is rendered in (e.g. camelCase, kebab-case, PascalCase).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcNamingConvention namingConvention = 1;</code>
@@ -553,7 +553,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * naming convention the name is in
+     * The naming convention this variant is rendered in (e.g. camelCase, kebab-case, PascalCase).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcNamingConvention namingConvention = 1;</code>
@@ -569,7 +569,7 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object name_ = "";
     /**
      * <pre>
-     * the name in the particular naming convention
+     * The entity/attribute/reference name transformed into the given naming convention.
      * </pre>
      *
      * <code>string name = 2;</code>
@@ -589,7 +589,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name in the particular naming convention
+     * The entity/attribute/reference name transformed into the given naming convention.
      * </pre>
      *
      * <code>string name = 2;</code>
@@ -610,7 +610,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name in the particular naming convention
+     * The entity/attribute/reference name transformed into the given naming convention.
      * </pre>
      *
      * <code>string name = 2;</code>
@@ -627,7 +627,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name in the particular naming convention
+     * The entity/attribute/reference name transformed into the given naming convention.
      * </pre>
      *
      * <code>string name = 2;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the name in the particular naming convention
+     * The entity/attribute/reference name transformed into the given naming convention.
      * </pre>
      *
      * <code>string name = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcNameVariantOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcNameVariantOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcNameVariantOrBuilder extends
 
   /**
    * <pre>
-   * naming convention the name is in
+   * The naming convention this variant is rendered in (e.g. camelCase, kebab-case, PascalCase).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcNamingConvention namingConvention = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcNameVariantOrBuilder extends
   int getNamingConventionValue();
   /**
    * <pre>
-   * naming convention the name is in
+   * The naming convention this variant is rendered in (e.g. camelCase, kebab-case, PascalCase).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcNamingConvention namingConvention = 1;</code>
@@ -52,7 +52,7 @@ public interface GrpcNameVariantOrBuilder extends
 
   /**
    * <pre>
-   * the name in the particular naming convention
+   * The entity/attribute/reference name transformed into the given naming convention.
    * </pre>
    *
    * <code>string name = 2;</code>
@@ -61,7 +61,7 @@ public interface GrpcNameVariantOrBuilder extends
   java.lang.String getName();
   /**
    * <pre>
-   * the name in the particular naming convention
+   * The entity/attribute/reference name transformed into the given naming convention.
    * </pre>
    *
    * <code>string name = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcOffsetDateTimeArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcOffsetDateTimeArray.java
@@ -29,7 +29,10 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Wrapper for representing an array of OffsetDateTimes.
+ * Wrapper for representing an array of OffsetDateTimes. Also used to carry LocalDateTime,
+ * LocalDate and LocalTime arrays; which Java array type applies is determined by the accompanying
+ * GrpcEvitaDataType (OFFSET_DATE_TIME_ARRAY, LOCAL_DATE_TIME_ARRAY, LOCAL_DATE_ARRAY or
+ * LOCAL_TIME_ARRAY).
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray}
@@ -72,7 +75,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime> value_;
   /**
    * <pre>
-   * Value that supports storing an OffsetDateTime array.
+   * The individual date/time elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -83,7 +86,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an OffsetDateTime array.
+   * The individual date/time elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -95,7 +98,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an OffsetDateTime array.
+   * The individual date/time elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -106,7 +109,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an OffsetDateTime array.
+   * The individual date/time elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -117,7 +120,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an OffsetDateTime array.
+   * The individual date/time elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -289,7 +292,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Wrapper for representing an array of OffsetDateTimes.
+   * Wrapper for representing an array of OffsetDateTimes. Also used to carry LocalDateTime,
+   * LocalDate and LocalTime arrays; which Java array type applies is determined by the accompanying
+   * GrpcEvitaDataType (OFFSET_DATE_TIME_ARRAY, LOCAL_DATE_TIME_ARRAY, LOCAL_DATE_ARRAY or
+   * LOCAL_TIME_ARRAY).
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray}
@@ -520,7 +526,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -534,7 +540,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -548,7 +554,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -562,7 +568,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -583,7 +589,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -601,7 +607,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -621,7 +627,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -642,7 +648,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -660,7 +666,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -678,7 +684,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -697,7 +703,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -714,7 +720,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -731,7 +737,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -742,7 +748,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -756,7 +762,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -771,7 +777,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -782,7 +788,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -794,7 +800,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OffsetDateTime array.
+     * The individual date/time elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcOffsetDateTimeArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcOffsetDateTimeArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcOffsetDateTimeArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing an OffsetDateTime array.
+   * The individual date/time elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcOffsetDateTimeArrayOrBuilder extends
       getValueList();
   /**
    * <pre>
-   * Value that supports storing an OffsetDateTime array.
+   * The individual date/time elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -50,7 +50,7 @@ public interface GrpcOffsetDateTimeArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getValue(int index);
   /**
    * <pre>
-   * Value that supports storing an OffsetDateTime array.
+   * The individual date/time elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -58,7 +58,7 @@ public interface GrpcOffsetDateTimeArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing an OffsetDateTime array.
+   * The individual date/time elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>
@@ -67,7 +67,7 @@ public interface GrpcOffsetDateTimeArrayOrBuilder extends
       getValueOrBuilderList();
   /**
    * <pre>
-   * Value that supports storing an OffsetDateTime array.
+   * The individual date/time elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcOrderDirectionArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcOrderDirectionArray.java
@@ -81,7 +81,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * Value that supports storing an OrderDirection array.
+   * The individual OrderDirection values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -94,7 +94,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an OrderDirection array.
+   * The individual OrderDirection values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an OrderDirection array.
+   * The individual OrderDirection values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -119,7 +119,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an OrderDirection array.
+   * The individual OrderDirection values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -132,7 +132,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing an OrderDirection array.
+   * The individual OrderDirection values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -524,7 +524,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OrderDirection array.
+     * The individual OrderDirection values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -536,7 +536,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OrderDirection array.
+     * The individual OrderDirection values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -547,7 +547,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OrderDirection array.
+     * The individual OrderDirection values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -559,7 +559,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OrderDirection array.
+     * The individual OrderDirection values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -579,7 +579,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OrderDirection array.
+     * The individual OrderDirection values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -597,7 +597,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OrderDirection array.
+     * The individual OrderDirection values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -615,7 +615,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OrderDirection array.
+     * The individual OrderDirection values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -629,7 +629,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OrderDirection array.
+     * The individual OrderDirection values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OrderDirection array.
+     * The individual OrderDirection values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -653,7 +653,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OrderDirection array.
+     * The individual OrderDirection values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -670,7 +670,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OrderDirection array.
+     * The individual OrderDirection values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -685,7 +685,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing an OrderDirection array.
+     * The individual OrderDirection values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcOrderDirectionArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcOrderDirectionArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcOrderDirectionArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing an OrderDirection array.
+   * The individual OrderDirection values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcOrderDirectionArrayOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcOrderDirection> getValueList();
   /**
    * <pre>
-   * Value that supports storing an OrderDirection array.
+   * The individual OrderDirection values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcOrderDirectionArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing an OrderDirection array.
+   * The individual OrderDirection values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -61,7 +61,7 @@ public interface GrpcOrderDirectionArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOrderDirection getValue(int index);
   /**
    * <pre>
-   * Value that supports storing an OrderDirection array.
+   * The individual OrderDirection values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>
@@ -71,7 +71,7 @@ public interface GrpcOrderDirectionArrayOrBuilder extends
   getValueValueList();
   /**
    * <pre>
-   * Value that supports storing an OrderDirection array.
+   * The individual OrderDirection values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcOrderDirection value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPaginatedList.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPaginatedList.java
@@ -29,7 +29,13 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Structure that represents a pagination within a data chunk.
+ * Page-based pagination descriptor for a `GrpcDataChunk`, reporting the page actually returned. The
+ * desired page is requested via the query's `page()` require constraint, not a field on this response
+ * structure - see `io.evitadb.api.query.require.Page` for the full contract. `pageNumber` is 1-indexed
+ * (page 1 is the first page) - see `io.evitadb.dataType.PaginatedList#getPageNumber`. A requested page
+ * number of 0 or less is rejected by the server; a requested page number beyond `lastPageNumber` is not
+ * rejected - the engine returns the first page instead, so `pageNumber` here can differ from what was
+ * requested.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcPaginatedList}
@@ -70,7 +76,8 @@ private static final long serialVersionUID = 0L;
   private int pageSize_ = 0;
   /**
    * <pre>
-   * The size of the page.
+   * Number of records requested per page, echoed back from the query's `page()` require constraint.
+   * Zero is valid and yields an empty page while `totalRecordCount`/`lastPageNumber` are still reported.
    * </pre>
    *
    * <code>int32 pageSize = 1;</code>
@@ -85,7 +92,8 @@ private static final long serialVersionUID = 0L;
   private int pageNumber_ = 0;
   /**
    * <pre>
-   * The number of the page.
+   * The page actually returned (1-indexed) - see the message-level comment for how this can differ from
+   * the requested page number.
    * </pre>
    *
    * <code>int32 pageNumber = 2;</code>
@@ -100,7 +108,7 @@ private static final long serialVersionUID = 0L;
   private int lastPageNumber_ = 0;
   /**
    * <pre>
-   * The number of the last page.
+   * The number of the last available page, given `pageSize` and the total record count.
    * </pre>
    *
    * <code>int32 lastPageNumber = 3;</code>
@@ -292,7 +300,13 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Structure that represents a pagination within a data chunk.
+   * Page-based pagination descriptor for a `GrpcDataChunk`, reporting the page actually returned. The
+   * desired page is requested via the query's `page()` require constraint, not a field on this response
+   * structure - see `io.evitadb.api.query.require.Page` for the full contract. `pageNumber` is 1-indexed
+   * (page 1 is the first page) - see `io.evitadb.dataType.PaginatedList#getPageNumber`. A requested page
+   * number of 0 or less is rejected by the server; a requested page number beyond `lastPageNumber` is not
+   * rejected - the engine returns the first page instead, so `pageNumber` here can differ from what was
+   * requested.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcPaginatedList}
@@ -489,7 +503,8 @@ private static final long serialVersionUID = 0L;
     private int pageSize_ ;
     /**
      * <pre>
-     * The size of the page.
+     * Number of records requested per page, echoed back from the query's `page()` require constraint.
+     * Zero is valid and yields an empty page while `totalRecordCount`/`lastPageNumber` are still reported.
      * </pre>
      *
      * <code>int32 pageSize = 1;</code>
@@ -501,7 +516,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page.
+     * Number of records requested per page, echoed back from the query's `page()` require constraint.
+     * Zero is valid and yields an empty page while `totalRecordCount`/`lastPageNumber` are still reported.
      * </pre>
      *
      * <code>int32 pageSize = 1;</code>
@@ -517,7 +533,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page.
+     * Number of records requested per page, echoed back from the query's `page()` require constraint.
+     * Zero is valid and yields an empty page while `totalRecordCount`/`lastPageNumber` are still reported.
      * </pre>
      *
      * <code>int32 pageSize = 1;</code>
@@ -533,7 +550,8 @@ private static final long serialVersionUID = 0L;
     private int pageNumber_ ;
     /**
      * <pre>
-     * The number of the page.
+     * The page actually returned (1-indexed) - see the message-level comment for how this can differ from
+     * the requested page number.
      * </pre>
      *
      * <code>int32 pageNumber = 2;</code>
@@ -545,7 +563,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The number of the page.
+     * The page actually returned (1-indexed) - see the message-level comment for how this can differ from
+     * the requested page number.
      * </pre>
      *
      * <code>int32 pageNumber = 2;</code>
@@ -561,7 +580,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The number of the page.
+     * The page actually returned (1-indexed) - see the message-level comment for how this can differ from
+     * the requested page number.
      * </pre>
      *
      * <code>int32 pageNumber = 2;</code>
@@ -577,7 +597,7 @@ private static final long serialVersionUID = 0L;
     private int lastPageNumber_ ;
     /**
      * <pre>
-     * The number of the last page.
+     * The number of the last available page, given `pageSize` and the total record count.
      * </pre>
      *
      * <code>int32 lastPageNumber = 3;</code>
@@ -589,7 +609,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The number of the last page.
+     * The number of the last available page, given `pageSize` and the total record count.
      * </pre>
      *
      * <code>int32 lastPageNumber = 3;</code>
@@ -605,7 +625,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The number of the last page.
+     * The number of the last available page, given `pageSize` and the total record count.
      * </pre>
      *
      * <code>int32 lastPageNumber = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPaginatedListOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPaginatedListOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcPaginatedListOrBuilder extends
 
   /**
    * <pre>
-   * The size of the page.
+   * Number of records requested per page, echoed back from the query's `page()` require constraint.
+   * Zero is valid and yields an empty page while `totalRecordCount`/`lastPageNumber` are still reported.
    * </pre>
    *
    * <code>int32 pageSize = 1;</code>
@@ -43,7 +44,8 @@ public interface GrpcPaginatedListOrBuilder extends
 
   /**
    * <pre>
-   * The number of the page.
+   * The page actually returned (1-indexed) - see the message-level comment for how this can differ from
+   * the requested page number.
    * </pre>
    *
    * <code>int32 pageNumber = 2;</code>
@@ -53,7 +55,7 @@ public interface GrpcPaginatedListOrBuilder extends
 
   /**
    * <pre>
-   * The number of the last page.
+   * The number of the last available page, given `pageSize` and the total record count.
    * </pre>
    *
    * <code>int32 lastPageNumber = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPredecessor.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPredecessor.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Structure for representing Predecessor objects.
+ * Structure for representing Predecessor objects, used to express a manually maintained ordering
+ * of sibling entities/references by pointing each one at the primary key of the item that precedes
+ * it.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcPredecessor}
@@ -71,7 +73,8 @@ private static final long serialVersionUID = 0L;
   private boolean head_ = false;
   /**
    * <pre>
-   * true if predecessor is a head, false otherwise
+   * If `true`, this is the first item in the ordering (no predecessor) and `predecessorId` is not
+   * set. If `false`, this item has a predecessor and `predecessorId` must be set.
    * </pre>
    *
    * <code>bool head = 1;</code>
@@ -86,7 +89,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value predecessorId_;
   /**
    * <pre>
-   * Value that supports storing a Predecessor.
+   * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+   * `head` is `true`; must be set when `head` is `false`.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -98,7 +102,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Predecessor.
+   * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+   * `head` is `true`; must be set when `head` is `false`.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -110,7 +115,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a Predecessor.
+   * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+   * `head` is `true`; must be set when `head` is `false`.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -296,7 +302,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Structure for representing Predecessor objects.
+   * Structure for representing Predecessor objects, used to express a manually maintained ordering
+   * of sibling entities/references by pointing each one at the primary key of the item that precedes
+   * it.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcPredecessor}
@@ -498,7 +506,8 @@ private static final long serialVersionUID = 0L;
     private boolean head_ ;
     /**
      * <pre>
-     * true if predecessor is a head, false otherwise
+     * If `true`, this is the first item in the ordering (no predecessor) and `predecessorId` is not
+     * set. If `false`, this item has a predecessor and `predecessorId` must be set.
      * </pre>
      *
      * <code>bool head = 1;</code>
@@ -510,7 +519,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * true if predecessor is a head, false otherwise
+     * If `true`, this is the first item in the ordering (no predecessor) and `predecessorId` is not
+     * set. If `false`, this item has a predecessor and `predecessorId` must be set.
      * </pre>
      *
      * <code>bool head = 1;</code>
@@ -526,7 +536,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * true if predecessor is a head, false otherwise
+     * If `true`, this is the first item in the ordering (no predecessor) and `predecessorId` is not
+     * set. If `false`, this item has a predecessor and `predecessorId` must be set.
      * </pre>
      *
      * <code>bool head = 1;</code>
@@ -544,7 +555,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> predecessorIdBuilder_;
     /**
      * <pre>
-     * Value that supports storing a Predecessor.
+     * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+     * `head` is `true`; must be set when `head` is `false`.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -555,7 +567,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Predecessor.
+     * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+     * `head` is `true`; must be set when `head` is `false`.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -570,7 +583,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Predecessor.
+     * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+     * `head` is `true`; must be set when `head` is `false`.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -590,7 +604,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Predecessor.
+     * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+     * `head` is `true`; must be set when `head` is `false`.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -608,7 +623,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Predecessor.
+     * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+     * `head` is `true`; must be set when `head` is `false`.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -633,7 +649,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Predecessor.
+     * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+     * `head` is `true`; must be set when `head` is `false`.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -650,7 +667,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Predecessor.
+     * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+     * `head` is `true`; must be set when `head` is `false`.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -662,7 +680,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Predecessor.
+     * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+     * `head` is `true`; must be set when `head` is `false`.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -677,7 +696,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a Predecessor.
+     * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+     * `head` is `true`; must be set when `head` is `false`.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value predecessorId = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPredecessorOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPredecessorOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcPredecessorOrBuilder extends
 
   /**
    * <pre>
-   * true if predecessor is a head, false otherwise
+   * If `true`, this is the first item in the ordering (no predecessor) and `predecessorId` is not
+   * set. If `false`, this item has a predecessor and `predecessorId` must be set.
    * </pre>
    *
    * <code>bool head = 1;</code>
@@ -43,7 +44,8 @@ public interface GrpcPredecessorOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a Predecessor.
+   * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+   * `head` is `true`; must be set when `head` is `false`.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -52,7 +54,8 @@ public interface GrpcPredecessorOrBuilder extends
   boolean hasPredecessorId();
   /**
    * <pre>
-   * Value that supports storing a Predecessor.
+   * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+   * `head` is `true`; must be set when `head` is `false`.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value predecessorId = 2;</code>
@@ -61,7 +64,8 @@ public interface GrpcPredecessorOrBuilder extends
   com.google.protobuf.Int32Value getPredecessorId();
   /**
    * <pre>
-   * Value that supports storing a Predecessor.
+   * The primary key of the entity/reference that precedes this one in the ordering. Unset when
+   * `head` is `true`; must be set when `head` is `false`.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value predecessorId = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPrice.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPrice.java
@@ -271,7 +271,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate_;
   /**
    * <pre>
-   * Price with tax.
+   * Tax rate percentage (i.e. for 19% it'll be 19.00)
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -283,7 +283,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Price with tax.
+   * Tax rate percentage (i.e. for 19% it'll be 19.00)
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -295,7 +295,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Price with tax.
+   * Tax rate percentage (i.e. for 19% it'll be 19.00)
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -309,7 +309,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax_;
   /**
    * <pre>
-   * Tax rate percentage (i.e. for 19% it'll be 19.00)
+   * Price with tax.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -321,7 +321,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Tax rate percentage (i.e. for 19% it'll be 19.00)
+   * Price with tax.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -333,7 +333,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Tax rate percentage (i.e. for 19% it'll be 19.00)
+   * Price with tax.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -1767,7 +1767,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBigDecimal, io.evitadb.externalApi.grpc.generated.GrpcBigDecimal.Builder, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalOrBuilder> taxRateBuilder_;
     /**
      * <pre>
-     * Price with tax.
+     * Tax rate percentage (i.e. for 19% it'll be 19.00)
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -1778,7 +1778,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Price with tax.
+     * Tax rate percentage (i.e. for 19% it'll be 19.00)
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -1793,7 +1793,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Price with tax.
+     * Tax rate percentage (i.e. for 19% it'll be 19.00)
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -1813,7 +1813,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Price with tax.
+     * Tax rate percentage (i.e. for 19% it'll be 19.00)
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -1831,7 +1831,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Price with tax.
+     * Tax rate percentage (i.e. for 19% it'll be 19.00)
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -1856,7 +1856,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Price with tax.
+     * Tax rate percentage (i.e. for 19% it'll be 19.00)
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -1873,7 +1873,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Price with tax.
+     * Tax rate percentage (i.e. for 19% it'll be 19.00)
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -1885,7 +1885,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Price with tax.
+     * Tax rate percentage (i.e. for 19% it'll be 19.00)
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -1900,7 +1900,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Price with tax.
+     * Tax rate percentage (i.e. for 19% it'll be 19.00)
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -1924,7 +1924,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBigDecimal, io.evitadb.externalApi.grpc.generated.GrpcBigDecimal.Builder, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalOrBuilder> priceWithTaxBuilder_;
     /**
      * <pre>
-     * Tax rate percentage (i.e. for 19% it'll be 19.00)
+     * Price with tax.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -1935,7 +1935,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Tax rate percentage (i.e. for 19% it'll be 19.00)
+     * Price with tax.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -1950,7 +1950,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Tax rate percentage (i.e. for 19% it'll be 19.00)
+     * Price with tax.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -1970,7 +1970,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Tax rate percentage (i.e. for 19% it'll be 19.00)
+     * Price with tax.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -1988,7 +1988,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Tax rate percentage (i.e. for 19% it'll be 19.00)
+     * Price with tax.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -2013,7 +2013,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Tax rate percentage (i.e. for 19% it'll be 19.00)
+     * Price with tax.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -2030,7 +2030,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Tax rate percentage (i.e. for 19% it'll be 19.00)
+     * Price with tax.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -2042,7 +2042,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Tax rate percentage (i.e. for 19% it'll be 19.00)
+     * Price with tax.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -2057,7 +2057,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Tax rate percentage (i.e. for 19% it'll be 19.00)
+     * Price with tax.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPriceContentModeArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPriceContentModeArray.java
@@ -81,7 +81,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * Value that supports storing a PriceContentMode array.
+   * The individual PriceContentMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -94,7 +94,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a PriceContentMode array.
+   * The individual PriceContentMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a PriceContentMode array.
+   * The individual PriceContentMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -119,7 +119,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a PriceContentMode array.
+   * The individual PriceContentMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -132,7 +132,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a PriceContentMode array.
+   * The individual PriceContentMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -524,7 +524,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a PriceContentMode array.
+     * The individual PriceContentMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -536,7 +536,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a PriceContentMode array.
+     * The individual PriceContentMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -547,7 +547,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a PriceContentMode array.
+     * The individual PriceContentMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -559,7 +559,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a PriceContentMode array.
+     * The individual PriceContentMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -579,7 +579,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a PriceContentMode array.
+     * The individual PriceContentMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -597,7 +597,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a PriceContentMode array.
+     * The individual PriceContentMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -615,7 +615,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a PriceContentMode array.
+     * The individual PriceContentMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -629,7 +629,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a PriceContentMode array.
+     * The individual PriceContentMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a PriceContentMode array.
+     * The individual PriceContentMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -653,7 +653,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a PriceContentMode array.
+     * The individual PriceContentMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -670,7 +670,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a PriceContentMode array.
+     * The individual PriceContentMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -685,7 +685,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a PriceContentMode array.
+     * The individual PriceContentMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPriceContentModeArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPriceContentModeArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcPriceContentModeArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a PriceContentMode array.
+   * The individual PriceContentMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcPriceContentModeArrayOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode> getValueList();
   /**
    * <pre>
-   * Value that supports storing a PriceContentMode array.
+   * The individual PriceContentMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcPriceContentModeArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a PriceContentMode array.
+   * The individual PriceContentMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -61,7 +61,7 @@ public interface GrpcPriceContentModeArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a PriceContentMode array.
+   * The individual PriceContentMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>
@@ -71,7 +71,7 @@ public interface GrpcPriceContentModeArrayOrBuilder extends
   getValueValueList();
   /**
    * <pre>
-   * Value that supports storing a PriceContentMode array.
+   * The individual PriceContentMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPriceOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcPriceOrBuilder.java
@@ -165,7 +165,7 @@ public interface GrpcPriceOrBuilder extends
 
   /**
    * <pre>
-   * Price with tax.
+   * Tax rate percentage (i.e. for 19% it'll be 19.00)
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -174,7 +174,7 @@ public interface GrpcPriceOrBuilder extends
   boolean hasTaxRate();
   /**
    * <pre>
-   * Price with tax.
+   * Tax rate percentage (i.e. for 19% it'll be 19.00)
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -183,7 +183,7 @@ public interface GrpcPriceOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimal getTaxRate();
   /**
    * <pre>
-   * Price with tax.
+   * Tax rate percentage (i.e. for 19% it'll be 19.00)
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal taxRate = 6;</code>
@@ -192,7 +192,7 @@ public interface GrpcPriceOrBuilder extends
 
   /**
    * <pre>
-   * Tax rate percentage (i.e. for 19% it'll be 19.00)
+   * Price with tax.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -201,7 +201,7 @@ public interface GrpcPriceOrBuilder extends
   boolean hasPriceWithTax();
   /**
    * <pre>
-   * Tax rate percentage (i.e. for 19% it'll be 19.00)
+   * Price with tax.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>
@@ -210,7 +210,7 @@ public interface GrpcPriceOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimal getPriceWithTax();
   /**
    * <pre>
-   * Tax rate percentage (i.e. for 19% it'll be 19.00)
+   * Price with tax.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal priceWithTax = 7;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryListResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryListResponse.java
@@ -29,7 +29,13 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response for query request executed when searched for a list of entities. The used field is decided by the require block in the query.
+ * Response for a query executed via QueryList, i.e. expecting a flat list of matching entities (no paging
+ * metadata - use plain `Query` via `GrpcQueryResponse` if paging is needed). Exactly one of
+ * `entityReferences`/`sealedEntities`/`binaryEntities` is the active field, chosen the same way as in
+ * `GrpcDataChunk`: no `entityFetch` requirement in the query's `require` block selects `entityReferences`;
+ * an `entityFetch` requirement selects `sealedEntities` (structured form) or `binaryEntities` (binary
+ * storage form), depending on whether the session uses the binary storage format. The other two fields are
+ * always left empty; note the active field is itself also empty when zero entities matched.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcQueryListResponse}
@@ -73,6 +79,11 @@ private static final long serialVersionUID = 0L;
   @SuppressWarnings("serial")
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcEntityReference> entityReferences_;
   /**
+   * <pre>
+   * Matched entities as references (type + primary key only). See the message-level comment for when this
+   * field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
    */
   @java.lang.Override
@@ -80,6 +91,11 @@ private static final long serialVersionUID = 0L;
     return entityReferences_;
   }
   /**
+   * <pre>
+   * Matched entities as references (type + primary key only). See the message-level comment for when this
+   * field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
    */
   @java.lang.Override
@@ -88,6 +104,11 @@ private static final long serialVersionUID = 0L;
     return entityReferences_;
   }
   /**
+   * <pre>
+   * Matched entities as references (type + primary key only). See the message-level comment for when this
+   * field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
    */
   @java.lang.Override
@@ -95,6 +116,11 @@ private static final long serialVersionUID = 0L;
     return entityReferences_.size();
   }
   /**
+   * <pre>
+   * Matched entities as references (type + primary key only). See the message-level comment for when this
+   * field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
    */
   @java.lang.Override
@@ -102,6 +128,11 @@ private static final long serialVersionUID = 0L;
     return entityReferences_.get(index);
   }
   /**
+   * <pre>
+   * Matched entities as references (type + primary key only). See the message-level comment for when this
+   * field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
    */
   @java.lang.Override
@@ -114,6 +145,11 @@ private static final long serialVersionUID = 0L;
   @SuppressWarnings("serial")
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcSealedEntity> sealedEntities_;
   /**
+   * <pre>
+   * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
    */
   @java.lang.Override
@@ -121,6 +157,11 @@ private static final long serialVersionUID = 0L;
     return sealedEntities_;
   }
   /**
+   * <pre>
+   * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
    */
   @java.lang.Override
@@ -129,6 +170,11 @@ private static final long serialVersionUID = 0L;
     return sealedEntities_;
   }
   /**
+   * <pre>
+   * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
    */
   @java.lang.Override
@@ -136,6 +182,11 @@ private static final long serialVersionUID = 0L;
     return sealedEntities_.size();
   }
   /**
+   * <pre>
+   * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
    */
   @java.lang.Override
@@ -143,6 +194,11 @@ private static final long serialVersionUID = 0L;
     return sealedEntities_.get(index);
   }
   /**
+   * <pre>
+   * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
    */
   @java.lang.Override
@@ -155,6 +211,11 @@ private static final long serialVersionUID = 0L;
   @SuppressWarnings("serial")
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity> binaryEntities_;
   /**
+   * <pre>
+   * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
    */
   @java.lang.Override
@@ -162,6 +223,11 @@ private static final long serialVersionUID = 0L;
     return binaryEntities_;
   }
   /**
+   * <pre>
+   * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
    */
   @java.lang.Override
@@ -170,6 +236,11 @@ private static final long serialVersionUID = 0L;
     return binaryEntities_;
   }
   /**
+   * <pre>
+   * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
    */
   @java.lang.Override
@@ -177,6 +248,11 @@ private static final long serialVersionUID = 0L;
     return binaryEntities_.size();
   }
   /**
+   * <pre>
+   * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
    */
   @java.lang.Override
@@ -184,6 +260,11 @@ private static final long serialVersionUID = 0L;
     return binaryEntities_.get(index);
   }
   /**
+   * <pre>
+   * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
    */
   @java.lang.Override
@@ -379,7 +460,13 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response for query request executed when searched for a list of entities. The used field is decided by the require block in the query.
+   * Response for a query executed via QueryList, i.e. expecting a flat list of matching entities (no paging
+   * metadata - use plain `Query` via `GrpcQueryResponse` if paging is needed). Exactly one of
+   * `entityReferences`/`sealedEntities`/`binaryEntities` is the active field, chosen the same way as in
+   * `GrpcDataChunk`: no `entityFetch` requirement in the query's `require` block selects `entityReferences`;
+   * an `entityFetch` requirement selects `sealedEntities` (structured form) or `binaryEntities` (binary
+   * storage form), depending on whether the session uses the binary storage format. The other two fields are
+   * always left empty; note the active field is itself also empty when zero entities matched.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcQueryListResponse}
@@ -719,6 +806,11 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEntityReference, io.evitadb.externalApi.grpc.generated.GrpcEntityReference.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceOrBuilder> entityReferencesBuilder_;
 
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcEntityReference> getEntityReferencesList() {
@@ -729,6 +821,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public int getEntityReferencesCount() {
@@ -739,6 +836,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcEntityReference getEntityReferences(int index) {
@@ -749,6 +851,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public Builder setEntityReferences(
@@ -766,6 +873,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public Builder setEntityReferences(
@@ -780,6 +892,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public Builder addEntityReferences(io.evitadb.externalApi.grpc.generated.GrpcEntityReference value) {
@@ -796,6 +913,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public Builder addEntityReferences(
@@ -813,6 +935,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public Builder addEntityReferences(
@@ -827,6 +954,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public Builder addEntityReferences(
@@ -841,6 +973,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public Builder addAllEntityReferences(
@@ -856,6 +993,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public Builder clearEntityReferences() {
@@ -869,6 +1011,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public Builder removeEntityReferences(int index) {
@@ -882,6 +1029,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcEntityReference.Builder getEntityReferencesBuilder(
@@ -889,6 +1041,11 @@ private static final long serialVersionUID = 0L;
       return getEntityReferencesFieldBuilder().getBuilder(index);
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceOrBuilder getEntityReferencesOrBuilder(
@@ -899,6 +1056,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceOrBuilder> 
@@ -910,6 +1072,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcEntityReference.Builder addEntityReferencesBuilder() {
@@ -917,6 +1084,11 @@ private static final long serialVersionUID = 0L;
           io.evitadb.externalApi.grpc.generated.GrpcEntityReference.getDefaultInstance());
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcEntityReference.Builder addEntityReferencesBuilder(
@@ -925,6 +1097,11 @@ private static final long serialVersionUID = 0L;
           index, io.evitadb.externalApi.grpc.generated.GrpcEntityReference.getDefaultInstance());
     }
     /**
+     * <pre>
+     * Matched entities as references (type + primary key only). See the message-level comment for when this
+     * field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
      */
     public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcEntityReference.Builder> 
@@ -959,6 +1136,11 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcSealedEntity, io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.Builder, io.evitadb.externalApi.grpc.generated.GrpcSealedEntityOrBuilder> sealedEntitiesBuilder_;
 
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcSealedEntity> getSealedEntitiesList() {
@@ -969,6 +1151,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public int getSealedEntitiesCount() {
@@ -979,6 +1166,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcSealedEntity getSealedEntities(int index) {
@@ -989,6 +1181,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public Builder setSealedEntities(
@@ -1006,6 +1203,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public Builder setSealedEntities(
@@ -1020,6 +1222,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public Builder addSealedEntities(io.evitadb.externalApi.grpc.generated.GrpcSealedEntity value) {
@@ -1036,6 +1243,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public Builder addSealedEntities(
@@ -1053,6 +1265,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public Builder addSealedEntities(
@@ -1067,6 +1284,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public Builder addSealedEntities(
@@ -1081,6 +1303,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public Builder addAllSealedEntities(
@@ -1096,6 +1323,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public Builder clearSealedEntities() {
@@ -1109,6 +1341,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public Builder removeSealedEntities(int index) {
@@ -1122,6 +1359,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.Builder getSealedEntitiesBuilder(
@@ -1129,6 +1371,11 @@ private static final long serialVersionUID = 0L;
       return getSealedEntitiesFieldBuilder().getBuilder(index);
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcSealedEntityOrBuilder getSealedEntitiesOrBuilder(
@@ -1139,6 +1386,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcSealedEntityOrBuilder> 
@@ -1150,6 +1402,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.Builder addSealedEntitiesBuilder() {
@@ -1157,6 +1414,11 @@ private static final long serialVersionUID = 0L;
           io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.getDefaultInstance());
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.Builder addSealedEntitiesBuilder(
@@ -1165,6 +1427,11 @@ private static final long serialVersionUID = 0L;
           index, io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.getDefaultInstance());
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
      */
     public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.Builder> 
@@ -1199,6 +1466,11 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity, io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity.Builder, io.evitadb.externalApi.grpc.generated.GrpcBinaryEntityOrBuilder> binaryEntitiesBuilder_;
 
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity> getBinaryEntitiesList() {
@@ -1209,6 +1481,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public int getBinaryEntitiesCount() {
@@ -1219,6 +1496,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity getBinaryEntities(int index) {
@@ -1229,6 +1511,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public Builder setBinaryEntities(
@@ -1246,6 +1533,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public Builder setBinaryEntities(
@@ -1260,6 +1552,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public Builder addBinaryEntities(io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity value) {
@@ -1276,6 +1573,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public Builder addBinaryEntities(
@@ -1293,6 +1595,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public Builder addBinaryEntities(
@@ -1307,6 +1614,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public Builder addBinaryEntities(
@@ -1321,6 +1633,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public Builder addAllBinaryEntities(
@@ -1336,6 +1653,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public Builder clearBinaryEntities() {
@@ -1349,6 +1671,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public Builder removeBinaryEntities(int index) {
@@ -1362,6 +1689,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity.Builder getBinaryEntitiesBuilder(
@@ -1369,6 +1701,11 @@ private static final long serialVersionUID = 0L;
       return getBinaryEntitiesFieldBuilder().getBuilder(index);
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcBinaryEntityOrBuilder getBinaryEntitiesOrBuilder(
@@ -1379,6 +1716,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcBinaryEntityOrBuilder> 
@@ -1390,6 +1732,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity.Builder addBinaryEntitiesBuilder() {
@@ -1397,6 +1744,11 @@ private static final long serialVersionUID = 0L;
           io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity.getDefaultInstance());
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity.Builder addBinaryEntitiesBuilder(
@@ -1405,6 +1757,11 @@ private static final long serialVersionUID = 0L;
           index, io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity.getDefaultInstance());
     }
     /**
+     * <pre>
+     * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is the active one.
+     * </pre>
+     *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
      */
     public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity.Builder> 

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryListResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryListResponseOrBuilder.java
@@ -32,72 +32,147 @@ public interface GrpcQueryListResponseOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   * <pre>
+   * Matched entities as references (type + primary key only). See the message-level comment for when this
+   * field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
    */
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcEntityReference> 
       getEntityReferencesList();
   /**
+   * <pre>
+   * Matched entities as references (type + primary key only). See the message-level comment for when this
+   * field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcEntityReference getEntityReferences(int index);
   /**
+   * <pre>
+   * Matched entities as references (type + primary key only). See the message-level comment for when this
+   * field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
    */
   int getEntityReferencesCount();
   /**
+   * <pre>
+   * Matched entities as references (type + primary key only). See the message-level comment for when this
+   * field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
    */
   java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceOrBuilder> 
       getEntityReferencesOrBuilderList();
   /**
+   * <pre>
+   * Matched entities as references (type + primary key only). See the message-level comment for when this
+   * field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReferences = 1;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceOrBuilder getEntityReferencesOrBuilder(
       int index);
 
   /**
+   * <pre>
+   * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
    */
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcSealedEntity> 
       getSealedEntitiesList();
   /**
+   * <pre>
+   * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcSealedEntity getSealedEntities(int index);
   /**
+   * <pre>
+   * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
    */
   int getSealedEntitiesCount();
   /**
+   * <pre>
+   * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
    */
   java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcSealedEntityOrBuilder> 
       getSealedEntitiesOrBuilderList();
   /**
+   * <pre>
+   * Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntities = 2;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcSealedEntityOrBuilder getSealedEntitiesOrBuilder(
       int index);
 
   /**
+   * <pre>
+   * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
    */
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity> 
       getBinaryEntitiesList();
   /**
+   * <pre>
+   * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity getBinaryEntities(int index);
   /**
+   * <pre>
+   * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
    */
   int getBinaryEntitiesCount();
   /**
+   * <pre>
+   * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
    */
   java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcBinaryEntityOrBuilder> 
       getBinaryEntitiesOrBuilderList();
   /**
+   * <pre>
+   * Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is the active one.
+   * </pre>
+   *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntities = 3;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcBinaryEntityOrBuilder getBinaryEntitiesOrBuilder(

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryOneResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryOneResponse.java
@@ -29,7 +29,12 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response for query request executed when searched for exactly one entity. The used field is decided by the require block in the query.
+ * Response for a query executed via QueryOne, i.e. expecting zero or one matching entity. At most one of
+ * `entityReference`/`sealedEntity`/`binaryEntity` is populated. If an entity matched, which one is chosen
+ * the same way as in `GrpcDataChunk`: no `entityFetch` requirement in the query's `require` block yields
+ * `entityReference`; an `entityFetch` requirement yields `sealedEntity` (structured form) or `binaryEntity`
+ * (binary storage form), depending on whether the session uses the binary storage format. If no entity
+ * matched the query, all three fields are left unset - this is not an error.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcQueryOneResponse}
@@ -71,7 +76,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference_;
   /**
    * <pre>
-   * Entity reference of the found entity.
+   * The matched entity as a reference (type + primary key only). See the message-level comment for when
+   * this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -83,7 +89,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Entity reference of the found entity.
+   * The matched entity as a reference (type + primary key only). See the message-level comment for when
+   * this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -95,7 +102,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Entity reference of the found entity.
+   * The matched entity as a reference (type + primary key only). See the message-level comment for when
+   * this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -109,7 +117,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity_;
   /**
    * <pre>
-   * Sealed entity of the found entity.
+   * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -121,7 +130,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Sealed entity of the found entity.
+   * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -133,7 +143,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Sealed entity of the found entity.
+   * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -147,7 +158,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity_;
   /**
    * <pre>
-   * Binary entity of the found entity.
+   * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -159,7 +171,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Binary entity of the found entity.
+   * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -171,7 +184,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Binary entity of the found entity.
+   * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -377,7 +391,12 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response for query request executed when searched for exactly one entity. The used field is decided by the require block in the query.
+   * Response for a query executed via QueryOne, i.e. expecting zero or one matching entity. At most one of
+   * `entityReference`/`sealedEntity`/`binaryEntity` is populated. If an entity matched, which one is chosen
+   * the same way as in `GrpcDataChunk`: no `entityFetch` requirement in the query's `require` block yields
+   * `entityReference`; an `entityFetch` requirement yields `sealedEntity` (structured form) or `binaryEntity`
+   * (binary storage form), depending on whether the session uses the binary storage format. If no entity
+   * matched the query, all three fields are left unset - this is not an error.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcQueryOneResponse}
@@ -613,7 +632,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEntityReference, io.evitadb.externalApi.grpc.generated.GrpcEntityReference.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceOrBuilder> entityReferenceBuilder_;
     /**
      * <pre>
-     * Entity reference of the found entity.
+     * The matched entity as a reference (type + primary key only). See the message-level comment for when
+     * this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -624,7 +644,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Entity reference of the found entity.
+     * The matched entity as a reference (type + primary key only). See the message-level comment for when
+     * this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -639,7 +660,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Entity reference of the found entity.
+     * The matched entity as a reference (type + primary key only). See the message-level comment for when
+     * this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -659,7 +681,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Entity reference of the found entity.
+     * The matched entity as a reference (type + primary key only). See the message-level comment for when
+     * this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -677,7 +700,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Entity reference of the found entity.
+     * The matched entity as a reference (type + primary key only). See the message-level comment for when
+     * this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -702,7 +726,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Entity reference of the found entity.
+     * The matched entity as a reference (type + primary key only). See the message-level comment for when
+     * this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -719,7 +744,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Entity reference of the found entity.
+     * The matched entity as a reference (type + primary key only). See the message-level comment for when
+     * this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -731,7 +757,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Entity reference of the found entity.
+     * The matched entity as a reference (type + primary key only). See the message-level comment for when
+     * this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -746,7 +773,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Entity reference of the found entity.
+     * The matched entity as a reference (type + primary key only). See the message-level comment for when
+     * this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -770,7 +798,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcSealedEntity, io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.Builder, io.evitadb.externalApi.grpc.generated.GrpcSealedEntityOrBuilder> sealedEntityBuilder_;
     /**
      * <pre>
-     * Sealed entity of the found entity.
+     * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -781,7 +810,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Sealed entity of the found entity.
+     * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -796,7 +826,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Sealed entity of the found entity.
+     * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -816,7 +847,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Sealed entity of the found entity.
+     * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -834,7 +866,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Sealed entity of the found entity.
+     * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -859,7 +892,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Sealed entity of the found entity.
+     * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -876,7 +910,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Sealed entity of the found entity.
+     * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -888,7 +923,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Sealed entity of the found entity.
+     * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -903,7 +939,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Sealed entity of the found entity.
+     * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+     * when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -927,7 +964,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity, io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity.Builder, io.evitadb.externalApi.grpc.generated.GrpcBinaryEntityOrBuilder> binaryEntityBuilder_;
     /**
      * <pre>
-     * Binary entity of the found entity.
+     * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -938,7 +976,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Binary entity of the found entity.
+     * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -953,7 +992,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Binary entity of the found entity.
+     * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -973,7 +1013,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Binary entity of the found entity.
+     * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -991,7 +1032,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Binary entity of the found entity.
+     * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -1016,7 +1058,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Binary entity of the found entity.
+     * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -1033,7 +1076,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Binary entity of the found entity.
+     * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -1045,7 +1089,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Binary entity of the found entity.
+     * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -1060,7 +1105,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Binary entity of the found entity.
+     * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+     * for when this field (vs. the other two) is populated.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryOneResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryOneResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcQueryOneResponseOrBuilder extends
 
   /**
    * <pre>
-   * Entity reference of the found entity.
+   * The matched entity as a reference (type + primary key only). See the message-level comment for when
+   * this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcQueryOneResponseOrBuilder extends
   boolean hasEntityReference();
   /**
    * <pre>
-   * Entity reference of the found entity.
+   * The matched entity as a reference (type + primary key only). See the message-level comment for when
+   * this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcQueryOneResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEntityReference getEntityReference();
   /**
    * <pre>
-   * Entity reference of the found entity.
+   * The matched entity as a reference (type + primary key only). See the message-level comment for when
+   * this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -60,7 +63,8 @@ public interface GrpcQueryOneResponseOrBuilder extends
 
   /**
    * <pre>
-   * Sealed entity of the found entity.
+   * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -69,7 +73,8 @@ public interface GrpcQueryOneResponseOrBuilder extends
   boolean hasSealedEntity();
   /**
    * <pre>
-   * Sealed entity of the found entity.
+   * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -78,7 +83,8 @@ public interface GrpcQueryOneResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcSealedEntity getSealedEntity();
   /**
    * <pre>
-   * Sealed entity of the found entity.
+   * The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+   * when this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity sealedEntity = 2;</code>
@@ -87,7 +93,8 @@ public interface GrpcQueryOneResponseOrBuilder extends
 
   /**
    * <pre>
-   * Binary entity of the found entity.
+   * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -96,7 +103,8 @@ public interface GrpcQueryOneResponseOrBuilder extends
   boolean hasBinaryEntity();
   /**
    * <pre>
-   * Binary entity of the found entity.
+   * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>
@@ -105,7 +113,8 @@ public interface GrpcQueryOneResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity getBinaryEntity();
   /**
    * <pre>
-   * Binary entity of the found entity.
+   * The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+   * for when this field (vs. the other two) is populated.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBinaryEntity binaryEntity = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryParam.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryParam.java
@@ -205,7 +205,8 @@ private static final long serialVersionUID = 0L;
   public static final int STRINGVALUE_FIELD_NUMBER = 1;
   /**
    * <pre>
-   * The string value.
+   * Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+   * `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
    * </pre>
    *
    * <code>string stringValue = 1;</code>
@@ -216,7 +217,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string value.
+   * Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+   * `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
    * </pre>
    *
    * <code>string stringValue = 1;</code>
@@ -241,7 +243,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string value.
+   * Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+   * `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
    * </pre>
    *
    * <code>string stringValue = 1;</code>
@@ -269,7 +272,7 @@ private static final long serialVersionUID = 0L;
   public static final int INTEGERVALUE_FIELD_NUMBER = 2;
   /**
    * <pre>
-   * The integer value.
+   * Binds an `int32` parameter into the query, typically used for primary keys or numeric literals.
    * </pre>
    *
    * <code>int32 integerValue = 2;</code>
@@ -281,7 +284,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The integer value.
+   * Binds an `int32` parameter into the query, typically used for primary keys or numeric literals.
    * </pre>
    *
    * <code>int32 integerValue = 2;</code>
@@ -298,7 +301,8 @@ private static final long serialVersionUID = 0L;
   public static final int LONGVALUE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   * The long value.
+   * Binds a `long` parameter into the query, typically used for primary keys or numeric literals
+   * that exceed the `int32` range.
    * </pre>
    *
    * <code>int64 longValue = 3;</code>
@@ -310,7 +314,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The long value.
+   * Binds a `long` parameter into the query, typically used for primary keys or numeric literals
+   * that exceed the `int32` range.
    * </pre>
    *
    * <code>int64 longValue = 3;</code>
@@ -327,7 +332,7 @@ private static final long serialVersionUID = 0L;
   public static final int BOOLEANVALUE_FIELD_NUMBER = 4;
   /**
    * <pre>
-   * The boolean value.
+   * Binds a boolean parameter into the query.
    * </pre>
    *
    * <code>bool booleanValue = 4;</code>
@@ -339,7 +344,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The boolean value.
+   * Binds a boolean parameter into the query.
    * </pre>
    *
    * <code>bool booleanValue = 4;</code>
@@ -356,7 +361,8 @@ private static final long serialVersionUID = 0L;
   public static final int BIGDECIMALVALUE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   * The big decimal value.
+   * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+   * other monetary/decimal literals.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -368,7 +374,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The big decimal value.
+   * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+   * other monetary/decimal literals.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -383,7 +390,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The big decimal value.
+   * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+   * other monetary/decimal literals.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -399,7 +407,8 @@ private static final long serialVersionUID = 0L;
   public static final int DATETIMERANGEVALUE_FIELD_NUMBER = 6;
   /**
    * <pre>
-   * The date time range value.
+   * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+   * style constraints that test whether a given instant falls within a validity range.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -411,7 +420,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The date time range value.
+   * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+   * style constraints that test whether a given instant falls within a validity range.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -426,7 +436,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The date time range value.
+   * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+   * style constraints that test whether a given instant falls within a validity range.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -442,7 +453,7 @@ private static final long serialVersionUID = 0L;
   public static final int INTEGERNUMBERRANGEVALUE_FIELD_NUMBER = 7;
   /**
    * <pre>
-   * The integer number range value.
+   * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -454,7 +465,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The integer number range value.
+   * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -469,7 +480,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The integer number range value.
+   * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -485,7 +496,7 @@ private static final long serialVersionUID = 0L;
   public static final int LONGNUMBERRANGEVALUE_FIELD_NUMBER = 8;
   /**
    * <pre>
-   * The long number range value.
+   * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -497,7 +508,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The long number range value.
+   * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -512,7 +523,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The long number range value.
+   * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -528,7 +539,8 @@ private static final long serialVersionUID = 0L;
   public static final int BIGDECIMALNUMBERRANGEVALUE_FIELD_NUMBER = 9;
   /**
    * <pre>
-   * The big decimal number range value.
+   * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+   * style range constraints over prices or other decimal values.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -540,7 +552,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The big decimal number range value.
+   * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+   * style range constraints over prices or other decimal values.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -555,7 +568,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The big decimal number range value.
+   * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+   * style range constraints over prices or other decimal values.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -571,7 +585,8 @@ private static final long serialVersionUID = 0L;
   public static final int OFFSETDATETIMEVALUE_FIELD_NUMBER = 10;
   /**
    * <pre>
-   * The offset date time value.
+   * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+   * `priceValidIn` to test price validity at a specific instant.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -583,7 +598,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The offset date time value.
+   * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+   * `priceValidIn` to test price validity at a specific instant.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -598,7 +614,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The offset date time value.
+   * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+   * `priceValidIn` to test price validity at a specific instant.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -614,7 +631,7 @@ private static final long serialVersionUID = 0L;
   public static final int LOCALEVALUE_FIELD_NUMBER = 11;
   /**
    * <pre>
-   * The locale value.
+   * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -626,7 +643,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The locale value.
+   * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -641,7 +658,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The locale value.
+   * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -657,7 +674,7 @@ private static final long serialVersionUID = 0L;
   public static final int CURRENCYVALUE_FIELD_NUMBER = 12;
   /**
    * <pre>
-   * The currency value.
+   * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -669,7 +686,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The currency value.
+   * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -684,7 +701,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The currency value.
+   * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -700,7 +717,8 @@ private static final long serialVersionUID = 0L;
   public static final int FACETSTATISTICSDEPTHVALUE_FIELD_NUMBER = 13;
   /**
    * <pre>
-   * The facet statistics depth enum value.
+   * Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+   * `facetSummary` requirement to select whether only counts or also selection impact is computed.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;</code>
@@ -711,7 +729,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The facet statistics depth enum value.
+   * Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+   * `facetSummary` requirement to select whether only counts or also selection impact is computed.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;</code>
@@ -725,7 +744,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The facet statistics depth enum value.
+   * Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+   * `facetSummary` requirement to select whether only counts or also selection impact is computed.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;</code>
@@ -743,7 +763,10 @@ private static final long serialVersionUID = 0L;
   public static final int QUERYPRICEMODELVALUE_FIELD_NUMBER = 14;
   /**
    * <pre>
-   * The query price mode enum value.
+   * Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+   * constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+   * is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+   * accessors and JSON field mapping for existing clients.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode queryPriceModelValue = 14;</code>
@@ -754,7 +777,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The query price mode enum value.
+   * Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+   * constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+   * is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+   * accessors and JSON field mapping for existing clients.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode queryPriceModelValue = 14;</code>
@@ -768,7 +794,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The query price mode enum value.
+   * Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+   * constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+   * is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+   * accessors and JSON field mapping for existing clients.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode queryPriceModelValue = 14;</code>
@@ -786,7 +815,8 @@ private static final long serialVersionUID = 0L;
   public static final int PRICECONTENTMODEVALUE_FIELD_NUMBER = 15;
   /**
    * <pre>
-   * The price content mode enum value.
+   * Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+   * requirement to select which prices are fetched along with the entity.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode priceContentModeValue = 15;</code>
@@ -797,7 +827,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The price content mode enum value.
+   * Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+   * requirement to select which prices are fetched along with the entity.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode priceContentModeValue = 15;</code>
@@ -811,7 +842,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The price content mode enum value.
+   * Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+   * requirement to select which prices are fetched along with the entity.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode priceContentModeValue = 15;</code>
@@ -829,7 +861,8 @@ private static final long serialVersionUID = 0L;
   public static final int ATTRIBUTESPECIALVALUE_FIELD_NUMBER = 16;
   /**
    * <pre>
-   * The attribute special value enum value.
+   * Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+   * to test whether an attribute value is `NULL` or `NOT_NULL`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue attributeSpecialValue = 16;</code>
@@ -840,7 +873,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The attribute special value enum value.
+   * Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+   * to test whether an attribute value is `NULL` or `NOT_NULL`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue attributeSpecialValue = 16;</code>
@@ -854,7 +888,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The attribute special value enum value.
+   * Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+   * to test whether an attribute value is `NULL` or `NOT_NULL`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue attributeSpecialValue = 16;</code>
@@ -872,7 +907,8 @@ private static final long serialVersionUID = 0L;
   public static final int ORDERDIRECTIONVALUE_FIELD_NUMBER = 17;
   /**
    * <pre>
-   * The order direction enum value.
+   * Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+   * and other ordering constraints to select ascending or descending order.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirection orderDirectionValue = 17;</code>
@@ -883,7 +919,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The order direction enum value.
+   * Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+   * and other ordering constraints to select ascending or descending order.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirection orderDirectionValue = 17;</code>
@@ -897,7 +934,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The order direction enum value.
+   * Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+   * and other ordering constraints to select ascending or descending order.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirection orderDirectionValue = 17;</code>
@@ -915,7 +953,9 @@ private static final long serialVersionUID = 0L;
   public static final int EMPTYHIERARCHICALENTITYBEHAVIOUR_FIELD_NUMBER = 18;
   /**
    * <pre>
-   * The empty hierarchical entity behaviour enum value.
+   * Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+   * statistics requirements to select whether hierarchy nodes with no referring entities are kept
+   * in or removed from the result tree.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;</code>
@@ -926,7 +966,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The empty hierarchical entity behaviour enum value.
+   * Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+   * statistics requirements to select whether hierarchy nodes with no referring entities are kept
+   * in or removed from the result tree.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;</code>
@@ -940,7 +982,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The empty hierarchical entity behaviour enum value.
+   * Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+   * statistics requirements to select whether hierarchy nodes with no referring entities are kept
+   * in or removed from the result tree.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;</code>
@@ -958,7 +1002,9 @@ private static final long serialVersionUID = 0L;
   public static final int STATISTICSBASE_FIELD_NUMBER = 19;
   /**
    * <pre>
-   * The statistics base enum value.
+   * Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+   * requirements to select which part of the `filterBy` constraint is considered when computing
+   * cardinalities.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase statisticsBase = 19;</code>
@@ -969,7 +1015,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The statistics base enum value.
+   * Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+   * requirements to select which part of the `filterBy` constraint is considered when computing
+   * cardinalities.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase statisticsBase = 19;</code>
@@ -983,7 +1031,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The statistics base enum value.
+   * Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+   * requirements to select which part of the `filterBy` constraint is considered when computing
+   * cardinalities.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase statisticsBase = 19;</code>
@@ -1001,7 +1051,8 @@ private static final long serialVersionUID = 0L;
   public static final int STATISTICSTYPE_FIELD_NUMBER = 20;
   /**
    * <pre>
-   * The statistics type enum value.
+   * Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+   * requirements to select whether children counts or queried-entity counts are produced.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsType statisticsType = 20;</code>
@@ -1012,7 +1063,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The statistics type enum value.
+   * Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+   * requirements to select whether children counts or queried-entity counts are produced.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsType statisticsType = 20;</code>
@@ -1026,7 +1078,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The statistics type enum value.
+   * Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+   * requirements to select whether children counts or queried-entity counts are produced.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsType statisticsType = 20;</code>
@@ -1044,7 +1097,9 @@ private static final long serialVersionUID = 0L;
   public static final int HISTOGRAMBEHAVIOR_FIELD_NUMBER = 21;
   /**
    * <pre>
-   * The histogram behavior enum value.
+   * Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+   * to select whether the histogram always has exactly the requested bucket count or an optimized,
+   * more compact bucket layout.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior histogramBehavior = 21;</code>
@@ -1055,7 +1110,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The histogram behavior enum value.
+   * Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+   * to select whether the histogram always has exactly the requested bucket count or an optimized,
+   * more compact bucket layout.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior histogramBehavior = 21;</code>
@@ -1069,7 +1126,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The histogram behavior enum value.
+   * Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+   * to select whether the histogram always has exactly the requested bucket count or an optimized,
+   * more compact bucket layout.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior histogramBehavior = 21;</code>
@@ -1087,7 +1146,9 @@ private static final long serialVersionUID = 0L;
   public static final int MANAGEDREFERENCESBEHAVIOUR_FIELD_NUMBER = 22;
   /**
    * <pre>
-   * The managed references behaviour
+   * Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+   * `referenceContent` requirement to select whether references to a managed entity that no longer
+   * exists are still returned.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;</code>
@@ -1098,7 +1159,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The managed references behaviour
+   * Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+   * `referenceContent` requirement to select whether references to a managed entity that no longer
+   * exists are still returned.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;</code>
@@ -1112,7 +1175,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The managed references behaviour
+   * Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+   * `referenceContent` requirement to select whether references to a managed entity that no longer
+   * exists are still returned.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;</code>
@@ -1130,7 +1195,8 @@ private static final long serialVersionUID = 0L;
   public static final int EXPRESSIONVALUE_FIELD_NUMBER = 23;
   /**
    * <pre>
-   * The expression
+   * Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+   * used as the size argument of the `gap` requirement to compute spacing between paginated results.
    * </pre>
    *
    * <code>string expressionValue = 23;</code>
@@ -1141,7 +1207,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The expression
+   * Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+   * used as the size argument of the `gap` requirement to compute spacing between paginated results.
    * </pre>
    *
    * <code>string expressionValue = 23;</code>
@@ -1166,7 +1233,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The expression
+   * Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+   * used as the size argument of the `gap` requirement to compute spacing between paginated results.
    * </pre>
    *
    * <code>string expressionValue = 23;</code>
@@ -1194,7 +1262,8 @@ private static final long serialVersionUID = 0L;
   public static final int SCOPE_FIELD_NUMBER = 24;
   /**
    * <pre>
-   * The scope enum value.
+   * Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+   * select whether live or archived entities are considered.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScope scope = 24;</code>
@@ -1205,7 +1274,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The scope enum value.
+   * Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+   * select whether live or archived entities are considered.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScope scope = 24;</code>
@@ -1219,7 +1289,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The scope enum value.
+   * Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+   * select whether live or archived entities are considered.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScope scope = 24;</code>
@@ -1237,7 +1308,9 @@ private static final long serialVersionUID = 0L;
   public static final int FACETRELATIONTYPE_FIELD_NUMBER = 25;
   /**
    * <pre>
-   * The facetRelationType enum value.
+   * Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+   * calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+   * applied between facets.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetRelationType facetRelationType = 25;</code>
@@ -1248,7 +1321,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The facetRelationType enum value.
+   * Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+   * calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+   * applied between facets.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetRelationType facetRelationType = 25;</code>
@@ -1262,7 +1337,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The facetRelationType enum value.
+   * Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+   * calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+   * applied between facets.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetRelationType facetRelationType = 25;</code>
@@ -1280,7 +1357,9 @@ private static final long serialVersionUID = 0L;
   public static final int FACETGROUPRELATIONLEVEL_FIELD_NUMBER = 26;
   /**
    * <pre>
-   * The facetGroupRelationLevel enum value.
+   * Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+   * impact calculation to select whether the relation applies between facets in the same group or
+   * across different groups/references.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;</code>
@@ -1291,7 +1370,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The facetGroupRelationLevel enum value.
+   * Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+   * impact calculation to select whether the relation applies between facets in the same group or
+   * across different groups/references.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;</code>
@@ -1305,7 +1386,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The facetGroupRelationLevel enum value.
+   * Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+   * impact calculation to select whether the relation applies between facets in the same group or
+   * across different groups/references.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;</code>
@@ -1323,7 +1406,8 @@ private static final long serialVersionUID = 0L;
   public static final int TRAVERSALMODE_FIELD_NUMBER = 27;
   /**
    * <pre>
-   * The facet traversal mode enum value.
+   * Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+   * `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTraversalMode traversalMode = 27;</code>
@@ -1334,7 +1418,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The facet traversal mode enum value.
+   * Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+   * `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTraversalMode traversalMode = 27;</code>
@@ -1348,7 +1433,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The facet traversal mode enum value.
+   * Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+   * `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTraversalMode traversalMode = 27;</code>
@@ -1366,7 +1452,8 @@ private static final long serialVersionUID = 0L;
   public static final int STRINGARRAYVALUE_FIELD_NUMBER = 101;
   /**
    * <pre>
-   * The string array value.
+   * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+   * as `attributeInSet` over string-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -1378,7 +1465,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string array value.
+   * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+   * as `attributeInSet` over string-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -1393,7 +1481,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string array value.
+   * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+   * as `attributeInSet` over string-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -1409,7 +1498,8 @@ private static final long serialVersionUID = 0L;
   public static final int INTEGERARRAYVALUE_FIELD_NUMBER = 102;
   /**
    * <pre>
-   * The integer array value.
+   * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+   * `attributeInSet` over integer-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -1421,7 +1511,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The integer array value.
+   * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+   * `attributeInSet` over integer-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -1436,7 +1527,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The integer array value.
+   * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+   * `attributeInSet` over integer-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -1452,7 +1544,8 @@ private static final long serialVersionUID = 0L;
   public static final int LONGARRAYVALUE_FIELD_NUMBER = 103;
   /**
    * <pre>
-   * The long array value.
+   * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+   * long-typed values that exceed the `int32` range.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -1464,7 +1557,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The long array value.
+   * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+   * long-typed values that exceed the `int32` range.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -1479,7 +1573,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The long array value.
+   * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+   * long-typed values that exceed the `int32` range.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -1495,7 +1590,8 @@ private static final long serialVersionUID = 0L;
   public static final int BOOLEANARRAYVALUE_FIELD_NUMBER = 104;
   /**
    * <pre>
-   * The boolean array value.
+   * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+   * boolean-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -1507,7 +1603,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The boolean array value.
+   * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+   * boolean-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -1522,7 +1619,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The boolean array value.
+   * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+   * boolean-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -1538,7 +1636,8 @@ private static final long serialVersionUID = 0L;
   public static final int BIGDECIMALARRAYVALUE_FIELD_NUMBER = 105;
   /**
    * <pre>
-   * The big decimal array value.
+   * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+   * `inSet`-style constraints over decimal-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -1550,7 +1649,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The big decimal array value.
+   * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+   * `inSet`-style constraints over decimal-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -1565,7 +1665,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The big decimal array value.
+   * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+   * `inSet`-style constraints over decimal-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -1581,7 +1682,8 @@ private static final long serialVersionUID = 0L;
   public static final int DATETIMERANGEARRAYVALUE_FIELD_NUMBER = 106;
   /**
    * <pre>
-   * The date time range array value.
+   * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+   * constraints over range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -1593,7 +1695,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The date time range array value.
+   * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+   * constraints over range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -1608,7 +1711,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The date time range array value.
+   * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+   * constraints over range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -1624,7 +1728,8 @@ private static final long serialVersionUID = 0L;
   public static final int INTEGERNUMBERRANGEARRAYVALUE_FIELD_NUMBER = 107;
   /**
    * <pre>
-   * The integer number range array value.
+   * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+   * constraints over integer-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -1636,7 +1741,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The integer number range array value.
+   * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+   * constraints over integer-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -1651,7 +1757,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The integer number range array value.
+   * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+   * constraints over integer-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -1667,7 +1774,8 @@ private static final long serialVersionUID = 0L;
   public static final int LONGNUMBERRANGEARRAYVALUE_FIELD_NUMBER = 108;
   /**
    * <pre>
-   * The long number range array value.
+   * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+   * over long-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -1679,7 +1787,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The long number range array value.
+   * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+   * over long-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -1694,7 +1803,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The long number range array value.
+   * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+   * over long-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -1710,7 +1820,8 @@ private static final long serialVersionUID = 0L;
   public static final int BIGDECIMALNUMBERRANGEARRAYVALUE_FIELD_NUMBER = 109;
   /**
    * <pre>
-   * The big decimal number range array value.
+   * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+   * `inSet`-style constraints over decimal-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -1722,7 +1833,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The big decimal number range array value.
+   * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+   * `inSet`-style constraints over decimal-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -1737,7 +1849,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The big decimal number range array value.
+   * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+   * `inSet`-style constraints over decimal-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -1753,7 +1866,8 @@ private static final long serialVersionUID = 0L;
   public static final int OFFSETDATETIMEARRAYVALUE_FIELD_NUMBER = 110;
   /**
    * <pre>
-   * The offset date time array value.
+   * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+   * constraints over date-time-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -1765,7 +1879,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The offset date time array value.
+   * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+   * constraints over date-time-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -1780,7 +1895,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The offset date time array value.
+   * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+   * constraints over date-time-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -1796,7 +1912,8 @@ private static final long serialVersionUID = 0L;
   public static final int LOCALEARRAYVALUE_FIELD_NUMBER = 111;
   /**
    * <pre>
-   * The locale array value.
+   * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+   * a single constraint or requirement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -1808,7 +1925,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The locale array value.
+   * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+   * a single constraint or requirement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -1823,7 +1941,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The locale array value.
+   * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+   * a single constraint or requirement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -1839,7 +1958,8 @@ private static final long serialVersionUID = 0L;
   public static final int CURRENCYARRAYVALUE_FIELD_NUMBER = 112;
   /**
    * <pre>
-   * The currency array value.
+   * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+   * in a single constraint or requirement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -1851,7 +1971,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The currency array value.
+   * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+   * in a single constraint or requirement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -1866,7 +1987,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The currency array value.
+   * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+   * in a single constraint or requirement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -1882,7 +2004,8 @@ private static final long serialVersionUID = 0L;
   public static final int FACETSTATISTICSDEPTHARRAYVALUE_FIELD_NUMBER = 113;
   /**
    * <pre>
-   * The facet statistics depth array value.
+   * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -1894,7 +2017,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The facet statistics depth array value.
+   * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -1909,7 +2033,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The facet statistics depth array value.
+   * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -1925,7 +2050,8 @@ private static final long serialVersionUID = 0L;
   public static final int QUERYPRICEMODELARRAYVALUE_FIELD_NUMBER = 114;
   /**
    * <pre>
-   * The query price mode array value.
+   * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -1937,7 +2063,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The query price mode array value.
+   * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -1952,7 +2079,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The query price mode array value.
+   * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -1968,7 +2096,8 @@ private static final long serialVersionUID = 0L;
   public static final int PRICECONTENTMODEARRAYVALUE_FIELD_NUMBER = 115;
   /**
    * <pre>
-   * The price content mode array value.
+   * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -1980,7 +2109,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The price content mode array value.
+   * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -1995,7 +2125,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The price content mode array value.
+   * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -2011,7 +2142,8 @@ private static final long serialVersionUID = 0L;
   public static final int ATTRIBUTESPECIALARRAYVALUE_FIELD_NUMBER = 116;
   /**
    * <pre>
-   * The attribute special value array value.
+   * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -2023,7 +2155,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The attribute special value array value.
+   * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -2038,7 +2171,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The attribute special value array value.
+   * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -2054,7 +2188,8 @@ private static final long serialVersionUID = 0L;
   public static final int ORDERDIRECTIONARRAYVALUE_FIELD_NUMBER = 117;
   /**
    * <pre>
-   * The order direction array value.
+   * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -2066,7 +2201,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The order direction array value.
+   * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -2081,7 +2217,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The order direction array value.
+   * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -2097,7 +2234,8 @@ private static final long serialVersionUID = 0L;
   public static final int EMPTYHIERARCHICALENTITYBEHAVIOURARRAYVALUE_FIELD_NUMBER = 118;
   /**
    * <pre>
-   * The empty hierarchical entity behaviour array value.
+   * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+   * where the placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -2109,7 +2247,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The empty hierarchical entity behaviour array value.
+   * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+   * where the placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -2124,7 +2263,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The empty hierarchical entity behaviour array value.
+   * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+   * where the placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -2140,7 +2280,8 @@ private static final long serialVersionUID = 0L;
   public static final int STATISTICSBASEARRAYVALUE_FIELD_NUMBER = 119;
   /**
    * <pre>
-   * The statistics base array value.
+   * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -2152,7 +2293,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The statistics base array value.
+   * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -2167,7 +2309,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The statistics base array value.
+   * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -2183,7 +2326,8 @@ private static final long serialVersionUID = 0L;
   public static final int STATISTICSTYPEARRAYVALUE_FIELD_NUMBER = 120;
   /**
    * <pre>
-   * The statistics type array value.
+   * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -2195,7 +2339,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The statistics type array value.
+   * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -2210,7 +2355,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The statistics type array value.
+   * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -2226,7 +2372,8 @@ private static final long serialVersionUID = 0L;
   public static final int HISTOGRAMBEHAVIORTYPEARRAYVALUE_FIELD_NUMBER = 121;
   /**
    * <pre>
-   * The histogram behavior enum value.
+   * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -2238,7 +2385,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The histogram behavior enum value.
+   * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -2253,7 +2401,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The histogram behavior enum value.
+   * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -2269,7 +2418,8 @@ private static final long serialVersionUID = 0L;
   public static final int SCOPEARRAYVALUE_FIELD_NUMBER = 122;
   /**
    * <pre>
-   * The scope enum value.
+   * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+   * that accept multiple scopes (live, archived) at once.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -2281,7 +2431,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The scope enum value.
+   * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+   * that accept multiple scopes (live, archived) at once.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -2296,7 +2447,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The scope enum value.
+   * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+   * that accept multiple scopes (live, archived) at once.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -4133,7 +4285,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The string value.
+     * Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+     * `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
      * </pre>
      *
      * <code>string stringValue = 1;</code>
@@ -4145,7 +4298,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string value.
+     * Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+     * `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
      * </pre>
      *
      * <code>string stringValue = 1;</code>
@@ -4171,7 +4325,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string value.
+     * Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+     * `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
      * </pre>
      *
      * <code>string stringValue = 1;</code>
@@ -4198,7 +4353,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string value.
+     * Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+     * `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
      * </pre>
      *
      * <code>string stringValue = 1;</code>
@@ -4215,7 +4371,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string value.
+     * Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+     * `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
      * </pre>
      *
      * <code>string stringValue = 1;</code>
@@ -4231,7 +4388,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string value.
+     * Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+     * `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
      * </pre>
      *
      * <code>string stringValue = 1;</code>
@@ -4250,7 +4408,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The integer value.
+     * Binds an `int32` parameter into the query, typically used for primary keys or numeric literals.
      * </pre>
      *
      * <code>int32 integerValue = 2;</code>
@@ -4261,7 +4419,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer value.
+     * Binds an `int32` parameter into the query, typically used for primary keys or numeric literals.
      * </pre>
      *
      * <code>int32 integerValue = 2;</code>
@@ -4275,7 +4433,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer value.
+     * Binds an `int32` parameter into the query, typically used for primary keys or numeric literals.
      * </pre>
      *
      * <code>int32 integerValue = 2;</code>
@@ -4291,7 +4449,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer value.
+     * Binds an `int32` parameter into the query, typically used for primary keys or numeric literals.
      * </pre>
      *
      * <code>int32 integerValue = 2;</code>
@@ -4308,7 +4466,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The long value.
+     * Binds a `long` parameter into the query, typically used for primary keys or numeric literals
+     * that exceed the `int32` range.
      * </pre>
      *
      * <code>int64 longValue = 3;</code>
@@ -4319,7 +4478,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long value.
+     * Binds a `long` parameter into the query, typically used for primary keys or numeric literals
+     * that exceed the `int32` range.
      * </pre>
      *
      * <code>int64 longValue = 3;</code>
@@ -4333,7 +4493,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long value.
+     * Binds a `long` parameter into the query, typically used for primary keys or numeric literals
+     * that exceed the `int32` range.
      * </pre>
      *
      * <code>int64 longValue = 3;</code>
@@ -4349,7 +4510,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long value.
+     * Binds a `long` parameter into the query, typically used for primary keys or numeric literals
+     * that exceed the `int32` range.
      * </pre>
      *
      * <code>int64 longValue = 3;</code>
@@ -4366,7 +4528,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The boolean value.
+     * Binds a boolean parameter into the query.
      * </pre>
      *
      * <code>bool booleanValue = 4;</code>
@@ -4377,7 +4539,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The boolean value.
+     * Binds a boolean parameter into the query.
      * </pre>
      *
      * <code>bool booleanValue = 4;</code>
@@ -4391,7 +4553,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The boolean value.
+     * Binds a boolean parameter into the query.
      * </pre>
      *
      * <code>bool booleanValue = 4;</code>
@@ -4407,7 +4569,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The boolean value.
+     * Binds a boolean parameter into the query.
      * </pre>
      *
      * <code>bool booleanValue = 4;</code>
@@ -4426,7 +4588,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBigDecimal, io.evitadb.externalApi.grpc.generated.GrpcBigDecimal.Builder, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalOrBuilder> bigDecimalValueBuilder_;
     /**
      * <pre>
-     * The big decimal value.
+     * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+     * other monetary/decimal literals.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -4438,7 +4601,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal value.
+     * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+     * other monetary/decimal literals.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -4460,7 +4624,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal value.
+     * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+     * other monetary/decimal literals.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -4480,7 +4645,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal value.
+     * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+     * other monetary/decimal literals.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -4498,7 +4664,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal value.
+     * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+     * other monetary/decimal literals.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -4525,7 +4692,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal value.
+     * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+     * other monetary/decimal literals.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -4548,7 +4716,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal value.
+     * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+     * other monetary/decimal literals.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -4558,7 +4727,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal value.
+     * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+     * other monetary/decimal literals.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -4576,7 +4746,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal value.
+     * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+     * other monetary/decimal literals.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -4604,7 +4775,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange, io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange.Builder, io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeOrBuilder> dateTimeRangeValueBuilder_;
     /**
      * <pre>
-     * The date time range value.
+     * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+     * style constraints that test whether a given instant falls within a validity range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -4616,7 +4788,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range value.
+     * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+     * style constraints that test whether a given instant falls within a validity range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -4638,7 +4811,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range value.
+     * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+     * style constraints that test whether a given instant falls within a validity range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -4658,7 +4832,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range value.
+     * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+     * style constraints that test whether a given instant falls within a validity range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -4676,7 +4851,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range value.
+     * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+     * style constraints that test whether a given instant falls within a validity range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -4703,7 +4879,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range value.
+     * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+     * style constraints that test whether a given instant falls within a validity range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -4726,7 +4903,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range value.
+     * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+     * style constraints that test whether a given instant falls within a validity range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -4736,7 +4914,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range value.
+     * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+     * style constraints that test whether a given instant falls within a validity range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -4754,7 +4933,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range value.
+     * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+     * style constraints that test whether a given instant falls within a validity range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -4782,7 +4962,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange, io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange.Builder, io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeOrBuilder> integerNumberRangeValueBuilder_;
     /**
      * <pre>
-     * The integer number range value.
+     * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -4794,7 +4974,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range value.
+     * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -4816,7 +4996,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range value.
+     * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -4836,7 +5016,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range value.
+     * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -4854,7 +5034,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range value.
+     * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -4881,7 +5061,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range value.
+     * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -4904,7 +5084,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range value.
+     * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -4914,7 +5094,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range value.
+     * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -4932,7 +5112,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range value.
+     * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -4960,7 +5140,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange, io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange.Builder, io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeOrBuilder> longNumberRangeValueBuilder_;
     /**
      * <pre>
-     * The long number range value.
+     * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -4972,7 +5152,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range value.
+     * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -4994,7 +5174,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range value.
+     * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -5014,7 +5194,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range value.
+     * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -5032,7 +5212,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range value.
+     * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -5059,7 +5239,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range value.
+     * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -5082,7 +5262,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range value.
+     * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -5092,7 +5272,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range value.
+     * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -5110,7 +5290,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range value.
+     * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -5138,7 +5318,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange.Builder, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeOrBuilder> bigDecimalNumberRangeValueBuilder_;
     /**
      * <pre>
-     * The big decimal number range value.
+     * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+     * style range constraints over prices or other decimal values.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -5150,7 +5331,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range value.
+     * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+     * style range constraints over prices or other decimal values.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -5172,7 +5354,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range value.
+     * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+     * style range constraints over prices or other decimal values.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -5192,7 +5375,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range value.
+     * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+     * style range constraints over prices or other decimal values.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -5210,7 +5394,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range value.
+     * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+     * style range constraints over prices or other decimal values.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -5237,7 +5422,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range value.
+     * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+     * style range constraints over prices or other decimal values.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -5260,7 +5446,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range value.
+     * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+     * style range constraints over prices or other decimal values.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -5270,7 +5457,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range value.
+     * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+     * style range constraints over prices or other decimal values.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -5288,7 +5476,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range value.
+     * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+     * style range constraints over prices or other decimal values.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -5316,7 +5505,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> offsetDateTimeValueBuilder_;
     /**
      * <pre>
-     * The offset date time value.
+     * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+     * `priceValidIn` to test price validity at a specific instant.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -5328,7 +5518,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time value.
+     * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+     * `priceValidIn` to test price validity at a specific instant.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -5350,7 +5541,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time value.
+     * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+     * `priceValidIn` to test price validity at a specific instant.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -5370,7 +5562,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time value.
+     * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+     * `priceValidIn` to test price validity at a specific instant.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -5388,7 +5581,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time value.
+     * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+     * `priceValidIn` to test price validity at a specific instant.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -5415,7 +5609,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time value.
+     * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+     * `priceValidIn` to test price validity at a specific instant.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -5438,7 +5633,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time value.
+     * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+     * `priceValidIn` to test price validity at a specific instant.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -5448,7 +5644,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time value.
+     * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+     * `priceValidIn` to test price validity at a specific instant.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -5466,7 +5663,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time value.
+     * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+     * `priceValidIn` to test price validity at a specific instant.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -5494,7 +5692,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcLocale, io.evitadb.externalApi.grpc.generated.GrpcLocale.Builder, io.evitadb.externalApi.grpc.generated.GrpcLocaleOrBuilder> localeValueBuilder_;
     /**
      * <pre>
-     * The locale value.
+     * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -5506,7 +5704,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale value.
+     * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -5528,7 +5726,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale value.
+     * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -5548,7 +5746,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale value.
+     * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -5566,7 +5764,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale value.
+     * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -5593,7 +5791,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale value.
+     * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -5616,7 +5814,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale value.
+     * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -5626,7 +5824,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale value.
+     * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -5644,7 +5842,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale value.
+     * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -5672,7 +5870,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcCurrency, io.evitadb.externalApi.grpc.generated.GrpcCurrency.Builder, io.evitadb.externalApi.grpc.generated.GrpcCurrencyOrBuilder> currencyValueBuilder_;
     /**
      * <pre>
-     * The currency value.
+     * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -5684,7 +5882,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency value.
+     * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -5706,7 +5904,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency value.
+     * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -5726,7 +5924,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency value.
+     * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -5744,7 +5942,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency value.
+     * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -5771,7 +5969,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency value.
+     * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -5794,7 +5992,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency value.
+     * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -5804,7 +6002,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency value.
+     * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -5822,7 +6020,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency value.
+     * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -5848,7 +6046,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The facet statistics depth enum value.
+     * Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+     * `facetSummary` requirement to select whether only counts or also selection impact is computed.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;</code>
@@ -5860,7 +6059,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth enum value.
+     * Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+     * `facetSummary` requirement to select whether only counts or also selection impact is computed.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;</code>
@@ -5875,7 +6075,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth enum value.
+     * Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+     * `facetSummary` requirement to select whether only counts or also selection impact is computed.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;</code>
@@ -5890,7 +6091,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth enum value.
+     * Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+     * `facetSummary` requirement to select whether only counts or also selection impact is computed.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;</code>
@@ -5907,7 +6109,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth enum value.
+     * Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+     * `facetSummary` requirement to select whether only counts or also selection impact is computed.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;</code>
@@ -5925,7 +6128,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth enum value.
+     * Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+     * `facetSummary` requirement to select whether only counts or also selection impact is computed.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;</code>
@@ -5942,7 +6146,10 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The query price mode enum value.
+     * Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+     * constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+     * is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+     * accessors and JSON field mapping for existing clients.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode queryPriceModelValue = 14;</code>
@@ -5954,7 +6161,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode enum value.
+     * Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+     * constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+     * is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+     * accessors and JSON field mapping for existing clients.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode queryPriceModelValue = 14;</code>
@@ -5969,7 +6179,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode enum value.
+     * Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+     * constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+     * is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+     * accessors and JSON field mapping for existing clients.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode queryPriceModelValue = 14;</code>
@@ -5984,7 +6197,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode enum value.
+     * Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+     * constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+     * is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+     * accessors and JSON field mapping for existing clients.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode queryPriceModelValue = 14;</code>
@@ -6001,7 +6217,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode enum value.
+     * Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+     * constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+     * is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+     * accessors and JSON field mapping for existing clients.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode queryPriceModelValue = 14;</code>
@@ -6019,7 +6238,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode enum value.
+     * Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+     * constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+     * is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+     * accessors and JSON field mapping for existing clients.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode queryPriceModelValue = 14;</code>
@@ -6036,7 +6258,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The price content mode enum value.
+     * Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+     * requirement to select which prices are fetched along with the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode priceContentModeValue = 15;</code>
@@ -6048,7 +6271,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode enum value.
+     * Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+     * requirement to select which prices are fetched along with the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode priceContentModeValue = 15;</code>
@@ -6063,7 +6287,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode enum value.
+     * Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+     * requirement to select which prices are fetched along with the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode priceContentModeValue = 15;</code>
@@ -6078,7 +6303,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode enum value.
+     * Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+     * requirement to select which prices are fetched along with the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode priceContentModeValue = 15;</code>
@@ -6095,7 +6321,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode enum value.
+     * Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+     * requirement to select which prices are fetched along with the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode priceContentModeValue = 15;</code>
@@ -6113,7 +6340,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode enum value.
+     * Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+     * requirement to select which prices are fetched along with the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode priceContentModeValue = 15;</code>
@@ -6130,7 +6358,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The attribute special value enum value.
+     * Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+     * to test whether an attribute value is `NULL` or `NOT_NULL`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue attributeSpecialValue = 16;</code>
@@ -6142,7 +6371,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value enum value.
+     * Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+     * to test whether an attribute value is `NULL` or `NOT_NULL`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue attributeSpecialValue = 16;</code>
@@ -6157,7 +6387,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value enum value.
+     * Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+     * to test whether an attribute value is `NULL` or `NOT_NULL`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue attributeSpecialValue = 16;</code>
@@ -6172,7 +6403,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value enum value.
+     * Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+     * to test whether an attribute value is `NULL` or `NOT_NULL`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue attributeSpecialValue = 16;</code>
@@ -6189,7 +6421,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value enum value.
+     * Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+     * to test whether an attribute value is `NULL` or `NOT_NULL`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue attributeSpecialValue = 16;</code>
@@ -6207,7 +6440,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value enum value.
+     * Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+     * to test whether an attribute value is `NULL` or `NOT_NULL`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue attributeSpecialValue = 16;</code>
@@ -6224,7 +6458,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The order direction enum value.
+     * Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+     * and other ordering constraints to select ascending or descending order.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirection orderDirectionValue = 17;</code>
@@ -6236,7 +6471,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction enum value.
+     * Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+     * and other ordering constraints to select ascending or descending order.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirection orderDirectionValue = 17;</code>
@@ -6251,7 +6487,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction enum value.
+     * Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+     * and other ordering constraints to select ascending or descending order.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirection orderDirectionValue = 17;</code>
@@ -6266,7 +6503,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction enum value.
+     * Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+     * and other ordering constraints to select ascending or descending order.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirection orderDirectionValue = 17;</code>
@@ -6283,7 +6521,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction enum value.
+     * Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+     * and other ordering constraints to select ascending or descending order.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirection orderDirectionValue = 17;</code>
@@ -6301,7 +6540,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction enum value.
+     * Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+     * and other ordering constraints to select ascending or descending order.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirection orderDirectionValue = 17;</code>
@@ -6318,7 +6558,9 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The empty hierarchical entity behaviour enum value.
+     * Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+     * statistics requirements to select whether hierarchy nodes with no referring entities are kept
+     * in or removed from the result tree.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;</code>
@@ -6330,7 +6572,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour enum value.
+     * Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+     * statistics requirements to select whether hierarchy nodes with no referring entities are kept
+     * in or removed from the result tree.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;</code>
@@ -6345,7 +6589,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour enum value.
+     * Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+     * statistics requirements to select whether hierarchy nodes with no referring entities are kept
+     * in or removed from the result tree.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;</code>
@@ -6360,7 +6606,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour enum value.
+     * Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+     * statistics requirements to select whether hierarchy nodes with no referring entities are kept
+     * in or removed from the result tree.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;</code>
@@ -6377,7 +6625,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour enum value.
+     * Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+     * statistics requirements to select whether hierarchy nodes with no referring entities are kept
+     * in or removed from the result tree.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;</code>
@@ -6395,7 +6645,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour enum value.
+     * Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+     * statistics requirements to select whether hierarchy nodes with no referring entities are kept
+     * in or removed from the result tree.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;</code>
@@ -6412,7 +6664,9 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The statistics base enum value.
+     * Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+     * requirements to select which part of the `filterBy` constraint is considered when computing
+     * cardinalities.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase statisticsBase = 19;</code>
@@ -6424,7 +6678,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base enum value.
+     * Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+     * requirements to select which part of the `filterBy` constraint is considered when computing
+     * cardinalities.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase statisticsBase = 19;</code>
@@ -6439,7 +6695,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base enum value.
+     * Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+     * requirements to select which part of the `filterBy` constraint is considered when computing
+     * cardinalities.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase statisticsBase = 19;</code>
@@ -6454,7 +6712,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base enum value.
+     * Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+     * requirements to select which part of the `filterBy` constraint is considered when computing
+     * cardinalities.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase statisticsBase = 19;</code>
@@ -6471,7 +6731,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base enum value.
+     * Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+     * requirements to select which part of the `filterBy` constraint is considered when computing
+     * cardinalities.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase statisticsBase = 19;</code>
@@ -6489,7 +6751,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base enum value.
+     * Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+     * requirements to select which part of the `filterBy` constraint is considered when computing
+     * cardinalities.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase statisticsBase = 19;</code>
@@ -6506,7 +6770,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The statistics type enum value.
+     * Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+     * requirements to select whether children counts or queried-entity counts are produced.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsType statisticsType = 20;</code>
@@ -6518,7 +6783,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type enum value.
+     * Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+     * requirements to select whether children counts or queried-entity counts are produced.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsType statisticsType = 20;</code>
@@ -6533,7 +6799,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type enum value.
+     * Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+     * requirements to select whether children counts or queried-entity counts are produced.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsType statisticsType = 20;</code>
@@ -6548,7 +6815,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type enum value.
+     * Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+     * requirements to select whether children counts or queried-entity counts are produced.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsType statisticsType = 20;</code>
@@ -6565,7 +6833,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type enum value.
+     * Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+     * requirements to select whether children counts or queried-entity counts are produced.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsType statisticsType = 20;</code>
@@ -6583,7 +6852,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type enum value.
+     * Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+     * requirements to select whether children counts or queried-entity counts are produced.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsType statisticsType = 20;</code>
@@ -6600,7 +6870,9 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+     * to select whether the histogram always has exactly the requested bucket count or an optimized,
+     * more compact bucket layout.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior histogramBehavior = 21;</code>
@@ -6612,7 +6884,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+     * to select whether the histogram always has exactly the requested bucket count or an optimized,
+     * more compact bucket layout.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior histogramBehavior = 21;</code>
@@ -6627,7 +6901,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+     * to select whether the histogram always has exactly the requested bucket count or an optimized,
+     * more compact bucket layout.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior histogramBehavior = 21;</code>
@@ -6642,7 +6918,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+     * to select whether the histogram always has exactly the requested bucket count or an optimized,
+     * more compact bucket layout.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior histogramBehavior = 21;</code>
@@ -6659,7 +6937,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+     * to select whether the histogram always has exactly the requested bucket count or an optimized,
+     * more compact bucket layout.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior histogramBehavior = 21;</code>
@@ -6677,7 +6957,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+     * to select whether the histogram always has exactly the requested bucket count or an optimized,
+     * more compact bucket layout.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior histogramBehavior = 21;</code>
@@ -6694,7 +6976,9 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The managed references behaviour
+     * Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+     * `referenceContent` requirement to select whether references to a managed entity that no longer
+     * exists are still returned.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;</code>
@@ -6706,7 +6990,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The managed references behaviour
+     * Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+     * `referenceContent` requirement to select whether references to a managed entity that no longer
+     * exists are still returned.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;</code>
@@ -6721,7 +7007,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The managed references behaviour
+     * Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+     * `referenceContent` requirement to select whether references to a managed entity that no longer
+     * exists are still returned.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;</code>
@@ -6736,7 +7024,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The managed references behaviour
+     * Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+     * `referenceContent` requirement to select whether references to a managed entity that no longer
+     * exists are still returned.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;</code>
@@ -6753,7 +7043,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The managed references behaviour
+     * Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+     * `referenceContent` requirement to select whether references to a managed entity that no longer
+     * exists are still returned.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;</code>
@@ -6771,7 +7063,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The managed references behaviour
+     * Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+     * `referenceContent` requirement to select whether references to a managed entity that no longer
+     * exists are still returned.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;</code>
@@ -6788,7 +7082,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The expression
+     * Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+     * used as the size argument of the `gap` requirement to compute spacing between paginated results.
      * </pre>
      *
      * <code>string expressionValue = 23;</code>
@@ -6800,7 +7095,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The expression
+     * Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+     * used as the size argument of the `gap` requirement to compute spacing between paginated results.
      * </pre>
      *
      * <code>string expressionValue = 23;</code>
@@ -6826,7 +7122,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The expression
+     * Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+     * used as the size argument of the `gap` requirement to compute spacing between paginated results.
      * </pre>
      *
      * <code>string expressionValue = 23;</code>
@@ -6853,7 +7150,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The expression
+     * Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+     * used as the size argument of the `gap` requirement to compute spacing between paginated results.
      * </pre>
      *
      * <code>string expressionValue = 23;</code>
@@ -6870,7 +7168,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The expression
+     * Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+     * used as the size argument of the `gap` requirement to compute spacing between paginated results.
      * </pre>
      *
      * <code>string expressionValue = 23;</code>
@@ -6886,7 +7185,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The expression
+     * Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+     * used as the size argument of the `gap` requirement to compute spacing between paginated results.
      * </pre>
      *
      * <code>string expressionValue = 23;</code>
@@ -6905,7 +7205,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+     * select whether live or archived entities are considered.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScope scope = 24;</code>
@@ -6917,7 +7218,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+     * select whether live or archived entities are considered.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScope scope = 24;</code>
@@ -6932,7 +7234,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+     * select whether live or archived entities are considered.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScope scope = 24;</code>
@@ -6947,7 +7250,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+     * select whether live or archived entities are considered.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScope scope = 24;</code>
@@ -6964,7 +7268,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+     * select whether live or archived entities are considered.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScope scope = 24;</code>
@@ -6982,7 +7287,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+     * select whether live or archived entities are considered.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScope scope = 24;</code>
@@ -6999,7 +7305,9 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The facetRelationType enum value.
+     * Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+     * calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+     * applied between facets.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetRelationType facetRelationType = 25;</code>
@@ -7011,7 +7319,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facetRelationType enum value.
+     * Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+     * calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+     * applied between facets.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetRelationType facetRelationType = 25;</code>
@@ -7026,7 +7336,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facetRelationType enum value.
+     * Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+     * calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+     * applied between facets.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetRelationType facetRelationType = 25;</code>
@@ -7041,7 +7353,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facetRelationType enum value.
+     * Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+     * calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+     * applied between facets.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetRelationType facetRelationType = 25;</code>
@@ -7058,7 +7372,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facetRelationType enum value.
+     * Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+     * calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+     * applied between facets.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetRelationType facetRelationType = 25;</code>
@@ -7076,7 +7392,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facetRelationType enum value.
+     * Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+     * calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+     * applied between facets.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetRelationType facetRelationType = 25;</code>
@@ -7093,7 +7411,9 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The facetGroupRelationLevel enum value.
+     * Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+     * impact calculation to select whether the relation applies between facets in the same group or
+     * across different groups/references.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;</code>
@@ -7105,7 +7425,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facetGroupRelationLevel enum value.
+     * Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+     * impact calculation to select whether the relation applies between facets in the same group or
+     * across different groups/references.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;</code>
@@ -7120,7 +7442,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facetGroupRelationLevel enum value.
+     * Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+     * impact calculation to select whether the relation applies between facets in the same group or
+     * across different groups/references.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;</code>
@@ -7135,7 +7459,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facetGroupRelationLevel enum value.
+     * Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+     * impact calculation to select whether the relation applies between facets in the same group or
+     * across different groups/references.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;</code>
@@ -7152,7 +7478,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facetGroupRelationLevel enum value.
+     * Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+     * impact calculation to select whether the relation applies between facets in the same group or
+     * across different groups/references.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;</code>
@@ -7170,7 +7498,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facetGroupRelationLevel enum value.
+     * Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+     * impact calculation to select whether the relation applies between facets in the same group or
+     * across different groups/references.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;</code>
@@ -7187,7 +7517,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The facet traversal mode enum value.
+     * Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+     * `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTraversalMode traversalMode = 27;</code>
@@ -7199,7 +7530,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet traversal mode enum value.
+     * Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+     * `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTraversalMode traversalMode = 27;</code>
@@ -7214,7 +7546,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet traversal mode enum value.
+     * Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+     * `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTraversalMode traversalMode = 27;</code>
@@ -7229,7 +7562,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet traversal mode enum value.
+     * Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+     * `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTraversalMode traversalMode = 27;</code>
@@ -7246,7 +7580,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet traversal mode enum value.
+     * Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+     * `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTraversalMode traversalMode = 27;</code>
@@ -7264,7 +7599,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet traversal mode enum value.
+     * Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+     * `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTraversalMode traversalMode = 27;</code>
@@ -7283,7 +7619,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcStringArray, io.evitadb.externalApi.grpc.generated.GrpcStringArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcStringArrayOrBuilder> stringArrayValueBuilder_;
     /**
      * <pre>
-     * The string array value.
+     * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+     * as `attributeInSet` over string-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -7295,7 +7632,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string array value.
+     * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+     * as `attributeInSet` over string-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -7317,7 +7655,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string array value.
+     * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+     * as `attributeInSet` over string-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -7337,7 +7676,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string array value.
+     * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+     * as `attributeInSet` over string-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -7355,7 +7695,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string array value.
+     * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+     * as `attributeInSet` over string-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -7382,7 +7723,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string array value.
+     * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+     * as `attributeInSet` over string-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -7405,7 +7747,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string array value.
+     * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+     * as `attributeInSet` over string-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -7415,7 +7758,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string array value.
+     * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+     * as `attributeInSet` over string-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -7433,7 +7777,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string array value.
+     * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+     * as `attributeInSet` over string-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -7461,7 +7806,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcIntegerArray, io.evitadb.externalApi.grpc.generated.GrpcIntegerArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcIntegerArrayOrBuilder> integerArrayValueBuilder_;
     /**
      * <pre>
-     * The integer array value.
+     * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+     * `attributeInSet` over integer-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -7473,7 +7819,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer array value.
+     * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+     * `attributeInSet` over integer-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -7495,7 +7842,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer array value.
+     * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+     * `attributeInSet` over integer-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -7515,7 +7863,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer array value.
+     * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+     * `attributeInSet` over integer-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -7533,7 +7882,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer array value.
+     * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+     * `attributeInSet` over integer-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -7560,7 +7910,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer array value.
+     * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+     * `attributeInSet` over integer-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -7583,7 +7934,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer array value.
+     * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+     * `attributeInSet` over integer-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -7593,7 +7945,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer array value.
+     * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+     * `attributeInSet` over integer-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -7611,7 +7964,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer array value.
+     * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+     * `attributeInSet` over integer-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -7639,7 +7993,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcLongArray, io.evitadb.externalApi.grpc.generated.GrpcLongArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcLongArrayOrBuilder> longArrayValueBuilder_;
     /**
      * <pre>
-     * The long array value.
+     * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+     * long-typed values that exceed the `int32` range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -7651,7 +8006,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long array value.
+     * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+     * long-typed values that exceed the `int32` range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -7673,7 +8029,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long array value.
+     * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+     * long-typed values that exceed the `int32` range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -7693,7 +8050,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long array value.
+     * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+     * long-typed values that exceed the `int32` range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -7711,7 +8069,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long array value.
+     * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+     * long-typed values that exceed the `int32` range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -7738,7 +8097,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long array value.
+     * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+     * long-typed values that exceed the `int32` range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -7761,7 +8121,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long array value.
+     * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+     * long-typed values that exceed the `int32` range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -7771,7 +8132,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long array value.
+     * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+     * long-typed values that exceed the `int32` range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -7789,7 +8151,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long array value.
+     * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+     * long-typed values that exceed the `int32` range.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -7817,7 +8180,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBooleanArray, io.evitadb.externalApi.grpc.generated.GrpcBooleanArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcBooleanArrayOrBuilder> booleanArrayValueBuilder_;
     /**
      * <pre>
-     * The boolean array value.
+     * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+     * boolean-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -7829,7 +8193,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The boolean array value.
+     * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+     * boolean-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -7851,7 +8216,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The boolean array value.
+     * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+     * boolean-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -7871,7 +8237,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The boolean array value.
+     * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+     * boolean-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -7889,7 +8256,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The boolean array value.
+     * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+     * boolean-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -7916,7 +8284,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The boolean array value.
+     * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+     * boolean-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -7939,7 +8308,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The boolean array value.
+     * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+     * boolean-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -7949,7 +8319,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The boolean array value.
+     * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+     * boolean-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -7967,7 +8338,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The boolean array value.
+     * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+     * boolean-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -7995,7 +8367,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArrayOrBuilder> bigDecimalArrayValueBuilder_;
     /**
      * <pre>
-     * The big decimal array value.
+     * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -8007,7 +8380,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal array value.
+     * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -8029,7 +8403,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal array value.
+     * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -8049,7 +8424,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal array value.
+     * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -8067,7 +8443,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal array value.
+     * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -8094,7 +8471,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal array value.
+     * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -8117,7 +8495,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal array value.
+     * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -8127,7 +8506,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal array value.
+     * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -8145,7 +8525,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal array value.
+     * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -8173,7 +8554,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray, io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArrayOrBuilder> dateTimeRangeArrayValueBuilder_;
     /**
      * <pre>
-     * The date time range array value.
+     * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+     * constraints over range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -8185,7 +8567,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range array value.
+     * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+     * constraints over range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -8207,7 +8590,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range array value.
+     * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+     * constraints over range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -8227,7 +8611,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range array value.
+     * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+     * constraints over range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -8245,7 +8630,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range array value.
+     * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+     * constraints over range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -8272,7 +8658,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range array value.
+     * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+     * constraints over range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -8295,7 +8682,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range array value.
+     * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+     * constraints over range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -8305,7 +8693,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range array value.
+     * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+     * constraints over range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -8323,7 +8712,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The date time range array value.
+     * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+     * constraints over range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -8351,7 +8741,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray, io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArrayOrBuilder> integerNumberRangeArrayValueBuilder_;
     /**
      * <pre>
-     * The integer number range array value.
+     * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+     * constraints over integer-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -8363,7 +8754,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range array value.
+     * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+     * constraints over integer-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -8385,7 +8777,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range array value.
+     * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+     * constraints over integer-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -8405,7 +8798,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range array value.
+     * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+     * constraints over integer-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -8423,7 +8817,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range array value.
+     * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+     * constraints over integer-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -8450,7 +8845,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range array value.
+     * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+     * constraints over integer-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -8473,7 +8869,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range array value.
+     * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+     * constraints over integer-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -8483,7 +8880,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range array value.
+     * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+     * constraints over integer-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -8501,7 +8899,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The integer number range array value.
+     * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+     * constraints over integer-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -8529,7 +8928,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray, io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArrayOrBuilder> longNumberRangeArrayValueBuilder_;
     /**
      * <pre>
-     * The long number range array value.
+     * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+     * over long-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -8541,7 +8941,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range array value.
+     * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+     * over long-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -8563,7 +8964,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range array value.
+     * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+     * over long-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -8583,7 +8985,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range array value.
+     * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+     * over long-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -8601,7 +9004,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range array value.
+     * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+     * over long-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -8628,7 +9032,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range array value.
+     * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+     * over long-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -8651,7 +9056,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range array value.
+     * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+     * over long-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -8661,7 +9067,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range array value.
+     * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+     * over long-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -8679,7 +9086,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The long number range array value.
+     * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+     * over long-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -8707,7 +9115,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArrayOrBuilder> bigDecimalNumberRangeArrayValueBuilder_;
     /**
      * <pre>
-     * The big decimal number range array value.
+     * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -8719,7 +9128,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range array value.
+     * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -8741,7 +9151,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range array value.
+     * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -8761,7 +9172,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range array value.
+     * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -8779,7 +9191,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range array value.
+     * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -8806,7 +9219,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range array value.
+     * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -8829,7 +9243,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range array value.
+     * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -8839,7 +9254,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range array value.
+     * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -8857,7 +9273,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The big decimal number range array value.
+     * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+     * `inSet`-style constraints over decimal-range-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -8885,7 +9302,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArrayOrBuilder> offsetDateTimeArrayValueBuilder_;
     /**
      * <pre>
-     * The offset date time array value.
+     * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+     * constraints over date-time-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -8897,7 +9315,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time array value.
+     * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+     * constraints over date-time-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -8919,7 +9338,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time array value.
+     * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+     * constraints over date-time-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -8939,7 +9359,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time array value.
+     * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+     * constraints over date-time-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -8957,7 +9378,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time array value.
+     * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+     * constraints over date-time-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -8984,7 +9406,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time array value.
+     * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+     * constraints over date-time-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -9007,7 +9430,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time array value.
+     * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+     * constraints over date-time-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -9017,7 +9441,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time array value.
+     * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+     * constraints over date-time-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -9035,7 +9460,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset date time array value.
+     * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+     * constraints over date-time-typed attributes.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -9063,7 +9489,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcLocaleArray, io.evitadb.externalApi.grpc.generated.GrpcLocaleArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcLocaleArrayOrBuilder> localeArrayValueBuilder_;
     /**
      * <pre>
-     * The locale array value.
+     * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+     * a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -9075,7 +9502,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale array value.
+     * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+     * a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -9097,7 +9525,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale array value.
+     * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+     * a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -9117,7 +9546,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale array value.
+     * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+     * a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -9135,7 +9565,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale array value.
+     * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+     * a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -9162,7 +9593,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale array value.
+     * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+     * a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -9185,7 +9617,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale array value.
+     * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+     * a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -9195,7 +9628,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale array value.
+     * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+     * a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -9213,7 +9647,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The locale array value.
+     * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+     * a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -9241,7 +9676,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray, io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcCurrencyArrayOrBuilder> currencyArrayValueBuilder_;
     /**
      * <pre>
-     * The currency array value.
+     * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+     * in a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -9253,7 +9689,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency array value.
+     * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+     * in a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -9275,7 +9712,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency array value.
+     * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+     * in a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -9295,7 +9733,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency array value.
+     * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+     * in a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -9313,7 +9752,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency array value.
+     * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+     * in a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -9340,7 +9780,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency array value.
+     * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+     * in a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -9363,7 +9804,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency array value.
+     * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+     * in a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -9373,7 +9815,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency array value.
+     * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+     * in a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -9391,7 +9834,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The currency array value.
+     * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+     * in a single constraint or requirement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -9419,7 +9863,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray, io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArrayOrBuilder> facetStatisticsDepthArrayValueBuilder_;
     /**
      * <pre>
-     * The facet statistics depth array value.
+     * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -9431,7 +9876,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth array value.
+     * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -9453,7 +9899,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth array value.
+     * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -9473,7 +9920,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth array value.
+     * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -9491,7 +9939,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth array value.
+     * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -9518,7 +9967,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth array value.
+     * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -9541,7 +9991,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth array value.
+     * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -9551,7 +10002,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth array value.
+     * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -9569,7 +10021,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The facet statistics depth array value.
+     * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -9597,7 +10050,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray, io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArrayOrBuilder> queryPriceModelArrayValueBuilder_;
     /**
      * <pre>
-     * The query price mode array value.
+     * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -9609,7 +10063,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode array value.
+     * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -9631,7 +10086,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode array value.
+     * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -9651,7 +10107,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode array value.
+     * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -9669,7 +10126,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode array value.
+     * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -9696,7 +10154,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode array value.
+     * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -9719,7 +10178,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode array value.
+     * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -9729,7 +10189,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode array value.
+     * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -9747,7 +10208,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The query price mode array value.
+     * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -9775,7 +10237,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray, io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArrayOrBuilder> priceContentModeArrayValueBuilder_;
     /**
      * <pre>
-     * The price content mode array value.
+     * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -9787,7 +10250,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode array value.
+     * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -9809,7 +10273,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode array value.
+     * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -9829,7 +10294,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode array value.
+     * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -9847,7 +10313,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode array value.
+     * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -9874,7 +10341,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode array value.
+     * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -9897,7 +10365,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode array value.
+     * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -9907,7 +10376,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode array value.
+     * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -9925,7 +10395,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The price content mode array value.
+     * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -9953,7 +10424,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray, io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArrayOrBuilder> attributeSpecialArrayValueBuilder_;
     /**
      * <pre>
-     * The attribute special value array value.
+     * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -9965,7 +10437,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value array value.
+     * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -9987,7 +10460,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value array value.
+     * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -10007,7 +10481,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value array value.
+     * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -10025,7 +10500,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value array value.
+     * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -10052,7 +10528,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value array value.
+     * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -10075,7 +10552,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value array value.
+     * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -10085,7 +10563,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value array value.
+     * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -10103,7 +10582,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The attribute special value array value.
+     * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -10131,7 +10611,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray, io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArrayOrBuilder> orderDirectionArrayValueBuilder_;
     /**
      * <pre>
-     * The order direction array value.
+     * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -10143,7 +10624,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction array value.
+     * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -10165,7 +10647,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction array value.
+     * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -10185,7 +10668,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction array value.
+     * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -10203,7 +10687,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction array value.
+     * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -10230,7 +10715,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction array value.
+     * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -10253,7 +10739,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction array value.
+     * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -10263,7 +10750,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction array value.
+     * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -10281,7 +10769,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The order direction array value.
+     * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -10309,7 +10798,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray, io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArrayOrBuilder> emptyHierarchicalEntityBehaviourArrayValueBuilder_;
     /**
      * <pre>
-     * The empty hierarchical entity behaviour array value.
+     * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+     * where the placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -10321,7 +10811,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour array value.
+     * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+     * where the placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -10343,7 +10834,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour array value.
+     * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+     * where the placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -10363,7 +10855,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour array value.
+     * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+     * where the placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -10381,7 +10874,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour array value.
+     * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+     * where the placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -10408,7 +10902,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour array value.
+     * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+     * where the placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -10431,7 +10926,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour array value.
+     * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+     * where the placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -10441,7 +10937,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour array value.
+     * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+     * where the placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -10459,7 +10956,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The empty hierarchical entity behaviour array value.
+     * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+     * where the placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -10487,7 +10985,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray, io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArrayOrBuilder> statisticsBaseArrayValueBuilder_;
     /**
      * <pre>
-     * The statistics base array value.
+     * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -10499,7 +10998,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base array value.
+     * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -10521,7 +11021,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base array value.
+     * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -10541,7 +11042,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base array value.
+     * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -10559,7 +11061,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base array value.
+     * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -10586,7 +11089,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base array value.
+     * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -10609,7 +11113,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base array value.
+     * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -10619,7 +11124,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base array value.
+     * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -10637,7 +11143,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics base array value.
+     * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -10665,7 +11172,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray, io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArrayOrBuilder> statisticsTypeArrayValueBuilder_;
     /**
      * <pre>
-     * The statistics type array value.
+     * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -10677,7 +11185,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type array value.
+     * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -10699,7 +11208,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type array value.
+     * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -10719,7 +11229,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type array value.
+     * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -10737,7 +11248,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type array value.
+     * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -10764,7 +11276,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type array value.
+     * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -10787,7 +11300,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type array value.
+     * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -10797,7 +11311,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type array value.
+     * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -10815,7 +11330,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The statistics type array value.
+     * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+     * resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -10843,7 +11359,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray, io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArrayOrBuilder> histogramBehaviorTypeArrayValueBuilder_;
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -10855,7 +11372,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -10877,7 +11395,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -10897,7 +11416,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -10915,7 +11435,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -10942,7 +11463,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -10965,7 +11487,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -10975,7 +11498,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -10993,7 +11517,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The histogram behavior enum value.
+     * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+     * placeholder resolves to a list rather than a single value.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -11021,7 +11546,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray, io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArrayOrBuilder> scopeArrayValueBuilder_;
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+     * that accept multiple scopes (live, archived) at once.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -11033,7 +11559,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+     * that accept multiple scopes (live, archived) at once.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -11055,7 +11582,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+     * that accept multiple scopes (live, archived) at once.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -11075,7 +11603,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+     * that accept multiple scopes (live, archived) at once.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -11093,7 +11622,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+     * that accept multiple scopes (live, archived) at once.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -11120,7 +11650,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+     * that accept multiple scopes (live, archived) at once.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -11143,7 +11674,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+     * that accept multiple scopes (live, archived) at once.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -11153,7 +11685,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+     * that accept multiple scopes (live, archived) at once.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -11171,7 +11704,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope enum value.
+     * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+     * that accept multiple scopes (live, archived) at once.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryParamOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryParamOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The string value.
+   * Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+   * `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
    * </pre>
    *
    * <code>string stringValue = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasStringValue();
   /**
    * <pre>
-   * The string value.
+   * Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+   * `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
    * </pre>
    *
    * <code>string stringValue = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcQueryParamOrBuilder extends
   java.lang.String getStringValue();
   /**
    * <pre>
-   * The string value.
+   * Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+   * `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
    * </pre>
    *
    * <code>string stringValue = 1;</code>
@@ -62,7 +65,7 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The integer value.
+   * Binds an `int32` parameter into the query, typically used for primary keys or numeric literals.
    * </pre>
    *
    * <code>int32 integerValue = 2;</code>
@@ -71,7 +74,7 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasIntegerValue();
   /**
    * <pre>
-   * The integer value.
+   * Binds an `int32` parameter into the query, typically used for primary keys or numeric literals.
    * </pre>
    *
    * <code>int32 integerValue = 2;</code>
@@ -81,7 +84,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The long value.
+   * Binds a `long` parameter into the query, typically used for primary keys or numeric literals
+   * that exceed the `int32` range.
    * </pre>
    *
    * <code>int64 longValue = 3;</code>
@@ -90,7 +94,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasLongValue();
   /**
    * <pre>
-   * The long value.
+   * Binds a `long` parameter into the query, typically used for primary keys or numeric literals
+   * that exceed the `int32` range.
    * </pre>
    *
    * <code>int64 longValue = 3;</code>
@@ -100,7 +105,7 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The boolean value.
+   * Binds a boolean parameter into the query.
    * </pre>
    *
    * <code>bool booleanValue = 4;</code>
@@ -109,7 +114,7 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasBooleanValue();
   /**
    * <pre>
-   * The boolean value.
+   * Binds a boolean parameter into the query.
    * </pre>
    *
    * <code>bool booleanValue = 4;</code>
@@ -119,7 +124,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The big decimal value.
+   * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+   * other monetary/decimal literals.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -128,7 +134,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasBigDecimalValue();
   /**
    * <pre>
-   * The big decimal value.
+   * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+   * other monetary/decimal literals.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -137,7 +144,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimal getBigDecimalValue();
   /**
    * <pre>
-   * The big decimal value.
+   * Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+   * other monetary/decimal literals.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimal bigDecimalValue = 5;</code>
@@ -146,7 +154,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The date time range value.
+   * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+   * style constraints that test whether a given instant falls within a validity range.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -155,7 +164,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasDateTimeRangeValue();
   /**
    * <pre>
-   * The date time range value.
+   * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+   * style constraints that test whether a given instant falls within a validity range.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -164,7 +174,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange getDateTimeRangeValue();
   /**
    * <pre>
-   * The date time range value.
+   * Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+   * style constraints that test whether a given instant falls within a validity range.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRange dateTimeRangeValue = 6;</code>
@@ -173,7 +184,7 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The integer number range value.
+   * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -182,7 +193,7 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasIntegerNumberRangeValue();
   /**
    * <pre>
-   * The integer number range value.
+   * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -191,7 +202,7 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange getIntegerNumberRangeValue();
   /**
    * <pre>
-   * The integer number range value.
+   * Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRange integerNumberRangeValue = 7;</code>
@@ -200,7 +211,7 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The long number range value.
+   * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -209,7 +220,7 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasLongNumberRangeValue();
   /**
    * <pre>
-   * The long number range value.
+   * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -218,7 +229,7 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange getLongNumberRangeValue();
   /**
    * <pre>
-   * The long number range value.
+   * Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRange longNumberRangeValue = 8;</code>
@@ -227,7 +238,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The big decimal number range value.
+   * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+   * style range constraints over prices or other decimal values.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -236,7 +248,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasBigDecimalNumberRangeValue();
   /**
    * <pre>
-   * The big decimal number range value.
+   * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+   * style range constraints over prices or other decimal values.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -245,7 +258,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange getBigDecimalNumberRangeValue();
   /**
    * <pre>
-   * The big decimal number range value.
+   * Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+   * style range constraints over prices or other decimal values.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;</code>
@@ -254,7 +268,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The offset date time value.
+   * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+   * `priceValidIn` to test price validity at a specific instant.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -263,7 +278,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasOffsetDateTimeValue();
   /**
    * <pre>
-   * The offset date time value.
+   * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+   * `priceValidIn` to test price validity at a specific instant.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -272,7 +288,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getOffsetDateTimeValue();
   /**
    * <pre>
-   * The offset date time value.
+   * Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+   * `priceValidIn` to test price validity at a specific instant.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime offsetDateTimeValue = 10;</code>
@@ -281,7 +298,7 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The locale value.
+   * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -290,7 +307,7 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasLocaleValue();
   /**
    * <pre>
-   * The locale value.
+   * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -299,7 +316,7 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcLocale getLocaleValue();
   /**
    * <pre>
-   * The locale value.
+   * Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocale localeValue = 11;</code>
@@ -308,7 +325,7 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The currency value.
+   * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -317,7 +334,7 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasCurrencyValue();
   /**
    * <pre>
-   * The currency value.
+   * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -326,7 +343,7 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcCurrency getCurrencyValue();
   /**
    * <pre>
-   * The currency value.
+   * Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrency currencyValue = 12;</code>
@@ -335,7 +352,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The facet statistics depth enum value.
+   * Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+   * `facetSummary` requirement to select whether only counts or also selection impact is computed.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;</code>
@@ -344,7 +362,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasFacetStatisticsDepthValue();
   /**
    * <pre>
-   * The facet statistics depth enum value.
+   * Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+   * `facetSummary` requirement to select whether only counts or also selection impact is computed.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;</code>
@@ -353,7 +372,8 @@ public interface GrpcQueryParamOrBuilder extends
   int getFacetStatisticsDepthValueValue();
   /**
    * <pre>
-   * The facet statistics depth enum value.
+   * Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+   * `facetSummary` requirement to select whether only counts or also selection impact is computed.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;</code>
@@ -363,7 +383,10 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The query price mode enum value.
+   * Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+   * constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+   * is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+   * accessors and JSON field mapping for existing clients.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode queryPriceModelValue = 14;</code>
@@ -372,7 +395,10 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasQueryPriceModelValue();
   /**
    * <pre>
-   * The query price mode enum value.
+   * Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+   * constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+   * is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+   * accessors and JSON field mapping for existing clients.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode queryPriceModelValue = 14;</code>
@@ -381,7 +407,10 @@ public interface GrpcQueryParamOrBuilder extends
   int getQueryPriceModelValueValue();
   /**
    * <pre>
-   * The query price mode enum value.
+   * Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+   * constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+   * is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+   * accessors and JSON field mapping for existing clients.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode queryPriceModelValue = 14;</code>
@@ -391,7 +420,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The price content mode enum value.
+   * Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+   * requirement to select which prices are fetched along with the entity.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode priceContentModeValue = 15;</code>
@@ -400,7 +430,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasPriceContentModeValue();
   /**
    * <pre>
-   * The price content mode enum value.
+   * Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+   * requirement to select which prices are fetched along with the entity.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode priceContentModeValue = 15;</code>
@@ -409,7 +440,8 @@ public interface GrpcQueryParamOrBuilder extends
   int getPriceContentModeValueValue();
   /**
    * <pre>
-   * The price content mode enum value.
+   * Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+   * requirement to select which prices are fetched along with the entity.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentMode priceContentModeValue = 15;</code>
@@ -419,7 +451,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The attribute special value enum value.
+   * Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+   * to test whether an attribute value is `NULL` or `NOT_NULL`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue attributeSpecialValue = 16;</code>
@@ -428,7 +461,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasAttributeSpecialValue();
   /**
    * <pre>
-   * The attribute special value enum value.
+   * Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+   * to test whether an attribute value is `NULL` or `NOT_NULL`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue attributeSpecialValue = 16;</code>
@@ -437,7 +471,8 @@ public interface GrpcQueryParamOrBuilder extends
   int getAttributeSpecialValueValue();
   /**
    * <pre>
-   * The attribute special value enum value.
+   * Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+   * to test whether an attribute value is `NULL` or `NOT_NULL`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValue attributeSpecialValue = 16;</code>
@@ -447,7 +482,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The order direction enum value.
+   * Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+   * and other ordering constraints to select ascending or descending order.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirection orderDirectionValue = 17;</code>
@@ -456,7 +492,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasOrderDirectionValue();
   /**
    * <pre>
-   * The order direction enum value.
+   * Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+   * and other ordering constraints to select ascending or descending order.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirection orderDirectionValue = 17;</code>
@@ -465,7 +502,8 @@ public interface GrpcQueryParamOrBuilder extends
   int getOrderDirectionValueValue();
   /**
    * <pre>
-   * The order direction enum value.
+   * Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+   * and other ordering constraints to select ascending or descending order.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirection orderDirectionValue = 17;</code>
@@ -475,7 +513,9 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The empty hierarchical entity behaviour enum value.
+   * Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+   * statistics requirements to select whether hierarchy nodes with no referring entities are kept
+   * in or removed from the result tree.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;</code>
@@ -484,7 +524,9 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasEmptyHierarchicalEntityBehaviour();
   /**
    * <pre>
-   * The empty hierarchical entity behaviour enum value.
+   * Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+   * statistics requirements to select whether hierarchy nodes with no referring entities are kept
+   * in or removed from the result tree.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;</code>
@@ -493,7 +535,9 @@ public interface GrpcQueryParamOrBuilder extends
   int getEmptyHierarchicalEntityBehaviourValue();
   /**
    * <pre>
-   * The empty hierarchical entity behaviour enum value.
+   * Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+   * statistics requirements to select whether hierarchy nodes with no referring entities are kept
+   * in or removed from the result tree.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;</code>
@@ -503,7 +547,9 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The statistics base enum value.
+   * Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+   * requirements to select which part of the `filterBy` constraint is considered when computing
+   * cardinalities.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase statisticsBase = 19;</code>
@@ -512,7 +558,9 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasStatisticsBase();
   /**
    * <pre>
-   * The statistics base enum value.
+   * Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+   * requirements to select which part of the `filterBy` constraint is considered when computing
+   * cardinalities.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase statisticsBase = 19;</code>
@@ -521,7 +569,9 @@ public interface GrpcQueryParamOrBuilder extends
   int getStatisticsBaseValue();
   /**
    * <pre>
-   * The statistics base enum value.
+   * Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+   * requirements to select which part of the `filterBy` constraint is considered when computing
+   * cardinalities.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase statisticsBase = 19;</code>
@@ -531,7 +581,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The statistics type enum value.
+   * Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+   * requirements to select whether children counts or queried-entity counts are produced.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsType statisticsType = 20;</code>
@@ -540,7 +591,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasStatisticsType();
   /**
    * <pre>
-   * The statistics type enum value.
+   * Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+   * requirements to select whether children counts or queried-entity counts are produced.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsType statisticsType = 20;</code>
@@ -549,7 +601,8 @@ public interface GrpcQueryParamOrBuilder extends
   int getStatisticsTypeValue();
   /**
    * <pre>
-   * The statistics type enum value.
+   * Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+   * requirements to select whether children counts or queried-entity counts are produced.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsType statisticsType = 20;</code>
@@ -559,7 +612,9 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The histogram behavior enum value.
+   * Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+   * to select whether the histogram always has exactly the requested bucket count or an optimized,
+   * more compact bucket layout.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior histogramBehavior = 21;</code>
@@ -568,7 +623,9 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasHistogramBehavior();
   /**
    * <pre>
-   * The histogram behavior enum value.
+   * Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+   * to select whether the histogram always has exactly the requested bucket count or an optimized,
+   * more compact bucket layout.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior histogramBehavior = 21;</code>
@@ -577,7 +634,9 @@ public interface GrpcQueryParamOrBuilder extends
   int getHistogramBehaviorValue();
   /**
    * <pre>
-   * The histogram behavior enum value.
+   * Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+   * to select whether the histogram always has exactly the requested bucket count or an optimized,
+   * more compact bucket layout.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehavior histogramBehavior = 21;</code>
@@ -587,7 +646,9 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The managed references behaviour
+   * Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+   * `referenceContent` requirement to select whether references to a managed entity that no longer
+   * exists are still returned.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;</code>
@@ -596,7 +657,9 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasManagedReferencesBehaviour();
   /**
    * <pre>
-   * The managed references behaviour
+   * Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+   * `referenceContent` requirement to select whether references to a managed entity that no longer
+   * exists are still returned.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;</code>
@@ -605,7 +668,9 @@ public interface GrpcQueryParamOrBuilder extends
   int getManagedReferencesBehaviourValue();
   /**
    * <pre>
-   * The managed references behaviour
+   * Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+   * `referenceContent` requirement to select whether references to a managed entity that no longer
+   * exists are still returned.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;</code>
@@ -615,7 +680,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The expression
+   * Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+   * used as the size argument of the `gap` requirement to compute spacing between paginated results.
    * </pre>
    *
    * <code>string expressionValue = 23;</code>
@@ -624,7 +690,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasExpressionValue();
   /**
    * <pre>
-   * The expression
+   * Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+   * used as the size argument of the `gap` requirement to compute spacing between paginated results.
    * </pre>
    *
    * <code>string expressionValue = 23;</code>
@@ -633,7 +700,8 @@ public interface GrpcQueryParamOrBuilder extends
   java.lang.String getExpressionValue();
   /**
    * <pre>
-   * The expression
+   * Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+   * used as the size argument of the `gap` requirement to compute spacing between paginated results.
    * </pre>
    *
    * <code>string expressionValue = 23;</code>
@@ -644,7 +712,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The scope enum value.
+   * Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+   * select whether live or archived entities are considered.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScope scope = 24;</code>
@@ -653,7 +722,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasScope();
   /**
    * <pre>
-   * The scope enum value.
+   * Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+   * select whether live or archived entities are considered.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScope scope = 24;</code>
@@ -662,7 +732,8 @@ public interface GrpcQueryParamOrBuilder extends
   int getScopeValue();
   /**
    * <pre>
-   * The scope enum value.
+   * Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+   * select whether live or archived entities are considered.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScope scope = 24;</code>
@@ -672,7 +743,9 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The facetRelationType enum value.
+   * Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+   * calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+   * applied between facets.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetRelationType facetRelationType = 25;</code>
@@ -681,7 +754,9 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasFacetRelationType();
   /**
    * <pre>
-   * The facetRelationType enum value.
+   * Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+   * calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+   * applied between facets.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetRelationType facetRelationType = 25;</code>
@@ -690,7 +765,9 @@ public interface GrpcQueryParamOrBuilder extends
   int getFacetRelationTypeValue();
   /**
    * <pre>
-   * The facetRelationType enum value.
+   * Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+   * calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+   * applied between facets.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetRelationType facetRelationType = 25;</code>
@@ -700,7 +777,9 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The facetGroupRelationLevel enum value.
+   * Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+   * impact calculation to select whether the relation applies between facets in the same group or
+   * across different groups/references.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;</code>
@@ -709,7 +788,9 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasFacetGroupRelationLevel();
   /**
    * <pre>
-   * The facetGroupRelationLevel enum value.
+   * Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+   * impact calculation to select whether the relation applies between facets in the same group or
+   * across different groups/references.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;</code>
@@ -718,7 +799,9 @@ public interface GrpcQueryParamOrBuilder extends
   int getFacetGroupRelationLevelValue();
   /**
    * <pre>
-   * The facetGroupRelationLevel enum value.
+   * Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+   * impact calculation to select whether the relation applies between facets in the same group or
+   * across different groups/references.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;</code>
@@ -728,7 +811,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The facet traversal mode enum value.
+   * Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+   * `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTraversalMode traversalMode = 27;</code>
@@ -737,7 +821,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasTraversalMode();
   /**
    * <pre>
-   * The facet traversal mode enum value.
+   * Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+   * `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTraversalMode traversalMode = 27;</code>
@@ -746,7 +831,8 @@ public interface GrpcQueryParamOrBuilder extends
   int getTraversalModeValue();
   /**
    * <pre>
-   * The facet traversal mode enum value.
+   * Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+   * `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTraversalMode traversalMode = 27;</code>
@@ -756,7 +842,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The string array value.
+   * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+   * as `attributeInSet` over string-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -765,7 +852,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasStringArrayValue();
   /**
    * <pre>
-   * The string array value.
+   * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+   * as `attributeInSet` over string-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -774,7 +862,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcStringArray getStringArrayValue();
   /**
    * <pre>
-   * The string array value.
+   * Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+   * as `attributeInSet` over string-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStringArray stringArrayValue = 101;</code>
@@ -783,7 +872,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The integer array value.
+   * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+   * `attributeInSet` over integer-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -792,7 +882,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasIntegerArrayValue();
   /**
    * <pre>
-   * The integer array value.
+   * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+   * `attributeInSet` over integer-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -801,7 +892,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcIntegerArray getIntegerArrayValue();
   /**
    * <pre>
-   * The integer array value.
+   * Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+   * `attributeInSet` over integer-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerArray integerArrayValue = 102;</code>
@@ -810,7 +902,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The long array value.
+   * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+   * long-typed values that exceed the `int32` range.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -819,7 +912,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasLongArrayValue();
   /**
    * <pre>
-   * The long array value.
+   * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+   * long-typed values that exceed the `int32` range.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -828,7 +922,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcLongArray getLongArrayValue();
   /**
    * <pre>
-   * The long array value.
+   * Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+   * long-typed values that exceed the `int32` range.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongArray longArrayValue = 103;</code>
@@ -837,7 +932,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The boolean array value.
+   * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+   * boolean-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -846,7 +942,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasBooleanArrayValue();
   /**
    * <pre>
-   * The boolean array value.
+   * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+   * boolean-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -855,7 +952,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBooleanArray getBooleanArrayValue();
   /**
    * <pre>
-   * The boolean array value.
+   * Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+   * boolean-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBooleanArray booleanArrayValue = 104;</code>
@@ -864,7 +962,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The big decimal array value.
+   * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+   * `inSet`-style constraints over decimal-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -873,7 +972,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasBigDecimalArrayValue();
   /**
    * <pre>
-   * The big decimal array value.
+   * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+   * `inSet`-style constraints over decimal-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -882,7 +982,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray getBigDecimalArrayValue();
   /**
    * <pre>
-   * The big decimal array value.
+   * Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+   * `inSet`-style constraints over decimal-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalArray bigDecimalArrayValue = 105;</code>
@@ -891,7 +992,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The date time range array value.
+   * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+   * constraints over range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -900,7 +1002,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasDateTimeRangeArrayValue();
   /**
    * <pre>
-   * The date time range array value.
+   * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+   * constraints over range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -909,7 +1012,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray getDateTimeRangeArrayValue();
   /**
    * <pre>
-   * The date time range array value.
+   * Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+   * constraints over range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;</code>
@@ -918,7 +1022,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The integer number range array value.
+   * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+   * constraints over integer-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -927,7 +1032,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasIntegerNumberRangeArrayValue();
   /**
    * <pre>
-   * The integer number range array value.
+   * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+   * constraints over integer-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -936,7 +1042,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray getIntegerNumberRangeArrayValue();
   /**
    * <pre>
-   * The integer number range array value.
+   * Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+   * constraints over integer-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;</code>
@@ -945,7 +1052,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The long number range array value.
+   * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+   * over long-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -954,7 +1062,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasLongNumberRangeArrayValue();
   /**
    * <pre>
-   * The long number range array value.
+   * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+   * over long-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -963,7 +1072,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray getLongNumberRangeArrayValue();
   /**
    * <pre>
-   * The long number range array value.
+   * Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+   * over long-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;</code>
@@ -972,7 +1082,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The big decimal number range array value.
+   * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+   * `inSet`-style constraints over decimal-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -981,7 +1092,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasBigDecimalNumberRangeArrayValue();
   /**
    * <pre>
-   * The big decimal number range array value.
+   * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+   * `inSet`-style constraints over decimal-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -990,7 +1102,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray getBigDecimalNumberRangeArrayValue();
   /**
    * <pre>
-   * The big decimal number range array value.
+   * Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+   * `inSet`-style constraints over decimal-range-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;</code>
@@ -999,7 +1112,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The offset date time array value.
+   * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+   * constraints over date-time-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -1008,7 +1122,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasOffsetDateTimeArrayValue();
   /**
    * <pre>
-   * The offset date time array value.
+   * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+   * constraints over date-time-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -1017,7 +1132,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray getOffsetDateTimeArrayValue();
   /**
    * <pre>
-   * The offset date time array value.
+   * Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+   * constraints over date-time-typed attributes.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;</code>
@@ -1026,7 +1142,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The locale array value.
+   * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+   * a single constraint or requirement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -1035,7 +1152,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasLocaleArrayValue();
   /**
    * <pre>
-   * The locale array value.
+   * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+   * a single constraint or requirement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -1044,7 +1162,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcLocaleArray getLocaleArrayValue();
   /**
    * <pre>
-   * The locale array value.
+   * Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+   * a single constraint or requirement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcLocaleArray localeArrayValue = 111;</code>
@@ -1053,7 +1172,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The currency array value.
+   * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+   * in a single constraint or requirement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -1062,7 +1182,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasCurrencyArrayValue();
   /**
    * <pre>
-   * The currency array value.
+   * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+   * in a single constraint or requirement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -1071,7 +1192,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray getCurrencyArrayValue();
   /**
    * <pre>
-   * The currency array value.
+   * Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+   * in a single constraint or requirement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCurrencyArray currencyArrayValue = 112;</code>
@@ -1080,7 +1202,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The facet statistics depth array value.
+   * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -1089,7 +1212,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasFacetStatisticsDepthArrayValue();
   /**
    * <pre>
-   * The facet statistics depth array value.
+   * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -1098,7 +1222,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray getFacetStatisticsDepthArrayValue();
   /**
    * <pre>
-   * The facet statistics depth array value.
+   * Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;</code>
@@ -1107,7 +1232,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The query price mode array value.
+   * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -1116,7 +1242,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasQueryPriceModelArrayValue();
   /**
    * <pre>
-   * The query price mode array value.
+   * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -1125,7 +1252,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray getQueryPriceModelArrayValue();
   /**
    * <pre>
-   * The query price mode array value.
+   * Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;</code>
@@ -1134,7 +1262,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The price content mode array value.
+   * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -1143,7 +1272,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasPriceContentModeArrayValue();
   /**
    * <pre>
-   * The price content mode array value.
+   * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -1152,7 +1282,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray getPriceContentModeArrayValue();
   /**
    * <pre>
-   * The price content mode array value.
+   * Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcPriceContentModeArray priceContentModeArrayValue = 115;</code>
@@ -1161,7 +1292,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The attribute special value array value.
+   * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -1170,7 +1302,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasAttributeSpecialArrayValue();
   /**
    * <pre>
-   * The attribute special value array value.
+   * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -1179,7 +1312,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray getAttributeSpecialArrayValue();
   /**
    * <pre>
-   * The attribute special value array value.
+   * Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;</code>
@@ -1188,7 +1322,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The order direction array value.
+   * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -1197,7 +1332,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasOrderDirectionArrayValue();
   /**
    * <pre>
-   * The order direction array value.
+   * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -1206,7 +1342,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray getOrderDirectionArrayValue();
   /**
    * <pre>
-   * The order direction array value.
+   * Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOrderDirectionArray orderDirectionArrayValue = 117;</code>
@@ -1215,7 +1352,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The empty hierarchical entity behaviour array value.
+   * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+   * where the placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -1224,7 +1362,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasEmptyHierarchicalEntityBehaviourArrayValue();
   /**
    * <pre>
-   * The empty hierarchical entity behaviour array value.
+   * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+   * where the placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -1233,7 +1372,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray getEmptyHierarchicalEntityBehaviourArrayValue();
   /**
    * <pre>
-   * The empty hierarchical entity behaviour array value.
+   * Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+   * where the placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;</code>
@@ -1242,7 +1382,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The statistics base array value.
+   * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -1251,7 +1392,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasStatisticsBaseArrayValue();
   /**
    * <pre>
-   * The statistics base array value.
+   * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -1260,7 +1402,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray getStatisticsBaseArrayValue();
   /**
    * <pre>
-   * The statistics base array value.
+   * Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;</code>
@@ -1269,7 +1412,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The statistics type array value.
+   * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -1278,7 +1422,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasStatisticsTypeArrayValue();
   /**
    * <pre>
-   * The statistics type array value.
+   * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -1287,7 +1432,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray getStatisticsTypeArrayValue();
   /**
    * <pre>
-   * The statistics type array value.
+   * Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+   * resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;</code>
@@ -1296,7 +1442,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The histogram behavior enum value.
+   * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -1305,7 +1452,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasHistogramBehaviorTypeArrayValue();
   /**
    * <pre>
-   * The histogram behavior enum value.
+   * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -1314,7 +1462,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray getHistogramBehaviorTypeArrayValue();
   /**
    * <pre>
-   * The histogram behavior enum value.
+   * Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+   * placeholder resolves to a list rather than a single value.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;</code>
@@ -1323,7 +1472,8 @@ public interface GrpcQueryParamOrBuilder extends
 
   /**
    * <pre>
-   * The scope enum value.
+   * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+   * that accept multiple scopes (live, archived) at once.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -1332,7 +1482,8 @@ public interface GrpcQueryParamOrBuilder extends
   boolean hasScopeArrayValue();
   /**
    * <pre>
-   * The scope enum value.
+   * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+   * that accept multiple scopes (live, archived) at once.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>
@@ -1341,7 +1492,8 @@ public interface GrpcQueryParamOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray getScopeArrayValue();
   /**
    * <pre>
-   * The scope enum value.
+   * Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+   * that accept multiple scopes (live, archived) at once.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityScopeArray scopeArrayValue = 122;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryPriceModeArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryPriceModeArray.java
@@ -81,7 +81,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * Value that supports storing a QueryPriceMode array.
+   * The individual QueryPriceMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -94,7 +94,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a QueryPriceMode array.
+   * The individual QueryPriceMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a QueryPriceMode array.
+   * The individual QueryPriceMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -119,7 +119,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a QueryPriceMode array.
+   * The individual QueryPriceMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -132,7 +132,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a QueryPriceMode array.
+   * The individual QueryPriceMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -524,7 +524,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a QueryPriceMode array.
+     * The individual QueryPriceMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -536,7 +536,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a QueryPriceMode array.
+     * The individual QueryPriceMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -547,7 +547,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a QueryPriceMode array.
+     * The individual QueryPriceMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -559,7 +559,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a QueryPriceMode array.
+     * The individual QueryPriceMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -579,7 +579,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a QueryPriceMode array.
+     * The individual QueryPriceMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -597,7 +597,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a QueryPriceMode array.
+     * The individual QueryPriceMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -615,7 +615,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a QueryPriceMode array.
+     * The individual QueryPriceMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -629,7 +629,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a QueryPriceMode array.
+     * The individual QueryPriceMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a QueryPriceMode array.
+     * The individual QueryPriceMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -653,7 +653,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a QueryPriceMode array.
+     * The individual QueryPriceMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -670,7 +670,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a QueryPriceMode array.
+     * The individual QueryPriceMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -685,7 +685,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a QueryPriceMode array.
+     * The individual QueryPriceMode values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryPriceModeArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryPriceModeArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcQueryPriceModeArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a QueryPriceMode array.
+   * The individual QueryPriceMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcQueryPriceModeArrayOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode> getValueList();
   /**
    * <pre>
-   * Value that supports storing a QueryPriceMode array.
+   * The individual QueryPriceMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcQueryPriceModeArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a QueryPriceMode array.
+   * The individual QueryPriceMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -61,7 +61,7 @@ public interface GrpcQueryPriceModeArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a QueryPriceMode array.
+   * The individual QueryPriceMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>
@@ -71,7 +71,7 @@ public interface GrpcQueryPriceModeArrayOrBuilder extends
   getValueValueList();
   /**
    * <pre>
-   * Value that supports storing a QueryPriceMode array.
+   * The individual QueryPriceMode values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryPriceMode value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryRequest.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request for specifying a query to be executed.
+ * Request for specifying a full EvitaQL query (filter, order and require blocks) to be executed.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcQueryRequest}
@@ -85,7 +85,10 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object query_ = "";
   /**
    * <pre>
-   * The string part of the parametrised query.
+   * The string part of the parametrised query, e.g. `query(collection('Product'), filterBy(entityPrimaryKeyInSet(?)))`.
+   * Parameter values are not embedded in this string but supplied separately via `positionalQueryParams`/
+   * `namedQueryParams` below. A `?` placeholder is a positional parameter, an `&#64;name` placeholder is a
+   * named parameter - see `positionalQueryParams` for the full binding contract, which applies identically here.
    * </pre>
    *
    * <code>string query = 1;</code>
@@ -106,7 +109,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string part of the parametrised query.
+   * The string part of the parametrised query, e.g. `query(collection('Product'), filterBy(entityPrimaryKeyInSet(?)))`.
+   * Parameter values are not embedded in this string but supplied separately via `positionalQueryParams`/
+   * `namedQueryParams` below. A `?` placeholder is a positional parameter, an `&#64;name` placeholder is a
+   * named parameter - see `positionalQueryParams` for the full binding contract, which applies identically here.
    * </pre>
    *
    * <code>string query = 1;</code>
@@ -132,7 +138,10 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcQueryParam> positionalQueryParams_;
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+   * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+   * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+   * of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -143,7 +152,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+   * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+   * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+   * of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -155,7 +167,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+   * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+   * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+   * of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -166,7 +181,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+   * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+   * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+   * of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -177,7 +195,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+   * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+   * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+   * of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -216,7 +237,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+   * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+   * "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -237,7 +260,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+   * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+   * "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -248,7 +273,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+   * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+   * "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -266,7 +293,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+   * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+   * "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -476,7 +505,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * Request for specifying a query to be executed.
+   * Request for specifying a full EvitaQL query (filter, order and require blocks) to be executed.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcQueryRequest}
@@ -748,7 +777,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     private java.lang.Object query_ = "";
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The string part of the parametrised query, e.g. `query(collection('Product'), filterBy(entityPrimaryKeyInSet(?)))`.
+     * Parameter values are not embedded in this string but supplied separately via `positionalQueryParams`/
+     * `namedQueryParams` below. A `?` placeholder is a positional parameter, an `&#64;name` placeholder is a
+     * named parameter - see `positionalQueryParams` for the full binding contract, which applies identically here.
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -768,7 +800,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The string part of the parametrised query, e.g. `query(collection('Product'), filterBy(entityPrimaryKeyInSet(?)))`.
+     * Parameter values are not embedded in this string but supplied separately via `positionalQueryParams`/
+     * `namedQueryParams` below. A `?` placeholder is a positional parameter, an `&#64;name` placeholder is a
+     * named parameter - see `positionalQueryParams` for the full binding contract, which applies identically here.
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -789,7 +824,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The string part of the parametrised query, e.g. `query(collection('Product'), filterBy(entityPrimaryKeyInSet(?)))`.
+     * Parameter values are not embedded in this string but supplied separately via `positionalQueryParams`/
+     * `namedQueryParams` below. A `?` placeholder is a positional parameter, an `&#64;name` placeholder is a
+     * named parameter - see `positionalQueryParams` for the full binding contract, which applies identically here.
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -806,7 +844,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The string part of the parametrised query, e.g. `query(collection('Product'), filterBy(entityPrimaryKeyInSet(?)))`.
+     * Parameter values are not embedded in this string but supplied separately via `positionalQueryParams`/
+     * `namedQueryParams` below. A `?` placeholder is a positional parameter, an `&#64;name` placeholder is a
+     * named parameter - see `positionalQueryParams` for the full binding contract, which applies identically here.
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -820,7 +861,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The string part of the parametrised query, e.g. `query(collection('Product'), filterBy(entityPrimaryKeyInSet(?)))`.
+     * Parameter values are not embedded in this string but supplied separately via `positionalQueryParams`/
+     * `namedQueryParams` below. A `?` placeholder is a positional parameter, an `&#64;name` placeholder is a
+     * named parameter - see `positionalQueryParams` for the full binding contract, which applies identically here.
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -851,7 +895,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
 
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -865,7 +912,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -879,7 +929,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -893,7 +946,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -914,7 +970,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -932,7 +991,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -952,7 +1014,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -973,7 +1038,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -991,7 +1059,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1009,7 +1080,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1028,7 +1102,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1045,7 +1122,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1062,7 +1142,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1073,7 +1156,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1087,7 +1173,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1102,7 +1191,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1113,7 +1205,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1125,7 +1220,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+     * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+     * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+     * of index N."; extra values are ignored.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -1186,7 +1284,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+     * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+     * "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1207,7 +1307,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+     * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+     * "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1218,7 +1320,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+     * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+     * "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1235,7 +1339,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+     * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+     * "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1257,7 +1363,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+     * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+     * "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1280,7 +1388,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+     * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+     * "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1297,7 +1407,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+     * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+     * "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -1316,7 +1428,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+     * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+     * "Missing argument of name `name`."; extra map entries are ignored.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryRequestOrBuilder.java
@@ -33,7 +33,10 @@ public interface GrpcQueryRequestOrBuilder extends
 
   /**
    * <pre>
-   * The string part of the parametrised query.
+   * The string part of the parametrised query, e.g. `query(collection('Product'), filterBy(entityPrimaryKeyInSet(?)))`.
+   * Parameter values are not embedded in this string but supplied separately via `positionalQueryParams`/
+   * `namedQueryParams` below. A `?` placeholder is a positional parameter, an `&#64;name` placeholder is a
+   * named parameter - see `positionalQueryParams` for the full binding contract, which applies identically here.
    * </pre>
    *
    * <code>string query = 1;</code>
@@ -42,7 +45,10 @@ public interface GrpcQueryRequestOrBuilder extends
   java.lang.String getQuery();
   /**
    * <pre>
-   * The string part of the parametrised query.
+   * The string part of the parametrised query, e.g. `query(collection('Product'), filterBy(entityPrimaryKeyInSet(?)))`.
+   * Parameter values are not embedded in this string but supplied separately via `positionalQueryParams`/
+   * `namedQueryParams` below. A `?` placeholder is a positional parameter, an `&#64;name` placeholder is a
+   * named parameter - see `positionalQueryParams` for the full binding contract, which applies identically here.
    * </pre>
    *
    * <code>string query = 1;</code>
@@ -53,7 +59,10 @@ public interface GrpcQueryRequestOrBuilder extends
 
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+   * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+   * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+   * of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -62,7 +71,10 @@ public interface GrpcQueryRequestOrBuilder extends
       getPositionalQueryParamsList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+   * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+   * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+   * of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -70,7 +82,10 @@ public interface GrpcQueryRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcQueryParam getPositionalQueryParams(int index);
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+   * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+   * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+   * of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -78,7 +93,10 @@ public interface GrpcQueryRequestOrBuilder extends
   int getPositionalQueryParamsCount();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+   * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+   * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+   * of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -87,7 +105,10 @@ public interface GrpcQueryRequestOrBuilder extends
       getPositionalQueryParamsOrBuilderList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+   * parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+   * (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+   * of index N."; extra values are ignored.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 2;</code>
@@ -97,7 +118,9 @@ public interface GrpcQueryRequestOrBuilder extends
 
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+   * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+   * "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -105,7 +128,9 @@ public interface GrpcQueryRequestOrBuilder extends
   int getNamedQueryParamsCount();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+   * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+   * "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -120,7 +145,9 @@ public interface GrpcQueryRequestOrBuilder extends
   getNamedQueryParams();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+   * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+   * "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -129,7 +156,9 @@ public interface GrpcQueryRequestOrBuilder extends
   getNamedQueryParamsMap();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+   * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+   * "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>
@@ -141,7 +170,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam getNamedQueryParamsOrDefaul
 io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue);
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `query`, keyed by the name used after `&#64;` in the string
+   * (without the `&#64;` prefix). An `&#64;name` placeholder with no matching map entry fails the request with
+   * "Missing argument of name `name`."; extra map entries are ignored.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryResponse.java
@@ -71,7 +71,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage_;
   /**
    * <pre>
-   * The fetched record page with entities.
+   * The fetched page or strip of entities (in whichever of the three representations the query's
+   * `require` block asked for - see `GrpcDataChunk`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -83,7 +84,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The fetched record page with entities.
+   * The fetched page or strip of entities (in whichever of the three representations the query's
+   * `require` block asked for - see `GrpcDataChunk`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -95,7 +97,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The fetched record page with entities.
+   * The fetched page or strip of entities (in whichever of the three representations the query's
+   * `require` block asked for - see `GrpcDataChunk`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -109,7 +112,9 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults_;
   /**
    * <pre>
-   * The computed extra results.
+   * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+   * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+   * requested none of these.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -121,7 +126,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The computed extra results.
+   * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+   * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+   * requested none of these.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -133,7 +140,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The computed extra results.
+   * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+   * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+   * requested none of these.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -537,7 +546,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcDataChunk, io.evitadb.externalApi.grpc.generated.GrpcDataChunk.Builder, io.evitadb.externalApi.grpc.generated.GrpcDataChunkOrBuilder> recordPageBuilder_;
     /**
      * <pre>
-     * The fetched record page with entities.
+     * The fetched page or strip of entities (in whichever of the three representations the query's
+     * `require` block asked for - see `GrpcDataChunk`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -548,7 +558,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The fetched record page with entities.
+     * The fetched page or strip of entities (in whichever of the three representations the query's
+     * `require` block asked for - see `GrpcDataChunk`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -563,7 +574,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The fetched record page with entities.
+     * The fetched page or strip of entities (in whichever of the three representations the query's
+     * `require` block asked for - see `GrpcDataChunk`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -583,7 +595,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The fetched record page with entities.
+     * The fetched page or strip of entities (in whichever of the three representations the query's
+     * `require` block asked for - see `GrpcDataChunk`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -601,7 +614,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The fetched record page with entities.
+     * The fetched page or strip of entities (in whichever of the three representations the query's
+     * `require` block asked for - see `GrpcDataChunk`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -626,7 +640,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The fetched record page with entities.
+     * The fetched page or strip of entities (in whichever of the three representations the query's
+     * `require` block asked for - see `GrpcDataChunk`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -643,7 +658,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The fetched record page with entities.
+     * The fetched page or strip of entities (in whichever of the three representations the query's
+     * `require` block asked for - see `GrpcDataChunk`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -655,7 +671,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The fetched record page with entities.
+     * The fetched page or strip of entities (in whichever of the three representations the query's
+     * `require` block asked for - see `GrpcDataChunk`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -670,7 +687,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The fetched record page with entities.
+     * The fetched page or strip of entities (in whichever of the three representations the query's
+     * `require` block asked for - see `GrpcDataChunk`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -694,7 +712,9 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcExtraResults, io.evitadb.externalApi.grpc.generated.GrpcExtraResults.Builder, io.evitadb.externalApi.grpc.generated.GrpcExtraResultsOrBuilder> extraResultsBuilder_;
     /**
      * <pre>
-     * The computed extra results.
+     * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+     * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+     * requested none of these.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -705,7 +725,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The computed extra results.
+     * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+     * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+     * requested none of these.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -720,7 +742,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The computed extra results.
+     * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+     * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+     * requested none of these.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -740,7 +764,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The computed extra results.
+     * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+     * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+     * requested none of these.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -758,7 +784,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The computed extra results.
+     * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+     * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+     * requested none of these.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -783,7 +811,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The computed extra results.
+     * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+     * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+     * requested none of these.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -800,7 +830,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The computed extra results.
+     * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+     * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+     * requested none of these.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -812,7 +844,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The computed extra results.
+     * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+     * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+     * requested none of these.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -827,7 +861,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The computed extra results.
+     * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+     * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+     * requested none of these.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcQueryResponseOrBuilder extends
 
   /**
    * <pre>
-   * The fetched record page with entities.
+   * The fetched page or strip of entities (in whichever of the three representations the query's
+   * `require` block asked for - see `GrpcDataChunk`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcQueryResponseOrBuilder extends
   boolean hasRecordPage();
   /**
    * <pre>
-   * The fetched record page with entities.
+   * The fetched page or strip of entities (in whichever of the three representations the query's
+   * `require` block asked for - see `GrpcDataChunk`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcQueryResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcDataChunk getRecordPage();
   /**
    * <pre>
-   * The fetched record page with entities.
+   * The fetched page or strip of entities (in whichever of the three representations the query's
+   * `require` block asked for - see `GrpcDataChunk`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcDataChunk recordPage = 1;</code>
@@ -60,7 +63,9 @@ public interface GrpcQueryResponseOrBuilder extends
 
   /**
    * <pre>
-   * The computed extra results.
+   * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+   * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+   * requested none of these.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -69,7 +74,9 @@ public interface GrpcQueryResponseOrBuilder extends
   boolean hasExtraResults();
   /**
    * <pre>
-   * The computed extra results.
+   * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+   * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+   * requested none of these.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>
@@ -78,7 +85,9 @@ public interface GrpcQueryResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcExtraResults getExtraResults();
   /**
    * <pre>
-   * The computed extra results.
+   * Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+   * hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+   * requested none of these.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcExtraResults extraResults = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryUnsafeRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryUnsafeRequest.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request for specifying a query to be executed.
+ * Request for specifying a full EvitaQL query with parameter values embedded directly in the string (no
+ * separate positional/named parameter binding). Internal/unsafe use only - see the `QueryUnsafe` RPC
+ * comment: applications should use `GrpcQueryRequest` instead.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcQueryUnsafeRequest}
@@ -72,7 +74,8 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object query_ = "";
   /**
    * <pre>
-   * The string part of the parametrised query.
+   * The complete query string, with any parameter values already embedded (no `?`/`&#64;name` placeholders
+   * to resolve).
    * </pre>
    *
    * <code>string query = 1;</code>
@@ -93,7 +96,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string part of the parametrised query.
+   * The complete query string, with any parameter values already embedded (no `?`/`&#64;name` placeholders
+   * to resolve).
    * </pre>
    *
    * <code>string query = 1;</code>
@@ -272,7 +276,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request for specifying a query to be executed.
+   * Request for specifying a full EvitaQL query with parameter values embedded directly in the string (no
+   * separate positional/named parameter binding). Internal/unsafe use only - see the `QueryUnsafe` RPC
+   * comment: applications should use `GrpcQueryRequest` instead.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcQueryUnsafeRequest}
@@ -447,7 +453,8 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object query_ = "";
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The complete query string, with any parameter values already embedded (no `?`/`&#64;name` placeholders
+     * to resolve).
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -467,7 +474,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The complete query string, with any parameter values already embedded (no `?`/`&#64;name` placeholders
+     * to resolve).
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -488,7 +496,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The complete query string, with any parameter values already embedded (no `?`/`&#64;name` placeholders
+     * to resolve).
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -505,7 +514,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The complete query string, with any parameter values already embedded (no `?`/`&#64;name` placeholders
+     * to resolve).
      * </pre>
      *
      * <code>string query = 1;</code>
@@ -519,7 +529,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The string part of the parametrised query.
+     * The complete query string, with any parameter values already embedded (no `?`/`&#64;name` placeholders
+     * to resolve).
      * </pre>
      *
      * <code>string query = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryUnsafeRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryUnsafeRequestOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcQueryUnsafeRequestOrBuilder extends
 
   /**
    * <pre>
-   * The string part of the parametrised query.
+   * The complete query string, with any parameter values already embedded (no `?`/`&#64;name` placeholders
+   * to resolve).
    * </pre>
    *
    * <code>string query = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcQueryUnsafeRequestOrBuilder extends
   java.lang.String getQuery();
   /**
    * <pre>
-   * The string part of the parametrised query.
+   * The complete query string, with any parameter values already embedded (no `?`/`&#64;name` placeholders
+   * to resolve).
    * </pre>
    *
    * <code>string query = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReferenceSchema.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReferenceSchema.java
@@ -344,7 +344,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>bool entityTypeRelatesToEntity = 6 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.entityTypeRelatesToEntity is deprecated.
-   *     See GrpcEntitySchema.proto;l=336
+   *     See GrpcEntitySchema.proto;l=338
    * @return The entityTypeRelatesToEntity.
    */
   @java.lang.Override
@@ -403,7 +403,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>bool groupTypeRelatesToEntity = 8 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.groupTypeRelatesToEntity is deprecated.
-   *     See GrpcEntitySchema.proto;l=342
+   *     See GrpcEntitySchema.proto;l=344
    * @return The groupTypeRelatesToEntity.
    */
   @java.lang.Override
@@ -428,7 +428,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>bool indexed = 9 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexed is deprecated.
-   *     See GrpcEntitySchema.proto;l=352
+   *     See GrpcEntitySchema.proto;l=354
    * @return The indexed.
    */
   @java.lang.Override
@@ -453,7 +453,7 @@ private static final long serialVersionUID = 0L;
    *
    * <code>bool faceted = 10 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.faceted is deprecated.
-   *     See GrpcEntitySchema.proto;l=362
+   *     See GrpcEntitySchema.proto;l=364
    * @return The faceted.
    */
   @java.lang.Override
@@ -1129,7 +1129,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-   *     See GrpcEntitySchema.proto;l=414
+   *     See GrpcEntitySchema.proto;l=416
    * @return A list containing the indexedInScopes.
    */
   @java.lang.Override
@@ -1152,7 +1152,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-   *     See GrpcEntitySchema.proto;l=414
+   *     See GrpcEntitySchema.proto;l=416
    * @return The count of indexedInScopes.
    */
   @java.lang.Override
@@ -1174,7 +1174,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-   *     See GrpcEntitySchema.proto;l=414
+   *     See GrpcEntitySchema.proto;l=416
    * @param index The index of the element to return.
    * @return The indexedInScopes at the given index.
    */
@@ -1197,7 +1197,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-   *     See GrpcEntitySchema.proto;l=414
+   *     See GrpcEntitySchema.proto;l=416
    * @return A list containing the enum numeric values on the wire for indexedInScopes.
    */
   @java.lang.Override
@@ -1220,7 +1220,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-   *     See GrpcEntitySchema.proto;l=414
+   *     See GrpcEntitySchema.proto;l=416
    * @param index The index of the value to return.
    * @return The enum numeric value on the wire of indexedInScopes at the given index.
    */
@@ -4052,7 +4052,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>bool entityTypeRelatesToEntity = 6 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.entityTypeRelatesToEntity is deprecated.
-     *     See GrpcEntitySchema.proto;l=336
+     *     See GrpcEntitySchema.proto;l=338
      * @return The entityTypeRelatesToEntity.
      */
     @java.lang.Override
@@ -4067,7 +4067,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>bool entityTypeRelatesToEntity = 6 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.entityTypeRelatesToEntity is deprecated.
-     *     See GrpcEntitySchema.proto;l=336
+     *     See GrpcEntitySchema.proto;l=338
      * @param value The entityTypeRelatesToEntity to set.
      * @return This builder for chaining.
      */
@@ -4086,7 +4086,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>bool entityTypeRelatesToEntity = 6 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.entityTypeRelatesToEntity is deprecated.
-     *     See GrpcEntitySchema.proto;l=336
+     *     See GrpcEntitySchema.proto;l=338
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearEntityTypeRelatesToEntity() {
@@ -4271,7 +4271,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>bool groupTypeRelatesToEntity = 8 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.groupTypeRelatesToEntity is deprecated.
-     *     See GrpcEntitySchema.proto;l=342
+     *     See GrpcEntitySchema.proto;l=344
      * @return The groupTypeRelatesToEntity.
      */
     @java.lang.Override
@@ -4286,7 +4286,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>bool groupTypeRelatesToEntity = 8 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.groupTypeRelatesToEntity is deprecated.
-     *     See GrpcEntitySchema.proto;l=342
+     *     See GrpcEntitySchema.proto;l=344
      * @param value The groupTypeRelatesToEntity to set.
      * @return This builder for chaining.
      */
@@ -4305,7 +4305,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>bool groupTypeRelatesToEntity = 8 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.groupTypeRelatesToEntity is deprecated.
-     *     See GrpcEntitySchema.proto;l=342
+     *     See GrpcEntitySchema.proto;l=344
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearGroupTypeRelatesToEntity() {
@@ -4331,7 +4331,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>bool indexed = 9 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexed is deprecated.
-     *     See GrpcEntitySchema.proto;l=352
+     *     See GrpcEntitySchema.proto;l=354
      * @return The indexed.
      */
     @java.lang.Override
@@ -4353,7 +4353,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>bool indexed = 9 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexed is deprecated.
-     *     See GrpcEntitySchema.proto;l=352
+     *     See GrpcEntitySchema.proto;l=354
      * @param value The indexed to set.
      * @return This builder for chaining.
      */
@@ -4379,7 +4379,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>bool indexed = 9 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexed is deprecated.
-     *     See GrpcEntitySchema.proto;l=352
+     *     See GrpcEntitySchema.proto;l=354
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearIndexed() {
@@ -4405,7 +4405,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>bool faceted = 10 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.faceted is deprecated.
-     *     See GrpcEntitySchema.proto;l=362
+     *     See GrpcEntitySchema.proto;l=364
      * @return The faceted.
      */
     @java.lang.Override
@@ -4427,7 +4427,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>bool faceted = 10 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.faceted is deprecated.
-     *     See GrpcEntitySchema.proto;l=362
+     *     See GrpcEntitySchema.proto;l=364
      * @param value The faceted to set.
      * @return This builder for chaining.
      */
@@ -4453,7 +4453,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>bool faceted = 10 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.faceted is deprecated.
-     *     See GrpcEntitySchema.proto;l=362
+     *     See GrpcEntitySchema.proto;l=364
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearFaceted() {
@@ -6580,7 +6580,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-     *     See GrpcEntitySchema.proto;l=414
+     *     See GrpcEntitySchema.proto;l=416
      * @return A list containing the indexedInScopes.
      */
     @java.lang.Deprecated public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcEntityScope> getIndexedInScopesList() {
@@ -6602,7 +6602,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-     *     See GrpcEntitySchema.proto;l=414
+     *     See GrpcEntitySchema.proto;l=416
      * @return The count of indexedInScopes.
      */
     @java.lang.Deprecated public int getIndexedInScopesCount() {
@@ -6623,7 +6623,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-     *     See GrpcEntitySchema.proto;l=414
+     *     See GrpcEntitySchema.proto;l=416
      * @param index The index of the element to return.
      * @return The indexedInScopes at the given index.
      */
@@ -6645,7 +6645,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-     *     See GrpcEntitySchema.proto;l=414
+     *     See GrpcEntitySchema.proto;l=416
      * @param index The index to set the value at.
      * @param value The indexedInScopes to set.
      * @return This builder for chaining.
@@ -6675,7 +6675,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-     *     See GrpcEntitySchema.proto;l=414
+     *     See GrpcEntitySchema.proto;l=416
      * @param value The indexedInScopes to add.
      * @return This builder for chaining.
      */
@@ -6703,7 +6703,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-     *     See GrpcEntitySchema.proto;l=414
+     *     See GrpcEntitySchema.proto;l=416
      * @param values The indexedInScopes to add.
      * @return This builder for chaining.
      */
@@ -6731,7 +6731,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-     *     See GrpcEntitySchema.proto;l=414
+     *     See GrpcEntitySchema.proto;l=416
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearIndexedInScopes() {
@@ -6755,7 +6755,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-     *     See GrpcEntitySchema.proto;l=414
+     *     See GrpcEntitySchema.proto;l=416
      * @return A list containing the enum numeric values on the wire for indexedInScopes.
      */
     @java.lang.Deprecated public java.util.List<java.lang.Integer>
@@ -6777,7 +6777,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-     *     See GrpcEntitySchema.proto;l=414
+     *     See GrpcEntitySchema.proto;l=416
      * @param index The index of the value to return.
      * @return The enum numeric value on the wire of indexedInScopes at the given index.
      */
@@ -6799,7 +6799,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-     *     See GrpcEntitySchema.proto;l=414
+     *     See GrpcEntitySchema.proto;l=416
      * @param index The index to set the value at.
      * @param value The enum numeric value on the wire for indexedInScopes to set.
      * @return This builder for chaining.
@@ -6826,7 +6826,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-     *     See GrpcEntitySchema.proto;l=414
+     *     See GrpcEntitySchema.proto;l=416
      * @param value The enum numeric value on the wire for indexedInScopes to add.
      * @return This builder for chaining.
      */
@@ -6851,7 +6851,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-     *     See GrpcEntitySchema.proto;l=414
+     *     See GrpcEntitySchema.proto;l=416
      * @param values The enum numeric values on the wire for indexedInScopes to add.
      * @return This builder for chaining.
      */

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReferenceSchemaOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReferenceSchemaOrBuilder.java
@@ -176,7 +176,7 @@ public interface GrpcReferenceSchemaOrBuilder extends
    *
    * <code>bool entityTypeRelatesToEntity = 6 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.entityTypeRelatesToEntity is deprecated.
-   *     See GrpcEntitySchema.proto;l=336
+   *     See GrpcEntitySchema.proto;l=338
    * @return The entityTypeRelatesToEntity.
    */
   @java.lang.Deprecated boolean getEntityTypeRelatesToEntity();
@@ -219,7 +219,7 @@ public interface GrpcReferenceSchemaOrBuilder extends
    *
    * <code>bool groupTypeRelatesToEntity = 8 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.groupTypeRelatesToEntity is deprecated.
-   *     See GrpcEntitySchema.proto;l=342
+   *     See GrpcEntitySchema.proto;l=344
    * @return The groupTypeRelatesToEntity.
    */
   @java.lang.Deprecated boolean getGroupTypeRelatesToEntity();
@@ -239,7 +239,7 @@ public interface GrpcReferenceSchemaOrBuilder extends
    *
    * <code>bool indexed = 9 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexed is deprecated.
-   *     See GrpcEntitySchema.proto;l=352
+   *     See GrpcEntitySchema.proto;l=354
    * @return The indexed.
    */
   @java.lang.Deprecated boolean getIndexed();
@@ -259,7 +259,7 @@ public interface GrpcReferenceSchemaOrBuilder extends
    *
    * <code>bool faceted = 10 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.faceted is deprecated.
-   *     See GrpcEntitySchema.proto;l=362
+   *     See GrpcEntitySchema.proto;l=364
    * @return The faceted.
    */
   @java.lang.Deprecated boolean getFaceted();
@@ -731,7 +731,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-   *     See GrpcEntitySchema.proto;l=414
+   *     See GrpcEntitySchema.proto;l=416
    * @return A list containing the indexedInScopes.
    */
   @java.lang.Deprecated java.util.List<io.evitadb.externalApi.grpc.generated.GrpcEntityScope> getIndexedInScopesList();
@@ -750,7 +750,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-   *     See GrpcEntitySchema.proto;l=414
+   *     See GrpcEntitySchema.proto;l=416
    * @return The count of indexedInScopes.
    */
   @java.lang.Deprecated int getIndexedInScopesCount();
@@ -769,7 +769,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-   *     See GrpcEntitySchema.proto;l=414
+   *     See GrpcEntitySchema.proto;l=416
    * @param index The index of the element to return.
    * @return The indexedInScopes at the given index.
    */
@@ -789,7 +789,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-   *     See GrpcEntitySchema.proto;l=414
+   *     See GrpcEntitySchema.proto;l=416
    * @return A list containing the enum numeric values on the wire for indexedInScopes.
    */
   @java.lang.Deprecated java.util.List<java.lang.Integer>
@@ -809,7 +809,7 @@ io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema defaul
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 26 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema.indexedInScopes is deprecated.
-   *     See GrpcEntitySchema.proto;l=414
+   *     See GrpcEntitySchema.proto;l=416
    * @param index The index of the value to return.
    * @return The enum numeric value on the wire of indexedInScopes at the given index.
    */

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterChangeCatalogCaptureRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterChangeCatalogCaptureRequest.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to RegisterChangeCatalogCapture request.
+ * Request to open a live subscription (RegisterChangeCatalogCapture) that streams mutations as they
+ * commit, optionally preceded by a historical replay starting at `sinceVersion`/`sinceIndex`.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRegisterChangeCatalogCaptureRequest}
@@ -73,7 +74,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value sinceVersion_;
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+   * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+   * subscription is registered are delivered, with no historical replay.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -85,7 +88,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+   * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+   * subscription is registered are delivered, with no historical replay.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -97,7 +102,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+   * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+   * subscription is registered are delivered, with no historical replay.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -111,7 +118,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value sinceIndex_;
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+   * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+   * If unset, defaults to 0, i.e. starting from that version's transaction header.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -123,7 +132,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+   * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+   * If unset, defaults to 0, i.e. starting from that version's transaction header.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -135,7 +146,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+   * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+   * If unset, defaults to 0, i.e. starting from that version's transaction header.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -150,7 +163,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria> criteria_;
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -161,7 +175,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -173,7 +188,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -184,7 +200,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -195,7 +212,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -210,7 +228,8 @@ private static final long serialVersionUID = 0L;
   private int content_ = 0;
   /**
    * <pre>
-   * The scope of the returned data - either header of the mutation, or the whole mutation
+   * Whether delivered captures carry only mutation headers (`CHANGE_HEADER`, the default - proto3 zero
+   * value - when this field is left unset) or full mutation bodies (`CHANGE_BODY`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -221,7 +240,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The scope of the returned data - either header of the mutation, or the whole mutation
+   * Whether delivered captures carry only mutation headers (`CHANGE_HEADER`, the default - proto3 zero
+   * value - when this field is left unset) or full mutation bodies (`CHANGE_BODY`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -435,7 +455,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to RegisterChangeCatalogCapture request.
+   * Request to open a live subscription (RegisterChangeCatalogCapture) that streams mutations as they
+   * commit, optionally preceded by a historical replay starting at `sinceVersion`/`sinceIndex`.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRegisterChangeCatalogCaptureRequest}
@@ -721,7 +742,9 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> sinceVersionBuilder_;
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+     * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+     * subscription is registered are delivered, with no historical replay.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -732,7 +755,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+     * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+     * subscription is registered are delivered, with no historical replay.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -747,7 +772,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+     * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+     * subscription is registered are delivered, with no historical replay.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -767,7 +794,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+     * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+     * subscription is registered are delivered, with no historical replay.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -785,7 +814,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+     * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+     * subscription is registered are delivered, with no historical replay.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -810,7 +841,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+     * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+     * subscription is registered are delivered, with no historical replay.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -827,7 +860,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+     * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+     * subscription is registered are delivered, with no historical replay.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -839,7 +874,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+     * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+     * subscription is registered are delivered, with no historical replay.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -854,7 +891,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (catalog version)
+     * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+     * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+     * subscription is registered are delivered, with no historical replay.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -878,7 +917,9 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> sinceIndexBuilder_;
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+     * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+     * If unset, defaults to 0, i.e. starting from that version's transaction header.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -889,7 +930,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+     * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+     * If unset, defaults to 0, i.e. starting from that version's transaction header.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -904,7 +947,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+     * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+     * If unset, defaults to 0, i.e. starting from that version's transaction header.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -924,7 +969,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+     * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+     * If unset, defaults to 0, i.e. starting from that version's transaction header.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -942,7 +989,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+     * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+     * If unset, defaults to 0, i.e. starting from that version's transaction header.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -967,7 +1016,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+     * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+     * If unset, defaults to 0, i.e. starting from that version's transaction header.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -984,7 +1035,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+     * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+     * If unset, defaults to 0, i.e. starting from that version's transaction header.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -996,7 +1049,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+     * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+     * If unset, defaults to 0, i.e. starting from that version's transaction header.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -1011,7 +1066,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within catalog version)
+     * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+     * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+     * If unset, defaults to 0, i.e. starting from that version's transaction header.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -1044,7 +1101,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1058,7 +1116,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1072,7 +1131,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1086,7 +1146,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1107,7 +1168,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1125,7 +1187,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1145,7 +1208,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1166,7 +1230,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1184,7 +1249,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1202,7 +1268,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1221,7 +1288,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1238,7 +1306,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1255,7 +1324,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1266,7 +1336,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1280,7 +1351,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1295,7 +1367,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1306,7 +1379,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1318,7 +1392,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The criteria of the capture, allows to define constraints on the returned mutations
+     * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+     * applies no criteria-based filtering.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -1345,7 +1420,8 @@ private static final long serialVersionUID = 0L;
     private int content_ = 0;
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether delivered captures carry only mutation headers (`CHANGE_HEADER`, the default - proto3 zero
+     * value - when this field is left unset) or full mutation bodies (`CHANGE_BODY`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -1356,7 +1432,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether delivered captures carry only mutation headers (`CHANGE_HEADER`, the default - proto3 zero
+     * value - when this field is left unset) or full mutation bodies (`CHANGE_BODY`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -1371,7 +1448,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether delivered captures carry only mutation headers (`CHANGE_HEADER`, the default - proto3 zero
+     * value - when this field is left unset) or full mutation bodies (`CHANGE_BODY`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -1384,7 +1462,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether delivered captures carry only mutation headers (`CHANGE_HEADER`, the default - proto3 zero
+     * value - when this field is left unset) or full mutation bodies (`CHANGE_BODY`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -1402,7 +1481,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The scope of the returned data - either header of the mutation, or the whole mutation
+     * Whether delivered captures carry only mutation headers (`CHANGE_HEADER`, the default - proto3 zero
+     * value - when this field is left unset) or full mutation bodies (`CHANGE_BODY`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterChangeCatalogCaptureRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterChangeCatalogCaptureRequestOrBuilder.java
@@ -33,7 +33,9 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
 
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+   * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+   * subscription is registered are delivered, with no historical replay.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -42,7 +44,9 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
   boolean hasSinceVersion();
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+   * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+   * subscription is registered are delivered, with no historical replay.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -51,7 +55,9 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
   com.google.protobuf.Int64Value getSinceVersion();
   /**
    * <pre>
-   * Starting point for the search (catalog version)
+   * Catalog version from which to start the historical replay portion of the subscription (inclusive).
+   * If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+   * subscription is registered are delivered, with no historical replay.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -60,7 +66,9 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
 
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+   * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+   * If unset, defaults to 0, i.e. starting from that version's transaction header.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -69,7 +77,9 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
   boolean hasSinceIndex();
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+   * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+   * If unset, defaults to 0, i.e. starting from that version's transaction header.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -78,7 +88,9 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
   com.google.protobuf.Int32Value getSinceIndex();
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within catalog version)
+   * Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+   * A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+   * If unset, defaults to 0, i.e. starting from that version's transaction header.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -87,7 +99,8 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
 
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -96,7 +109,8 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
       getCriteriaList();
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -104,7 +118,8 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria getCriteria(int index);
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -112,7 +127,8 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
   int getCriteriaCount();
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -121,7 +137,8 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
       getCriteriaOrBuilderList();
   /**
    * <pre>
-   * The criteria of the capture, allows to define constraints on the returned mutations
+   * Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+   * applies no criteria-based filtering.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureCriteria criteria = 3;</code>
@@ -131,7 +148,8 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
 
   /**
    * <pre>
-   * The scope of the returned data - either header of the mutation, or the whole mutation
+   * Whether delivered captures carry only mutation headers (`CHANGE_HEADER`, the default - proto3 zero
+   * value - when this field is left unset) or full mutation bodies (`CHANGE_BODY`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>
@@ -140,7 +158,8 @@ public interface GrpcRegisterChangeCatalogCaptureRequestOrBuilder extends
   int getContentValue();
   /**
    * <pre>
-   * The scope of the returned data - either header of the mutation, or the whole mutation
+   * Whether delivered captures carry only mutation headers (`CHANGE_HEADER`, the default - proto3 zero
+   * value - when this field is left unset) or full mutation bodies (`CHANGE_BODY`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCaptureContent content = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterChangeCatalogCaptureResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterChangeCatalogCaptureResponse.java
@@ -29,7 +29,10 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to RegisterChangeCatalogCapture request.
+ * One message of the RegisterChangeCatalogCapture stream. `responseType` selects which payload is
+ * meaningful: `ACKNOWLEDGEMENT` (subscription set up; `heartBeat` populated, `capture` is not),
+ * `CHANGE` (`capture` populated, `heartBeat` is not), or `HEARTBEAT` (`heartBeat` populated, `capture`
+ * is not) - the periodic keep-alive sent while no matching mutation has occurred.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRegisterChangeCatalogCaptureResponse}
@@ -72,7 +75,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcUuid uuid_;
   /**
    * <pre>
-   * Identification of the registered capture
+   * Identification of the registered subscription. Present on every message, not just the initial
+   * acknowledgement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -84,7 +88,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Identification of the registered capture
+   * Identification of the registered subscription. Present on every message, not just the initial
+   * acknowledgement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -96,7 +101,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Identification of the registered capture
+   * Identification of the registered subscription. Present on every message, not just the initial
+   * acknowledgement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -110,7 +116,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture_;
   /**
    * <pre>
-   * The list of mutations (CDC events) that match the criteria
+   * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+   * `CHANGE`; unset otherwise.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -122,7 +129,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of mutations (CDC events) that match the criteria
+   * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+   * `CHANGE`; unset otherwise.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -134,7 +142,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of mutations (CDC events) that match the criteria
+   * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+   * `CHANGE`; unset otherwise.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -148,8 +157,8 @@ private static final long serialVersionUID = 0L;
   private int responseType_ = 0;
   /**
    * <pre>
-   * The type of the response - when subscription is set-up, acknowledgement is sent
-   * Then with each capture event, the type is set to `change`
+   * Which payload field (`capture` or `heartBeat`) is populated on this message - see the message-level
+   * comment above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -160,8 +169,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The type of the response - when subscription is set-up, acknowledgement is sent
-   * Then with each capture event, the type is set to `change`
+   * Which payload field (`capture` or `heartBeat`) is populated on this message - see the message-level
+   * comment above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -176,7 +185,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat_;
   /**
    * <pre>
-   * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+   * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+   * `responseType` is `CHANGE`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -188,7 +198,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+   * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+   * `responseType` is `CHANGE`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -200,7 +211,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+   * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+   * `responseType` is `CHANGE`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -416,7 +428,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to RegisterChangeCatalogCapture request.
+   * One message of the RegisterChangeCatalogCapture stream. `responseType` selects which payload is
+   * meaningful: `ACKNOWLEDGEMENT` (subscription set up; `heartBeat` populated, `capture` is not),
+   * `CHANGE` (`capture` populated, `heartBeat` is not), or `HEARTBEAT` (`heartBeat` populated, `capture`
+   * is not) - the periodic keep-alive sent while no matching mutation has occurred.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRegisterChangeCatalogCaptureResponse}
@@ -664,7 +679,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcUuid, io.evitadb.externalApi.grpc.generated.GrpcUuid.Builder, io.evitadb.externalApi.grpc.generated.GrpcUuidOrBuilder> uuidBuilder_;
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Present on every message, not just the initial
+     * acknowledgement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -675,7 +691,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Present on every message, not just the initial
+     * acknowledgement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -690,7 +707,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Present on every message, not just the initial
+     * acknowledgement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -710,7 +728,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Present on every message, not just the initial
+     * acknowledgement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -728,7 +747,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Present on every message, not just the initial
+     * acknowledgement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -753,7 +773,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Present on every message, not just the initial
+     * acknowledgement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -770,7 +791,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Present on every message, not just the initial
+     * acknowledgement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -782,7 +804,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Present on every message, not just the initial
+     * acknowledgement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -797,7 +820,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Present on every message, not just the initial
+     * acknowledgement.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -821,7 +845,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture, io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture.Builder, io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCaptureOrBuilder> captureBuilder_;
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+     * `CHANGE`; unset otherwise.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -832,7 +857,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+     * `CHANGE`; unset otherwise.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -847,7 +873,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+     * `CHANGE`; unset otherwise.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -867,7 +894,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+     * `CHANGE`; unset otherwise.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -885,7 +913,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+     * `CHANGE`; unset otherwise.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -910,7 +939,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+     * `CHANGE`; unset otherwise.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -927,7 +957,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+     * `CHANGE`; unset otherwise.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -939,7 +970,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+     * `CHANGE`; unset otherwise.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -954,7 +986,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+     * `CHANGE`; unset otherwise.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -976,8 +1009,8 @@ private static final long serialVersionUID = 0L;
     private int responseType_ = 0;
     /**
      * <pre>
-     * The type of the response - when subscription is set-up, acknowledgement is sent
-     * Then with each capture event, the type is set to `change`
+     * Which payload field (`capture` or `heartBeat`) is populated on this message - see the message-level
+     * comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -988,8 +1021,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the response - when subscription is set-up, acknowledgement is sent
-     * Then with each capture event, the type is set to `change`
+     * Which payload field (`capture` or `heartBeat`) is populated on this message - see the message-level
+     * comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -1004,8 +1037,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the response - when subscription is set-up, acknowledgement is sent
-     * Then with each capture event, the type is set to `change`
+     * Which payload field (`capture` or `heartBeat`) is populated on this message - see the message-level
+     * comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -1018,8 +1051,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the response - when subscription is set-up, acknowledgement is sent
-     * Then with each capture event, the type is set to `change`
+     * Which payload field (`capture` or `heartBeat`) is populated on this message - see the message-level
+     * comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -1037,8 +1070,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the response - when subscription is set-up, acknowledgement is sent
-     * Then with each capture event, the type is set to `change`
+     * Which payload field (`capture` or `heartBeat`) is populated on this message - see the message-level
+     * comment above.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -1056,7 +1089,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcHeartBeat, io.evitadb.externalApi.grpc.generated.GrpcHeartBeat.Builder, io.evitadb.externalApi.grpc.generated.GrpcHeartBeatOrBuilder> heartBeatBuilder_;
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+     * `responseType` is `CHANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1067,7 +1101,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+     * `responseType` is `CHANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1082,7 +1117,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+     * `responseType` is `CHANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1102,7 +1138,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+     * `responseType` is `CHANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1120,7 +1157,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+     * `responseType` is `CHANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1145,7 +1183,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+     * `responseType` is `CHANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1162,7 +1201,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+     * `responseType` is `CHANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1174,7 +1214,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+     * `responseType` is `CHANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1189,7 +1230,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+     * `responseType` is `CHANGE`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterChangeCatalogCaptureResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterChangeCatalogCaptureResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcRegisterChangeCatalogCaptureResponseOrBuilder extends
 
   /**
    * <pre>
-   * Identification of the registered capture
+   * Identification of the registered subscription. Present on every message, not just the initial
+   * acknowledgement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcRegisterChangeCatalogCaptureResponseOrBuilder extends
   boolean hasUuid();
   /**
    * <pre>
-   * Identification of the registered capture
+   * Identification of the registered subscription. Present on every message, not just the initial
+   * acknowledgement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcRegisterChangeCatalogCaptureResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuid getUuid();
   /**
    * <pre>
-   * Identification of the registered capture
+   * Identification of the registered subscription. Present on every message, not just the initial
+   * acknowledgement.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -60,7 +63,8 @@ public interface GrpcRegisterChangeCatalogCaptureResponseOrBuilder extends
 
   /**
    * <pre>
-   * The list of mutations (CDC events) that match the criteria
+   * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+   * `CHANGE`; unset otherwise.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -69,7 +73,8 @@ public interface GrpcRegisterChangeCatalogCaptureResponseOrBuilder extends
   boolean hasCapture();
   /**
    * <pre>
-   * The list of mutations (CDC events) that match the criteria
+   * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+   * `CHANGE`; unset otherwise.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -78,7 +83,8 @@ public interface GrpcRegisterChangeCatalogCaptureResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture getCapture();
   /**
    * <pre>
-   * The list of mutations (CDC events) that match the criteria
+   * The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+   * `CHANGE`; unset otherwise.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeCatalogCapture capture = 2;</code>
@@ -87,8 +93,8 @@ public interface GrpcRegisterChangeCatalogCaptureResponseOrBuilder extends
 
   /**
    * <pre>
-   * The type of the response - when subscription is set-up, acknowledgement is sent
-   * Then with each capture event, the type is set to `change`
+   * Which payload field (`capture` or `heartBeat`) is populated on this message - see the message-level
+   * comment above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -97,8 +103,8 @@ public interface GrpcRegisterChangeCatalogCaptureResponseOrBuilder extends
   int getResponseTypeValue();
   /**
    * <pre>
-   * The type of the response - when subscription is set-up, acknowledgement is sent
-   * Then with each capture event, the type is set to `change`
+   * Which payload field (`capture` or `heartBeat`) is populated on this message - see the message-level
+   * comment above.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -108,7 +114,8 @@ public interface GrpcRegisterChangeCatalogCaptureResponseOrBuilder extends
 
   /**
    * <pre>
-   * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+   * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+   * `responseType` is `CHANGE`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -117,7 +124,8 @@ public interface GrpcRegisterChangeCatalogCaptureResponseOrBuilder extends
   boolean hasHeartBeat();
   /**
    * <pre>
-   * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+   * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+   * `responseType` is `CHANGE`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -126,7 +134,8 @@ public interface GrpcRegisterChangeCatalogCaptureResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcHeartBeat getHeartBeat();
   /**
    * <pre>
-   * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+   * Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+   * `responseType` is `CHANGE`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterSystemChangeCaptureRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterSystemChangeCaptureRequest.java
@@ -73,7 +73,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value sinceVersion_;
   /**
    * <pre>
-   * Starting point for the search (engine version)
+   * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+   * recent / greatest available engine version rather than replaying history from the beginning.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -85,7 +86,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (engine version)
+   * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+   * recent / greatest available engine version rather than replaying history from the beginning.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -97,7 +99,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (engine version)
+   * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+   * recent / greatest available engine version rather than replaying history from the beginning.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -111,7 +114,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value sinceIndex_;
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+   * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+   * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+   * `sinceVersion` rather than resuming mid-transaction.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -123,7 +128,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+   * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+   * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+   * `sinceVersion` rather than resuming mid-transaction.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -135,7 +142,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+   * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+   * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+   * `sinceVersion` rather than resuming mid-transaction.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -733,7 +742,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> sinceVersionBuilder_;
     /**
      * <pre>
-     * Starting point for the search (engine version)
+     * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+     * recent / greatest available engine version rather than replaying history from the beginning.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -744,7 +754,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (engine version)
+     * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+     * recent / greatest available engine version rather than replaying history from the beginning.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -759,7 +770,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (engine version)
+     * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+     * recent / greatest available engine version rather than replaying history from the beginning.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -779,7 +791,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (engine version)
+     * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+     * recent / greatest available engine version rather than replaying history from the beginning.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -797,7 +810,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (engine version)
+     * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+     * recent / greatest available engine version rather than replaying history from the beginning.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -822,7 +836,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (engine version)
+     * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+     * recent / greatest available engine version rather than replaying history from the beginning.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -839,7 +854,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (engine version)
+     * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+     * recent / greatest available engine version rather than replaying history from the beginning.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -851,7 +867,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (engine version)
+     * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+     * recent / greatest available engine version rather than replaying history from the beginning.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -866,7 +883,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (engine version)
+     * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+     * recent / greatest available engine version rather than replaying history from the beginning.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -890,7 +908,9 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> sinceIndexBuilder_;
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+     * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+     * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+     * `sinceVersion` rather than resuming mid-transaction.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -901,7 +921,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+     * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+     * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+     * `sinceVersion` rather than resuming mid-transaction.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -916,7 +938,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+     * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+     * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+     * `sinceVersion` rather than resuming mid-transaction.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -936,7 +960,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+     * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+     * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+     * `sinceVersion` rather than resuming mid-transaction.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -954,7 +980,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+     * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+     * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+     * `sinceVersion` rather than resuming mid-transaction.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -979,7 +1007,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+     * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+     * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+     * `sinceVersion` rather than resuming mid-transaction.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -996,7 +1026,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+     * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+     * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+     * `sinceVersion` rather than resuming mid-transaction.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -1008,7 +1040,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+     * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+     * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+     * `sinceVersion` rather than resuming mid-transaction.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -1023,7 +1057,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+     * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+     * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+     * `sinceVersion` rather than resuming mid-transaction.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterSystemChangeCaptureRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterSystemChangeCaptureRequestOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcRegisterSystemChangeCaptureRequestOrBuilder extends
 
   /**
    * <pre>
-   * Starting point for the search (engine version)
+   * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+   * recent / greatest available engine version rather than replaying history from the beginning.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcRegisterSystemChangeCaptureRequestOrBuilder extends
   boolean hasSinceVersion();
   /**
    * <pre>
-   * Starting point for the search (engine version)
+   * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+   * recent / greatest available engine version rather than replaying history from the beginning.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcRegisterSystemChangeCaptureRequestOrBuilder extends
   com.google.protobuf.Int64Value getSinceVersion();
   /**
    * <pre>
-   * Starting point for the search (engine version)
+   * Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+   * recent / greatest available engine version rather than replaying history from the beginning.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceVersion = 1;</code>
@@ -60,7 +63,9 @@ public interface GrpcRegisterSystemChangeCaptureRequestOrBuilder extends
 
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+   * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+   * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+   * `sinceVersion` rather than resuming mid-transaction.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -69,7 +74,9 @@ public interface GrpcRegisterSystemChangeCaptureRequestOrBuilder extends
   boolean hasSinceIndex();
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+   * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+   * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+   * `sinceVersion` rather than resuming mid-transaction.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>
@@ -78,7 +85,9 @@ public interface GrpcRegisterSystemChangeCaptureRequestOrBuilder extends
   com.google.protobuf.Int32Value getSinceIndex();
   /**
    * <pre>
-   * Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+   * Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+   * engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+   * `sinceVersion` rather than resuming mid-transaction.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceIndex = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterSystemChangeCaptureResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterSystemChangeCaptureResponse.java
@@ -72,7 +72,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcUuid uuid_;
   /**
    * <pre>
-   * Identification of the registered capture
+   * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+   * subscription id is available), unset on `CHANGE` responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -84,7 +85,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Identification of the registered capture
+   * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+   * subscription id is available), unset on `CHANGE` responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -96,7 +98,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Identification of the registered capture
+   * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+   * subscription id is available), unset on `CHANGE` responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -110,7 +113,9 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture_;
   /**
    * <pre>
-   * The list of mutations (CDC events) that match the criteria
+   * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+   * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+   * responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -122,7 +127,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of mutations (CDC events) that match the criteria
+   * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+   * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+   * responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -134,7 +141,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The list of mutations (CDC events) that match the criteria
+   * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+   * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+   * responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -148,8 +157,9 @@ private static final long serialVersionUID = 0L;
   private int responseType_ = 0;
   /**
    * <pre>
-   * The type of the response - when subscription is set-up, acknowledgement is sent
-   * Then with each capture event, the type is set to `change`
+   * The kind of this response: `ACKNOWLEDGEMENT` is sent exactly once, when the subscription is set up; `CHANGE`
+   * is sent for each matching capture event; `HEARTBEAT` is sent periodically as a keep-alive while no matching
+   * event has occurred.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -160,8 +170,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The type of the response - when subscription is set-up, acknowledgement is sent
-   * Then with each capture event, the type is set to `change`
+   * The kind of this response: `ACKNOWLEDGEMENT` is sent exactly once, when the subscription is set up; `CHANGE`
+   * is sent for each matching capture event; `HEARTBEAT` is sent periodically as a keep-alive while no matching
+   * event has occurred.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -176,7 +187,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat_;
   /**
    * <pre>
-   * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+   * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -188,7 +199,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+   * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -200,7 +211,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+   * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -664,7 +675,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcUuid, io.evitadb.externalApi.grpc.generated.GrpcUuid.Builder, io.evitadb.externalApi.grpc.generated.GrpcUuidOrBuilder> uuidBuilder_;
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+     * subscription id is available), unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -675,7 +687,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+     * subscription id is available), unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -690,7 +703,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+     * subscription id is available), unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -710,7 +724,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+     * subscription id is available), unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -728,7 +743,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+     * subscription id is available), unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -753,7 +769,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+     * subscription id is available), unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -770,7 +787,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+     * subscription id is available), unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -782,7 +800,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+     * subscription id is available), unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -797,7 +816,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the registered capture
+     * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+     * subscription id is available), unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -821,7 +841,9 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture, io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture.Builder, io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCaptureOrBuilder> captureBuilder_;
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+     * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+     * responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -832,7 +854,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+     * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+     * responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -847,7 +871,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+     * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+     * responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -867,7 +893,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+     * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+     * responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -885,7 +913,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+     * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+     * responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -910,7 +940,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+     * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+     * responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -927,7 +959,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+     * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+     * responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -939,7 +973,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+     * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+     * responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -954,7 +990,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The list of mutations (CDC events) that match the criteria
+     * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+     * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+     * responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -976,8 +1014,9 @@ private static final long serialVersionUID = 0L;
     private int responseType_ = 0;
     /**
      * <pre>
-     * The type of the response - when subscription is set-up, acknowledgement is sent
-     * Then with each capture event, the type is set to `change`
+     * The kind of this response: `ACKNOWLEDGEMENT` is sent exactly once, when the subscription is set up; `CHANGE`
+     * is sent for each matching capture event; `HEARTBEAT` is sent periodically as a keep-alive while no matching
+     * event has occurred.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -988,8 +1027,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the response - when subscription is set-up, acknowledgement is sent
-     * Then with each capture event, the type is set to `change`
+     * The kind of this response: `ACKNOWLEDGEMENT` is sent exactly once, when the subscription is set up; `CHANGE`
+     * is sent for each matching capture event; `HEARTBEAT` is sent periodically as a keep-alive while no matching
+     * event has occurred.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -1004,8 +1044,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the response - when subscription is set-up, acknowledgement is sent
-     * Then with each capture event, the type is set to `change`
+     * The kind of this response: `ACKNOWLEDGEMENT` is sent exactly once, when the subscription is set up; `CHANGE`
+     * is sent for each matching capture event; `HEARTBEAT` is sent periodically as a keep-alive while no matching
+     * event has occurred.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -1018,8 +1059,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the response - when subscription is set-up, acknowledgement is sent
-     * Then with each capture event, the type is set to `change`
+     * The kind of this response: `ACKNOWLEDGEMENT` is sent exactly once, when the subscription is set up; `CHANGE`
+     * is sent for each matching capture event; `HEARTBEAT` is sent periodically as a keep-alive while no matching
+     * event has occurred.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -1037,8 +1079,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The type of the response - when subscription is set-up, acknowledgement is sent
-     * Then with each capture event, the type is set to `change`
+     * The kind of this response: `ACKNOWLEDGEMENT` is sent exactly once, when the subscription is set up; `CHANGE`
+     * is sent for each matching capture event; `HEARTBEAT` is sent periodically as a keep-alive while no matching
+     * event has occurred.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -1056,7 +1099,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcHeartBeat, io.evitadb.externalApi.grpc.generated.GrpcHeartBeat.Builder, io.evitadb.externalApi.grpc.generated.GrpcHeartBeatOrBuilder> heartBeatBuilder_;
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1067,7 +1110,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1082,7 +1125,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1102,7 +1145,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1120,7 +1163,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1145,7 +1188,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1162,7 +1205,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1174,7 +1217,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -1189,7 +1232,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+     * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterSystemChangeCaptureResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRegisterSystemChangeCaptureResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcRegisterSystemChangeCaptureResponseOrBuilder extends
 
   /**
    * <pre>
-   * Identification of the registered capture
+   * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+   * subscription id is available), unset on `CHANGE` responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcRegisterSystemChangeCaptureResponseOrBuilder extends
   boolean hasUuid();
   /**
    * <pre>
-   * Identification of the registered capture
+   * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+   * subscription id is available), unset on `CHANGE` responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -51,7 +53,8 @@ public interface GrpcRegisterSystemChangeCaptureResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuid getUuid();
   /**
    * <pre>
-   * Identification of the registered capture
+   * Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+   * subscription id is available), unset on `CHANGE` responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid uuid = 1;</code>
@@ -60,7 +63,9 @@ public interface GrpcRegisterSystemChangeCaptureResponseOrBuilder extends
 
   /**
    * <pre>
-   * The list of mutations (CDC events) that match the criteria
+   * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+   * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+   * responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -69,7 +74,9 @@ public interface GrpcRegisterSystemChangeCaptureResponseOrBuilder extends
   boolean hasCapture();
   /**
    * <pre>
-   * The list of mutations (CDC events) that match the criteria
+   * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+   * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+   * responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -78,7 +85,9 @@ public interface GrpcRegisterSystemChangeCaptureResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture getCapture();
   /**
    * <pre>
-   * The list of mutations (CDC events) that match the criteria
+   * A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+   * one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+   * responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcChangeSystemCapture capture = 2;</code>
@@ -87,8 +96,9 @@ public interface GrpcRegisterSystemChangeCaptureResponseOrBuilder extends
 
   /**
    * <pre>
-   * The type of the response - when subscription is set-up, acknowledgement is sent
-   * Then with each capture event, the type is set to `change`
+   * The kind of this response: `ACKNOWLEDGEMENT` is sent exactly once, when the subscription is set up; `CHANGE`
+   * is sent for each matching capture event; `HEARTBEAT` is sent periodically as a keep-alive while no matching
+   * event has occurred.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -97,8 +107,9 @@ public interface GrpcRegisterSystemChangeCaptureResponseOrBuilder extends
   int getResponseTypeValue();
   /**
    * <pre>
-   * The type of the response - when subscription is set-up, acknowledgement is sent
-   * Then with each capture event, the type is set to `change`
+   * The kind of this response: `ACKNOWLEDGEMENT` is sent exactly once, when the subscription is set up; `CHANGE`
+   * is sent for each matching capture event; `HEARTBEAT` is sent periodically as a keep-alive while no matching
+   * event has occurred.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType responseType = 3;</code>
@@ -108,7 +119,7 @@ public interface GrpcRegisterSystemChangeCaptureResponseOrBuilder extends
 
   /**
    * <pre>
-   * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+   * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -117,7 +128,7 @@ public interface GrpcRegisterSystemChangeCaptureResponseOrBuilder extends
   boolean hasHeartBeat();
   /**
    * <pre>
-   * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+   * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>
@@ -126,7 +137,7 @@ public interface GrpcRegisterSystemChangeCaptureResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcHeartBeat getHeartBeat();
   /**
    * <pre>
-   * Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+   * Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcHeartBeat heartBeat = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRemovePriceMutation.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRemovePriceMutation.java
@@ -28,6 +28,10 @@
 package io.evitadb.externalApi.grpc.generated;
 
 /**
+ * <pre>
+ * This mutation allows to remove an existing `price` of the entity, identified by price ID, price list and currency.
+ * </pre>
+ *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRemovePriceMutation}
  */
 public final class GrpcRemovePriceMutation extends
@@ -363,6 +367,10 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
+   * <pre>
+   * This mutation allows to remove an existing `price` of the entity, identified by price ID, price list and currency.
+   * </pre>
+   *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRemovePriceMutation}
    */
   public static final class Builder extends

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReplaceCatalogRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReplaceCatalogRequest.java
@@ -73,7 +73,9 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object catalogNameToBeReplacedWith_ = "";
   /**
    * <pre>
-   * Name of the catalog that will become the successor of the original catalog (old name)
+   * Name of the source catalog whose content takes over. After a successful replace, this name no longer exists -
+   * the catalog is consumed and its content is now served under `catalogNameToBeReplaced`. If the operation fails,
+   * the state of this catalog is unknown and must be treated as damaged.
    * </pre>
    *
    * <code>string catalogNameToBeReplacedWith = 1;</code>
@@ -94,7 +96,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Name of the catalog that will become the successor of the original catalog (old name)
+   * Name of the source catalog whose content takes over. After a successful replace, this name no longer exists -
+   * the catalog is consumed and its content is now served under `catalogNameToBeReplaced`. If the operation fails,
+   * the state of this catalog is unknown and must be treated as damaged.
    * </pre>
    *
    * <code>string catalogNameToBeReplacedWith = 1;</code>
@@ -120,7 +124,9 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object catalogNameToBeReplaced_ = "";
   /**
    * <pre>
-   * Name of the catalog that will be replaced and dropped (new name)
+   * Name of the target catalog to replace. Its existing content is dropped and replaced by the content of
+   * `catalogNameToBeReplacedWith`, while the name itself is preserved and keeps serving requests under it. If the
+   * operation fails, this catalog is guaranteed to remain untouched.
    * </pre>
    *
    * <code>string catalogNameToBeReplaced = 2;</code>
@@ -141,7 +147,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Name of the catalog that will be replaced and dropped (new name)
+   * Name of the target catalog to replace. Its existing content is dropped and replaced by the content of
+   * `catalogNameToBeReplacedWith`, while the name itself is preserved and keeps serving requests under it. If the
+   * operation fails, this catalog is guaranteed to remain untouched.
    * </pre>
    *
    * <code>string catalogNameToBeReplaced = 2;</code>
@@ -519,7 +527,9 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object catalogNameToBeReplacedWith_ = "";
     /**
      * <pre>
-     * Name of the catalog that will become the successor of the original catalog (old name)
+     * Name of the source catalog whose content takes over. After a successful replace, this name no longer exists -
+     * the catalog is consumed and its content is now served under `catalogNameToBeReplaced`. If the operation fails,
+     * the state of this catalog is unknown and must be treated as damaged.
      * </pre>
      *
      * <code>string catalogNameToBeReplacedWith = 1;</code>
@@ -539,7 +549,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog that will become the successor of the original catalog (old name)
+     * Name of the source catalog whose content takes over. After a successful replace, this name no longer exists -
+     * the catalog is consumed and its content is now served under `catalogNameToBeReplaced`. If the operation fails,
+     * the state of this catalog is unknown and must be treated as damaged.
      * </pre>
      *
      * <code>string catalogNameToBeReplacedWith = 1;</code>
@@ -560,7 +572,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog that will become the successor of the original catalog (old name)
+     * Name of the source catalog whose content takes over. After a successful replace, this name no longer exists -
+     * the catalog is consumed and its content is now served under `catalogNameToBeReplaced`. If the operation fails,
+     * the state of this catalog is unknown and must be treated as damaged.
      * </pre>
      *
      * <code>string catalogNameToBeReplacedWith = 1;</code>
@@ -577,7 +591,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog that will become the successor of the original catalog (old name)
+     * Name of the source catalog whose content takes over. After a successful replace, this name no longer exists -
+     * the catalog is consumed and its content is now served under `catalogNameToBeReplaced`. If the operation fails,
+     * the state of this catalog is unknown and must be treated as damaged.
      * </pre>
      *
      * <code>string catalogNameToBeReplacedWith = 1;</code>
@@ -591,7 +607,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog that will become the successor of the original catalog (old name)
+     * Name of the source catalog whose content takes over. After a successful replace, this name no longer exists -
+     * the catalog is consumed and its content is now served under `catalogNameToBeReplaced`. If the operation fails,
+     * the state of this catalog is unknown and must be treated as damaged.
      * </pre>
      *
      * <code>string catalogNameToBeReplacedWith = 1;</code>
@@ -611,7 +629,9 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object catalogNameToBeReplaced_ = "";
     /**
      * <pre>
-     * Name of the catalog that will be replaced and dropped (new name)
+     * Name of the target catalog to replace. Its existing content is dropped and replaced by the content of
+     * `catalogNameToBeReplacedWith`, while the name itself is preserved and keeps serving requests under it. If the
+     * operation fails, this catalog is guaranteed to remain untouched.
      * </pre>
      *
      * <code>string catalogNameToBeReplaced = 2;</code>
@@ -631,7 +651,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog that will be replaced and dropped (new name)
+     * Name of the target catalog to replace. Its existing content is dropped and replaced by the content of
+     * `catalogNameToBeReplacedWith`, while the name itself is preserved and keeps serving requests under it. If the
+     * operation fails, this catalog is guaranteed to remain untouched.
      * </pre>
      *
      * <code>string catalogNameToBeReplaced = 2;</code>
@@ -652,7 +674,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog that will be replaced and dropped (new name)
+     * Name of the target catalog to replace. Its existing content is dropped and replaced by the content of
+     * `catalogNameToBeReplacedWith`, while the name itself is preserved and keeps serving requests under it. If the
+     * operation fails, this catalog is guaranteed to remain untouched.
      * </pre>
      *
      * <code>string catalogNameToBeReplaced = 2;</code>
@@ -669,7 +693,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog that will be replaced and dropped (new name)
+     * Name of the target catalog to replace. Its existing content is dropped and replaced by the content of
+     * `catalogNameToBeReplacedWith`, while the name itself is preserved and keeps serving requests under it. If the
+     * operation fails, this catalog is guaranteed to remain untouched.
      * </pre>
      *
      * <code>string catalogNameToBeReplaced = 2;</code>
@@ -683,7 +709,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog that will be replaced and dropped (new name)
+     * Name of the target catalog to replace. Its existing content is dropped and replaced by the content of
+     * `catalogNameToBeReplacedWith`, while the name itself is preserved and keeps serving requests under it. If the
+     * operation fails, this catalog is guaranteed to remain untouched.
      * </pre>
      *
      * <code>string catalogNameToBeReplaced = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReplaceCatalogRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReplaceCatalogRequestOrBuilder.java
@@ -33,7 +33,9 @@ public interface GrpcReplaceCatalogRequestOrBuilder extends
 
   /**
    * <pre>
-   * Name of the catalog that will become the successor of the original catalog (old name)
+   * Name of the source catalog whose content takes over. After a successful replace, this name no longer exists -
+   * the catalog is consumed and its content is now served under `catalogNameToBeReplaced`. If the operation fails,
+   * the state of this catalog is unknown and must be treated as damaged.
    * </pre>
    *
    * <code>string catalogNameToBeReplacedWith = 1;</code>
@@ -42,7 +44,9 @@ public interface GrpcReplaceCatalogRequestOrBuilder extends
   java.lang.String getCatalogNameToBeReplacedWith();
   /**
    * <pre>
-   * Name of the catalog that will become the successor of the original catalog (old name)
+   * Name of the source catalog whose content takes over. After a successful replace, this name no longer exists -
+   * the catalog is consumed and its content is now served under `catalogNameToBeReplaced`. If the operation fails,
+   * the state of this catalog is unknown and must be treated as damaged.
    * </pre>
    *
    * <code>string catalogNameToBeReplacedWith = 1;</code>
@@ -53,7 +57,9 @@ public interface GrpcReplaceCatalogRequestOrBuilder extends
 
   /**
    * <pre>
-   * Name of the catalog that will be replaced and dropped (new name)
+   * Name of the target catalog to replace. Its existing content is dropped and replaced by the content of
+   * `catalogNameToBeReplacedWith`, while the name itself is preserved and keeps serving requests under it. If the
+   * operation fails, this catalog is guaranteed to remain untouched.
    * </pre>
    *
    * <code>string catalogNameToBeReplaced = 2;</code>
@@ -62,7 +68,9 @@ public interface GrpcReplaceCatalogRequestOrBuilder extends
   java.lang.String getCatalogNameToBeReplaced();
   /**
    * <pre>
-   * Name of the catalog that will be replaced and dropped (new name)
+   * Name of the target catalog to replace. Its existing content is dropped and replaced by the content of
+   * `catalogNameToBeReplacedWith`, while the name itself is preserved and keeps serving requests under it. If the
+   * operation fails, this catalog is guaranteed to remain untouched.
    * </pre>
    *
    * <code>string catalogNameToBeReplaced = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReplaceCollectionRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReplaceCollectionRequest.java
@@ -28,6 +28,13 @@
 package io.evitadb.externalApi.grpc.generated;
 
 /**
+ * <pre>
+ * Request for replacing an entity collection's contents with those of another collection. On success,
+ * `entityTypeToBeReplaced` is purged and its name is taken over by the (dropped) `entityTypeToBeReplacedWith`
+ * collection. If an error occurs mid-operation, both collections are guaranteed to be left untouched under
+ * their original names.
+ * </pre>
+ *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcReplaceCollectionRequest}
  */
 public final class GrpcReplaceCollectionRequest extends
@@ -69,7 +76,8 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object entityTypeToBeReplaced_ = "";
   /**
    * <pre>
-   * Name of the entity collection that will be replaced and dropped (new name)
+   * Name of the collection that will be replaced: its current contents are dropped, and it will end up
+   * holding the contents of `entityTypeToBeReplacedWith` under this same name.
    * </pre>
    *
    * <code>string entityTypeToBeReplaced = 1;</code>
@@ -90,7 +98,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Name of the entity collection that will be replaced and dropped (new name)
+   * Name of the collection that will be replaced: its current contents are dropped, and it will end up
+   * holding the contents of `entityTypeToBeReplacedWith` under this same name.
    * </pre>
    *
    * <code>string entityTypeToBeReplaced = 1;</code>
@@ -116,7 +125,8 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object entityTypeToBeReplacedWith_ = "";
   /**
    * <pre>
-   * Name of the entity collection that will become the successor of the original collection (old name)
+   * Name of the collection whose contents become the new contents of `entityTypeToBeReplaced`. This
+   * collection itself no longer exists under its own name once the replacement completes.
    * </pre>
    *
    * <code>string entityTypeToBeReplacedWith = 2;</code>
@@ -137,7 +147,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Name of the entity collection that will become the successor of the original collection (old name)
+   * Name of the collection whose contents become the new contents of `entityTypeToBeReplaced`. This
+   * collection itself no longer exists under its own name once the replacement completes.
    * </pre>
    *
    * <code>string entityTypeToBeReplacedWith = 2;</code>
@@ -325,6 +336,13 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
+   * <pre>
+   * Request for replacing an entity collection's contents with those of another collection. On success,
+   * `entityTypeToBeReplaced` is purged and its name is taken over by the (dropped) `entityTypeToBeReplacedWith`
+   * collection. If an error occurs mid-operation, both collections are guaranteed to be left untouched under
+   * their original names.
+   * </pre>
+   *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcReplaceCollectionRequest}
    */
   public static final class Builder extends
@@ -511,7 +529,8 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object entityTypeToBeReplaced_ = "";
     /**
      * <pre>
-     * Name of the entity collection that will be replaced and dropped (new name)
+     * Name of the collection that will be replaced: its current contents are dropped, and it will end up
+     * holding the contents of `entityTypeToBeReplacedWith` under this same name.
      * </pre>
      *
      * <code>string entityTypeToBeReplaced = 1;</code>
@@ -531,7 +550,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the entity collection that will be replaced and dropped (new name)
+     * Name of the collection that will be replaced: its current contents are dropped, and it will end up
+     * holding the contents of `entityTypeToBeReplacedWith` under this same name.
      * </pre>
      *
      * <code>string entityTypeToBeReplaced = 1;</code>
@@ -552,7 +572,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the entity collection that will be replaced and dropped (new name)
+     * Name of the collection that will be replaced: its current contents are dropped, and it will end up
+     * holding the contents of `entityTypeToBeReplacedWith` under this same name.
      * </pre>
      *
      * <code>string entityTypeToBeReplaced = 1;</code>
@@ -569,7 +590,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the entity collection that will be replaced and dropped (new name)
+     * Name of the collection that will be replaced: its current contents are dropped, and it will end up
+     * holding the contents of `entityTypeToBeReplacedWith` under this same name.
      * </pre>
      *
      * <code>string entityTypeToBeReplaced = 1;</code>
@@ -583,7 +605,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the entity collection that will be replaced and dropped (new name)
+     * Name of the collection that will be replaced: its current contents are dropped, and it will end up
+     * holding the contents of `entityTypeToBeReplacedWith` under this same name.
      * </pre>
      *
      * <code>string entityTypeToBeReplaced = 1;</code>
@@ -603,7 +626,8 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object entityTypeToBeReplacedWith_ = "";
     /**
      * <pre>
-     * Name of the entity collection that will become the successor of the original collection (old name)
+     * Name of the collection whose contents become the new contents of `entityTypeToBeReplaced`. This
+     * collection itself no longer exists under its own name once the replacement completes.
      * </pre>
      *
      * <code>string entityTypeToBeReplacedWith = 2;</code>
@@ -623,7 +647,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the entity collection that will become the successor of the original collection (old name)
+     * Name of the collection whose contents become the new contents of `entityTypeToBeReplaced`. This
+     * collection itself no longer exists under its own name once the replacement completes.
      * </pre>
      *
      * <code>string entityTypeToBeReplacedWith = 2;</code>
@@ -644,7 +669,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the entity collection that will become the successor of the original collection (old name)
+     * Name of the collection whose contents become the new contents of `entityTypeToBeReplaced`. This
+     * collection itself no longer exists under its own name once the replacement completes.
      * </pre>
      *
      * <code>string entityTypeToBeReplacedWith = 2;</code>
@@ -661,7 +687,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the entity collection that will become the successor of the original collection (old name)
+     * Name of the collection whose contents become the new contents of `entityTypeToBeReplaced`. This
+     * collection itself no longer exists under its own name once the replacement completes.
      * </pre>
      *
      * <code>string entityTypeToBeReplacedWith = 2;</code>
@@ -675,7 +702,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the entity collection that will become the successor of the original collection (old name)
+     * Name of the collection whose contents become the new contents of `entityTypeToBeReplaced`. This
+     * collection itself no longer exists under its own name once the replacement completes.
      * </pre>
      *
      * <code>string entityTypeToBeReplacedWith = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReplaceCollectionRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReplaceCollectionRequestOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcReplaceCollectionRequestOrBuilder extends
 
   /**
    * <pre>
-   * Name of the entity collection that will be replaced and dropped (new name)
+   * Name of the collection that will be replaced: its current contents are dropped, and it will end up
+   * holding the contents of `entityTypeToBeReplacedWith` under this same name.
    * </pre>
    *
    * <code>string entityTypeToBeReplaced = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcReplaceCollectionRequestOrBuilder extends
   java.lang.String getEntityTypeToBeReplaced();
   /**
    * <pre>
-   * Name of the entity collection that will be replaced and dropped (new name)
+   * Name of the collection that will be replaced: its current contents are dropped, and it will end up
+   * holding the contents of `entityTypeToBeReplacedWith` under this same name.
    * </pre>
    *
    * <code>string entityTypeToBeReplaced = 1;</code>
@@ -53,7 +55,8 @@ public interface GrpcReplaceCollectionRequestOrBuilder extends
 
   /**
    * <pre>
-   * Name of the entity collection that will become the successor of the original collection (old name)
+   * Name of the collection whose contents become the new contents of `entityTypeToBeReplaced`. This
+   * collection itself no longer exists under its own name once the replacement completes.
    * </pre>
    *
    * <code>string entityTypeToBeReplacedWith = 2;</code>
@@ -62,7 +65,8 @@ public interface GrpcReplaceCollectionRequestOrBuilder extends
   java.lang.String getEntityTypeToBeReplacedWith();
   /**
    * <pre>
-   * Name of the entity collection that will become the successor of the original collection (old name)
+   * Name of the collection whose contents become the new contents of `entityTypeToBeReplaced`. This
+   * collection itself no longer exists under its own name once the replacement completes.
    * </pre>
    *
    * <code>string entityTypeToBeReplacedWith = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReservedKeyword.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReservedKeyword.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Single reserved keyword
+ * A single reserved keyword that cannot be used as a classifier of the given type (e.g. as an
+ * entity type, attribute name, or reference name) - client-side validation of user-supplied
+ * classifiers can use this list to reject collisions early, before the server does.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword}
@@ -74,7 +76,7 @@ private static final long serialVersionUID = 0L;
   private int classifierType_ = 0;
   /**
    * <pre>
-   * Type of the keyword
+   * The kind of classifier this keyword is reserved against (e.g. entity type, attribute name).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcClassifierType classifierType = 1;</code>
@@ -85,7 +87,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Type of the keyword
+   * The kind of classifier this keyword is reserved against (e.g. entity type, attribute name).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcClassifierType classifierType = 1;</code>
@@ -101,7 +103,9 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object classifier_ = "";
   /**
    * <pre>
-   * Reserved keyword
+   * The reserved keyword in its normalized (camelCase) form. A candidate classifier is considered
+   * colliding if it matches this value in any of evitaDB's supported naming conventions
+   * (camelCase, PascalCase, snake_case, UPPER_SNAKE_CASE, kebab-case), not just this exact form.
    * </pre>
    *
    * <code>string classifier = 2;</code>
@@ -122,7 +126,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Reserved keyword
+   * The reserved keyword in its normalized (camelCase) form. A candidate classifier is considered
+   * colliding if it matches this value in any of evitaDB's supported naming conventions
+   * (camelCase, PascalCase, snake_case, UPPER_SNAKE_CASE, kebab-case), not just this exact form.
    * </pre>
    *
    * <code>string classifier = 2;</code>
@@ -149,7 +155,8 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
-   * List of words that are part of the keyword
+   * The individual words `classifier` is composed of, used to detect a collision across the
+   * supported naming conventions regardless of separator or case.
    * </pre>
    *
    * <code>repeated string words = 3;</code>
@@ -161,7 +168,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * List of words that are part of the keyword
+   * The individual words `classifier` is composed of, used to detect a collision across the
+   * supported naming conventions regardless of separator or case.
    * </pre>
    *
    * <code>repeated string words = 3;</code>
@@ -172,7 +180,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * List of words that are part of the keyword
+   * The individual words `classifier` is composed of, used to detect a collision across the
+   * supported naming conventions regardless of separator or case.
    * </pre>
    *
    * <code>repeated string words = 3;</code>
@@ -184,7 +193,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * List of words that are part of the keyword
+   * The individual words `classifier` is composed of, used to detect a collision across the
+   * supported naming conventions regardless of separator or case.
    * </pre>
    *
    * <code>repeated string words = 3;</code>
@@ -381,7 +391,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Single reserved keyword
+   * A single reserved keyword that cannot be used as a classifier of the given type (e.g. as an
+   * entity type, attribute name, or reference name) - client-side validation of user-supplied
+   * classifiers can use this list to reject collisions early, before the server does.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword}
@@ -590,7 +602,7 @@ private static final long serialVersionUID = 0L;
     private int classifierType_ = 0;
     /**
      * <pre>
-     * Type of the keyword
+     * The kind of classifier this keyword is reserved against (e.g. entity type, attribute name).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcClassifierType classifierType = 1;</code>
@@ -601,7 +613,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Type of the keyword
+     * The kind of classifier this keyword is reserved against (e.g. entity type, attribute name).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcClassifierType classifierType = 1;</code>
@@ -616,7 +628,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Type of the keyword
+     * The kind of classifier this keyword is reserved against (e.g. entity type, attribute name).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcClassifierType classifierType = 1;</code>
@@ -629,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Type of the keyword
+     * The kind of classifier this keyword is reserved against (e.g. entity type, attribute name).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcClassifierType classifierType = 1;</code>
@@ -647,7 +659,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Type of the keyword
+     * The kind of classifier this keyword is reserved against (e.g. entity type, attribute name).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcClassifierType classifierType = 1;</code>
@@ -663,7 +675,9 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object classifier_ = "";
     /**
      * <pre>
-     * Reserved keyword
+     * The reserved keyword in its normalized (camelCase) form. A candidate classifier is considered
+     * colliding if it matches this value in any of evitaDB's supported naming conventions
+     * (camelCase, PascalCase, snake_case, UPPER_SNAKE_CASE, kebab-case), not just this exact form.
      * </pre>
      *
      * <code>string classifier = 2;</code>
@@ -683,7 +697,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Reserved keyword
+     * The reserved keyword in its normalized (camelCase) form. A candidate classifier is considered
+     * colliding if it matches this value in any of evitaDB's supported naming conventions
+     * (camelCase, PascalCase, snake_case, UPPER_SNAKE_CASE, kebab-case), not just this exact form.
      * </pre>
      *
      * <code>string classifier = 2;</code>
@@ -704,7 +720,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Reserved keyword
+     * The reserved keyword in its normalized (camelCase) form. A candidate classifier is considered
+     * colliding if it matches this value in any of evitaDB's supported naming conventions
+     * (camelCase, PascalCase, snake_case, UPPER_SNAKE_CASE, kebab-case), not just this exact form.
      * </pre>
      *
      * <code>string classifier = 2;</code>
@@ -721,7 +739,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Reserved keyword
+     * The reserved keyword in its normalized (camelCase) form. A candidate classifier is considered
+     * colliding if it matches this value in any of evitaDB's supported naming conventions
+     * (camelCase, PascalCase, snake_case, UPPER_SNAKE_CASE, kebab-case), not just this exact form.
      * </pre>
      *
      * <code>string classifier = 2;</code>
@@ -735,7 +755,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Reserved keyword
+     * The reserved keyword in its normalized (camelCase) form. A candidate classifier is considered
+     * colliding if it matches this value in any of evitaDB's supported naming conventions
+     * (camelCase, PascalCase, snake_case, UPPER_SNAKE_CASE, kebab-case), not just this exact form.
      * </pre>
      *
      * <code>string classifier = 2;</code>
@@ -762,7 +784,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of words that are part of the keyword
+     * The individual words `classifier` is composed of, used to detect a collision across the
+     * supported naming conventions regardless of separator or case.
      * </pre>
      *
      * <code>repeated string words = 3;</code>
@@ -775,7 +798,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of words that are part of the keyword
+     * The individual words `classifier` is composed of, used to detect a collision across the
+     * supported naming conventions regardless of separator or case.
      * </pre>
      *
      * <code>repeated string words = 3;</code>
@@ -786,7 +810,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of words that are part of the keyword
+     * The individual words `classifier` is composed of, used to detect a collision across the
+     * supported naming conventions regardless of separator or case.
      * </pre>
      *
      * <code>repeated string words = 3;</code>
@@ -798,7 +823,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of words that are part of the keyword
+     * The individual words `classifier` is composed of, used to detect a collision across the
+     * supported naming conventions regardless of separator or case.
      * </pre>
      *
      * <code>repeated string words = 3;</code>
@@ -811,7 +837,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of words that are part of the keyword
+     * The individual words `classifier` is composed of, used to detect a collision across the
+     * supported naming conventions regardless of separator or case.
      * </pre>
      *
      * <code>repeated string words = 3;</code>
@@ -830,7 +857,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of words that are part of the keyword
+     * The individual words `classifier` is composed of, used to detect a collision across the
+     * supported naming conventions regardless of separator or case.
      * </pre>
      *
      * <code>repeated string words = 3;</code>
@@ -848,7 +876,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of words that are part of the keyword
+     * The individual words `classifier` is composed of, used to detect a collision across the
+     * supported naming conventions regardless of separator or case.
      * </pre>
      *
      * <code>repeated string words = 3;</code>
@@ -866,7 +895,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of words that are part of the keyword
+     * The individual words `classifier` is composed of, used to detect a collision across the
+     * supported naming conventions regardless of separator or case.
      * </pre>
      *
      * <code>repeated string words = 3;</code>
@@ -881,7 +911,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of words that are part of the keyword
+     * The individual words `classifier` is composed of, used to detect a collision across the
+     * supported naming conventions regardless of separator or case.
      * </pre>
      *
      * <code>repeated string words = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReservedKeywordOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReservedKeywordOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcReservedKeywordOrBuilder extends
 
   /**
    * <pre>
-   * Type of the keyword
+   * The kind of classifier this keyword is reserved against (e.g. entity type, attribute name).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcClassifierType classifierType = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcReservedKeywordOrBuilder extends
   int getClassifierTypeValue();
   /**
    * <pre>
-   * Type of the keyword
+   * The kind of classifier this keyword is reserved against (e.g. entity type, attribute name).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcClassifierType classifierType = 1;</code>
@@ -52,7 +52,9 @@ public interface GrpcReservedKeywordOrBuilder extends
 
   /**
    * <pre>
-   * Reserved keyword
+   * The reserved keyword in its normalized (camelCase) form. A candidate classifier is considered
+   * colliding if it matches this value in any of evitaDB's supported naming conventions
+   * (camelCase, PascalCase, snake_case, UPPER_SNAKE_CASE, kebab-case), not just this exact form.
    * </pre>
    *
    * <code>string classifier = 2;</code>
@@ -61,7 +63,9 @@ public interface GrpcReservedKeywordOrBuilder extends
   java.lang.String getClassifier();
   /**
    * <pre>
-   * Reserved keyword
+   * The reserved keyword in its normalized (camelCase) form. A candidate classifier is considered
+   * colliding if it matches this value in any of evitaDB's supported naming conventions
+   * (camelCase, PascalCase, snake_case, UPPER_SNAKE_CASE, kebab-case), not just this exact form.
    * </pre>
    *
    * <code>string classifier = 2;</code>
@@ -72,7 +76,8 @@ public interface GrpcReservedKeywordOrBuilder extends
 
   /**
    * <pre>
-   * List of words that are part of the keyword
+   * The individual words `classifier` is composed of, used to detect a collision across the
+   * supported naming conventions regardless of separator or case.
    * </pre>
    *
    * <code>repeated string words = 3;</code>
@@ -82,7 +87,8 @@ public interface GrpcReservedKeywordOrBuilder extends
       getWordsList();
   /**
    * <pre>
-   * List of words that are part of the keyword
+   * The individual words `classifier` is composed of, used to detect a collision across the
+   * supported naming conventions regardless of separator or case.
    * </pre>
    *
    * <code>repeated string words = 3;</code>
@@ -91,7 +97,8 @@ public interface GrpcReservedKeywordOrBuilder extends
   int getWordsCount();
   /**
    * <pre>
-   * List of words that are part of the keyword
+   * The individual words `classifier` is composed of, used to detect a collision across the
+   * supported naming conventions regardless of separator or case.
    * </pre>
    *
    * <code>repeated string words = 3;</code>
@@ -101,7 +108,8 @@ public interface GrpcReservedKeywordOrBuilder extends
   java.lang.String getWords(int index);
   /**
    * <pre>
-   * List of words that are part of the keyword
+   * The individual words `classifier` is composed of, used to detect a collision across the
+   * supported naming conventions regardless of separator or case.
    * </pre>
    *
    * <code>repeated string words = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReservedKeywordsResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReservedKeywordsResponse.java
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword> keywords_;
   /**
    * <pre>
-   * List of reserved keywords
+   * All reserved keywords, across all classifier types.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -83,7 +83,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * List of reserved keywords
+   * All reserved keywords, across all classifier types.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -95,7 +95,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * List of reserved keywords
+   * All reserved keywords, across all classifier types.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * List of reserved keywords
+   * All reserved keywords, across all classifier types.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -117,7 +117,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * List of reserved keywords
+   * All reserved keywords, across all classifier types.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -534,7 +534,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -548,7 +548,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -583,7 +583,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -601,7 +601,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -621,7 +621,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -642,7 +642,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -660,7 +660,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -678,7 +678,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -697,7 +697,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -714,7 +714,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -731,7 +731,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -742,7 +742,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -756,7 +756,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -771,7 +771,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -782,7 +782,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -794,7 +794,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of reserved keywords
+     * All reserved keywords, across all classifier types.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReservedKeywordsResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcReservedKeywordsResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcReservedKeywordsResponseOrBuilder extends
 
   /**
    * <pre>
-   * List of reserved keywords
+   * All reserved keywords, across all classifier types.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcReservedKeywordsResponseOrBuilder extends
       getKeywordsList();
   /**
    * <pre>
-   * List of reserved keywords
+   * All reserved keywords, across all classifier types.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -50,7 +50,7 @@ public interface GrpcReservedKeywordsResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword getKeywords(int index);
   /**
    * <pre>
-   * List of reserved keywords
+   * All reserved keywords, across all classifier types.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -58,7 +58,7 @@ public interface GrpcReservedKeywordsResponseOrBuilder extends
   int getKeywordsCount();
   /**
    * <pre>
-   * List of reserved keywords
+   * All reserved keywords, across all classifier types.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>
@@ -67,7 +67,7 @@ public interface GrpcReservedKeywordsResponseOrBuilder extends
       getKeywordsOrBuilderList();
   /**
    * <pre>
-   * List of reserved keywords
+   * All reserved keywords, across all classifier types.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcReservedKeyword keywords = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogFromServerFileRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogFromServerFileRequest.java
@@ -29,7 +29,10 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to restore a catalog.
+ * Request to restore a catalog from a backup file that already exists on the server (e.g. produced
+ * by a prior backup task, or a previous restore upload) - in contrast to
+ * `GrpcRestoreCatalogRequest` and `GrpcRestoreCatalogUnaryRequest`, which upload a new backup file
+ * as part of the call.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogFromServerFileRequest}
@@ -73,8 +76,8 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object catalogName_ = "";
   /**
    * <pre>
-   * Name of the catalog where the backup will be restored
-   * The name must not clash with any of existing catalogs
+   * Name of the target catalog into which the backup will be restored.
+   * Must not clash with the name of any existing catalog.
    * </pre>
    *
    * <code>string catalogName = 1;</code>
@@ -95,8 +98,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Name of the catalog where the backup will be restored
-   * The name must not clash with any of existing catalogs
+   * Name of the target catalog into which the backup will be restored.
+   * Must not clash with the name of any existing catalog.
    * </pre>
    *
    * <code>string catalogName = 1;</code>
@@ -121,7 +124,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcUuid fileId_;
   /**
    * <pre>
-   * The identification of the file on the server that should be restored
+   * Identification of the backup file already stored on the server that should be restored.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -133,7 +136,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The identification of the file on the server that should be restored
+   * Identification of the backup file already stored on the server that should be restored.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -145,7 +148,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The identification of the file on the server that should be restored
+   * Identification of the backup file already stored on the server that should be restored.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -329,7 +332,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to restore a catalog.
+   * Request to restore a catalog from a backup file that already exists on the server (e.g. produced
+   * by a prior backup task, or a previous restore upload) - in contrast to
+   * `GrpcRestoreCatalogRequest` and `GrpcRestoreCatalogUnaryRequest`, which upload a new backup file
+   * as part of the call.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogFromServerFileRequest}
@@ -533,8 +539,8 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object catalogName_ = "";
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -554,8 +560,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -576,8 +582,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -594,8 +600,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -609,8 +615,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -632,7 +638,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcUuid, io.evitadb.externalApi.grpc.generated.GrpcUuid.Builder, io.evitadb.externalApi.grpc.generated.GrpcUuidOrBuilder> fileIdBuilder_;
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identification of the backup file already stored on the server that should be restored.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -643,7 +649,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identification of the backup file already stored on the server that should be restored.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -658,7 +664,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identification of the backup file already stored on the server that should be restored.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -678,7 +684,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identification of the backup file already stored on the server that should be restored.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -696,7 +702,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identification of the backup file already stored on the server that should be restored.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -721,7 +727,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identification of the backup file already stored on the server that should be restored.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -738,7 +744,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identification of the backup file already stored on the server that should be restored.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -750,7 +756,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identification of the backup file already stored on the server that should be restored.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -765,7 +771,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identification of the backup file already stored on the server that should be restored.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogFromServerFileRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogFromServerFileRequestOrBuilder.java
@@ -33,8 +33,8 @@ public interface GrpcRestoreCatalogFromServerFileRequestOrBuilder extends
 
   /**
    * <pre>
-   * Name of the catalog where the backup will be restored
-   * The name must not clash with any of existing catalogs
+   * Name of the target catalog into which the backup will be restored.
+   * Must not clash with the name of any existing catalog.
    * </pre>
    *
    * <code>string catalogName = 1;</code>
@@ -43,8 +43,8 @@ public interface GrpcRestoreCatalogFromServerFileRequestOrBuilder extends
   java.lang.String getCatalogName();
   /**
    * <pre>
-   * Name of the catalog where the backup will be restored
-   * The name must not clash with any of existing catalogs
+   * Name of the target catalog into which the backup will be restored.
+   * Must not clash with the name of any existing catalog.
    * </pre>
    *
    * <code>string catalogName = 1;</code>
@@ -55,7 +55,7 @@ public interface GrpcRestoreCatalogFromServerFileRequestOrBuilder extends
 
   /**
    * <pre>
-   * The identification of the file on the server that should be restored
+   * Identification of the backup file already stored on the server that should be restored.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -64,7 +64,7 @@ public interface GrpcRestoreCatalogFromServerFileRequestOrBuilder extends
   boolean hasFileId();
   /**
    * <pre>
-   * The identification of the file on the server that should be restored
+   * Identification of the backup file already stored on the server that should be restored.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -73,7 +73,7 @@ public interface GrpcRestoreCatalogFromServerFileRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuid getFileId();
   /**
    * <pre>
-   * The identification of the file on the server that should be restored
+   * Identification of the backup file already stored on the server that should be restored.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogRequest.java
@@ -29,7 +29,11 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to restore a catalog.
+ * One chunk of a streamed catalog restore. The client sends a sequence of these messages over the
+ * same gRPC client stream, each carrying one slice of the backup archive; the server concatenates
+ * `backupFile` across all messages, in arrival order, into a single ZIP file. `catalogName` is
+ * expected to be identical on every chunk - only the value from the last message in the stream is
+ * actually used to name the restored catalog.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogRequest}
@@ -73,8 +77,8 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object catalogName_ = "";
   /**
    * <pre>
-   * Name of the catalog where the backup will be restored
-   * The name must not clash with any of existing catalogs
+   * Name of the target catalog into which the backup will be restored.
+   * Must not clash with the name of any existing catalog.
    * </pre>
    *
    * <code>string catalogName = 1;</code>
@@ -95,8 +99,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Name of the catalog where the backup will be restored
-   * The name must not clash with any of existing catalogs
+   * Name of the target catalog into which the backup will be restored.
+   * Must not clash with the name of any existing catalog.
    * </pre>
    *
    * <code>string catalogName = 1;</code>
@@ -121,7 +125,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.ByteString backupFile_ = com.google.protobuf.ByteString.EMPTY;
   /**
    * <pre>
-   * Binary contents of the backup file.
+   * One chunk of the binary backup ZIP archive; concatenate `backupFile` from all messages in the
+   * stream, in order, to reconstruct the full archive.
    * </pre>
    *
    * <code>bytes backupFile = 2;</code>
@@ -301,7 +306,11 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to restore a catalog.
+   * One chunk of a streamed catalog restore. The client sends a sequence of these messages over the
+   * same gRPC client stream, each carrying one slice of the backup archive; the server concatenates
+   * `backupFile` across all messages, in arrival order, into a single ZIP file. `catalogName` is
+   * expected to be identical on every chunk - only the value from the last message in the stream is
+   * actually used to name the restored catalog.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogRequest}
@@ -488,8 +497,8 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object catalogName_ = "";
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -509,8 +518,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -531,8 +540,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -549,8 +558,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -564,8 +573,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -585,7 +594,8 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.ByteString backupFile_ = com.google.protobuf.ByteString.EMPTY;
     /**
      * <pre>
-     * Binary contents of the backup file.
+     * One chunk of the binary backup ZIP archive; concatenate `backupFile` from all messages in the
+     * stream, in order, to reconstruct the full archive.
      * </pre>
      *
      * <code>bytes backupFile = 2;</code>
@@ -597,7 +607,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Binary contents of the backup file.
+     * One chunk of the binary backup ZIP archive; concatenate `backupFile` from all messages in the
+     * stream, in order, to reconstruct the full archive.
      * </pre>
      *
      * <code>bytes backupFile = 2;</code>
@@ -613,7 +624,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Binary contents of the backup file.
+     * One chunk of the binary backup ZIP archive; concatenate `backupFile` from all messages in the
+     * stream, in order, to reconstruct the full archive.
      * </pre>
      *
      * <code>bytes backupFile = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogRequestOrBuilder.java
@@ -33,8 +33,8 @@ public interface GrpcRestoreCatalogRequestOrBuilder extends
 
   /**
    * <pre>
-   * Name of the catalog where the backup will be restored
-   * The name must not clash with any of existing catalogs
+   * Name of the target catalog into which the backup will be restored.
+   * Must not clash with the name of any existing catalog.
    * </pre>
    *
    * <code>string catalogName = 1;</code>
@@ -43,8 +43,8 @@ public interface GrpcRestoreCatalogRequestOrBuilder extends
   java.lang.String getCatalogName();
   /**
    * <pre>
-   * Name of the catalog where the backup will be restored
-   * The name must not clash with any of existing catalogs
+   * Name of the target catalog into which the backup will be restored.
+   * Must not clash with the name of any existing catalog.
    * </pre>
    *
    * <code>string catalogName = 1;</code>
@@ -55,7 +55,8 @@ public interface GrpcRestoreCatalogRequestOrBuilder extends
 
   /**
    * <pre>
-   * Binary contents of the backup file.
+   * One chunk of the binary backup ZIP archive; concatenate `backupFile` from all messages in the
+   * stream, in order, to reconstruct the full archive.
    * </pre>
    *
    * <code>bytes backupFile = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogResponse.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to a catalog restore request.
+ * Response to a catalog restore request. Returned by both `RestoreCatalog` and
+ * `RestoreCatalogFromServerFile`.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogResponse}
@@ -71,7 +72,9 @@ private static final long serialVersionUID = 0L;
   private long read_ = 0L;
   /**
    * <pre>
-   * returns the number of bytes read from the backup file
+   * Total number of bytes read from the backup file (bytes). Only meaningful for `RestoreCatalog`,
+   * where it reports the cumulative size of the uploaded stream; always 0 for
+   * `RestoreCatalogFromServerFile`, which does not populate this field.
    * </pre>
    *
    * <code>int64 read = 1;</code>
@@ -86,7 +89,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task_;
   /**
    * <pre>
-   * the task that is used to restore the catalog and getting its progress
+   * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+   * progress.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -98,7 +102,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the task that is used to restore the catalog and getting its progress
+   * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+   * progress.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -110,7 +115,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the task that is used to restore the catalog and getting its progress
+   * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+   * progress.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -296,7 +302,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to a catalog restore request.
+   * Response to a catalog restore request. Returned by both `RestoreCatalog` and
+   * `RestoreCatalogFromServerFile`.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogResponse}
@@ -498,7 +505,9 @@ private static final long serialVersionUID = 0L;
     private long read_ ;
     /**
      * <pre>
-     * returns the number of bytes read from the backup file
+     * Total number of bytes read from the backup file (bytes). Only meaningful for `RestoreCatalog`,
+     * where it reports the cumulative size of the uploaded stream; always 0 for
+     * `RestoreCatalogFromServerFile`, which does not populate this field.
      * </pre>
      *
      * <code>int64 read = 1;</code>
@@ -510,7 +519,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * returns the number of bytes read from the backup file
+     * Total number of bytes read from the backup file (bytes). Only meaningful for `RestoreCatalog`,
+     * where it reports the cumulative size of the uploaded stream; always 0 for
+     * `RestoreCatalogFromServerFile`, which does not populate this field.
      * </pre>
      *
      * <code>int64 read = 1;</code>
@@ -526,7 +537,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * returns the number of bytes read from the backup file
+     * Total number of bytes read from the backup file (bytes). Only meaningful for `RestoreCatalog`,
+     * where it reports the cumulative size of the uploaded stream; always 0 for
+     * `RestoreCatalogFromServerFile`, which does not populate this field.
      * </pre>
      *
      * <code>int64 read = 1;</code>
@@ -544,7 +557,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcTaskStatus, io.evitadb.externalApi.grpc.generated.GrpcTaskStatus.Builder, io.evitadb.externalApi.grpc.generated.GrpcTaskStatusOrBuilder> taskBuilder_;
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -555,7 +569,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -570,7 +585,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -590,7 +606,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -608,7 +625,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -633,7 +651,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -650,7 +669,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -662,7 +682,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -677,7 +698,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogResponseOrBuilder.java
@@ -33,7 +33,9 @@ public interface GrpcRestoreCatalogResponseOrBuilder extends
 
   /**
    * <pre>
-   * returns the number of bytes read from the backup file
+   * Total number of bytes read from the backup file (bytes). Only meaningful for `RestoreCatalog`,
+   * where it reports the cumulative size of the uploaded stream; always 0 for
+   * `RestoreCatalogFromServerFile`, which does not populate this field.
    * </pre>
    *
    * <code>int64 read = 1;</code>
@@ -43,7 +45,8 @@ public interface GrpcRestoreCatalogResponseOrBuilder extends
 
   /**
    * <pre>
-   * the task that is used to restore the catalog and getting its progress
+   * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+   * progress.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -52,7 +55,8 @@ public interface GrpcRestoreCatalogResponseOrBuilder extends
   boolean hasTask();
   /**
    * <pre>
-   * the task that is used to restore the catalog and getting its progress
+   * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+   * progress.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -61,7 +65,8 @@ public interface GrpcRestoreCatalogResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTaskStatus getTask();
   /**
    * <pre>
-   * the task that is used to restore the catalog and getting its progress
+   * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+   * progress.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogUnaryRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogUnaryRequest.java
@@ -29,7 +29,10 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to restore a catalog.
+ * One chunk of a catalog restore uploaded via repeated unary calls, used where true client-side
+ * streaming (as in `GrpcRestoreCatalogRequest`) is unavailable, e.g. gRPC-Web. The client calls
+ * `RestoreCatalogUnary` once per chunk, feeding back the `fileId` it received in the previous
+ * response so the server appends to the same upload; see `GrpcRestoreCatalogUnaryResponse`.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogUnaryRequest}
@@ -74,8 +77,8 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object catalogName_ = "";
   /**
    * <pre>
-   * Name of the catalog where the backup will be restored
-   * The name must not clash with any of existing catalogs
+   * Name of the target catalog into which the backup will be restored.
+   * Must not clash with the name of any existing catalog.
    * </pre>
    *
    * <code>string catalogName = 1;</code>
@@ -96,8 +99,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Name of the catalog where the backup will be restored
-   * The name must not clash with any of existing catalogs
+   * Name of the target catalog into which the backup will be restored.
+   * Must not clash with the name of any existing catalog.
    * </pre>
    *
    * <code>string catalogName = 1;</code>
@@ -122,7 +125,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.ByteString backupFile_ = com.google.protobuf.ByteString.EMPTY;
   /**
    * <pre>
-   * Binary contents of the backup file.
+   * One chunk of the binary backup ZIP archive; the server appends it to the chunks already
+   * received for this upload (identified by `fileId`).
    * </pre>
    *
    * <code>bytes backupFile = 2;</code>
@@ -137,7 +141,11 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcUuid fileId_;
   /**
    * <pre>
-   * Identification of the task (for continuation purpose)
+   * Identifies the upload this chunk continues.
+   *
+   * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+   * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+   * this same upload, and this chunk is appended to it.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -149,7 +157,11 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Identification of the task (for continuation purpose)
+   * Identifies the upload this chunk continues.
+   *
+   * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+   * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+   * this same upload, and this chunk is appended to it.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -161,7 +173,11 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Identification of the task (for continuation purpose)
+   * Identifies the upload this chunk continues.
+   *
+   * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+   * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+   * this same upload, and this chunk is appended to it.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -175,7 +191,11 @@ private static final long serialVersionUID = 0L;
   private long totalSizeInBytes_ = 0L;
   /**
    * <pre>
-   * Total size of uploaded file in Bytes, when the size is reached, restore automatically starts
+   * Total size of the complete backup file (bytes), as expected once all chunks have been
+   * received; sent with every chunk. Once the bytes received so far reach exactly this size, the
+   * restore starts automatically. If more bytes are received than this, the server still returns
+   * a normal response for that (final) chunk and only afterwards discards the partial upload - an
+   * overshoot is not guaranteed to surface to the client as an error, so do not exceed it.
    * </pre>
    *
    * <code>int64 totalSizeInBytes = 4;</code>
@@ -383,7 +403,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to restore a catalog.
+   * One chunk of a catalog restore uploaded via repeated unary calls, used where true client-side
+   * streaming (as in `GrpcRestoreCatalogRequest`) is unavailable, e.g. gRPC-Web. The client calls
+   * `RestoreCatalogUnary` once per chunk, feeding back the `fileId` it received in the previous
+   * response so the server appends to the same upload; see `GrpcRestoreCatalogUnaryResponse`.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogUnaryRequest}
@@ -611,8 +634,8 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object catalogName_ = "";
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -632,8 +655,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -654,8 +677,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -672,8 +695,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -687,8 +710,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog where the backup will be restored
-     * The name must not clash with any of existing catalogs
+     * Name of the target catalog into which the backup will be restored.
+     * Must not clash with the name of any existing catalog.
      * </pre>
      *
      * <code>string catalogName = 1;</code>
@@ -708,7 +731,8 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.ByteString backupFile_ = com.google.protobuf.ByteString.EMPTY;
     /**
      * <pre>
-     * Binary contents of the backup file.
+     * One chunk of the binary backup ZIP archive; the server appends it to the chunks already
+     * received for this upload (identified by `fileId`).
      * </pre>
      *
      * <code>bytes backupFile = 2;</code>
@@ -720,7 +744,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Binary contents of the backup file.
+     * One chunk of the binary backup ZIP archive; the server appends it to the chunks already
+     * received for this upload (identified by `fileId`).
      * </pre>
      *
      * <code>bytes backupFile = 2;</code>
@@ -736,7 +761,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Binary contents of the backup file.
+     * One chunk of the binary backup ZIP archive; the server appends it to the chunks already
+     * received for this upload (identified by `fileId`).
      * </pre>
      *
      * <code>bytes backupFile = 2;</code>
@@ -754,7 +780,11 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcUuid, io.evitadb.externalApi.grpc.generated.GrpcUuid.Builder, io.evitadb.externalApi.grpc.generated.GrpcUuidOrBuilder> fileIdBuilder_;
     /**
      * <pre>
-     * Identification of the task (for continuation purpose)
+     * Identifies the upload this chunk continues.
+     *
+     * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+     * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+     * this same upload, and this chunk is appended to it.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -765,7 +795,11 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task (for continuation purpose)
+     * Identifies the upload this chunk continues.
+     *
+     * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+     * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+     * this same upload, and this chunk is appended to it.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -780,7 +814,11 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task (for continuation purpose)
+     * Identifies the upload this chunk continues.
+     *
+     * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+     * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+     * this same upload, and this chunk is appended to it.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -800,7 +838,11 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task (for continuation purpose)
+     * Identifies the upload this chunk continues.
+     *
+     * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+     * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+     * this same upload, and this chunk is appended to it.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -818,7 +860,11 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task (for continuation purpose)
+     * Identifies the upload this chunk continues.
+     *
+     * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+     * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+     * this same upload, and this chunk is appended to it.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -843,7 +889,11 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task (for continuation purpose)
+     * Identifies the upload this chunk continues.
+     *
+     * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+     * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+     * this same upload, and this chunk is appended to it.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -860,7 +910,11 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task (for continuation purpose)
+     * Identifies the upload this chunk continues.
+     *
+     * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+     * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+     * this same upload, and this chunk is appended to it.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -872,7 +926,11 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task (for continuation purpose)
+     * Identifies the upload this chunk continues.
+     *
+     * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+     * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+     * this same upload, and this chunk is appended to it.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -887,7 +945,11 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task (for continuation purpose)
+     * Identifies the upload this chunk continues.
+     *
+     * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+     * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+     * this same upload, and this chunk is appended to it.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -909,7 +971,11 @@ private static final long serialVersionUID = 0L;
     private long totalSizeInBytes_ ;
     /**
      * <pre>
-     * Total size of uploaded file in Bytes, when the size is reached, restore automatically starts
+     * Total size of the complete backup file (bytes), as expected once all chunks have been
+     * received; sent with every chunk. Once the bytes received so far reach exactly this size, the
+     * restore starts automatically. If more bytes are received than this, the server still returns
+     * a normal response for that (final) chunk and only afterwards discards the partial upload - an
+     * overshoot is not guaranteed to surface to the client as an error, so do not exceed it.
      * </pre>
      *
      * <code>int64 totalSizeInBytes = 4;</code>
@@ -921,7 +987,11 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Total size of uploaded file in Bytes, when the size is reached, restore automatically starts
+     * Total size of the complete backup file (bytes), as expected once all chunks have been
+     * received; sent with every chunk. Once the bytes received so far reach exactly this size, the
+     * restore starts automatically. If more bytes are received than this, the server still returns
+     * a normal response for that (final) chunk and only afterwards discards the partial upload - an
+     * overshoot is not guaranteed to surface to the client as an error, so do not exceed it.
      * </pre>
      *
      * <code>int64 totalSizeInBytes = 4;</code>
@@ -937,7 +1007,11 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Total size of uploaded file in Bytes, when the size is reached, restore automatically starts
+     * Total size of the complete backup file (bytes), as expected once all chunks have been
+     * received; sent with every chunk. Once the bytes received so far reach exactly this size, the
+     * restore starts automatically. If more bytes are received than this, the server still returns
+     * a normal response for that (final) chunk and only afterwards discards the partial upload - an
+     * overshoot is not guaranteed to surface to the client as an error, so do not exceed it.
      * </pre>
      *
      * <code>int64 totalSizeInBytes = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogUnaryRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogUnaryRequestOrBuilder.java
@@ -33,8 +33,8 @@ public interface GrpcRestoreCatalogUnaryRequestOrBuilder extends
 
   /**
    * <pre>
-   * Name of the catalog where the backup will be restored
-   * The name must not clash with any of existing catalogs
+   * Name of the target catalog into which the backup will be restored.
+   * Must not clash with the name of any existing catalog.
    * </pre>
    *
    * <code>string catalogName = 1;</code>
@@ -43,8 +43,8 @@ public interface GrpcRestoreCatalogUnaryRequestOrBuilder extends
   java.lang.String getCatalogName();
   /**
    * <pre>
-   * Name of the catalog where the backup will be restored
-   * The name must not clash with any of existing catalogs
+   * Name of the target catalog into which the backup will be restored.
+   * Must not clash with the name of any existing catalog.
    * </pre>
    *
    * <code>string catalogName = 1;</code>
@@ -55,7 +55,8 @@ public interface GrpcRestoreCatalogUnaryRequestOrBuilder extends
 
   /**
    * <pre>
-   * Binary contents of the backup file.
+   * One chunk of the binary backup ZIP archive; the server appends it to the chunks already
+   * received for this upload (identified by `fileId`).
    * </pre>
    *
    * <code>bytes backupFile = 2;</code>
@@ -65,7 +66,11 @@ public interface GrpcRestoreCatalogUnaryRequestOrBuilder extends
 
   /**
    * <pre>
-   * Identification of the task (for continuation purpose)
+   * Identifies the upload this chunk continues.
+   *
+   * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+   * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+   * this same upload, and this chunk is appended to it.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -74,7 +79,11 @@ public interface GrpcRestoreCatalogUnaryRequestOrBuilder extends
   boolean hasFileId();
   /**
    * <pre>
-   * Identification of the task (for continuation purpose)
+   * Identifies the upload this chunk continues.
+   *
+   * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+   * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+   * this same upload, and this chunk is appended to it.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -83,7 +92,11 @@ public interface GrpcRestoreCatalogUnaryRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuid getFileId();
   /**
    * <pre>
-   * Identification of the task (for continuation purpose)
+   * Identifies the upload this chunk continues.
+   *
+   * If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+   * returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+   * this same upload, and this chunk is appended to it.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 3;</code>
@@ -92,7 +105,11 @@ public interface GrpcRestoreCatalogUnaryRequestOrBuilder extends
 
   /**
    * <pre>
-   * Total size of uploaded file in Bytes, when the size is reached, restore automatically starts
+   * Total size of the complete backup file (bytes), as expected once all chunks have been
+   * received; sent with every chunk. Once the bytes received so far reach exactly this size, the
+   * restore starts automatically. If more bytes are received than this, the server still returns
+   * a normal response for that (final) chunk and only afterwards discards the partial upload - an
+   * overshoot is not guaranteed to surface to the client as an error, so do not exceed it.
    * </pre>
    *
    * <code>int64 totalSizeInBytes = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogUnaryResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogUnaryResponse.java
@@ -72,7 +72,8 @@ private static final long serialVersionUID = 0L;
   private long read_ = 0L;
   /**
    * <pre>
-   * returns the number of bytes read from the backup file
+   * Cumulative number of bytes received for this upload so far, across this and all preceding
+   * chunks (bytes).
    * </pre>
    *
    * <code>int64 read = 1;</code>
@@ -87,7 +88,9 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcUuid fileId_;
   /**
    * <pre>
-   * The identification of the file on the server that should be restored
+   * Identifies this upload. Echo this value back as `fileId` in the next
+   * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+   * chunk of an upload the server allocates this id and returns it here for the first time.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -99,7 +102,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The identification of the file on the server that should be restored
+   * Identifies this upload. Echo this value back as `fileId` in the next
+   * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+   * chunk of an upload the server allocates this id and returns it here for the first time.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -111,7 +116,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The identification of the file on the server that should be restored
+   * Identifies this upload. Echo this value back as `fileId` in the next
+   * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+   * chunk of an upload the server allocates this id and returns it here for the first time.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -125,7 +132,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task_;
   /**
    * <pre>
-   * the task that is used to restore the catalog and getting its progress
+   * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+   * progress.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -137,7 +145,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the task that is used to restore the catalog and getting its progress
+   * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+   * progress.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -149,7 +158,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * the task that is used to restore the catalog and getting its progress
+   * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+   * progress.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -576,7 +586,8 @@ private static final long serialVersionUID = 0L;
     private long read_ ;
     /**
      * <pre>
-     * returns the number of bytes read from the backup file
+     * Cumulative number of bytes received for this upload so far, across this and all preceding
+     * chunks (bytes).
      * </pre>
      *
      * <code>int64 read = 1;</code>
@@ -588,7 +599,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * returns the number of bytes read from the backup file
+     * Cumulative number of bytes received for this upload so far, across this and all preceding
+     * chunks (bytes).
      * </pre>
      *
      * <code>int64 read = 1;</code>
@@ -604,7 +616,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * returns the number of bytes read from the backup file
+     * Cumulative number of bytes received for this upload so far, across this and all preceding
+     * chunks (bytes).
      * </pre>
      *
      * <code>int64 read = 1;</code>
@@ -622,7 +635,9 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcUuid, io.evitadb.externalApi.grpc.generated.GrpcUuid.Builder, io.evitadb.externalApi.grpc.generated.GrpcUuidOrBuilder> fileIdBuilder_;
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identifies this upload. Echo this value back as `fileId` in the next
+     * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+     * chunk of an upload the server allocates this id and returns it here for the first time.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -633,7 +648,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identifies this upload. Echo this value back as `fileId` in the next
+     * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+     * chunk of an upload the server allocates this id and returns it here for the first time.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -648,7 +665,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identifies this upload. Echo this value back as `fileId` in the next
+     * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+     * chunk of an upload the server allocates this id and returns it here for the first time.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -668,7 +687,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identifies this upload. Echo this value back as `fileId` in the next
+     * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+     * chunk of an upload the server allocates this id and returns it here for the first time.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -686,7 +707,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identifies this upload. Echo this value back as `fileId` in the next
+     * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+     * chunk of an upload the server allocates this id and returns it here for the first time.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -711,7 +734,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identifies this upload. Echo this value back as `fileId` in the next
+     * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+     * chunk of an upload the server allocates this id and returns it here for the first time.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -728,7 +753,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identifies this upload. Echo this value back as `fileId` in the next
+     * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+     * chunk of an upload the server allocates this id and returns it here for the first time.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -740,7 +767,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identifies this upload. Echo this value back as `fileId` in the next
+     * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+     * chunk of an upload the server allocates this id and returns it here for the first time.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -755,7 +784,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The identification of the file on the server that should be restored
+     * Identifies this upload. Echo this value back as `fileId` in the next
+     * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+     * chunk of an upload the server allocates this id and returns it here for the first time.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -779,7 +810,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcTaskStatus, io.evitadb.externalApi.grpc.generated.GrpcTaskStatus.Builder, io.evitadb.externalApi.grpc.generated.GrpcTaskStatusOrBuilder> taskBuilder_;
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -790,7 +822,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -805,7 +838,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -825,7 +859,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -843,7 +878,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -868,7 +904,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -885,7 +922,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -897,7 +935,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -912,7 +951,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * the task that is used to restore the catalog and getting its progress
+     * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+     * progress.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogUnaryResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreCatalogUnaryResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcRestoreCatalogUnaryResponseOrBuilder extends
 
   /**
    * <pre>
-   * returns the number of bytes read from the backup file
+   * Cumulative number of bytes received for this upload so far, across this and all preceding
+   * chunks (bytes).
    * </pre>
    *
    * <code>int64 read = 1;</code>
@@ -43,7 +44,9 @@ public interface GrpcRestoreCatalogUnaryResponseOrBuilder extends
 
   /**
    * <pre>
-   * The identification of the file on the server that should be restored
+   * Identifies this upload. Echo this value back as `fileId` in the next
+   * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+   * chunk of an upload the server allocates this id and returns it here for the first time.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -52,7 +55,9 @@ public interface GrpcRestoreCatalogUnaryResponseOrBuilder extends
   boolean hasFileId();
   /**
    * <pre>
-   * The identification of the file on the server that should be restored
+   * Identifies this upload. Echo this value back as `fileId` in the next
+   * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+   * chunk of an upload the server allocates this id and returns it here for the first time.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -61,7 +66,9 @@ public interface GrpcRestoreCatalogUnaryResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuid getFileId();
   /**
    * <pre>
-   * The identification of the file on the server that should be restored
+   * Identifies this upload. Echo this value back as `fileId` in the next
+   * `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+   * chunk of an upload the server allocates this id and returns it here for the first time.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid fileId = 2;</code>
@@ -70,7 +77,8 @@ public interface GrpcRestoreCatalogUnaryResponseOrBuilder extends
 
   /**
    * <pre>
-   * the task that is used to restore the catalog and getting its progress
+   * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+   * progress.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -79,7 +87,8 @@ public interface GrpcRestoreCatalogUnaryResponseOrBuilder extends
   boolean hasTask();
   /**
    * <pre>
-   * the task that is used to restore the catalog and getting its progress
+   * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+   * progress.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>
@@ -88,7 +97,8 @@ public interface GrpcRestoreCatalogUnaryResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTaskStatus getTask();
   /**
    * <pre>
-   * the task that is used to restore the catalog and getting its progress
+   * The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+   * progress.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus task = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreEntityRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreEntityRequest.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request for deleting an entity that should return the restored entity with required richness.
+ * Request for restoring a single previously archived entity by primary key and returning it fetched in
+ * the richness described by `require`.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRestoreEntityRequest}
@@ -87,7 +88,7 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object entityType_ = "";
   /**
    * <pre>
-   * Entity type of the entity to be restored.
+   * Entity type (collection name) the entity to restore belongs to.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -108,7 +109,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Entity type of the entity to be restored.
+   * Entity type (collection name) the entity to restore belongs to.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -133,7 +134,9 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value primaryKey_;
   /**
    * <pre>
-   * Primary key of the entity to be restored.
+   * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -145,7 +148,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Primary key of the entity to be restored.
+   * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -157,7 +162,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Primary key of the entity to be restored.
+   * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -172,7 +179,10 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object require_ = "";
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+   * back after it is restored. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -193,7 +203,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+   * back after it is restored. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -219,7 +232,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcQueryParam> positionalQueryParams_;
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -230,7 +244,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -242,7 +257,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -253,7 +269,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -264,7 +281,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -303,7 +321,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -324,7 +343,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -335,7 +355,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -353,7 +374,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -589,7 +611,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * Request for deleting an entity that should return the restored entity with required richness.
+   * Request for restoring a single previously archived entity by primary key and returning it fetched in
+   * the richness described by `require`.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcRestoreEntityRequest}
@@ -905,7 +928,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     private java.lang.Object entityType_ = "";
     /**
      * <pre>
-     * Entity type of the entity to be restored.
+     * Entity type (collection name) the entity to restore belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -925,7 +948,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Entity type of the entity to be restored.
+     * Entity type (collection name) the entity to restore belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -946,7 +969,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Entity type of the entity to be restored.
+     * Entity type (collection name) the entity to restore belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -963,7 +986,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Entity type of the entity to be restored.
+     * Entity type (collection name) the entity to restore belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -977,7 +1000,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Entity type of the entity to be restored.
+     * Entity type (collection name) the entity to restore belongs to.
      * </pre>
      *
      * <code>string entityType = 1;</code>
@@ -999,7 +1022,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> primaryKeyBuilder_;
     /**
      * <pre>
-     * Primary key of the entity to be restored.
+     * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1010,7 +1035,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be restored.
+     * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1025,7 +1052,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be restored.
+     * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1045,7 +1074,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be restored.
+     * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1063,7 +1094,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be restored.
+     * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1088,7 +1121,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be restored.
+     * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1105,7 +1140,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be restored.
+     * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1117,7 +1154,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be restored.
+     * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1132,7 +1171,9 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Primary key of the entity to be restored.
+     * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+     * its value directly without checking presence, so an unset value is treated identically to an explicit
+     * `0` rather than as "no primary key" - always set this field explicitly.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -1154,7 +1195,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     private java.lang.Object require_ = "";
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back after it is restored. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1174,7 +1218,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back after it is restored. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1195,7 +1242,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back after it is restored. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1212,7 +1262,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back after it is restored. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1226,7 +1279,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+     * back after it is restored. `?`/`&#64;name` placeholders are bound the same way as
+     * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+     * contract.
      * </pre>
      *
      * <code>string require = 3;</code>
@@ -1257,7 +1313,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
 
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1271,7 +1328,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1285,7 +1343,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1299,7 +1358,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1320,7 +1380,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1338,7 +1399,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1358,7 +1420,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1379,7 +1442,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1397,7 +1461,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1415,7 +1480,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1434,7 +1500,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1451,7 +1518,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1468,7 +1536,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1479,7 +1548,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1493,7 +1563,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1508,7 +1579,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1519,7 +1591,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1531,7 +1604,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -1592,7 +1666,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1613,7 +1688,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1624,7 +1700,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1641,7 +1718,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1663,7 +1741,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1686,7 +1765,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1703,7 +1783,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -1722,7 +1803,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreEntityRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreEntityRequestOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * Entity type of the entity to be restored.
+   * Entity type (collection name) the entity to restore belongs to.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
   java.lang.String getEntityType();
   /**
    * <pre>
-   * Entity type of the entity to be restored.
+   * Entity type (collection name) the entity to restore belongs to.
    * </pre>
    *
    * <code>string entityType = 1;</code>
@@ -53,7 +53,9 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * Primary key of the entity to be restored.
+   * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -62,7 +64,9 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
   boolean hasPrimaryKey();
   /**
    * <pre>
-   * Primary key of the entity to be restored.
+   * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -71,7 +75,9 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
   com.google.protobuf.Int32Value getPrimaryKey();
   /**
    * <pre>
-   * Primary key of the entity to be restored.
+   * Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+   * its value directly without checking presence, so an unset value is treated identically to an explicit
+   * `0` rather than as "no primary key" - always set this field explicitly.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value primaryKey = 2;</code>
@@ -80,7 +86,10 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+   * back after it is restored. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -89,7 +98,10 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
   java.lang.String getRequire();
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+   * back after it is restored. `?`/`&#64;name` placeholders are bound the same way as
+   * `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+   * contract.
    * </pre>
    *
    * <code>string require = 3;</code>
@@ -100,7 +112,8 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -109,7 +122,8 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
       getPositionalQueryParamsList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -117,7 +131,8 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcQueryParam getPositionalQueryParams(int index);
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -125,7 +140,8 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
   int getPositionalQueryParamsCount();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -134,7 +150,8 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
       getPositionalQueryParamsOrBuilderList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 4;</code>
@@ -144,7 +161,8 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -152,7 +170,8 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
   int getNamedQueryParamsCount();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -167,7 +186,8 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
   getNamedQueryParams();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -176,7 +196,8 @@ public interface GrpcRestoreEntityRequestOrBuilder extends
   getNamedQueryParamsMap();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>
@@ -188,7 +209,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam getNamedQueryParamsOrDefaul
 io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue);
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreEntityResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreEntityResponse.java
@@ -111,7 +111,7 @@ private static final long serialVersionUID = 0L;
   public static final int ENTITYREFERENCE_FIELD_NUMBER = 1;
   /**
    * <pre>
-   * The restored entity reference.
+   * The restored entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -123,7 +123,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The restored entity reference.
+   * The restored entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -138,7 +138,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The restored entity reference.
+   * The restored entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -154,7 +154,7 @@ private static final long serialVersionUID = 0L;
   public static final int ENTITY_FIELD_NUMBER = 2;
   /**
    * <pre>
-   * The restored entity.
+   * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -166,7 +166,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The restored entity.
+   * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -181,7 +181,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The restored entity.
+   * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -607,7 +607,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEntityReference, io.evitadb.externalApi.grpc.generated.GrpcEntityReference.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceOrBuilder> entityReferenceBuilder_;
     /**
      * <pre>
-     * The restored entity reference.
+     * The restored entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -619,7 +619,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity reference.
+     * The restored entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity reference.
+     * The restored entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -661,7 +661,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity reference.
+     * The restored entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -679,7 +679,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity reference.
+     * The restored entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -706,7 +706,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity reference.
+     * The restored entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -729,7 +729,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity reference.
+     * The restored entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -739,7 +739,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity reference.
+     * The restored entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -757,7 +757,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity reference.
+     * The restored entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -785,7 +785,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcSealedEntity, io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.Builder, io.evitadb.externalApi.grpc.generated.GrpcSealedEntityOrBuilder> entityBuilder_;
     /**
      * <pre>
-     * The restored entity.
+     * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -797,7 +797,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity.
+     * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -819,7 +819,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity.
+     * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -839,7 +839,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity.
+     * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -857,7 +857,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity.
+     * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -884,7 +884,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity.
+     * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -907,7 +907,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity.
+     * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -917,7 +917,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity.
+     * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -935,7 +935,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The restored entity.
+     * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreEntityResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcRestoreEntityResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcRestoreEntityResponseOrBuilder extends
 
   /**
    * <pre>
-   * The restored entity reference.
+   * The restored entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcRestoreEntityResponseOrBuilder extends
   boolean hasEntityReference();
   /**
    * <pre>
-   * The restored entity reference.
+   * The restored entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcRestoreEntityResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEntityReference getEntityReference();
   /**
    * <pre>
-   * The restored entity reference.
+   * The restored entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -60,7 +60,7 @@ public interface GrpcRestoreEntityResponseOrBuilder extends
 
   /**
    * <pre>
-   * The restored entity.
+   * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -69,7 +69,7 @@ public interface GrpcRestoreEntityResponseOrBuilder extends
   boolean hasEntity();
   /**
    * <pre>
-   * The restored entity.
+   * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -78,7 +78,7 @@ public interface GrpcRestoreEntityResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcSealedEntity getEntity();
   /**
    * <pre>
-   * The restored entity.
+   * The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSetEntitySchemaWithPriceMutation.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSetEntitySchemaWithPriceMutation.java
@@ -129,7 +129,7 @@ private static final long serialVersionUID = 0L;
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -147,7 +147,7 @@ private static final long serialVersionUID = 0L;
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -164,7 +164,7 @@ private static final long serialVersionUID = 0L;
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -182,7 +182,7 @@ private static final long serialVersionUID = 0L;
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -200,7 +200,7 @@ private static final long serialVersionUID = 0L;
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -771,7 +771,7 @@ private static final long serialVersionUID = 0L;
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -788,7 +788,7 @@ private static final long serialVersionUID = 0L;
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -804,7 +804,7 @@ private static final long serialVersionUID = 0L;
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -821,7 +821,7 @@ private static final long serialVersionUID = 0L;
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -846,7 +846,7 @@ private static final long serialVersionUID = 0L;
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -869,7 +869,7 @@ private static final long serialVersionUID = 0L;
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -892,7 +892,7 @@ private static final long serialVersionUID = 0L;
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -911,7 +911,7 @@ private static final long serialVersionUID = 0L;
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -928,7 +928,7 @@ private static final long serialVersionUID = 0L;
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -945,7 +945,7 @@ private static final long serialVersionUID = 0L;
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -967,7 +967,7 @@ private static final long serialVersionUID = 0L;
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -987,7 +987,7 @@ private static final long serialVersionUID = 0L;
      * can define its price), but it is not possible to work with the price information in any other way (calculating
      * price histogram, filtering, sorting by price, etc.).
      *
-     * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+     * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSetEntitySchemaWithPriceMutationOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSetEntitySchemaWithPriceMutationOrBuilder.java
@@ -71,7 +71,7 @@ public interface GrpcSetEntitySchemaWithPriceMutationOrBuilder extends
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -85,7 +85,7 @@ public interface GrpcSetEntitySchemaWithPriceMutationOrBuilder extends
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -99,7 +99,7 @@ public interface GrpcSetEntitySchemaWithPriceMutationOrBuilder extends
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -114,7 +114,7 @@ public interface GrpcSetEntitySchemaWithPriceMutationOrBuilder extends
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>
@@ -129,7 +129,7 @@ public interface GrpcSetEntitySchemaWithPriceMutationOrBuilder extends
    * can define its price), but it is not possible to work with the price information in any other way (calculating
    * price histogram, filtering, sorting by price, etc.).
    *
-   * Prices can be also set as non-indexed individually by setting {&#64;link PriceContract#indexed()} to false.
+   * Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcEntityScope indexedInScopes = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSortableAttributeCompoundSchemaMutation.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSortableAttributeCompoundSchemaMutation.java
@@ -28,6 +28,10 @@
 package io.evitadb.externalApi.grpc.generated;
 
 /**
+ * <pre>
+ * Mutation of a sortable attribute compound schema.
+ * </pre>
+ *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchemaMutation}
  */
 public final class GrpcSortableAttributeCompoundSchemaMutation extends
@@ -114,6 +118,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int CREATESORTABLEATTRIBUTECOMPOUNDSCHEMAMUTATION_FIELD_NUMBER = 1;
   /**
+   * <pre>
+   * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
    * @return Whether the createSortableAttributeCompoundSchemaMutation field is set.
    */
@@ -122,6 +130,10 @@ private static final long serialVersionUID = 0L;
     return mutationCase_ == 1;
   }
   /**
+   * <pre>
+   * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
    * @return The createSortableAttributeCompoundSchemaMutation.
    */
@@ -133,6 +145,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
    */
   @java.lang.Override
@@ -145,6 +161,11 @@ private static final long serialVersionUID = 0L;
 
   public static final int MODIFYSORTABLEATTRIBUTECOMPOUNDSCHEMADEPRECATIONNOTICEMUTATION_FIELD_NUMBER = 2;
   /**
+   * <pre>
+   * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+   * in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
    * @return Whether the modifySortableAttributeCompoundSchemaDeprecationNoticeMutation field is set.
    */
@@ -153,6 +174,11 @@ private static final long serialVersionUID = 0L;
     return mutationCase_ == 2;
   }
   /**
+   * <pre>
+   * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+   * in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
    * @return The modifySortableAttributeCompoundSchemaDeprecationNoticeMutation.
    */
@@ -164,6 +190,11 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+   * in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
    */
   @java.lang.Override
@@ -176,6 +207,11 @@ private static final long serialVersionUID = 0L;
 
   public static final int MODIFYSORTABLEATTRIBUTECOMPOUNDSCHEMADESCRIPTIONMUTATION_FIELD_NUMBER = 3;
   /**
+   * <pre>
+   * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+   * in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
    * @return Whether the modifySortableAttributeCompoundSchemaDescriptionMutation field is set.
    */
@@ -184,6 +220,11 @@ private static final long serialVersionUID = 0L;
     return mutationCase_ == 3;
   }
   /**
+   * <pre>
+   * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+   * in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
    * @return The modifySortableAttributeCompoundSchemaDescriptionMutation.
    */
@@ -195,6 +236,11 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+   * in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
    */
   @java.lang.Override
@@ -207,6 +253,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int MODIFYSORTABLEATTRIBUTECOMPOUNDSCHEMANAMEMUTATION_FIELD_NUMBER = 4;
   /**
+   * <pre>
+   * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
    * @return Whether the modifySortableAttributeCompoundSchemaNameMutation field is set.
    */
@@ -215,6 +265,10 @@ private static final long serialVersionUID = 0L;
     return mutationCase_ == 4;
   }
   /**
+   * <pre>
+   * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
    * @return The modifySortableAttributeCompoundSchemaNameMutation.
    */
@@ -226,6 +280,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
    */
   @java.lang.Override
@@ -238,6 +296,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int REMOVESORTABLEATTRIBUTECOMPOUNDSCHEMAMUTATION_FIELD_NUMBER = 5;
   /**
+   * <pre>
+   * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
    * @return Whether the removeSortableAttributeCompoundSchemaMutation field is set.
    */
@@ -246,6 +308,10 @@ private static final long serialVersionUID = 0L;
     return mutationCase_ == 5;
   }
   /**
+   * <pre>
+   * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
    * @return The removeSortableAttributeCompoundSchemaMutation.
    */
@@ -257,6 +323,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
    */
   @java.lang.Override
@@ -269,6 +339,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int SETSORTABLEATTRIBUTECOMPOUNDINDEXEDMUTATION_FIELD_NUMBER = 6;
   /**
+   * <pre>
+   * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
    * @return Whether the setSortableAttributeCompoundIndexedMutation field is set.
    */
@@ -277,6 +351,10 @@ private static final long serialVersionUID = 0L;
     return mutationCase_ == 6;
   }
   /**
+   * <pre>
+   * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
    * @return The setSortableAttributeCompoundIndexedMutation.
    */
@@ -288,6 +366,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
    */
   @java.lang.Override
@@ -544,6 +626,10 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
+   * <pre>
+   * Mutation of a sortable attribute compound schema.
+   * </pre>
+   *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchemaMutation}
    */
   public static final class Builder extends
@@ -838,6 +924,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation, io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation.Builder, io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutationOrBuilder> createSortableAttributeCompoundSchemaMutationBuilder_;
     /**
+     * <pre>
+     * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
      * @return Whether the createSortableAttributeCompoundSchemaMutation field is set.
      */
@@ -846,6 +936,10 @@ private static final long serialVersionUID = 0L;
       return mutationCase_ == 1;
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
      * @return The createSortableAttributeCompoundSchemaMutation.
      */
@@ -864,6 +958,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
      */
     public Builder setCreateSortableAttributeCompoundSchemaMutation(io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation value) {
@@ -880,6 +978,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
      */
     public Builder setCreateSortableAttributeCompoundSchemaMutation(
@@ -894,6 +996,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
      */
     public Builder mergeCreateSortableAttributeCompoundSchemaMutation(io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation value) {
@@ -917,6 +1023,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
      */
     public Builder clearCreateSortableAttributeCompoundSchemaMutation() {
@@ -936,12 +1046,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation.Builder getCreateSortableAttributeCompoundSchemaMutationBuilder() {
       return getCreateSortableAttributeCompoundSchemaMutationFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
      */
     @java.lang.Override
@@ -956,6 +1074,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -980,6 +1102,11 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation, io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation.Builder, io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutationOrBuilder> modifySortableAttributeCompoundSchemaDeprecationNoticeMutationBuilder_;
     /**
+     * <pre>
+     * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
      * @return Whether the modifySortableAttributeCompoundSchemaDeprecationNoticeMutation field is set.
      */
@@ -988,6 +1115,11 @@ private static final long serialVersionUID = 0L;
       return mutationCase_ == 2;
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
      * @return The modifySortableAttributeCompoundSchemaDeprecationNoticeMutation.
      */
@@ -1006,6 +1138,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
      */
     public Builder setModifySortableAttributeCompoundSchemaDeprecationNoticeMutation(io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation value) {
@@ -1022,6 +1159,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
      */
     public Builder setModifySortableAttributeCompoundSchemaDeprecationNoticeMutation(
@@ -1036,6 +1178,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
      */
     public Builder mergeModifySortableAttributeCompoundSchemaDeprecationNoticeMutation(io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation value) {
@@ -1059,6 +1206,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
      */
     public Builder clearModifySortableAttributeCompoundSchemaDeprecationNoticeMutation() {
@@ -1078,12 +1230,22 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation.Builder getModifySortableAttributeCompoundSchemaDeprecationNoticeMutationBuilder() {
       return getModifySortableAttributeCompoundSchemaDeprecationNoticeMutationFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
      */
     @java.lang.Override
@@ -1098,6 +1260,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -1122,6 +1289,11 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation, io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation.Builder, io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutationOrBuilder> modifySortableAttributeCompoundSchemaDescriptionMutationBuilder_;
     /**
+     * <pre>
+     * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
      * @return Whether the modifySortableAttributeCompoundSchemaDescriptionMutation field is set.
      */
@@ -1130,6 +1302,11 @@ private static final long serialVersionUID = 0L;
       return mutationCase_ == 3;
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
      * @return The modifySortableAttributeCompoundSchemaDescriptionMutation.
      */
@@ -1148,6 +1325,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
      */
     public Builder setModifySortableAttributeCompoundSchemaDescriptionMutation(io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation value) {
@@ -1164,6 +1346,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
      */
     public Builder setModifySortableAttributeCompoundSchemaDescriptionMutation(
@@ -1178,6 +1365,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
      */
     public Builder mergeModifySortableAttributeCompoundSchemaDescriptionMutation(io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation value) {
@@ -1201,6 +1393,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
      */
     public Builder clearModifySortableAttributeCompoundSchemaDescriptionMutation() {
@@ -1220,12 +1417,22 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation.Builder getModifySortableAttributeCompoundSchemaDescriptionMutationBuilder() {
       return getModifySortableAttributeCompoundSchemaDescriptionMutationFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
      */
     @java.lang.Override
@@ -1240,6 +1447,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+     * in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -1264,6 +1476,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation, io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation.Builder, io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutationOrBuilder> modifySortableAttributeCompoundSchemaNameMutationBuilder_;
     /**
+     * <pre>
+     * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
      * @return Whether the modifySortableAttributeCompoundSchemaNameMutation field is set.
      */
@@ -1272,6 +1488,10 @@ private static final long serialVersionUID = 0L;
       return mutationCase_ == 4;
     }
     /**
+     * <pre>
+     * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
      * @return The modifySortableAttributeCompoundSchemaNameMutation.
      */
@@ -1290,6 +1510,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
      */
     public Builder setModifySortableAttributeCompoundSchemaNameMutation(io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation value) {
@@ -1306,6 +1530,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
      */
     public Builder setModifySortableAttributeCompoundSchemaNameMutation(
@@ -1320,6 +1548,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
      */
     public Builder mergeModifySortableAttributeCompoundSchemaNameMutation(io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation value) {
@@ -1343,6 +1575,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
      */
     public Builder clearModifySortableAttributeCompoundSchemaNameMutation() {
@@ -1362,12 +1598,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation.Builder getModifySortableAttributeCompoundSchemaNameMutationBuilder() {
       return getModifySortableAttributeCompoundSchemaNameMutationFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
      */
     @java.lang.Override
@@ -1382,6 +1626,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -1406,6 +1654,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation, io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation.Builder, io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutationOrBuilder> removeSortableAttributeCompoundSchemaMutationBuilder_;
     /**
+     * <pre>
+     * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
      * @return Whether the removeSortableAttributeCompoundSchemaMutation field is set.
      */
@@ -1414,6 +1666,10 @@ private static final long serialVersionUID = 0L;
       return mutationCase_ == 5;
     }
     /**
+     * <pre>
+     * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
      * @return The removeSortableAttributeCompoundSchemaMutation.
      */
@@ -1432,6 +1688,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
      */
     public Builder setRemoveSortableAttributeCompoundSchemaMutation(io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation value) {
@@ -1448,6 +1708,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
      */
     public Builder setRemoveSortableAttributeCompoundSchemaMutation(
@@ -1462,6 +1726,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
      */
     public Builder mergeRemoveSortableAttributeCompoundSchemaMutation(io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation value) {
@@ -1485,6 +1753,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
      */
     public Builder clearRemoveSortableAttributeCompoundSchemaMutation() {
@@ -1504,12 +1776,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation.Builder getRemoveSortableAttributeCompoundSchemaMutationBuilder() {
       return getRemoveSortableAttributeCompoundSchemaMutationFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
      */
     @java.lang.Override
@@ -1524,6 +1804,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -1548,6 +1832,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation, io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation.Builder, io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutationOrBuilder> setSortableAttributeCompoundIndexedMutationBuilder_;
     /**
+     * <pre>
+     * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
      * @return Whether the setSortableAttributeCompoundIndexedMutation field is set.
      */
@@ -1556,6 +1844,10 @@ private static final long serialVersionUID = 0L;
       return mutationCase_ == 6;
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
      * @return The setSortableAttributeCompoundIndexedMutation.
      */
@@ -1574,6 +1866,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
      */
     public Builder setSetSortableAttributeCompoundIndexedMutation(io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation value) {
@@ -1590,6 +1886,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
      */
     public Builder setSetSortableAttributeCompoundIndexedMutation(
@@ -1604,6 +1904,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
      */
     public Builder mergeSetSortableAttributeCompoundIndexedMutation(io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation value) {
@@ -1627,6 +1931,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
      */
     public Builder clearSetSortableAttributeCompoundIndexedMutation() {
@@ -1646,12 +1954,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation.Builder getSetSortableAttributeCompoundIndexedMutationBuilder() {
       return getSetSortableAttributeCompoundIndexedMutationFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
      */
     @java.lang.Override
@@ -1666,6 +1982,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSortableAttributeCompoundSchemaMutationOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSortableAttributeCompoundSchemaMutationOrBuilder.java
@@ -32,91 +32,169 @@ public interface GrpcSortableAttributeCompoundSchemaMutationOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
+   * <pre>
+   * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
    * @return Whether the createSortableAttributeCompoundSchemaMutation field is set.
    */
   boolean hasCreateSortableAttributeCompoundSchemaMutation();
   /**
+   * <pre>
+   * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
    * @return The createSortableAttributeCompoundSchemaMutation.
    */
   io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation getCreateSortableAttributeCompoundSchemaMutation();
   /**
+   * <pre>
+   * Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcCreateSortableAttributeCompoundSchemaMutationOrBuilder getCreateSortableAttributeCompoundSchemaMutationOrBuilder();
 
   /**
+   * <pre>
+   * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+   * in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
    * @return Whether the modifySortableAttributeCompoundSchemaDeprecationNoticeMutation field is set.
    */
   boolean hasModifySortableAttributeCompoundSchemaDeprecationNoticeMutation();
   /**
+   * <pre>
+   * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+   * in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
    * @return The modifySortableAttributeCompoundSchemaDeprecationNoticeMutation.
    */
   io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation getModifySortableAttributeCompoundSchemaDeprecationNoticeMutation();
   /**
+   * <pre>
+   * Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+   * in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutationOrBuilder getModifySortableAttributeCompoundSchemaDeprecationNoticeMutationOrBuilder();
 
   /**
+   * <pre>
+   * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+   * in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
    * @return Whether the modifySortableAttributeCompoundSchemaDescriptionMutation field is set.
    */
   boolean hasModifySortableAttributeCompoundSchemaDescriptionMutation();
   /**
+   * <pre>
+   * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+   * in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
    * @return The modifySortableAttributeCompoundSchemaDescriptionMutation.
    */
   io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation getModifySortableAttributeCompoundSchemaDescriptionMutation();
   /**
+   * <pre>
+   * Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+   * in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaDescriptionMutationOrBuilder getModifySortableAttributeCompoundSchemaDescriptionMutationOrBuilder();
 
   /**
+   * <pre>
+   * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
    * @return Whether the modifySortableAttributeCompoundSchemaNameMutation field is set.
    */
   boolean hasModifySortableAttributeCompoundSchemaNameMutation();
   /**
+   * <pre>
+   * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
    * @return The modifySortableAttributeCompoundSchemaNameMutation.
    */
   io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation getModifySortableAttributeCompoundSchemaNameMutation();
   /**
+   * <pre>
+   * Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcModifySortableAttributeCompoundSchemaNameMutationOrBuilder getModifySortableAttributeCompoundSchemaNameMutationOrBuilder();
 
   /**
+   * <pre>
+   * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
    * @return Whether the removeSortableAttributeCompoundSchemaMutation field is set.
    */
   boolean hasRemoveSortableAttributeCompoundSchemaMutation();
   /**
+   * <pre>
+   * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
    * @return The removeSortableAttributeCompoundSchemaMutation.
    */
   io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation getRemoveSortableAttributeCompoundSchemaMutation();
   /**
+   * <pre>
+   * Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcRemoveSortableAttributeCompoundSchemaMutationOrBuilder getRemoveSortableAttributeCompoundSchemaMutationOrBuilder();
 
   /**
+   * <pre>
+   * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
    * @return Whether the setSortableAttributeCompoundIndexedMutation field is set.
    */
   boolean hasSetSortableAttributeCompoundIndexedMutation();
   /**
+   * <pre>
+   * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
    * @return The setSortableAttributeCompoundIndexedMutation.
    */
   io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation getSetSortableAttributeCompoundIndexedMutation();
   /**
+   * <pre>
+   * Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcSetSortableAttributeCompoundIndexedMutationOrBuilder getSetSortableAttributeCompoundIndexedMutationOrBuilder();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSpecifiedTaskStatusesRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSpecifiedTaskStatusesRequest.java
@@ -72,7 +72,9 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcUuid> taskIds_;
   /**
    * <pre>
-   * set of task ids to be listed
+   * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+   * known task are silently omitted from the response - see
+   * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -83,7 +85,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * set of task ids to be listed
+   * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+   * known task are silently omitted from the response - see
+   * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -95,7 +99,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * set of task ids to be listed
+   * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+   * known task are silently omitted from the response - see
+   * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -106,7 +112,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * set of task ids to be listed
+   * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+   * known task are silently omitted from the response - see
+   * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -117,7 +125,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * set of task ids to be listed
+   * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+   * known task are silently omitted from the response - see
+   * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -520,7 +530,9 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -534,7 +546,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -548,7 +562,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -562,7 +578,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -583,7 +601,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -601,7 +621,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -621,7 +643,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -642,7 +666,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -660,7 +686,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -678,7 +706,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -697,7 +727,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -714,7 +746,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -731,7 +765,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -742,7 +778,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -756,7 +794,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -771,7 +811,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -782,7 +824,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -794,7 +838,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * set of task ids to be listed
+     * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+     * known task are silently omitted from the response - see
+     * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSpecifiedTaskStatusesRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSpecifiedTaskStatusesRequestOrBuilder.java
@@ -33,7 +33,9 @@ public interface GrpcSpecifiedTaskStatusesRequestOrBuilder extends
 
   /**
    * <pre>
-   * set of task ids to be listed
+   * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+   * known task are silently omitted from the response - see
+   * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -42,7 +44,9 @@ public interface GrpcSpecifiedTaskStatusesRequestOrBuilder extends
       getTaskIdsList();
   /**
    * <pre>
-   * set of task ids to be listed
+   * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+   * known task are silently omitted from the response - see
+   * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -50,7 +54,9 @@ public interface GrpcSpecifiedTaskStatusesRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuid getTaskIds(int index);
   /**
    * <pre>
-   * set of task ids to be listed
+   * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+   * known task are silently omitted from the response - see
+   * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -58,7 +64,9 @@ public interface GrpcSpecifiedTaskStatusesRequestOrBuilder extends
   int getTaskIdsCount();
   /**
    * <pre>
-   * set of task ids to be listed
+   * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+   * known task are silently omitted from the response - see
+   * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>
@@ -67,7 +75,9 @@ public interface GrpcSpecifiedTaskStatusesRequestOrBuilder extends
       getTaskIdsOrBuilderList();
   /**
    * <pre>
-   * set of task ids to be listed
+   * Identifications of the tasks whose statuses should be returned. Ids that don't match any
+   * known task are silently omitted from the response - see
+   * `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid taskIds = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSpecifiedTaskStatusesResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSpecifiedTaskStatusesResponse.java
@@ -72,7 +72,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcTaskStatus> taskStatus_;
   /**
    * <pre>
-   * Collection of task statuses.
+   * Statuses of the requested tasks that were found, in no particular order; ids from the request
+   * that don't match any known task are simply absent here, no error is raised for them.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -83,7 +84,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of task statuses.
+   * Statuses of the requested tasks that were found, in no particular order; ids from the request
+   * that don't match any known task are simply absent here, no error is raised for them.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -95,7 +97,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of task statuses.
+   * Statuses of the requested tasks that were found, in no particular order; ids from the request
+   * that don't match any known task are simply absent here, no error is raised for them.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -106,7 +109,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of task statuses.
+   * Statuses of the requested tasks that were found, in no particular order; ids from the request
+   * that don't match any known task are simply absent here, no error is raised for them.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -117,7 +121,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of task statuses.
+   * Statuses of the requested tasks that were found, in no particular order; ids from the request
+   * that don't match any known task are simply absent here, no error is raised for them.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -520,7 +525,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -534,7 +540,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -548,7 +555,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -562,7 +570,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -583,7 +592,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -601,7 +611,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -621,7 +632,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -642,7 +654,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -660,7 +673,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -678,7 +692,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -697,7 +712,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -714,7 +730,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -731,7 +748,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -742,7 +760,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -756,7 +775,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -771,7 +791,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -782,7 +803,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -794,7 +816,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Statuses of the requested tasks that were found, in no particular order; ids from the request
+     * that don't match any known task are simply absent here, no error is raised for them.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSpecifiedTaskStatusesResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSpecifiedTaskStatusesResponseOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcSpecifiedTaskStatusesResponseOrBuilder extends
 
   /**
    * <pre>
-   * Collection of task statuses.
+   * Statuses of the requested tasks that were found, in no particular order; ids from the request
+   * that don't match any known task are simply absent here, no error is raised for them.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcSpecifiedTaskStatusesResponseOrBuilder extends
       getTaskStatusList();
   /**
    * <pre>
-   * Collection of task statuses.
+   * Statuses of the requested tasks that were found, in no particular order; ids from the request
+   * that don't match any known task are simply absent here, no error is raised for them.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -50,7 +52,8 @@ public interface GrpcSpecifiedTaskStatusesResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTaskStatus getTaskStatus(int index);
   /**
    * <pre>
-   * Collection of task statuses.
+   * Statuses of the requested tasks that were found, in no particular order; ids from the request
+   * that don't match any known task are simply absent here, no error is raised for them.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -58,7 +61,8 @@ public interface GrpcSpecifiedTaskStatusesResponseOrBuilder extends
   int getTaskStatusCount();
   /**
    * <pre>
-   * Collection of task statuses.
+   * Statuses of the requested tasks that were found, in no particular order; ids from the request
+   * that don't match any known task are simply absent here, no error is raised for them.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -67,7 +71,8 @@ public interface GrpcSpecifiedTaskStatusesResponseOrBuilder extends
       getTaskStatusOrBuilderList();
   /**
    * <pre>
-   * Collection of task statuses.
+   * Statuses of the requested tasks that were found, in no particular order; ids from the request
+   * that don't match any known task are simply absent here, no error is raised for them.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStartTrafficRecordingRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStartTrafficRecordingRequest.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request to StartTrafficRecording request.
+ * Request to start a new traffic recording session. Only one recording may be in progress at a time; starting a
+ * new one while another is still running fails.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcStartTrafficRecordingRequest}
@@ -102,7 +103,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value maxDurationInMilliseconds_;
   /**
    * <pre>
-   * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+   * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+   * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -114,7 +116,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+   * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+   * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -126,7 +129,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+   * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+   * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -140,7 +144,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value maxFileSizeInBytes_;
   /**
    * <pre>
-   * The size of the recording in bytes, after this size the recording will be stopped automatically.
+   * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+   * has been captured. If unset, no size-based automatic stop is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -152,7 +157,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The size of the recording in bytes, after this size the recording will be stopped automatically.
+   * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+   * has been captured. If unset, no size-based automatic stop is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -164,7 +170,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The size of the recording in bytes, after this size the recording will be stopped automatically.
+   * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+   * has been captured. If unset, no size-based automatic stop is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -178,7 +185,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value chunkFileSizeInBytes_;
   /**
    * <pre>
-   * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+   * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+   * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -190,7 +198,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+   * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+   * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -202,7 +211,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+   * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+   * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -431,7 +441,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request to StartTrafficRecording request.
+   * Request to start a new traffic recording session. Only one recording may be in progress at a time; starting a
+   * new one while another is still running fails.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcStartTrafficRecordingRequest}
@@ -782,7 +793,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> maxDurationInMillisecondsBuilder_;
     /**
      * <pre>
-     * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+     * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+     * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -793,7 +805,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+     * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+     * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -808,7 +821,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+     * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+     * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -828,7 +842,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+     * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+     * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -846,7 +861,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+     * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+     * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -871,7 +887,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+     * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+     * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -888,7 +905,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+     * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+     * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -900,7 +918,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+     * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+     * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -915,7 +934,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+     * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+     * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -939,7 +959,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> maxFileSizeInBytesBuilder_;
     /**
      * <pre>
-     * The size of the recording in bytes, after this size the recording will be stopped automatically.
+     * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+     * has been captured. If unset, no size-based automatic stop is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -950,7 +971,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the recording in bytes, after this size the recording will be stopped automatically.
+     * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+     * has been captured. If unset, no size-based automatic stop is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -965,7 +987,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the recording in bytes, after this size the recording will be stopped automatically.
+     * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+     * has been captured. If unset, no size-based automatic stop is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -985,7 +1008,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the recording in bytes, after this size the recording will be stopped automatically.
+     * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+     * has been captured. If unset, no size-based automatic stop is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -1003,7 +1027,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the recording in bytes, after this size the recording will be stopped automatically.
+     * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+     * has been captured. If unset, no size-based automatic stop is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -1028,7 +1053,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the recording in bytes, after this size the recording will be stopped automatically.
+     * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+     * has been captured. If unset, no size-based automatic stop is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -1045,7 +1071,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the recording in bytes, after this size the recording will be stopped automatically.
+     * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+     * has been captured. If unset, no size-based automatic stop is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -1057,7 +1084,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the recording in bytes, after this size the recording will be stopped automatically.
+     * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+     * has been captured. If unset, no size-based automatic stop is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -1072,7 +1100,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the recording in bytes, after this size the recording will be stopped automatically.
+     * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+     * has been captured. If unset, no size-based automatic stop is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -1096,7 +1125,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> chunkFileSizeInBytesBuilder_;
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -1107,7 +1137,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -1122,7 +1153,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -1142,7 +1174,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -1160,7 +1193,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -1185,7 +1219,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -1202,7 +1237,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -1214,7 +1250,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -1229,7 +1266,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+     * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+     * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStartTrafficRecordingRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStartTrafficRecordingRequestOrBuilder.java
@@ -54,7 +54,8 @@ public interface GrpcStartTrafficRecordingRequestOrBuilder extends
 
   /**
    * <pre>
-   * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+   * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+   * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -63,7 +64,8 @@ public interface GrpcStartTrafficRecordingRequestOrBuilder extends
   boolean hasMaxDurationInMilliseconds();
   /**
    * <pre>
-   * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+   * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+   * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -72,7 +74,8 @@ public interface GrpcStartTrafficRecordingRequestOrBuilder extends
   com.google.protobuf.Int64Value getMaxDurationInMilliseconds();
   /**
    * <pre>
-   * The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+   * The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+   * has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value maxDurationInMilliseconds = 3;</code>
@@ -81,7 +84,8 @@ public interface GrpcStartTrafficRecordingRequestOrBuilder extends
 
   /**
    * <pre>
-   * The size of the recording in bytes, after this size the recording will be stopped automatically.
+   * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+   * has been captured. If unset, no size-based automatic stop is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -90,7 +94,8 @@ public interface GrpcStartTrafficRecordingRequestOrBuilder extends
   boolean hasMaxFileSizeInBytes();
   /**
    * <pre>
-   * The size of the recording in bytes, after this size the recording will be stopped automatically.
+   * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+   * has been captured. If unset, no size-based automatic stop is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -99,7 +104,8 @@ public interface GrpcStartTrafficRecordingRequestOrBuilder extends
   com.google.protobuf.Int64Value getMaxFileSizeInBytes();
   /**
    * <pre>
-   * The size of the recording in bytes, after this size the recording will be stopped automatically.
+   * The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+   * has been captured. If unset, no size-based automatic stop is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value maxFileSizeInBytes = 4;</code>
@@ -108,7 +114,8 @@ public interface GrpcStartTrafficRecordingRequestOrBuilder extends
 
   /**
    * <pre>
-   * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+   * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+   * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -117,7 +124,8 @@ public interface GrpcStartTrafficRecordingRequestOrBuilder extends
   boolean hasChunkFileSizeInBytes();
   /**
    * <pre>
-   * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+   * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+   * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>
@@ -126,7 +134,8 @@ public interface GrpcStartTrafficRecordingRequestOrBuilder extends
   com.google.protobuf.Int64Value getChunkFileSizeInBytes();
   /**
    * <pre>
-   * The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+   * The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+   * of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value chunkFileSizeInBytes = 5;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStatisticsBaseArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStatisticsBaseArray.java
@@ -81,7 +81,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * Value that supports storing a StatisticsBase array.
+   * The individual StatisticsBase values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -94,7 +94,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a StatisticsBase array.
+   * The individual StatisticsBase values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a StatisticsBase array.
+   * The individual StatisticsBase values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -119,7 +119,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a StatisticsBase array.
+   * The individual StatisticsBase values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -132,7 +132,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a StatisticsBase array.
+   * The individual StatisticsBase values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -524,7 +524,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsBase array.
+     * The individual StatisticsBase values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -536,7 +536,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsBase array.
+     * The individual StatisticsBase values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -547,7 +547,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsBase array.
+     * The individual StatisticsBase values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -559,7 +559,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsBase array.
+     * The individual StatisticsBase values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -579,7 +579,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsBase array.
+     * The individual StatisticsBase values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -597,7 +597,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsBase array.
+     * The individual StatisticsBase values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -615,7 +615,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsBase array.
+     * The individual StatisticsBase values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -629,7 +629,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsBase array.
+     * The individual StatisticsBase values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsBase array.
+     * The individual StatisticsBase values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -653,7 +653,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsBase array.
+     * The individual StatisticsBase values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -670,7 +670,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsBase array.
+     * The individual StatisticsBase values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -685,7 +685,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsBase array.
+     * The individual StatisticsBase values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStatisticsBaseArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStatisticsBaseArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcStatisticsBaseArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a StatisticsBase array.
+   * The individual StatisticsBase values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcStatisticsBaseArrayOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase> getValueList();
   /**
    * <pre>
-   * Value that supports storing a StatisticsBase array.
+   * The individual StatisticsBase values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcStatisticsBaseArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a StatisticsBase array.
+   * The individual StatisticsBase values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -61,7 +61,7 @@ public interface GrpcStatisticsBaseArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a StatisticsBase array.
+   * The individual StatisticsBase values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>
@@ -71,7 +71,7 @@ public interface GrpcStatisticsBaseArrayOrBuilder extends
   getValueValueList();
   /**
    * <pre>
-   * Value that supports storing a StatisticsBase array.
+   * The individual StatisticsBase values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsBase value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStatisticsTypeArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStatisticsTypeArray.java
@@ -81,7 +81,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * Value that supports storing a StatisticsType array.
+   * The individual StatisticsType values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -94,7 +94,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a StatisticsType array.
+   * The individual StatisticsType values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a StatisticsType array.
+   * The individual StatisticsType values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -119,7 +119,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a StatisticsType array.
+   * The individual StatisticsType values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -132,7 +132,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a StatisticsType array.
+   * The individual StatisticsType values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -524,7 +524,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsType array.
+     * The individual StatisticsType values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -536,7 +536,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsType array.
+     * The individual StatisticsType values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -547,7 +547,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsType array.
+     * The individual StatisticsType values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -559,7 +559,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsType array.
+     * The individual StatisticsType values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -579,7 +579,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsType array.
+     * The individual StatisticsType values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -597,7 +597,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsType array.
+     * The individual StatisticsType values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -615,7 +615,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsType array.
+     * The individual StatisticsType values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -629,7 +629,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsType array.
+     * The individual StatisticsType values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -641,7 +641,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsType array.
+     * The individual StatisticsType values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -653,7 +653,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsType array.
+     * The individual StatisticsType values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -670,7 +670,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsType array.
+     * The individual StatisticsType values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -685,7 +685,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a StatisticsType array.
+     * The individual StatisticsType values, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStatisticsTypeArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStatisticsTypeArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcStatisticsTypeArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a StatisticsType array.
+   * The individual StatisticsType values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcStatisticsTypeArrayOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcStatisticsType> getValueList();
   /**
    * <pre>
-   * Value that supports storing a StatisticsType array.
+   * The individual StatisticsType values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcStatisticsTypeArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a StatisticsType array.
+   * The individual StatisticsType values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -61,7 +61,7 @@ public interface GrpcStatisticsTypeArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcStatisticsType getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a StatisticsType array.
+   * The individual StatisticsType values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>
@@ -71,7 +71,7 @@ public interface GrpcStatisticsTypeArrayOrBuilder extends
   getValueValueList();
   /**
    * <pre>
-   * Value that supports storing a StatisticsType array.
+   * The individual StatisticsType values, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcStatisticsType value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStringArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStringArray.java
@@ -29,7 +29,9 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Wrapper for representing an array of strings.
+ * Wrapper for representing an array of strings. Also used to carry a Character array — each
+ * element is then a single-character string; which Java array type applies is determined by the
+ * accompanying GrpcEvitaDataType (STRING_ARRAY vs CHARACTER_ARRAY).
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcStringArray}
@@ -74,7 +76,8 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
-   * Value that supports storing a string array.
+   * The individual string (or, for a character array, single-character) elements, in their
+   * original order.
    * </pre>
    *
    * <code>repeated string value = 1;</code>
@@ -86,7 +89,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a string array.
+   * The individual string (or, for a character array, single-character) elements, in their
+   * original order.
    * </pre>
    *
    * <code>repeated string value = 1;</code>
@@ -97,7 +101,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a string array.
+   * The individual string (or, for a character array, single-character) elements, in their
+   * original order.
    * </pre>
    *
    * <code>repeated string value = 1;</code>
@@ -109,7 +114,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a string array.
+   * The individual string (or, for a character array, single-character) elements, in their
+   * original order.
    * </pre>
    *
    * <code>repeated string value = 1;</code>
@@ -286,7 +292,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Wrapper for representing an array of strings.
+   * Wrapper for representing an array of strings. Also used to carry a Character array — each
+   * element is then a single-character string; which Java array type applies is determined by the
+   * accompanying GrpcEvitaDataType (STRING_ARRAY vs CHARACTER_ARRAY).
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcStringArray}
@@ -476,7 +484,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a string array.
+     * The individual string (or, for a character array, single-character) elements, in their
+     * original order.
      * </pre>
      *
      * <code>repeated string value = 1;</code>
@@ -489,7 +498,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a string array.
+     * The individual string (or, for a character array, single-character) elements, in their
+     * original order.
      * </pre>
      *
      * <code>repeated string value = 1;</code>
@@ -500,7 +510,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a string array.
+     * The individual string (or, for a character array, single-character) elements, in their
+     * original order.
      * </pre>
      *
      * <code>repeated string value = 1;</code>
@@ -512,7 +523,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a string array.
+     * The individual string (or, for a character array, single-character) elements, in their
+     * original order.
      * </pre>
      *
      * <code>repeated string value = 1;</code>
@@ -525,7 +537,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a string array.
+     * The individual string (or, for a character array, single-character) elements, in their
+     * original order.
      * </pre>
      *
      * <code>repeated string value = 1;</code>
@@ -544,7 +557,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a string array.
+     * The individual string (or, for a character array, single-character) elements, in their
+     * original order.
      * </pre>
      *
      * <code>repeated string value = 1;</code>
@@ -562,7 +576,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a string array.
+     * The individual string (or, for a character array, single-character) elements, in their
+     * original order.
      * </pre>
      *
      * <code>repeated string value = 1;</code>
@@ -580,7 +595,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a string array.
+     * The individual string (or, for a character array, single-character) elements, in their
+     * original order.
      * </pre>
      *
      * <code>repeated string value = 1;</code>
@@ -595,7 +611,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a string array.
+     * The individual string (or, for a character array, single-character) elements, in their
+     * original order.
      * </pre>
      *
      * <code>repeated string value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStringArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStringArrayOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcStringArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a string array.
+   * The individual string (or, for a character array, single-character) elements, in their
+   * original order.
    * </pre>
    *
    * <code>repeated string value = 1;</code>
@@ -43,7 +44,8 @@ public interface GrpcStringArrayOrBuilder extends
       getValueList();
   /**
    * <pre>
-   * Value that supports storing a string array.
+   * The individual string (or, for a character array, single-character) elements, in their
+   * original order.
    * </pre>
    *
    * <code>repeated string value = 1;</code>
@@ -52,7 +54,8 @@ public interface GrpcStringArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a string array.
+   * The individual string (or, for a character array, single-character) elements, in their
+   * original order.
    * </pre>
    *
    * <code>repeated string value = 1;</code>
@@ -62,7 +65,8 @@ public interface GrpcStringArrayOrBuilder extends
   java.lang.String getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a string array.
+   * The individual string (or, for a character array, single-character) elements, in their
+   * original order.
    * </pre>
    *
    * <code>repeated string value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStripList.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStripList.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Structure that represents a strip within a data chunk.
+ * Strip/offset-based pagination descriptor for a `GrpcDataChunk` - the alternative to `GrpcPaginatedList`
+ * used when the query's `require` block specifies a `strip()` requirement instead of `page()`.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcStripList}
@@ -70,7 +71,7 @@ private static final long serialVersionUID = 0L;
   private int limit_ = 0;
   /**
    * <pre>
-   * The size of the strip.
+   * Maximum number of records returned in this strip.
    * </pre>
    *
    * <code>int32 limit = 1;</code>
@@ -85,7 +86,9 @@ private static final long serialVersionUID = 0L;
   private int offset_ = 0;
   /**
    * <pre>
-   * The offset of the strip - count of records from the beginning to skip.
+   * Number of records skipped from the beginning of the result set before this strip starts. 0-indexed:
+   * an offset of 0 starts at the very first record - unlike `GrpcPaginatedList.pageNumber`, this is not a
+   * page number.
    * </pre>
    *
    * <code>int32 offset = 2;</code>
@@ -266,7 +269,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Structure that represents a strip within a data chunk.
+   * Strip/offset-based pagination descriptor for a `GrpcDataChunk` - the alternative to `GrpcPaginatedList`
+   * used when the query's `require` block specifies a `strip()` requirement instead of `page()`.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcStripList}
@@ -451,7 +455,7 @@ private static final long serialVersionUID = 0L;
     private int limit_ ;
     /**
      * <pre>
-     * The size of the strip.
+     * Maximum number of records returned in this strip.
      * </pre>
      *
      * <code>int32 limit = 1;</code>
@@ -463,7 +467,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the strip.
+     * Maximum number of records returned in this strip.
      * </pre>
      *
      * <code>int32 limit = 1;</code>
@@ -479,7 +483,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the strip.
+     * Maximum number of records returned in this strip.
      * </pre>
      *
      * <code>int32 limit = 1;</code>
@@ -495,7 +499,9 @@ private static final long serialVersionUID = 0L;
     private int offset_ ;
     /**
      * <pre>
-     * The offset of the strip - count of records from the beginning to skip.
+     * Number of records skipped from the beginning of the result set before this strip starts. 0-indexed:
+     * an offset of 0 starts at the very first record - unlike `GrpcPaginatedList.pageNumber`, this is not a
+     * page number.
      * </pre>
      *
      * <code>int32 offset = 2;</code>
@@ -507,7 +513,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset of the strip - count of records from the beginning to skip.
+     * Number of records skipped from the beginning of the result set before this strip starts. 0-indexed:
+     * an offset of 0 starts at the very first record - unlike `GrpcPaginatedList.pageNumber`, this is not a
+     * page number.
      * </pre>
      *
      * <code>int32 offset = 2;</code>
@@ -523,7 +531,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The offset of the strip - count of records from the beginning to skip.
+     * Number of records skipped from the beginning of the result set before this strip starts. 0-indexed:
+     * an offset of 0 starts at the very first record - unlike `GrpcPaginatedList.pageNumber`, this is not a
+     * page number.
      * </pre>
      *
      * <code>int32 offset = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStripListOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcStripListOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcStripListOrBuilder extends
 
   /**
    * <pre>
-   * The size of the strip.
+   * Maximum number of records returned in this strip.
    * </pre>
    *
    * <code>int32 limit = 1;</code>
@@ -43,7 +43,9 @@ public interface GrpcStripListOrBuilder extends
 
   /**
    * <pre>
-   * The offset of the strip - count of records from the beginning to skip.
+   * Number of records skipped from the beginning of the result set before this strip starts. 0-indexed:
+   * an offset of 0 starts at the very first record - unlike `GrpcPaginatedList.pageNumber`, this is not a
+   * page number.
    * </pre>
    *
    * <code>int32 offset = 2;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatus.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatus.java
@@ -221,7 +221,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcUuid taskId_;
   /**
    * <pre>
-   * Identification of the task
+   * Unique identifier of this task instance; use it to reference this task in status lookups or
+   * cancellation requests.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -233,7 +234,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Identification of the task
+   * Unique identifier of this task instance; use it to reference this task in status lookups or
+   * cancellation requests.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -245,7 +247,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Identification of the task
+   * Unique identifier of this task instance; use it to reference this task in status lookups or
+   * cancellation requests.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -259,7 +262,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.StringValue catalogName_;
   /**
    * <pre>
-   * Name of the catalog the task is related to (optional)
+   * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+   * catalog (e.g. server-wide/system tasks).
    * </pre>
    *
    * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -271,7 +275,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Name of the catalog the task is related to (optional)
+   * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+   * catalog (e.g. server-wide/system tasks).
    * </pre>
    *
    * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -283,7 +288,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Name of the catalog the task is related to (optional)
+   * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+   * catalog (e.g. server-wide/system tasks).
    * </pre>
    *
    * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -297,7 +303,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued_;
   /**
    * <pre>
-   * Date and time when the task was issued
+   * Date and time when the task was issued for execution (queued to run). Unset while the task is
+   * still pending and has not yet been issued.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -309,7 +316,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Date and time when the task was issued
+   * Date and time when the task was issued for execution (queued to run). Unset while the task is
+   * still pending and has not yet been issued.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -321,7 +329,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Date and time when the task was issued
+   * Date and time when the task was issued for execution (queued to run). Unset while the task is
+   * still pending and has not yet been issued.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -335,7 +344,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started_;
   /**
    * <pre>
-   * Date and time when the task was started
+   * Date and time when the task started executing. Unset before execution begins.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -347,7 +356,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Date and time when the task was started
+   * Date and time when the task started executing. Unset before execution begins.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -359,7 +368,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Date and time when the task was started
+   * Date and time when the task started executing. Unset before execution begins.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -373,7 +382,8 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished_;
   /**
    * <pre>
-   * Date and time when the task was finished
+   * Date and time when the task finished executing, successfully or with an error. Unset while
+   * the task is still running.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -385,7 +395,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Date and time when the task was finished
+   * Date and time when the task finished executing, successfully or with an error. Unset while
+   * the task is still running.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -397,7 +408,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Date and time when the task was finished
+   * Date and time when the task finished executing, successfully or with an error. Unset while
+   * the task is still running.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -411,7 +423,8 @@ private static final long serialVersionUID = 0L;
   private int simplifiedState_ = 0;
   /**
    * <pre>
-   * Simplified state of the status
+   * Coarse-grained lifecycle state of the task (queued, running, finished or failed), derived
+   * from the task's more detailed internal state.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 8;</code>
@@ -422,7 +435,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Simplified state of the status
+   * Coarse-grained lifecycle state of the task (queued, running, finished or failed), derived
+   * from the task's more detailed internal state.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 8;</code>
@@ -452,7 +466,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.StringValue settings_;
   /**
    * <pre>
-   * Configuration settings of the task
+   * String representation (`toString()`) of the task's configuration settings. Read back as an
+   * empty string if unset.
    * </pre>
    *
    * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -464,7 +479,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Configuration settings of the task
+   * String representation (`toString()`) of the task's configuration settings. Read back as an
+   * empty string if unset.
    * </pre>
    *
    * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -476,7 +492,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Configuration settings of the task
+   * String representation (`toString()`) of the task's configuration settings. Read back as an
+   * empty string if unset.
    * </pre>
    *
    * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -489,7 +506,8 @@ private static final long serialVersionUID = 0L;
   public static final int TEXT_FIELD_NUMBER = 11;
   /**
    * <pre>
-   * Textual result of the task
+   * String representation (`toString()`) of the task's result object, used for any result other
+   * than a fetchable file.
    * </pre>
    *
    * <code>.google.protobuf.StringValue text = 11;</code>
@@ -501,7 +519,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Textual result of the task
+   * String representation (`toString()`) of the task's result object, used for any result other
+   * than a fetchable file.
    * </pre>
    *
    * <code>.google.protobuf.StringValue text = 11;</code>
@@ -516,7 +535,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Textual result of the task
+   * String representation (`toString()`) of the task's result object, used for any result other
+   * than a fetchable file.
    * </pre>
    *
    * <code>.google.protobuf.StringValue text = 11;</code>
@@ -532,7 +552,7 @@ private static final long serialVersionUID = 0L;
   public static final int FILE_FIELD_NUMBER = 12;
   /**
    * <pre>
-   * File that was created by the task and is available for fetching
+   * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -544,7 +564,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * File that was created by the task and is available for fetching
+   * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -559,7 +579,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * File that was created by the task and is available for fetching
+   * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -576,7 +596,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.StringValue exception_;
   /**
    * <pre>
-   * Exception that occurred during the task execution
+   * Public-safe error message if the task failed. Unset while the task is running or if it
+   * completed without error.
    * </pre>
    *
    * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -588,7 +609,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Exception that occurred during the task execution
+   * Public-safe error message if the task failed. Unset while the task is running or if it
+   * completed without error.
    * </pre>
    *
    * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -600,7 +622,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Exception that occurred during the task execution
+   * Public-safe error message if the task failed. Unset while the task is running or if it
+   * completed without error.
    * </pre>
    *
    * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -624,7 +647,8 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * List of task traits
+   * Capabilities available for this task instance (e.g. whether it can be manually started,
+   * cancelled, or must be explicitly stopped).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -637,7 +661,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * List of task traits
+   * Capabilities available for this task instance (e.g. whether it can be manually started,
+   * cancelled, or must be explicitly stopped).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -649,7 +674,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * List of task traits
+   * Capabilities available for this task instance (e.g. whether it can be manually started,
+   * cancelled, or must be explicitly stopped).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -662,7 +688,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * List of task traits
+   * Capabilities available for this task instance (e.g. whether it can be manually started,
+   * cancelled, or must be explicitly stopped).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -675,7 +702,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * List of task traits
+   * Capabilities available for this task instance (e.g. whether it can be manually started,
+   * cancelled, or must be explicitly stopped).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -692,7 +720,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created_;
   /**
    * <pre>
-   * Date and time when the task was created
+   * Date and time when this task status record was created; always set, and precedes `issued`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -704,7 +732,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Date and time when the task was created
+   * Date and time when this task status record was created; always set, and precedes `issued`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -716,7 +744,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Date and time when the task was created
+   * Date and time when this task status record was created; always set, and precedes `issued`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -1816,7 +1844,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcUuid, io.evitadb.externalApi.grpc.generated.GrpcUuid.Builder, io.evitadb.externalApi.grpc.generated.GrpcUuidOrBuilder> taskIdBuilder_;
     /**
      * <pre>
-     * Identification of the task
+     * Unique identifier of this task instance; use it to reference this task in status lookups or
+     * cancellation requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -1827,7 +1856,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task
+     * Unique identifier of this task instance; use it to reference this task in status lookups or
+     * cancellation requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -1842,7 +1872,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task
+     * Unique identifier of this task instance; use it to reference this task in status lookups or
+     * cancellation requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -1862,7 +1893,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task
+     * Unique identifier of this task instance; use it to reference this task in status lookups or
+     * cancellation requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -1880,7 +1912,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task
+     * Unique identifier of this task instance; use it to reference this task in status lookups or
+     * cancellation requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -1905,7 +1938,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task
+     * Unique identifier of this task instance; use it to reference this task in status lookups or
+     * cancellation requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -1922,7 +1956,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task
+     * Unique identifier of this task instance; use it to reference this task in status lookups or
+     * cancellation requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -1934,7 +1969,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task
+     * Unique identifier of this task instance; use it to reference this task in status lookups or
+     * cancellation requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -1949,7 +1985,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Identification of the task
+     * Unique identifier of this task instance; use it to reference this task in status lookups or
+     * cancellation requests.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -1973,7 +2010,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> catalogNameBuilder_;
     /**
      * <pre>
-     * Name of the catalog the task is related to (optional)
+     * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+     * catalog (e.g. server-wide/system tasks).
      * </pre>
      *
      * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -1984,7 +2022,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog the task is related to (optional)
+     * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+     * catalog (e.g. server-wide/system tasks).
      * </pre>
      *
      * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -1999,7 +2038,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog the task is related to (optional)
+     * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+     * catalog (e.g. server-wide/system tasks).
      * </pre>
      *
      * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -2019,7 +2059,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog the task is related to (optional)
+     * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+     * catalog (e.g. server-wide/system tasks).
      * </pre>
      *
      * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -2037,7 +2078,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog the task is related to (optional)
+     * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+     * catalog (e.g. server-wide/system tasks).
      * </pre>
      *
      * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -2062,7 +2104,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog the task is related to (optional)
+     * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+     * catalog (e.g. server-wide/system tasks).
      * </pre>
      *
      * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -2079,7 +2122,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog the task is related to (optional)
+     * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+     * catalog (e.g. server-wide/system tasks).
      * </pre>
      *
      * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -2091,7 +2135,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog the task is related to (optional)
+     * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+     * catalog (e.g. server-wide/system tasks).
      * </pre>
      *
      * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -2106,7 +2151,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Name of the catalog the task is related to (optional)
+     * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+     * catalog (e.g. server-wide/system tasks).
      * </pre>
      *
      * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -2130,7 +2176,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> issuedBuilder_;
     /**
      * <pre>
-     * Date and time when the task was issued
+     * Date and time when the task was issued for execution (queued to run). Unset while the task is
+     * still pending and has not yet been issued.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -2141,7 +2188,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was issued
+     * Date and time when the task was issued for execution (queued to run). Unset while the task is
+     * still pending and has not yet been issued.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -2156,7 +2204,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was issued
+     * Date and time when the task was issued for execution (queued to run). Unset while the task is
+     * still pending and has not yet been issued.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -2176,7 +2225,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was issued
+     * Date and time when the task was issued for execution (queued to run). Unset while the task is
+     * still pending and has not yet been issued.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -2194,7 +2244,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was issued
+     * Date and time when the task was issued for execution (queued to run). Unset while the task is
+     * still pending and has not yet been issued.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -2219,7 +2270,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was issued
+     * Date and time when the task was issued for execution (queued to run). Unset while the task is
+     * still pending and has not yet been issued.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -2236,7 +2288,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was issued
+     * Date and time when the task was issued for execution (queued to run). Unset while the task is
+     * still pending and has not yet been issued.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -2248,7 +2301,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was issued
+     * Date and time when the task was issued for execution (queued to run). Unset while the task is
+     * still pending and has not yet been issued.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -2263,7 +2317,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was issued
+     * Date and time when the task was issued for execution (queued to run). Unset while the task is
+     * still pending and has not yet been issued.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -2287,7 +2342,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> startedBuilder_;
     /**
      * <pre>
-     * Date and time when the task was started
+     * Date and time when the task started executing. Unset before execution begins.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -2298,7 +2353,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was started
+     * Date and time when the task started executing. Unset before execution begins.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -2313,7 +2368,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was started
+     * Date and time when the task started executing. Unset before execution begins.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -2333,7 +2388,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was started
+     * Date and time when the task started executing. Unset before execution begins.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -2351,7 +2406,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was started
+     * Date and time when the task started executing. Unset before execution begins.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -2376,7 +2431,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was started
+     * Date and time when the task started executing. Unset before execution begins.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -2393,7 +2448,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was started
+     * Date and time when the task started executing. Unset before execution begins.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -2405,7 +2460,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was started
+     * Date and time when the task started executing. Unset before execution begins.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -2420,7 +2475,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was started
+     * Date and time when the task started executing. Unset before execution begins.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -2444,7 +2499,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> finishedBuilder_;
     /**
      * <pre>
-     * Date and time when the task was finished
+     * Date and time when the task finished executing, successfully or with an error. Unset while
+     * the task is still running.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -2455,7 +2511,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was finished
+     * Date and time when the task finished executing, successfully or with an error. Unset while
+     * the task is still running.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -2470,7 +2527,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was finished
+     * Date and time when the task finished executing, successfully or with an error. Unset while
+     * the task is still running.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -2490,7 +2548,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was finished
+     * Date and time when the task finished executing, successfully or with an error. Unset while
+     * the task is still running.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -2508,7 +2567,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was finished
+     * Date and time when the task finished executing, successfully or with an error. Unset while
+     * the task is still running.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -2533,7 +2593,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was finished
+     * Date and time when the task finished executing, successfully or with an error. Unset while
+     * the task is still running.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -2550,7 +2611,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was finished
+     * Date and time when the task finished executing, successfully or with an error. Unset while
+     * the task is still running.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -2562,7 +2624,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was finished
+     * Date and time when the task finished executing, successfully or with an error. Unset while
+     * the task is still running.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -2577,7 +2640,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was finished
+     * Date and time when the task finished executing, successfully or with an error. Unset while
+     * the task is still running.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -2599,7 +2663,8 @@ private static final long serialVersionUID = 0L;
     private int simplifiedState_ = 0;
     /**
      * <pre>
-     * Simplified state of the status
+     * Coarse-grained lifecycle state of the task (queued, running, finished or failed), derived
+     * from the task's more detailed internal state.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 8;</code>
@@ -2610,7 +2675,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Simplified state of the status
+     * Coarse-grained lifecycle state of the task (queued, running, finished or failed), derived
+     * from the task's more detailed internal state.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 8;</code>
@@ -2625,7 +2691,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Simplified state of the status
+     * Coarse-grained lifecycle state of the task (queued, running, finished or failed), derived
+     * from the task's more detailed internal state.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 8;</code>
@@ -2638,7 +2705,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Simplified state of the status
+     * Coarse-grained lifecycle state of the task (queued, running, finished or failed), derived
+     * from the task's more detailed internal state.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 8;</code>
@@ -2656,7 +2724,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Simplified state of the status
+     * Coarse-grained lifecycle state of the task (queued, running, finished or failed), derived
+     * from the task's more detailed internal state.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 8;</code>
@@ -2718,7 +2787,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> settingsBuilder_;
     /**
      * <pre>
-     * Configuration settings of the task
+     * String representation (`toString()`) of the task's configuration settings. Read back as an
+     * empty string if unset.
      * </pre>
      *
      * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -2729,7 +2799,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Configuration settings of the task
+     * String representation (`toString()`) of the task's configuration settings. Read back as an
+     * empty string if unset.
      * </pre>
      *
      * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -2744,7 +2815,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Configuration settings of the task
+     * String representation (`toString()`) of the task's configuration settings. Read back as an
+     * empty string if unset.
      * </pre>
      *
      * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -2764,7 +2836,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Configuration settings of the task
+     * String representation (`toString()`) of the task's configuration settings. Read back as an
+     * empty string if unset.
      * </pre>
      *
      * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -2782,7 +2855,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Configuration settings of the task
+     * String representation (`toString()`) of the task's configuration settings. Read back as an
+     * empty string if unset.
      * </pre>
      *
      * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -2807,7 +2881,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Configuration settings of the task
+     * String representation (`toString()`) of the task's configuration settings. Read back as an
+     * empty string if unset.
      * </pre>
      *
      * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -2824,7 +2899,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Configuration settings of the task
+     * String representation (`toString()`) of the task's configuration settings. Read back as an
+     * empty string if unset.
      * </pre>
      *
      * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -2836,7 +2912,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Configuration settings of the task
+     * String representation (`toString()`) of the task's configuration settings. Read back as an
+     * empty string if unset.
      * </pre>
      *
      * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -2851,7 +2928,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Configuration settings of the task
+     * String representation (`toString()`) of the task's configuration settings. Read back as an
+     * empty string if unset.
      * </pre>
      *
      * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -2874,7 +2952,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> textBuilder_;
     /**
      * <pre>
-     * Textual result of the task
+     * String representation (`toString()`) of the task's result object, used for any result other
+     * than a fetchable file.
      * </pre>
      *
      * <code>.google.protobuf.StringValue text = 11;</code>
@@ -2886,7 +2965,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Textual result of the task
+     * String representation (`toString()`) of the task's result object, used for any result other
+     * than a fetchable file.
      * </pre>
      *
      * <code>.google.protobuf.StringValue text = 11;</code>
@@ -2908,7 +2988,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Textual result of the task
+     * String representation (`toString()`) of the task's result object, used for any result other
+     * than a fetchable file.
      * </pre>
      *
      * <code>.google.protobuf.StringValue text = 11;</code>
@@ -2928,7 +3009,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Textual result of the task
+     * String representation (`toString()`) of the task's result object, used for any result other
+     * than a fetchable file.
      * </pre>
      *
      * <code>.google.protobuf.StringValue text = 11;</code>
@@ -2946,7 +3028,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Textual result of the task
+     * String representation (`toString()`) of the task's result object, used for any result other
+     * than a fetchable file.
      * </pre>
      *
      * <code>.google.protobuf.StringValue text = 11;</code>
@@ -2973,7 +3056,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Textual result of the task
+     * String representation (`toString()`) of the task's result object, used for any result other
+     * than a fetchable file.
      * </pre>
      *
      * <code>.google.protobuf.StringValue text = 11;</code>
@@ -2996,7 +3080,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Textual result of the task
+     * String representation (`toString()`) of the task's result object, used for any result other
+     * than a fetchable file.
      * </pre>
      *
      * <code>.google.protobuf.StringValue text = 11;</code>
@@ -3006,7 +3091,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Textual result of the task
+     * String representation (`toString()`) of the task's result object, used for any result other
+     * than a fetchable file.
      * </pre>
      *
      * <code>.google.protobuf.StringValue text = 11;</code>
@@ -3024,7 +3110,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Textual result of the task
+     * String representation (`toString()`) of the task's result object, used for any result other
+     * than a fetchable file.
      * </pre>
      *
      * <code>.google.protobuf.StringValue text = 11;</code>
@@ -3052,7 +3139,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcFile, io.evitadb.externalApi.grpc.generated.GrpcFile.Builder, io.evitadb.externalApi.grpc.generated.GrpcFileOrBuilder> fileBuilder_;
     /**
      * <pre>
-     * File that was created by the task and is available for fetching
+     * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -3064,7 +3151,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File that was created by the task and is available for fetching
+     * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -3086,7 +3173,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File that was created by the task and is available for fetching
+     * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -3106,7 +3193,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File that was created by the task and is available for fetching
+     * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -3124,7 +3211,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File that was created by the task and is available for fetching
+     * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -3151,7 +3238,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File that was created by the task and is available for fetching
+     * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -3174,7 +3261,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File that was created by the task and is available for fetching
+     * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -3184,7 +3271,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File that was created by the task and is available for fetching
+     * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -3202,7 +3289,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * File that was created by the task and is available for fetching
+     * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -3231,7 +3318,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> exceptionBuilder_;
     /**
      * <pre>
-     * Exception that occurred during the task execution
+     * Public-safe error message if the task failed. Unset while the task is running or if it
+     * completed without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -3242,7 +3330,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Exception that occurred during the task execution
+     * Public-safe error message if the task failed. Unset while the task is running or if it
+     * completed without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -3257,7 +3346,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Exception that occurred during the task execution
+     * Public-safe error message if the task failed. Unset while the task is running or if it
+     * completed without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -3277,7 +3367,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Exception that occurred during the task execution
+     * Public-safe error message if the task failed. Unset while the task is running or if it
+     * completed without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -3295,7 +3386,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Exception that occurred during the task execution
+     * Public-safe error message if the task failed. Unset while the task is running or if it
+     * completed without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -3320,7 +3412,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Exception that occurred during the task execution
+     * Public-safe error message if the task failed. Unset while the task is running or if it
+     * completed without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -3337,7 +3430,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Exception that occurred during the task execution
+     * Public-safe error message if the task failed. Unset while the task is running or if it
+     * completed without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -3349,7 +3443,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Exception that occurred during the task execution
+     * Public-safe error message if the task failed. Unset while the task is running or if it
+     * completed without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -3364,7 +3459,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Exception that occurred during the task execution
+     * Public-safe error message if the task failed. Unset while the task is running or if it
+     * completed without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -3393,7 +3489,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of task traits
+     * Capabilities available for this task instance (e.g. whether it can be manually started,
+     * cancelled, or must be explicitly stopped).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -3405,7 +3502,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of task traits
+     * Capabilities available for this task instance (e.g. whether it can be manually started,
+     * cancelled, or must be explicitly stopped).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -3416,7 +3514,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of task traits
+     * Capabilities available for this task instance (e.g. whether it can be manually started,
+     * cancelled, or must be explicitly stopped).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -3428,7 +3527,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of task traits
+     * Capabilities available for this task instance (e.g. whether it can be manually started,
+     * cancelled, or must be explicitly stopped).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -3448,7 +3548,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of task traits
+     * Capabilities available for this task instance (e.g. whether it can be manually started,
+     * cancelled, or must be explicitly stopped).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -3466,7 +3567,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of task traits
+     * Capabilities available for this task instance (e.g. whether it can be manually started,
+     * cancelled, or must be explicitly stopped).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -3484,7 +3586,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of task traits
+     * Capabilities available for this task instance (e.g. whether it can be manually started,
+     * cancelled, or must be explicitly stopped).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -3498,7 +3601,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of task traits
+     * Capabilities available for this task instance (e.g. whether it can be manually started,
+     * cancelled, or must be explicitly stopped).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -3510,7 +3614,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of task traits
+     * Capabilities available for this task instance (e.g. whether it can be manually started,
+     * cancelled, or must be explicitly stopped).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -3522,7 +3627,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of task traits
+     * Capabilities available for this task instance (e.g. whether it can be manually started,
+     * cancelled, or must be explicitly stopped).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -3539,7 +3645,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of task traits
+     * Capabilities available for this task instance (e.g. whether it can be manually started,
+     * cancelled, or must be explicitly stopped).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -3554,7 +3661,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * List of task traits
+     * Capabilities available for this task instance (e.g. whether it can be manually started,
+     * cancelled, or must be explicitly stopped).
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -3576,7 +3684,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> createdBuilder_;
     /**
      * <pre>
-     * Date and time when the task was created
+     * Date and time when this task status record was created; always set, and precedes `issued`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -3587,7 +3695,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was created
+     * Date and time when this task status record was created; always set, and precedes `issued`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -3602,7 +3710,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was created
+     * Date and time when this task status record was created; always set, and precedes `issued`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -3622,7 +3730,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was created
+     * Date and time when this task status record was created; always set, and precedes `issued`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -3640,7 +3748,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was created
+     * Date and time when this task status record was created; always set, and precedes `issued`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -3665,7 +3773,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was created
+     * Date and time when this task status record was created; always set, and precedes `issued`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -3682,7 +3790,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was created
+     * Date and time when this task status record was created; always set, and precedes `issued`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -3694,7 +3802,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was created
+     * Date and time when this task status record was created; always set, and precedes `issued`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -3709,7 +3817,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time when the task was created
+     * Date and time when this task status record was created; always set, and precedes `issued`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusOrBuilder.java
@@ -83,7 +83,8 @@ public interface GrpcTaskStatusOrBuilder extends
 
   /**
    * <pre>
-   * Identification of the task
+   * Unique identifier of this task instance; use it to reference this task in status lookups or
+   * cancellation requests.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -92,7 +93,8 @@ public interface GrpcTaskStatusOrBuilder extends
   boolean hasTaskId();
   /**
    * <pre>
-   * Identification of the task
+   * Unique identifier of this task instance; use it to reference this task in status lookups or
+   * cancellation requests.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -101,7 +103,8 @@ public interface GrpcTaskStatusOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuid getTaskId();
   /**
    * <pre>
-   * Identification of the task
+   * Unique identifier of this task instance; use it to reference this task in status lookups or
+   * cancellation requests.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcUuid taskId = 3;</code>
@@ -110,7 +113,8 @@ public interface GrpcTaskStatusOrBuilder extends
 
   /**
    * <pre>
-   * Name of the catalog the task is related to (optional)
+   * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+   * catalog (e.g. server-wide/system tasks).
    * </pre>
    *
    * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -119,7 +123,8 @@ public interface GrpcTaskStatusOrBuilder extends
   boolean hasCatalogName();
   /**
    * <pre>
-   * Name of the catalog the task is related to (optional)
+   * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+   * catalog (e.g. server-wide/system tasks).
    * </pre>
    *
    * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -128,7 +133,8 @@ public interface GrpcTaskStatusOrBuilder extends
   com.google.protobuf.StringValue getCatalogName();
   /**
    * <pre>
-   * Name of the catalog the task is related to (optional)
+   * Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+   * catalog (e.g. server-wide/system tasks).
    * </pre>
    *
    * <code>.google.protobuf.StringValue catalogName = 4;</code>
@@ -137,7 +143,8 @@ public interface GrpcTaskStatusOrBuilder extends
 
   /**
    * <pre>
-   * Date and time when the task was issued
+   * Date and time when the task was issued for execution (queued to run). Unset while the task is
+   * still pending and has not yet been issued.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -146,7 +153,8 @@ public interface GrpcTaskStatusOrBuilder extends
   boolean hasIssued();
   /**
    * <pre>
-   * Date and time when the task was issued
+   * Date and time when the task was issued for execution (queued to run). Unset while the task is
+   * still pending and has not yet been issued.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -155,7 +163,8 @@ public interface GrpcTaskStatusOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getIssued();
   /**
    * <pre>
-   * Date and time when the task was issued
+   * Date and time when the task was issued for execution (queued to run). Unset while the task is
+   * still pending and has not yet been issued.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime issued = 5;</code>
@@ -164,7 +173,7 @@ public interface GrpcTaskStatusOrBuilder extends
 
   /**
    * <pre>
-   * Date and time when the task was started
+   * Date and time when the task started executing. Unset before execution begins.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -173,7 +182,7 @@ public interface GrpcTaskStatusOrBuilder extends
   boolean hasStarted();
   /**
    * <pre>
-   * Date and time when the task was started
+   * Date and time when the task started executing. Unset before execution begins.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -182,7 +191,7 @@ public interface GrpcTaskStatusOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getStarted();
   /**
    * <pre>
-   * Date and time when the task was started
+   * Date and time when the task started executing. Unset before execution begins.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime started = 6;</code>
@@ -191,7 +200,8 @@ public interface GrpcTaskStatusOrBuilder extends
 
   /**
    * <pre>
-   * Date and time when the task was finished
+   * Date and time when the task finished executing, successfully or with an error. Unset while
+   * the task is still running.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -200,7 +210,8 @@ public interface GrpcTaskStatusOrBuilder extends
   boolean hasFinished();
   /**
    * <pre>
-   * Date and time when the task was finished
+   * Date and time when the task finished executing, successfully or with an error. Unset while
+   * the task is still running.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -209,7 +220,8 @@ public interface GrpcTaskStatusOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getFinished();
   /**
    * <pre>
-   * Date and time when the task was finished
+   * Date and time when the task finished executing, successfully or with an error. Unset while
+   * the task is still running.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime finished = 7;</code>
@@ -218,7 +230,8 @@ public interface GrpcTaskStatusOrBuilder extends
 
   /**
    * <pre>
-   * Simplified state of the status
+   * Coarse-grained lifecycle state of the task (queued, running, finished or failed), derived
+   * from the task's more detailed internal state.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 8;</code>
@@ -227,7 +240,8 @@ public interface GrpcTaskStatusOrBuilder extends
   int getSimplifiedStateValue();
   /**
    * <pre>
-   * Simplified state of the status
+   * Coarse-grained lifecycle state of the task (queued, running, finished or failed), derived
+   * from the task's more detailed internal state.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 8;</code>
@@ -247,7 +261,8 @@ public interface GrpcTaskStatusOrBuilder extends
 
   /**
    * <pre>
-   * Configuration settings of the task
+   * String representation (`toString()`) of the task's configuration settings. Read back as an
+   * empty string if unset.
    * </pre>
    *
    * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -256,7 +271,8 @@ public interface GrpcTaskStatusOrBuilder extends
   boolean hasSettings();
   /**
    * <pre>
-   * Configuration settings of the task
+   * String representation (`toString()`) of the task's configuration settings. Read back as an
+   * empty string if unset.
    * </pre>
    *
    * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -265,7 +281,8 @@ public interface GrpcTaskStatusOrBuilder extends
   com.google.protobuf.StringValue getSettings();
   /**
    * <pre>
-   * Configuration settings of the task
+   * String representation (`toString()`) of the task's configuration settings. Read back as an
+   * empty string if unset.
    * </pre>
    *
    * <code>.google.protobuf.StringValue settings = 10;</code>
@@ -274,7 +291,8 @@ public interface GrpcTaskStatusOrBuilder extends
 
   /**
    * <pre>
-   * Textual result of the task
+   * String representation (`toString()`) of the task's result object, used for any result other
+   * than a fetchable file.
    * </pre>
    *
    * <code>.google.protobuf.StringValue text = 11;</code>
@@ -283,7 +301,8 @@ public interface GrpcTaskStatusOrBuilder extends
   boolean hasText();
   /**
    * <pre>
-   * Textual result of the task
+   * String representation (`toString()`) of the task's result object, used for any result other
+   * than a fetchable file.
    * </pre>
    *
    * <code>.google.protobuf.StringValue text = 11;</code>
@@ -292,7 +311,8 @@ public interface GrpcTaskStatusOrBuilder extends
   com.google.protobuf.StringValue getText();
   /**
    * <pre>
-   * Textual result of the task
+   * String representation (`toString()`) of the task's result object, used for any result other
+   * than a fetchable file.
    * </pre>
    *
    * <code>.google.protobuf.StringValue text = 11;</code>
@@ -301,7 +321,7 @@ public interface GrpcTaskStatusOrBuilder extends
 
   /**
    * <pre>
-   * File that was created by the task and is available for fetching
+   * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -310,7 +330,7 @@ public interface GrpcTaskStatusOrBuilder extends
   boolean hasFile();
   /**
    * <pre>
-   * File that was created by the task and is available for fetching
+   * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -319,7 +339,7 @@ public interface GrpcTaskStatusOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcFile getFile();
   /**
    * <pre>
-   * File that was created by the task and is available for fetching
+   * The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcFile file = 12;</code>
@@ -328,7 +348,8 @@ public interface GrpcTaskStatusOrBuilder extends
 
   /**
    * <pre>
-   * Exception that occurred during the task execution
+   * Public-safe error message if the task failed. Unset while the task is running or if it
+   * completed without error.
    * </pre>
    *
    * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -337,7 +358,8 @@ public interface GrpcTaskStatusOrBuilder extends
   boolean hasException();
   /**
    * <pre>
-   * Exception that occurred during the task execution
+   * Public-safe error message if the task failed. Unset while the task is running or if it
+   * completed without error.
    * </pre>
    *
    * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -346,7 +368,8 @@ public interface GrpcTaskStatusOrBuilder extends
   com.google.protobuf.StringValue getException();
   /**
    * <pre>
-   * Exception that occurred during the task execution
+   * Public-safe error message if the task failed. Unset while the task is running or if it
+   * completed without error.
    * </pre>
    *
    * <code>.google.protobuf.StringValue exception = 13;</code>
@@ -355,7 +378,8 @@ public interface GrpcTaskStatusOrBuilder extends
 
   /**
    * <pre>
-   * List of task traits
+   * Capabilities available for this task instance (e.g. whether it can be manually started,
+   * cancelled, or must be explicitly stopped).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -364,7 +388,8 @@ public interface GrpcTaskStatusOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcTaskTrait> getTraitList();
   /**
    * <pre>
-   * List of task traits
+   * Capabilities available for this task instance (e.g. whether it can be manually started,
+   * cancelled, or must be explicitly stopped).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -373,7 +398,8 @@ public interface GrpcTaskStatusOrBuilder extends
   int getTraitCount();
   /**
    * <pre>
-   * List of task traits
+   * Capabilities available for this task instance (e.g. whether it can be manually started,
+   * cancelled, or must be explicitly stopped).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -383,7 +409,8 @@ public interface GrpcTaskStatusOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTaskTrait getTrait(int index);
   /**
    * <pre>
-   * List of task traits
+   * Capabilities available for this task instance (e.g. whether it can be manually started,
+   * cancelled, or must be explicitly stopped).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -393,7 +420,8 @@ public interface GrpcTaskStatusOrBuilder extends
   getTraitValueList();
   /**
    * <pre>
-   * List of task traits
+   * Capabilities available for this task instance (e.g. whether it can be manually started,
+   * cancelled, or must be explicitly stopped).
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskTrait trait = 14;</code>
@@ -404,7 +432,7 @@ public interface GrpcTaskStatusOrBuilder extends
 
   /**
    * <pre>
-   * Date and time when the task was created
+   * Date and time when this task status record was created; always set, and precedes `issued`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -413,7 +441,7 @@ public interface GrpcTaskStatusOrBuilder extends
   boolean hasCreated();
   /**
    * <pre>
-   * Date and time when the task was created
+   * Date and time when this task status record was created; always set, and precedes `issued`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>
@@ -422,7 +450,7 @@ public interface GrpcTaskStatusOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getCreated();
   /**
    * <pre>
-   * Date and time when the task was created
+   * Date and time when this task status record was created; always set, and precedes `issued`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime created = 15;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusResponse.java
@@ -71,7 +71,12 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus_;
   /**
    * <pre>
-   * Task status if found
+   * Status of the requested task. If no task exists for the given id, the server currently does
+   * not send this response message at all, rather than sending it with this field unset - for
+   * this unary call, that means the call does not complete normally rather than yielding an empty
+   * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+   * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+   * error, since it returns a normal (possibly empty) response instead.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -83,7 +88,12 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Task status if found
+   * Status of the requested task. If no task exists for the given id, the server currently does
+   * not send this response message at all, rather than sending it with this field unset - for
+   * this unary call, that means the call does not complete normally rather than yielding an empty
+   * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+   * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+   * error, since it returns a normal (possibly empty) response instead.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -95,7 +105,12 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Task status if found
+   * Status of the requested task. If no task exists for the given id, the server currently does
+   * not send this response message at all, rather than sending it with this field unset - for
+   * this unary call, that means the call does not complete normally rather than yielding an empty
+   * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+   * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+   * error, since it returns a normal (possibly empty) response instead.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -461,7 +476,12 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcTaskStatus, io.evitadb.externalApi.grpc.generated.GrpcTaskStatus.Builder, io.evitadb.externalApi.grpc.generated.GrpcTaskStatusOrBuilder> taskStatusBuilder_;
     /**
      * <pre>
-     * Task status if found
+     * Status of the requested task. If no task exists for the given id, the server currently does
+     * not send this response message at all, rather than sending it with this field unset - for
+     * this unary call, that means the call does not complete normally rather than yielding an empty
+     * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+     * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+     * error, since it returns a normal (possibly empty) response instead.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -472,7 +492,12 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Task status if found
+     * Status of the requested task. If no task exists for the given id, the server currently does
+     * not send this response message at all, rather than sending it with this field unset - for
+     * this unary call, that means the call does not complete normally rather than yielding an empty
+     * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+     * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+     * error, since it returns a normal (possibly empty) response instead.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -487,7 +512,12 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Task status if found
+     * Status of the requested task. If no task exists for the given id, the server currently does
+     * not send this response message at all, rather than sending it with this field unset - for
+     * this unary call, that means the call does not complete normally rather than yielding an empty
+     * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+     * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+     * error, since it returns a normal (possibly empty) response instead.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -507,7 +537,12 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Task status if found
+     * Status of the requested task. If no task exists for the given id, the server currently does
+     * not send this response message at all, rather than sending it with this field unset - for
+     * this unary call, that means the call does not complete normally rather than yielding an empty
+     * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+     * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+     * error, since it returns a normal (possibly empty) response instead.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -525,7 +560,12 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Task status if found
+     * Status of the requested task. If no task exists for the given id, the server currently does
+     * not send this response message at all, rather than sending it with this field unset - for
+     * this unary call, that means the call does not complete normally rather than yielding an empty
+     * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+     * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+     * error, since it returns a normal (possibly empty) response instead.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -550,7 +590,12 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Task status if found
+     * Status of the requested task. If no task exists for the given id, the server currently does
+     * not send this response message at all, rather than sending it with this field unset - for
+     * this unary call, that means the call does not complete normally rather than yielding an empty
+     * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+     * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+     * error, since it returns a normal (possibly empty) response instead.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -567,7 +612,12 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Task status if found
+     * Status of the requested task. If no task exists for the given id, the server currently does
+     * not send this response message at all, rather than sending it with this field unset - for
+     * this unary call, that means the call does not complete normally rather than yielding an empty
+     * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+     * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+     * error, since it returns a normal (possibly empty) response instead.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -579,7 +629,12 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Task status if found
+     * Status of the requested task. If no task exists for the given id, the server currently does
+     * not send this response message at all, rather than sending it with this field unset - for
+     * this unary call, that means the call does not complete normally rather than yielding an empty
+     * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+     * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+     * error, since it returns a normal (possibly empty) response instead.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -594,7 +649,12 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Task status if found
+     * Status of the requested task. If no task exists for the given id, the server currently does
+     * not send this response message at all, rather than sending it with this field unset - for
+     * this unary call, that means the call does not complete normally rather than yielding an empty
+     * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+     * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+     * error, since it returns a normal (possibly empty) response instead.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusResponseOrBuilder.java
@@ -33,7 +33,12 @@ public interface GrpcTaskStatusResponseOrBuilder extends
 
   /**
    * <pre>
-   * Task status if found
+   * Status of the requested task. If no task exists for the given id, the server currently does
+   * not send this response message at all, rather than sending it with this field unset - for
+   * this unary call, that means the call does not complete normally rather than yielding an empty
+   * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+   * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+   * error, since it returns a normal (possibly empty) response instead.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -42,7 +47,12 @@ public interface GrpcTaskStatusResponseOrBuilder extends
   boolean hasTaskStatus();
   /**
    * <pre>
-   * Task status if found
+   * Status of the requested task. If no task exists for the given id, the server currently does
+   * not send this response message at all, rather than sending it with this field unset - for
+   * this unary call, that means the call does not complete normally rather than yielding an empty
+   * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+   * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+   * error, since it returns a normal (possibly empty) response instead.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>
@@ -51,7 +61,12 @@ public interface GrpcTaskStatusResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTaskStatus getTaskStatus();
   /**
    * <pre>
-   * Task status if found
+   * Status of the requested task. If no task exists for the given id, the server currently does
+   * not send this response message at all, rather than sending it with this field unset - for
+   * this unary call, that means the call does not complete normally rather than yielding an empty
+   * result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+   * status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+   * error, since it returns a normal (possibly empty) response instead.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusesRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusesRequest.java
@@ -72,7 +72,8 @@ private static final long serialVersionUID = 0L;
   private int pageNumber_ = 0;
   /**
    * <pre>
-   * Page number of the task statuses to be listed.
+   * Page number of the task statuses to be listed. Page-based paging: 1-indexed, page 1 is the
+   * first page (see `io.evitadb.dataType.PaginatedList#getPageNumber`).
    * </pre>
    *
    * <code>int32 pageNumber = 1;</code>
@@ -87,7 +88,7 @@ private static final long serialVersionUID = 0L;
   private int pageSize_ = 0;
   /**
    * <pre>
-   * Number of task statuses per page.
+   * Number of task statuses per page. No server-side maximum is enforced.
    * </pre>
    *
    * <code>int32 pageSize = 2;</code>
@@ -103,8 +104,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<com.google.protobuf.StringValue> taskType_;
   /**
    * <pre>
-   * Optional taskType of the listed task, passing non-null value
-   * in this argument filters the returned status to only those that are related to the tasks of specified type
+   * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+   * its type is any of the listed values. Empty (the default) means no filtering by type.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -115,8 +116,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional taskType of the listed task, passing non-null value
-   * in this argument filters the returned status to only those that are related to the tasks of specified type
+   * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+   * its type is any of the listed values. Empty (the default) means no filtering by type.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -128,8 +129,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional taskType of the listed task, passing non-null value
-   * in this argument filters the returned status to only those that are related to the tasks of specified type
+   * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+   * its type is any of the listed values. Empty (the default) means no filtering by type.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -140,8 +141,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional taskType of the listed task, passing non-null value
-   * in this argument filters the returned status to only those that are related to the tasks of specified type
+   * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+   * its type is any of the listed values. Empty (the default) means no filtering by type.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -152,8 +153,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional taskType of the listed task, passing non-null value
-   * in this argument filters the returned status to only those that are related to the tasks of specified type
+   * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+   * its type is any of the listed values. Empty (the default) means no filtering by type.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -178,8 +179,9 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * Optional set of simplified task states, passing list of enums in this argument
-   * filters the returned statuses to only those that match this simplified status
+   * Simplified task states to filter by; a task matches if its state is any of the listed values.
+   * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+   * are non-empty, a task must satisfy both filters.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -192,8 +194,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional set of simplified task states, passing list of enums in this argument
-   * filters the returned statuses to only those that match this simplified status
+   * Simplified task states to filter by; a task matches if its state is any of the listed values.
+   * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+   * are non-empty, a task must satisfy both filters.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -205,8 +208,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional set of simplified task states, passing list of enums in this argument
-   * filters the returned statuses to only those that match this simplified status
+   * Simplified task states to filter by; a task matches if its state is any of the listed values.
+   * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+   * are non-empty, a task must satisfy both filters.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -219,8 +223,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional set of simplified task states, passing list of enums in this argument
-   * filters the returned statuses to only those that match this simplified status
+   * Simplified task states to filter by; a task matches if its state is any of the listed values.
+   * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+   * are non-empty, a task must satisfy both filters.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -233,8 +238,9 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Optional set of simplified task states, passing list of enums in this argument
-   * filters the returned statuses to only those that match this simplified status
+   * Simplified task states to filter by; a task matches if its state is any of the listed values.
+   * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+   * are non-empty, a task must satisfy both filters.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -733,7 +739,8 @@ private static final long serialVersionUID = 0L;
     private int pageNumber_ ;
     /**
      * <pre>
-     * Page number of the task statuses to be listed.
+     * Page number of the task statuses to be listed. Page-based paging: 1-indexed, page 1 is the
+     * first page (see `io.evitadb.dataType.PaginatedList#getPageNumber`).
      * </pre>
      *
      * <code>int32 pageNumber = 1;</code>
@@ -745,7 +752,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Page number of the task statuses to be listed.
+     * Page number of the task statuses to be listed. Page-based paging: 1-indexed, page 1 is the
+     * first page (see `io.evitadb.dataType.PaginatedList#getPageNumber`).
      * </pre>
      *
      * <code>int32 pageNumber = 1;</code>
@@ -761,7 +769,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Page number of the task statuses to be listed.
+     * Page number of the task statuses to be listed. Page-based paging: 1-indexed, page 1 is the
+     * first page (see `io.evitadb.dataType.PaginatedList#getPageNumber`).
      * </pre>
      *
      * <code>int32 pageNumber = 1;</code>
@@ -777,7 +786,7 @@ private static final long serialVersionUID = 0L;
     private int pageSize_ ;
     /**
      * <pre>
-     * Number of task statuses per page.
+     * Number of task statuses per page. No server-side maximum is enforced.
      * </pre>
      *
      * <code>int32 pageSize = 2;</code>
@@ -789,7 +798,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Number of task statuses per page.
+     * Number of task statuses per page. No server-side maximum is enforced.
      * </pre>
      *
      * <code>int32 pageSize = 2;</code>
@@ -805,7 +814,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Number of task statuses per page.
+     * Number of task statuses per page. No server-side maximum is enforced.
      * </pre>
      *
      * <code>int32 pageSize = 2;</code>
@@ -832,8 +841,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -847,8 +856,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -862,8 +871,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -877,8 +886,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -899,8 +908,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -918,8 +927,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -939,8 +948,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -961,8 +970,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -980,8 +989,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -999,8 +1008,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -1019,8 +1028,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -1037,8 +1046,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -1055,8 +1064,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -1067,8 +1076,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -1082,8 +1091,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -1098,8 +1107,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -1110,8 +1119,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -1123,8 +1132,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional taskType of the listed task, passing non-null value
-     * in this argument filters the returned status to only those that are related to the tasks of specified type
+     * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+     * its type is any of the listed values. Empty (the default) means no filtering by type.
      * </pre>
      *
      * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -1158,8 +1167,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional set of simplified task states, passing list of enums in this argument
-     * filters the returned statuses to only those that match this simplified status
+     * Simplified task states to filter by; a task matches if its state is any of the listed values.
+     * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+     * are non-empty, a task must satisfy both filters.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -1171,8 +1181,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional set of simplified task states, passing list of enums in this argument
-     * filters the returned statuses to only those that match this simplified status
+     * Simplified task states to filter by; a task matches if its state is any of the listed values.
+     * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+     * are non-empty, a task must satisfy both filters.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -1183,8 +1194,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional set of simplified task states, passing list of enums in this argument
-     * filters the returned statuses to only those that match this simplified status
+     * Simplified task states to filter by; a task matches if its state is any of the listed values.
+     * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+     * are non-empty, a task must satisfy both filters.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -1196,8 +1208,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional set of simplified task states, passing list of enums in this argument
-     * filters the returned statuses to only those that match this simplified status
+     * Simplified task states to filter by; a task matches if its state is any of the listed values.
+     * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+     * are non-empty, a task must satisfy both filters.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -1217,8 +1230,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional set of simplified task states, passing list of enums in this argument
-     * filters the returned statuses to only those that match this simplified status
+     * Simplified task states to filter by; a task matches if its state is any of the listed values.
+     * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+     * are non-empty, a task must satisfy both filters.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -1236,8 +1250,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional set of simplified task states, passing list of enums in this argument
-     * filters the returned statuses to only those that match this simplified status
+     * Simplified task states to filter by; a task matches if its state is any of the listed values.
+     * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+     * are non-empty, a task must satisfy both filters.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -1255,8 +1270,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional set of simplified task states, passing list of enums in this argument
-     * filters the returned statuses to only those that match this simplified status
+     * Simplified task states to filter by; a task matches if its state is any of the listed values.
+     * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+     * are non-empty, a task must satisfy both filters.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -1270,8 +1286,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional set of simplified task states, passing list of enums in this argument
-     * filters the returned statuses to only those that match this simplified status
+     * Simplified task states to filter by; a task matches if its state is any of the listed values.
+     * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+     * are non-empty, a task must satisfy both filters.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -1283,8 +1300,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional set of simplified task states, passing list of enums in this argument
-     * filters the returned statuses to only those that match this simplified status
+     * Simplified task states to filter by; a task matches if its state is any of the listed values.
+     * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+     * are non-empty, a task must satisfy both filters.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -1296,8 +1314,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional set of simplified task states, passing list of enums in this argument
-     * filters the returned statuses to only those that match this simplified status
+     * Simplified task states to filter by; a task matches if its state is any of the listed values.
+     * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+     * are non-empty, a task must satisfy both filters.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -1314,8 +1333,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional set of simplified task states, passing list of enums in this argument
-     * filters the returned statuses to only those that match this simplified status
+     * Simplified task states to filter by; a task matches if its state is any of the listed values.
+     * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+     * are non-empty, a task must satisfy both filters.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -1330,8 +1350,9 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Optional set of simplified task states, passing list of enums in this argument
-     * filters the returned statuses to only those that match this simplified status
+     * Simplified task states to filter by; a task matches if its state is any of the listed values.
+     * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+     * are non-empty, a task must satisfy both filters.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusesRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusesRequestOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcTaskStatusesRequestOrBuilder extends
 
   /**
    * <pre>
-   * Page number of the task statuses to be listed.
+   * Page number of the task statuses to be listed. Page-based paging: 1-indexed, page 1 is the
+   * first page (see `io.evitadb.dataType.PaginatedList#getPageNumber`).
    * </pre>
    *
    * <code>int32 pageNumber = 1;</code>
@@ -43,7 +44,7 @@ public interface GrpcTaskStatusesRequestOrBuilder extends
 
   /**
    * <pre>
-   * Number of task statuses per page.
+   * Number of task statuses per page. No server-side maximum is enforced.
    * </pre>
    *
    * <code>int32 pageSize = 2;</code>
@@ -53,8 +54,8 @@ public interface GrpcTaskStatusesRequestOrBuilder extends
 
   /**
    * <pre>
-   * Optional taskType of the listed task, passing non-null value
-   * in this argument filters the returned status to only those that are related to the tasks of specified type
+   * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+   * its type is any of the listed values. Empty (the default) means no filtering by type.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -63,8 +64,8 @@ public interface GrpcTaskStatusesRequestOrBuilder extends
       getTaskTypeList();
   /**
    * <pre>
-   * Optional taskType of the listed task, passing non-null value
-   * in this argument filters the returned status to only those that are related to the tasks of specified type
+   * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+   * its type is any of the listed values. Empty (the default) means no filtering by type.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -72,8 +73,8 @@ public interface GrpcTaskStatusesRequestOrBuilder extends
   com.google.protobuf.StringValue getTaskType(int index);
   /**
    * <pre>
-   * Optional taskType of the listed task, passing non-null value
-   * in this argument filters the returned status to only those that are related to the tasks of specified type
+   * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+   * its type is any of the listed values. Empty (the default) means no filtering by type.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -81,8 +82,8 @@ public interface GrpcTaskStatusesRequestOrBuilder extends
   int getTaskTypeCount();
   /**
    * <pre>
-   * Optional taskType of the listed task, passing non-null value
-   * in this argument filters the returned status to only those that are related to the tasks of specified type
+   * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+   * its type is any of the listed values. Empty (the default) means no filtering by type.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -91,8 +92,8 @@ public interface GrpcTaskStatusesRequestOrBuilder extends
       getTaskTypeOrBuilderList();
   /**
    * <pre>
-   * Optional taskType of the listed task, passing non-null value
-   * in this argument filters the returned status to only those that are related to the tasks of specified type
+   * Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+   * its type is any of the listed values. Empty (the default) means no filtering by type.
    * </pre>
    *
    * <code>repeated .google.protobuf.StringValue taskType = 3;</code>
@@ -102,8 +103,9 @@ public interface GrpcTaskStatusesRequestOrBuilder extends
 
   /**
    * <pre>
-   * Optional set of simplified task states, passing list of enums in this argument
-   * filters the returned statuses to only those that match this simplified status
+   * Simplified task states to filter by; a task matches if its state is any of the listed values.
+   * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+   * are non-empty, a task must satisfy both filters.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -112,8 +114,9 @@ public interface GrpcTaskStatusesRequestOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState> getSimplifiedStateList();
   /**
    * <pre>
-   * Optional set of simplified task states, passing list of enums in this argument
-   * filters the returned statuses to only those that match this simplified status
+   * Simplified task states to filter by; a task matches if its state is any of the listed values.
+   * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+   * are non-empty, a task must satisfy both filters.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -122,8 +125,9 @@ public interface GrpcTaskStatusesRequestOrBuilder extends
   int getSimplifiedStateCount();
   /**
    * <pre>
-   * Optional set of simplified task states, passing list of enums in this argument
-   * filters the returned statuses to only those that match this simplified status
+   * Simplified task states to filter by; a task matches if its state is any of the listed values.
+   * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+   * are non-empty, a task must satisfy both filters.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -133,8 +137,9 @@ public interface GrpcTaskStatusesRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState getSimplifiedState(int index);
   /**
    * <pre>
-   * Optional set of simplified task states, passing list of enums in this argument
-   * filters the returned statuses to only those that match this simplified status
+   * Simplified task states to filter by; a task matches if its state is any of the listed values.
+   * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+   * are non-empty, a task must satisfy both filters.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>
@@ -144,8 +149,9 @@ public interface GrpcTaskStatusesRequestOrBuilder extends
   getSimplifiedStateValueList();
   /**
    * <pre>
-   * Optional set of simplified task states, passing list of enums in this argument
-   * filters the returned statuses to only those that match this simplified status
+   * Simplified task states to filter by; a task matches if its state is any of the listed values.
+   * Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+   * are non-empty, a task must satisfy both filters.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskSimplifiedState simplifiedState = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusesResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusesResponse.java
@@ -71,7 +71,7 @@ private static final long serialVersionUID = 0L;
   private int pageSize_ = 0;
   /**
    * <pre>
-   * The size of the page.
+   * The page size that was actually applied (echoes the request's `pageSize`).
    * </pre>
    *
    * <code>int32 pageSize = 1;</code>
@@ -86,7 +86,8 @@ private static final long serialVersionUID = 0L;
   private int pageNumber_ = 0;
   /**
    * <pre>
-   * The number of the page.
+   * The page number that was actually applied (echoes the request's `pageNumber`); 1-indexed, see
+   * `GrpcTaskStatusesRequest.pageNumber` for the paging model.
    * </pre>
    *
    * <code>int32 pageNumber = 2;</code>
@@ -102,7 +103,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcTaskStatus> taskStatus_;
   /**
    * <pre>
-   * Collection of task statuses.
+   * Task statuses on this page, matching the filters from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -113,7 +114,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of task statuses.
+   * Task statuses on this page, matching the filters from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -125,7 +126,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of task statuses.
+   * Task statuses on this page, matching the filters from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -136,7 +137,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of task statuses.
+   * Task statuses on this page, matching the filters from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -147,7 +148,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Collection of task statuses.
+   * Task statuses on this page, matching the filters from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -162,7 +163,8 @@ private static final long serialVersionUID = 0L;
   private int totalNumberOfRecords_ = 0;
   /**
    * <pre>
-   * Total number of task statuses.
+   * Total number of task statuses matching the request's filters across all pages, not just this
+   * one.
    * </pre>
    *
    * <code>int32 totalNumberOfRecords = 4;</code>
@@ -623,7 +625,7 @@ private static final long serialVersionUID = 0L;
     private int pageSize_ ;
     /**
      * <pre>
-     * The size of the page.
+     * The page size that was actually applied (echoes the request's `pageSize`).
      * </pre>
      *
      * <code>int32 pageSize = 1;</code>
@@ -635,7 +637,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page.
+     * The page size that was actually applied (echoes the request's `pageSize`).
      * </pre>
      *
      * <code>int32 pageSize = 1;</code>
@@ -651,7 +653,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The size of the page.
+     * The page size that was actually applied (echoes the request's `pageSize`).
      * </pre>
      *
      * <code>int32 pageSize = 1;</code>
@@ -667,7 +669,8 @@ private static final long serialVersionUID = 0L;
     private int pageNumber_ ;
     /**
      * <pre>
-     * The number of the page.
+     * The page number that was actually applied (echoes the request's `pageNumber`); 1-indexed, see
+     * `GrpcTaskStatusesRequest.pageNumber` for the paging model.
      * </pre>
      *
      * <code>int32 pageNumber = 2;</code>
@@ -679,7 +682,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The number of the page.
+     * The page number that was actually applied (echoes the request's `pageNumber`); 1-indexed, see
+     * `GrpcTaskStatusesRequest.pageNumber` for the paging model.
      * </pre>
      *
      * <code>int32 pageNumber = 2;</code>
@@ -695,7 +699,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The number of the page.
+     * The page number that was actually applied (echoes the request's `pageNumber`); 1-indexed, see
+     * `GrpcTaskStatusesRequest.pageNumber` for the paging model.
      * </pre>
      *
      * <code>int32 pageNumber = 2;</code>
@@ -722,7 +727,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -736,7 +741,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -750,7 +755,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -764,7 +769,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -785,7 +790,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -803,7 +808,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -823,7 +828,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -844,7 +849,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -862,7 +867,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -880,7 +885,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -899,7 +904,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -916,7 +921,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -933,7 +938,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -944,7 +949,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -958,7 +963,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -973,7 +978,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -984,7 +989,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -996,7 +1001,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Collection of task statuses.
+     * Task statuses on this page, matching the filters from the request.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -1023,7 +1028,8 @@ private static final long serialVersionUID = 0L;
     private int totalNumberOfRecords_ ;
     /**
      * <pre>
-     * Total number of task statuses.
+     * Total number of task statuses matching the request's filters across all pages, not just this
+     * one.
      * </pre>
      *
      * <code>int32 totalNumberOfRecords = 4;</code>
@@ -1035,7 +1041,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Total number of task statuses.
+     * Total number of task statuses matching the request's filters across all pages, not just this
+     * one.
      * </pre>
      *
      * <code>int32 totalNumberOfRecords = 4;</code>
@@ -1051,7 +1058,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Total number of task statuses.
+     * Total number of task statuses matching the request's filters across all pages, not just this
+     * one.
      * </pre>
      *
      * <code>int32 totalNumberOfRecords = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusesResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskStatusesResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcTaskStatusesResponseOrBuilder extends
 
   /**
    * <pre>
-   * The size of the page.
+   * The page size that was actually applied (echoes the request's `pageSize`).
    * </pre>
    *
    * <code>int32 pageSize = 1;</code>
@@ -43,7 +43,8 @@ public interface GrpcTaskStatusesResponseOrBuilder extends
 
   /**
    * <pre>
-   * The number of the page.
+   * The page number that was actually applied (echoes the request's `pageNumber`); 1-indexed, see
+   * `GrpcTaskStatusesRequest.pageNumber` for the paging model.
    * </pre>
    *
    * <code>int32 pageNumber = 2;</code>
@@ -53,7 +54,7 @@ public interface GrpcTaskStatusesResponseOrBuilder extends
 
   /**
    * <pre>
-   * Collection of task statuses.
+   * Task statuses on this page, matching the filters from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -62,7 +63,7 @@ public interface GrpcTaskStatusesResponseOrBuilder extends
       getTaskStatusList();
   /**
    * <pre>
-   * Collection of task statuses.
+   * Task statuses on this page, matching the filters from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -70,7 +71,7 @@ public interface GrpcTaskStatusesResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTaskStatus getTaskStatus(int index);
   /**
    * <pre>
-   * Collection of task statuses.
+   * Task statuses on this page, matching the filters from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -78,7 +79,7 @@ public interface GrpcTaskStatusesResponseOrBuilder extends
   int getTaskStatusCount();
   /**
    * <pre>
-   * Collection of task statuses.
+   * Task statuses on this page, matching the filters from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -87,7 +88,7 @@ public interface GrpcTaskStatusesResponseOrBuilder extends
       getTaskStatusOrBuilderList();
   /**
    * <pre>
-   * Collection of task statuses.
+   * Task statuses on this page, matching the filters from the request.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTaskStatus taskStatus = 3;</code>
@@ -97,7 +98,8 @@ public interface GrpcTaskStatusesResponseOrBuilder extends
 
   /**
    * <pre>
-   * Total number of task statuses.
+   * Total number of task statuses matching the request's filters across all pages, not just this
+   * one.
    * </pre>
    *
    * <code>int32 totalNumberOfRecords = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficRecord.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficRecord.java
@@ -320,7 +320,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.StringValue finishedWithError_;
   /**
    * <pre>
-   * Returns non-null error message if the action the recording relates to finished with an error.
+   * The error message the operation this record represents finished with. If unset, the operation completed
+   * without error.
    * </pre>
    *
    * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -332,7 +333,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Returns non-null error message if the action the recording relates to finished with an error.
+   * The error message the operation this record represents finished with. If unset, the operation completed
+   * without error.
    * </pre>
    *
    * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -344,7 +346,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Returns non-null error message if the action the recording relates to finished with an error.
+   * The error message the operation this record represents finished with. If unset, the operation completed
+   * without error.
    * </pre>
    *
    * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -356,6 +359,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int MUTATION_FIELD_NUMBER = 101;
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
    * @return Whether the mutation field is set.
    */
@@ -364,6 +371,10 @@ private static final long serialVersionUID = 0L;
     return bodyCase_ == 101;
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
    * @return The mutation.
    */
@@ -375,6 +386,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
    */
   @java.lang.Override
@@ -387,6 +402,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int QUERY_FIELD_NUMBER = 102;
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
    * @return Whether the query field is set.
    */
@@ -395,6 +414,10 @@ private static final long serialVersionUID = 0L;
     return bodyCase_ == 102;
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
    * @return The query.
    */
@@ -406,6 +429,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
    */
   @java.lang.Override
@@ -418,6 +445,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int ENRICHMENT_FIELD_NUMBER = 103;
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
    * @return Whether the enrichment field is set.
    */
@@ -426,6 +457,10 @@ private static final long serialVersionUID = 0L;
     return bodyCase_ == 103;
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
    * @return The enrichment.
    */
@@ -437,6 +472,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
    */
   @java.lang.Override
@@ -449,6 +488,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int FETCH_FIELD_NUMBER = 104;
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
    * @return Whether the fetch field is set.
    */
@@ -457,6 +500,10 @@ private static final long serialVersionUID = 0L;
     return bodyCase_ == 104;
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
    * @return The fetch.
    */
@@ -468,6 +515,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
    */
   @java.lang.Override
@@ -480,6 +531,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int SESSIONCLOSE_FIELD_NUMBER = 105;
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
    * @return Whether the sessionClose field is set.
    */
@@ -488,6 +543,10 @@ private static final long serialVersionUID = 0L;
     return bodyCase_ == 105;
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
    * @return The sessionClose.
    */
@@ -499,6 +558,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
    */
   @java.lang.Override
@@ -511,6 +574,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int SESSIONSTART_FIELD_NUMBER = 106;
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
    * @return Whether the sessionStart field is set.
    */
@@ -519,6 +586,10 @@ private static final long serialVersionUID = 0L;
     return bodyCase_ == 106;
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
    * @return The sessionStart.
    */
@@ -530,6 +601,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
    */
   @java.lang.Override
@@ -542,6 +617,10 @@ private static final long serialVersionUID = 0L;
 
   public static final int SOURCEQUERY_FIELD_NUMBER = 107;
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
    * @return Whether the sourceQuery field is set.
    */
@@ -550,6 +629,10 @@ private static final long serialVersionUID = 0L;
     return bodyCase_ == 107;
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
    * @return The sourceQuery.
    */
@@ -561,6 +644,10 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
    */
   @java.lang.Override
@@ -573,6 +660,11 @@ private static final long serialVersionUID = 0L;
 
   public static final int SOURCEQUERYSTATISTICS_FIELD_NUMBER = 108;
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+   * operations related to a single source query.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
    * @return Whether the sourceQueryStatistics field is set.
    */
@@ -581,6 +673,11 @@ private static final long serialVersionUID = 0L;
     return bodyCase_ == 108;
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+   * operations related to a single source query.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
    * @return The sourceQueryStatistics.
    */
@@ -592,6 +689,11 @@ private static final long serialVersionUID = 0L;
     return io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer.getDefaultInstance();
   }
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+   * operations related to a single source query.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
    */
   @java.lang.Override
@@ -2153,7 +2255,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> finishedWithErrorBuilder_;
     /**
      * <pre>
-     * Returns non-null error message if the action the recording relates to finished with an error.
+     * The error message the operation this record represents finished with. If unset, the operation completed
+     * without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -2164,7 +2267,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Returns non-null error message if the action the recording relates to finished with an error.
+     * The error message the operation this record represents finished with. If unset, the operation completed
+     * without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -2179,7 +2283,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Returns non-null error message if the action the recording relates to finished with an error.
+     * The error message the operation this record represents finished with. If unset, the operation completed
+     * without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -2199,7 +2304,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Returns non-null error message if the action the recording relates to finished with an error.
+     * The error message the operation this record represents finished with. If unset, the operation completed
+     * without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -2217,7 +2323,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Returns non-null error message if the action the recording relates to finished with an error.
+     * The error message the operation this record represents finished with. If unset, the operation completed
+     * without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -2242,7 +2349,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Returns non-null error message if the action the recording relates to finished with an error.
+     * The error message the operation this record represents finished with. If unset, the operation completed
+     * without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -2259,7 +2367,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Returns non-null error message if the action the recording relates to finished with an error.
+     * The error message the operation this record represents finished with. If unset, the operation completed
+     * without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -2271,7 +2380,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Returns non-null error message if the action the recording relates to finished with an error.
+     * The error message the operation this record represents finished with. If unset, the operation completed
+     * without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -2286,7 +2396,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Returns non-null error message if the action the recording relates to finished with an error.
+     * The error message the operation this record represents finished with. If unset, the operation completed
+     * without error.
      * </pre>
      *
      * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -2308,6 +2419,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer, io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer.Builder, io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainerOrBuilder> mutationBuilder_;
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
      * @return Whether the mutation field is set.
      */
@@ -2316,6 +2431,10 @@ private static final long serialVersionUID = 0L;
       return bodyCase_ == 101;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
      * @return The mutation.
      */
@@ -2334,6 +2453,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
      */
     public Builder setMutation(io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer value) {
@@ -2350,6 +2473,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
      */
     public Builder setMutation(
@@ -2364,6 +2491,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
      */
     public Builder mergeMutation(io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer value) {
@@ -2387,6 +2518,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
      */
     public Builder clearMutation() {
@@ -2406,12 +2541,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer.Builder getMutationBuilder() {
       return getMutationFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
      */
     @java.lang.Override
@@ -2426,6 +2569,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -2450,6 +2597,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer, io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer.Builder, io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainerOrBuilder> queryBuilder_;
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
      * @return Whether the query field is set.
      */
@@ -2458,6 +2609,10 @@ private static final long serialVersionUID = 0L;
       return bodyCase_ == 102;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
      * @return The query.
      */
@@ -2476,6 +2631,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
      */
     public Builder setQuery(io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer value) {
@@ -2492,6 +2651,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
      */
     public Builder setQuery(
@@ -2506,6 +2669,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
      */
     public Builder mergeQuery(io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer value) {
@@ -2529,6 +2696,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
      */
     public Builder clearQuery() {
@@ -2548,12 +2719,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer.Builder getQueryBuilder() {
       return getQueryFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
      */
     @java.lang.Override
@@ -2568,6 +2747,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -2592,6 +2775,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer, io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer.Builder, io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainerOrBuilder> enrichmentBuilder_;
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
      * @return Whether the enrichment field is set.
      */
@@ -2600,6 +2787,10 @@ private static final long serialVersionUID = 0L;
       return bodyCase_ == 103;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
      * @return The enrichment.
      */
@@ -2618,6 +2809,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
      */
     public Builder setEnrichment(io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer value) {
@@ -2634,6 +2829,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
      */
     public Builder setEnrichment(
@@ -2648,6 +2847,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
      */
     public Builder mergeEnrichment(io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer value) {
@@ -2671,6 +2874,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
      */
     public Builder clearEnrichment() {
@@ -2690,12 +2897,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer.Builder getEnrichmentBuilder() {
       return getEnrichmentFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
      */
     @java.lang.Override
@@ -2710,6 +2925,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -2734,6 +2953,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer, io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer.Builder, io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainerOrBuilder> fetchBuilder_;
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
      * @return Whether the fetch field is set.
      */
@@ -2742,6 +2965,10 @@ private static final long serialVersionUID = 0L;
       return bodyCase_ == 104;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
      * @return The fetch.
      */
@@ -2760,6 +2987,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
      */
     public Builder setFetch(io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer value) {
@@ -2776,6 +3007,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
      */
     public Builder setFetch(
@@ -2790,6 +3025,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
      */
     public Builder mergeFetch(io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer value) {
@@ -2813,6 +3052,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
      */
     public Builder clearFetch() {
@@ -2832,12 +3075,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer.Builder getFetchBuilder() {
       return getFetchFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
      */
     @java.lang.Override
@@ -2852,6 +3103,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -2876,6 +3131,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer, io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer.Builder, io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainerOrBuilder> sessionCloseBuilder_;
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
      * @return Whether the sessionClose field is set.
      */
@@ -2884,6 +3143,10 @@ private static final long serialVersionUID = 0L;
       return bodyCase_ == 105;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
      * @return The sessionClose.
      */
@@ -2902,6 +3165,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
      */
     public Builder setSessionClose(io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer value) {
@@ -2918,6 +3185,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
      */
     public Builder setSessionClose(
@@ -2932,6 +3203,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
      */
     public Builder mergeSessionClose(io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer value) {
@@ -2955,6 +3230,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
      */
     public Builder clearSessionClose() {
@@ -2974,12 +3253,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer.Builder getSessionCloseBuilder() {
       return getSessionCloseFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
      */
     @java.lang.Override
@@ -2994,6 +3281,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -3018,6 +3309,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer, io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer.Builder, io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainerOrBuilder> sessionStartBuilder_;
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
      * @return Whether the sessionStart field is set.
      */
@@ -3026,6 +3321,10 @@ private static final long serialVersionUID = 0L;
       return bodyCase_ == 106;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
      * @return The sessionStart.
      */
@@ -3044,6 +3343,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
      */
     public Builder setSessionStart(io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer value) {
@@ -3060,6 +3363,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
      */
     public Builder setSessionStart(
@@ -3074,6 +3381,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
      */
     public Builder mergeSessionStart(io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer value) {
@@ -3097,6 +3408,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
      */
     public Builder clearSessionStart() {
@@ -3116,12 +3431,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer.Builder getSessionStartBuilder() {
       return getSessionStartFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
      */
     @java.lang.Override
@@ -3136,6 +3459,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -3160,6 +3487,10 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer, io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer.Builder, io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainerOrBuilder> sourceQueryBuilder_;
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
      * @return Whether the sourceQuery field is set.
      */
@@ -3168,6 +3499,10 @@ private static final long serialVersionUID = 0L;
       return bodyCase_ == 107;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
      * @return The sourceQuery.
      */
@@ -3186,6 +3521,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
      */
     public Builder setSourceQuery(io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer value) {
@@ -3202,6 +3541,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
      */
     public Builder setSourceQuery(
@@ -3216,6 +3559,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
      */
     public Builder mergeSourceQuery(io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer value) {
@@ -3239,6 +3586,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
      */
     public Builder clearSourceQuery() {
@@ -3258,12 +3609,20 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer.Builder getSourceQueryBuilder() {
       return getSourceQueryFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
      */
     @java.lang.Override
@@ -3278,6 +3637,10 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
@@ -3302,6 +3665,11 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.SingleFieldBuilderV3<
         io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer, io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer.Builder, io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainerOrBuilder> sourceQueryStatisticsBuilder_;
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+     * operations related to a single source query.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
      * @return Whether the sourceQueryStatistics field is set.
      */
@@ -3310,6 +3678,11 @@ private static final long serialVersionUID = 0L;
       return bodyCase_ == 108;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+     * operations related to a single source query.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
      * @return The sourceQueryStatistics.
      */
@@ -3328,6 +3701,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+     * operations related to a single source query.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
      */
     public Builder setSourceQueryStatistics(io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer value) {
@@ -3344,6 +3722,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+     * operations related to a single source query.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
      */
     public Builder setSourceQueryStatistics(
@@ -3358,6 +3741,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+     * operations related to a single source query.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
      */
     public Builder mergeSourceQueryStatistics(io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer value) {
@@ -3381,6 +3769,11 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+     * operations related to a single source query.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
      */
     public Builder clearSourceQueryStatistics() {
@@ -3400,12 +3793,22 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+     * operations related to a single source query.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
      */
     public io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer.Builder getSourceQueryStatisticsBuilder() {
       return getSourceQueryStatisticsFieldBuilder().getBuilder();
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+     * operations related to a single source query.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
      */
     @java.lang.Override
@@ -3420,6 +3823,11 @@ private static final long serialVersionUID = 0L;
       }
     }
     /**
+     * <pre>
+     * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+     * operations related to a single source query.
+     * </pre>
+     *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficRecordOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficRecordOrBuilder.java
@@ -168,7 +168,8 @@ public interface GrpcTrafficRecordOrBuilder extends
 
   /**
    * <pre>
-   * Returns non-null error message if the action the recording relates to finished with an error.
+   * The error message the operation this record represents finished with. If unset, the operation completed
+   * without error.
    * </pre>
    *
    * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -177,7 +178,8 @@ public interface GrpcTrafficRecordOrBuilder extends
   boolean hasFinishedWithError();
   /**
    * <pre>
-   * Returns non-null error message if the action the recording relates to finished with an error.
+   * The error message the operation this record represents finished with. If unset, the operation completed
+   * without error.
    * </pre>
    *
    * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -186,7 +188,8 @@ public interface GrpcTrafficRecordOrBuilder extends
   com.google.protobuf.StringValue getFinishedWithError();
   /**
    * <pre>
-   * Returns non-null error message if the action the recording relates to finished with an error.
+   * The error message the operation this record represents finished with. If unset, the operation completed
+   * without error.
    * </pre>
    *
    * <code>.google.protobuf.StringValue finishedWithError = 10;</code>
@@ -194,121 +197,220 @@ public interface GrpcTrafficRecordOrBuilder extends
   com.google.protobuf.StringValueOrBuilder getFinishedWithErrorOrBuilder();
 
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
    * @return Whether the mutation field is set.
    */
   boolean hasMutation();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
    * @return The mutation.
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer getMutation();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainer mutation = 101;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficMutationContainerOrBuilder getMutationOrBuilder();
 
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
    * @return Whether the query field is set.
    */
   boolean hasQuery();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
    * @return The query.
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer getQuery();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainer query = 102;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficQueryContainerOrBuilder getQueryOrBuilder();
 
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
    * @return Whether the enrichment field is set.
    */
   boolean hasEnrichment();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
    * @return The enrichment.
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer getEnrichment();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainer enrichment = 103;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityEnrichmentContainerOrBuilder getEnrichmentOrBuilder();
 
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
    * @return Whether the fetch field is set.
    */
   boolean hasFetch();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
    * @return The fetch.
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer getFetch();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainer fetch = 104;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficEntityFetchContainerOrBuilder getFetchOrBuilder();
 
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
    * @return Whether the sessionClose field is set.
    */
   boolean hasSessionClose();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
    * @return The sessionClose.
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer getSessionClose();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainer sessionClose = 105;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionCloseContainerOrBuilder getSessionCloseOrBuilder();
 
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
    * @return Whether the sessionStart field is set.
    */
   boolean hasSessionStart();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
    * @return The sessionStart.
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer getSessionStart();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainer sessionStart = 106;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficSessionStartContainerOrBuilder getSessionStartOrBuilder();
 
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
    * @return Whether the sourceQuery field is set.
    */
   boolean hasSourceQuery();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
    * @return The sourceQuery.
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer getSourceQuery();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainer sourceQuery = 107;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryContainerOrBuilder getSourceQueryOrBuilder();
 
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+   * operations related to a single source query.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
    * @return Whether the sourceQueryStatistics field is set.
    */
   boolean hasSourceQueryStatistics();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+   * operations related to a single source query.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
    * @return The sourceQueryStatistics.
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer getSourceQueryStatistics();
   /**
+   * <pre>
+   * Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+   * operations related to a single source query.
+   * </pre>
+   *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;</code>
    */
   io.evitadb.externalApi.grpc.generated.GrpcTrafficSourceQueryStatisticsContainerOrBuilder getSourceQueryStatisticsOrBuilder();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficRecordingCaptureCriteria.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficRecordingCaptureCriteria.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Record for the criteria of the capture request allowing to limit mutations to specific area of interest an its
+ * Record for the criteria of the capture request allowing to limit mutations to specific area of interest and its
  * properties.
  * </pre>
  *
@@ -76,7 +76,8 @@ private static final long serialVersionUID = 0L;
   private int content_ = 0;
   /**
    * <pre>
-   * content determines whether only basic information about the traffic recording is returned or the actual content
+   * Determines whether only basic information about the traffic recording is returned, or the actual event
+   * content as well (see the `body` oneof on `GrpcTrafficRecord`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingContent content = 1;</code>
@@ -87,7 +88,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * content determines whether only basic information about the traffic recording is returned or the actual content
+   * Determines whether only basic information about the traffic recording is returned, or the actual event
+   * content as well (see the `body` oneof on `GrpcTrafficRecord`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingContent content = 1;</code>
@@ -102,7 +104,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since_;
   /**
    * <pre>
-   * since specifies the time from which the traffic recording should be returned
+   * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -114,7 +116,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * since specifies the time from which the traffic recording should be returned
+   * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -126,7 +128,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * since specifies the time from which the traffic recording should be returned
+   * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -140,7 +142,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int64Value sinceSessionSequenceId_;
   /**
    * <pre>
-   * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+   * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+   * be returned (inclusive). If unset, no session-sequence lower bound is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -152,7 +155,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+   * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+   * be returned (inclusive). If unset, no session-sequence lower bound is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -164,7 +168,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+   * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+   * be returned (inclusive). If unset, no session-sequence lower bound is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -178,10 +183,10 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value sinceRecordSessionOffset_;
   /**
    * <pre>
-   * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-   *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-   *                          to continue fetching the traffic recording from the last fetched record when session
-   *                          was not fully fetched
+   * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+   * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+   * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+   * previous call. If unset, records are returned from the start of the session.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -193,10 +198,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-   *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-   *                          to continue fetching the traffic recording from the last fetched record when session
-   *                          was not fully fetched
+   * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+   * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+   * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+   * previous call. If unset, records are returned from the start of the session.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -208,10 +213,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-   *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-   *                          to continue fetching the traffic recording from the last fetched record when session
-   *                          was not fully fetched
+   * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+   * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+   * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+   * previous call. If unset, records are returned from the start of the session.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -235,7 +240,7 @@ private static final long serialVersionUID = 0L;
           };
   /**
    * <pre>
-   * type specifies the types of traffic recording to be returned
+   * The types of traffic recording to be returned. If empty, records of all types are returned.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -248,7 +253,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * type specifies the types of traffic recording to be returned
+   * The types of traffic recording to be returned. If empty, records of all types are returned.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -260,7 +265,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * type specifies the types of traffic recording to be returned
+   * The types of traffic recording to be returned. If empty, records of all types are returned.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -273,7 +278,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * type specifies the types of traffic recording to be returned
+   * The types of traffic recording to be returned. If empty, records of all types are returned.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -286,7 +291,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * type specifies the types of traffic recording to be returned
+   * The types of traffic recording to be returned. If empty, records of all types are returned.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -304,7 +309,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcUuid> sessionId_;
   /**
    * <pre>
-   * sessionId specifies the session ID from which the traffic recording should be returned
+   * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -315,7 +320,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * sessionId specifies the session ID from which the traffic recording should be returned
+   * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -327,7 +332,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * sessionId specifies the session ID from which the traffic recording should be returned
+   * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -338,7 +343,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * sessionId specifies the session ID from which the traffic recording should be returned
+   * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -349,7 +354,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * sessionId specifies the session ID from which the traffic recording should be returned
+   * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -364,7 +369,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value longerThanMilliseconds_;
   /**
    * <pre>
-   * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+   * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+   * no minimum-duration filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -376,7 +382,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+   * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+   * no minimum-duration filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -388,7 +395,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+   * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+   * no minimum-duration filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -402,7 +410,8 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Int32Value fetchingMoreBytesThan_;
   /**
    * <pre>
-   * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+   * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+   * no minimum-size filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -414,7 +423,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+   * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+   * no minimum-size filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -426,7 +436,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+   * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+   * no minimum-size filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -441,7 +452,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcQueryLabel> labels_;
   /**
    * <pre>
-   * labels specifies the client labels that the traffic recording must have (both name and value must match)
+   * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+   * is applied.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -452,7 +464,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * labels specifies the client labels that the traffic recording must have (both name and value must match)
+   * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+   * is applied.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -464,7 +477,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * labels specifies the client labels that the traffic recording must have (both name and value must match)
+   * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+   * is applied.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -475,7 +489,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * labels specifies the client labels that the traffic recording must have (both name and value must match)
+   * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+   * is applied.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -486,7 +501,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * labels specifies the client labels that the traffic recording must have (both name and value must match)
+   * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+   * is applied.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -786,7 +802,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Record for the criteria of the capture request allowing to limit mutations to specific area of interest an its
+   * Record for the criteria of the capture request allowing to limit mutations to specific area of interest and its
    * properties.
    * </pre>
    *
@@ -1227,7 +1243,8 @@ private static final long serialVersionUID = 0L;
     private int content_ = 0;
     /**
      * <pre>
-     * content determines whether only basic information about the traffic recording is returned or the actual content
+     * Determines whether only basic information about the traffic recording is returned, or the actual event
+     * content as well (see the `body` oneof on `GrpcTrafficRecord`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingContent content = 1;</code>
@@ -1238,7 +1255,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * content determines whether only basic information about the traffic recording is returned or the actual content
+     * Determines whether only basic information about the traffic recording is returned, or the actual event
+     * content as well (see the `body` oneof on `GrpcTrafficRecord`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingContent content = 1;</code>
@@ -1253,7 +1271,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * content determines whether only basic information about the traffic recording is returned or the actual content
+     * Determines whether only basic information about the traffic recording is returned, or the actual event
+     * content as well (see the `body` oneof on `GrpcTrafficRecord`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingContent content = 1;</code>
@@ -1266,7 +1285,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * content determines whether only basic information about the traffic recording is returned or the actual content
+     * Determines whether only basic information about the traffic recording is returned, or the actual event
+     * content as well (see the `body` oneof on `GrpcTrafficRecord`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingContent content = 1;</code>
@@ -1284,7 +1304,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * content determines whether only basic information about the traffic recording is returned or the actual content
+     * Determines whether only basic information about the traffic recording is returned, or the actual event
+     * content as well (see the `body` oneof on `GrpcTrafficRecord`).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingContent content = 1;</code>
@@ -1302,7 +1323,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> sinceBuilder_;
     /**
      * <pre>
-     * since specifies the time from which the traffic recording should be returned
+     * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -1313,7 +1334,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * since specifies the time from which the traffic recording should be returned
+     * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -1328,7 +1349,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * since specifies the time from which the traffic recording should be returned
+     * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -1348,7 +1369,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * since specifies the time from which the traffic recording should be returned
+     * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -1366,7 +1387,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * since specifies the time from which the traffic recording should be returned
+     * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -1391,7 +1412,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * since specifies the time from which the traffic recording should be returned
+     * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -1408,7 +1429,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * since specifies the time from which the traffic recording should be returned
+     * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -1420,7 +1441,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * since specifies the time from which the traffic recording should be returned
+     * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -1435,7 +1456,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * since specifies the time from which the traffic recording should be returned
+     * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -1459,7 +1480,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> sinceSessionSequenceIdBuilder_;
     /**
      * <pre>
-     * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+     * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+     * be returned (inclusive). If unset, no session-sequence lower bound is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -1470,7 +1492,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+     * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+     * be returned (inclusive). If unset, no session-sequence lower bound is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -1485,7 +1508,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+     * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+     * be returned (inclusive). If unset, no session-sequence lower bound is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -1505,7 +1529,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+     * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+     * be returned (inclusive). If unset, no session-sequence lower bound is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -1523,7 +1548,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+     * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+     * be returned (inclusive). If unset, no session-sequence lower bound is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -1548,7 +1574,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+     * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+     * be returned (inclusive). If unset, no session-sequence lower bound is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -1565,7 +1592,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+     * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+     * be returned (inclusive). If unset, no session-sequence lower bound is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -1577,7 +1605,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+     * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+     * be returned (inclusive). If unset, no session-sequence lower bound is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -1592,7 +1621,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+     * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+     * be returned (inclusive). If unset, no session-sequence lower bound is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -1616,10 +1646,10 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> sinceRecordSessionOffsetBuilder_;
     /**
      * <pre>
-     * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-     *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-     *                          to continue fetching the traffic recording from the last fetched record when session
-     *                          was not fully fetched
+     * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+     * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+     * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+     * previous call. If unset, records are returned from the start of the session.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -1630,10 +1660,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-     *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-     *                          to continue fetching the traffic recording from the last fetched record when session
-     *                          was not fully fetched
+     * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+     * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+     * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+     * previous call. If unset, records are returned from the start of the session.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -1648,10 +1678,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-     *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-     *                          to continue fetching the traffic recording from the last fetched record when session
-     *                          was not fully fetched
+     * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+     * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+     * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+     * previous call. If unset, records are returned from the start of the session.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -1671,10 +1701,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-     *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-     *                          to continue fetching the traffic recording from the last fetched record when session
-     *                          was not fully fetched
+     * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+     * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+     * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+     * previous call. If unset, records are returned from the start of the session.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -1692,10 +1722,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-     *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-     *                          to continue fetching the traffic recording from the last fetched record when session
-     *                          was not fully fetched
+     * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+     * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+     * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+     * previous call. If unset, records are returned from the start of the session.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -1720,10 +1750,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-     *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-     *                          to continue fetching the traffic recording from the last fetched record when session
-     *                          was not fully fetched
+     * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+     * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+     * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+     * previous call. If unset, records are returned from the start of the session.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -1740,10 +1770,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-     *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-     *                          to continue fetching the traffic recording from the last fetched record when session
-     *                          was not fully fetched
+     * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+     * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+     * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+     * previous call. If unset, records are returned from the start of the session.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -1755,10 +1785,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-     *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-     *                          to continue fetching the traffic recording from the last fetched record when session
-     *                          was not fully fetched
+     * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+     * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+     * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+     * previous call. If unset, records are returned from the start of the session.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -1773,10 +1803,10 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-     *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-     *                          to continue fetching the traffic recording from the last fetched record when session
-     *                          was not fully fetched
+     * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+     * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+     * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+     * previous call. If unset, records are returned from the start of the session.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -1805,7 +1835,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * type specifies the types of traffic recording to be returned
+     * The types of traffic recording to be returned. If empty, records of all types are returned.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -1817,7 +1847,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * type specifies the types of traffic recording to be returned
+     * The types of traffic recording to be returned. If empty, records of all types are returned.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -1828,7 +1858,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * type specifies the types of traffic recording to be returned
+     * The types of traffic recording to be returned. If empty, records of all types are returned.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -1840,7 +1870,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * type specifies the types of traffic recording to be returned
+     * The types of traffic recording to be returned. If empty, records of all types are returned.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -1860,7 +1890,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * type specifies the types of traffic recording to be returned
+     * The types of traffic recording to be returned. If empty, records of all types are returned.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -1878,7 +1908,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * type specifies the types of traffic recording to be returned
+     * The types of traffic recording to be returned. If empty, records of all types are returned.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -1896,7 +1926,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * type specifies the types of traffic recording to be returned
+     * The types of traffic recording to be returned. If empty, records of all types are returned.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -1910,7 +1940,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * type specifies the types of traffic recording to be returned
+     * The types of traffic recording to be returned. If empty, records of all types are returned.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -1922,7 +1952,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * type specifies the types of traffic recording to be returned
+     * The types of traffic recording to be returned. If empty, records of all types are returned.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -1934,7 +1964,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * type specifies the types of traffic recording to be returned
+     * The types of traffic recording to be returned. If empty, records of all types are returned.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -1951,7 +1981,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * type specifies the types of traffic recording to be returned
+     * The types of traffic recording to be returned. If empty, records of all types are returned.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -1966,7 +1996,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * type specifies the types of traffic recording to be returned
+     * The types of traffic recording to be returned. If empty, records of all types are returned.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -1997,7 +2027,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2011,7 +2041,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2025,7 +2055,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2039,7 +2069,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2060,7 +2090,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2078,7 +2108,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2098,7 +2128,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2119,7 +2149,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2137,7 +2167,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2155,7 +2185,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2174,7 +2204,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2191,7 +2221,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2208,7 +2238,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2219,7 +2249,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2233,7 +2263,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2248,7 +2278,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2259,7 +2289,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2271,7 +2301,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * sessionId specifies the session ID from which the traffic recording should be returned
+     * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -2300,7 +2330,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> longerThanMillisecondsBuilder_;
     /**
      * <pre>
-     * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+     * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+     * no minimum-duration filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -2311,7 +2342,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+     * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+     * no minimum-duration filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -2326,7 +2358,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+     * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+     * no minimum-duration filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -2346,7 +2379,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+     * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+     * no minimum-duration filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -2364,7 +2398,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+     * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+     * no minimum-duration filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -2389,7 +2424,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+     * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+     * no minimum-duration filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -2406,7 +2442,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+     * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+     * no minimum-duration filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -2418,7 +2455,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+     * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+     * no minimum-duration filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -2433,7 +2471,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+     * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+     * no minimum-duration filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -2457,7 +2496,8 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Int32Value, com.google.protobuf.Int32Value.Builder, com.google.protobuf.Int32ValueOrBuilder> fetchingMoreBytesThanBuilder_;
     /**
      * <pre>
-     * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+     * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+     * no minimum-size filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -2468,7 +2508,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+     * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+     * no minimum-size filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -2483,7 +2524,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+     * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+     * no minimum-size filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -2503,7 +2545,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+     * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+     * no minimum-size filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -2521,7 +2564,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+     * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+     * no minimum-size filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -2546,7 +2590,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+     * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+     * no minimum-size filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -2563,7 +2608,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+     * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+     * no minimum-size filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -2575,7 +2621,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+     * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+     * no minimum-size filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -2590,7 +2637,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+     * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+     * no minimum-size filter is applied.
      * </pre>
      *
      * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -2623,7 +2671,8 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2637,7 +2686,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2651,7 +2701,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2665,7 +2716,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2686,7 +2738,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2704,7 +2757,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2724,7 +2778,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2745,7 +2800,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2763,7 +2819,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2781,7 +2838,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2800,7 +2858,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2817,7 +2876,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2834,7 +2894,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2845,7 +2906,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2859,7 +2921,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2874,7 +2937,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2885,7 +2949,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -2897,7 +2962,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * labels specifies the client labels that the traffic recording must have (both name and value must match)
+     * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+     * is applied.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficRecordingCaptureCriteriaOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficRecordingCaptureCriteriaOrBuilder.java
@@ -33,7 +33,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
 
   /**
    * <pre>
-   * content determines whether only basic information about the traffic recording is returned or the actual content
+   * Determines whether only basic information about the traffic recording is returned, or the actual event
+   * content as well (see the `body` oneof on `GrpcTrafficRecord`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingContent content = 1;</code>
@@ -42,7 +43,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   int getContentValue();
   /**
    * <pre>
-   * content determines whether only basic information about the traffic recording is returned or the actual content
+   * Determines whether only basic information about the traffic recording is returned, or the actual event
+   * content as well (see the `body` oneof on `GrpcTrafficRecord`).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingContent content = 1;</code>
@@ -52,7 +54,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
 
   /**
    * <pre>
-   * since specifies the time from which the traffic recording should be returned
+   * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -61,7 +63,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   boolean hasSince();
   /**
    * <pre>
-   * since specifies the time from which the traffic recording should be returned
+   * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -70,7 +72,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getSince();
   /**
    * <pre>
-   * since specifies the time from which the traffic recording should be returned
+   * The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime since = 2;</code>
@@ -79,7 +81,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
 
   /**
    * <pre>
-   * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+   * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+   * be returned (inclusive). If unset, no session-sequence lower bound is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -88,7 +91,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   boolean hasSinceSessionSequenceId();
   /**
    * <pre>
-   * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+   * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+   * be returned (inclusive). If unset, no session-sequence lower bound is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -97,7 +101,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   com.google.protobuf.Int64Value getSinceSessionSequenceId();
   /**
    * <pre>
-   * sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+   * The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+   * be returned (inclusive). If unset, no session-sequence lower bound is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int64Value sinceSessionSequenceId = 3;</code>
@@ -106,10 +111,10 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
 
   /**
    * <pre>
-   * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-   *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-   *                          to continue fetching the traffic recording from the last fetched record when session
-   *                          was not fully fetched
+   * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+   * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+   * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+   * previous call. If unset, records are returned from the start of the session.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -118,10 +123,10 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   boolean hasSinceRecordSessionOffset();
   /**
    * <pre>
-   * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-   *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-   *                          to continue fetching the traffic recording from the last fetched record when session
-   *                          was not fully fetched
+   * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+   * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+   * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+   * previous call. If unset, records are returned from the start of the session.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -130,10 +135,10 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   com.google.protobuf.Int32Value getSinceRecordSessionOffset();
   /**
    * <pre>
-   * sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-   *                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-   *                          to continue fetching the traffic recording from the last fetched record when session
-   *                          was not fully fetched
+   * The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+   * should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+   * fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+   * previous call. If unset, records are returned from the start of the session.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value sinceRecordSessionOffset = 4;</code>
@@ -142,7 +147,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
 
   /**
    * <pre>
-   * type specifies the types of traffic recording to be returned
+   * The types of traffic recording to be returned. If empty, records of all types are returned.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -151,7 +156,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   java.util.List<io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType> getTypeList();
   /**
    * <pre>
-   * type specifies the types of traffic recording to be returned
+   * The types of traffic recording to be returned. If empty, records of all types are returned.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -160,7 +165,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   int getTypeCount();
   /**
    * <pre>
-   * type specifies the types of traffic recording to be returned
+   * The types of traffic recording to be returned. If empty, records of all types are returned.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -170,7 +175,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType getType(int index);
   /**
    * <pre>
-   * type specifies the types of traffic recording to be returned
+   * The types of traffic recording to be returned. If empty, records of all types are returned.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -180,7 +185,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   getTypeValueList();
   /**
    * <pre>
-   * type specifies the types of traffic recording to be returned
+   * The types of traffic recording to be returned. If empty, records of all types are returned.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcTrafficRecordingType type = 5;</code>
@@ -191,7 +196,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
 
   /**
    * <pre>
-   * sessionId specifies the session ID from which the traffic recording should be returned
+   * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -200,7 +205,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
       getSessionIdList();
   /**
    * <pre>
-   * sessionId specifies the session ID from which the traffic recording should be returned
+   * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -208,7 +213,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuid getSessionId(int index);
   /**
    * <pre>
-   * sessionId specifies the session ID from which the traffic recording should be returned
+   * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -216,7 +221,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   int getSessionIdCount();
   /**
    * <pre>
-   * sessionId specifies the session ID from which the traffic recording should be returned
+   * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -225,7 +230,7 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
       getSessionIdOrBuilderList();
   /**
    * <pre>
-   * sessionId specifies the session ID from which the traffic recording should be returned
+   * The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid sessionId = 6;</code>
@@ -235,7 +240,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
 
   /**
    * <pre>
-   * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+   * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+   * no minimum-duration filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -244,7 +250,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   boolean hasLongerThanMilliseconds();
   /**
    * <pre>
-   * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+   * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+   * no minimum-duration filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -253,7 +260,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   com.google.protobuf.Int32Value getLongerThanMilliseconds();
   /**
    * <pre>
-   * longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+   * The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+   * no minimum-duration filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value longerThanMilliseconds = 7;</code>
@@ -262,7 +270,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
 
   /**
    * <pre>
-   * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+   * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+   * no minimum-size filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -271,7 +280,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   boolean hasFetchingMoreBytesThan();
   /**
    * <pre>
-   * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+   * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+   * no minimum-size filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -280,7 +290,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   com.google.protobuf.Int32Value getFetchingMoreBytesThan();
   /**
    * <pre>
-   * fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+   * The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+   * no minimum-size filter is applied.
    * </pre>
    *
    * <code>.google.protobuf.Int32Value fetchingMoreBytesThan = 8;</code>
@@ -289,7 +300,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
 
   /**
    * <pre>
-   * labels specifies the client labels that the traffic recording must have (both name and value must match)
+   * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+   * is applied.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -298,7 +310,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
       getLabelsList();
   /**
    * <pre>
-   * labels specifies the client labels that the traffic recording must have (both name and value must match)
+   * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+   * is applied.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -306,7 +319,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcQueryLabel getLabels(int index);
   /**
    * <pre>
-   * labels specifies the client labels that the traffic recording must have (both name and value must match)
+   * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+   * is applied.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -314,7 +328,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
   int getLabelsCount();
   /**
    * <pre>
-   * labels specifies the client labels that the traffic recording must have (both name and value must match)
+   * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+   * is applied.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>
@@ -323,7 +338,8 @@ public interface GrpcTrafficRecordingCaptureCriteriaOrBuilder extends
       getLabelsOrBuilderList();
   /**
    * <pre>
-   * labels specifies the client labels that the traffic recording must have (both name and value must match)
+   * The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+   * is applied.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryLabel labels = 9;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficRecordingType.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficRecordingType.java
@@ -46,7 +46,7 @@ public enum GrpcTrafficRecordingType
   TRAFFIC_RECORDING_SESSION_START(0),
   /**
    * <pre>
-   ** evitaDB session closed.
+   * evitaDB session closed.
    * </pre>
    *
    * <code>TRAFFIC_RECORDING_SESSION_FINISH = 1;</code>
@@ -116,7 +116,7 @@ public enum GrpcTrafficRecordingType
   public static final int TRAFFIC_RECORDING_SESSION_START_VALUE = 0;
   /**
    * <pre>
-   ** evitaDB session closed.
+   * evitaDB session closed.
    * </pre>
    *
    * <code>TRAFFIC_RECORDING_SESSION_FINISH = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficSourceQueryStatisticsContainer.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficSourceQueryStatisticsContainer.java
@@ -109,7 +109,7 @@ private static final long serialVersionUID = 0L;
   private int returnedRecordCount_ = 0;
   /**
    * <pre>
-   * The total number of records returned by the query ({&#64;link EvitaResponse#getRecordData()} size)
+   * The number of records actually returned by the query, i.e. the size of the fetched data chunk after pagination.
    * </pre>
    *
    * <code>int32 returnedRecordCount = 2;</code>
@@ -124,7 +124,7 @@ private static final long serialVersionUID = 0L;
   private int totalRecordCount_ = 0;
   /**
    * <pre>
-   * The total number of records calculated by the query ({&#64;link EvitaResponse#getTotalRecordCount()})
+   * The total number of records matching the query, before pagination is applied.
    * </pre>
    *
    * <code>int32 totalRecordCount = 3;</code>
@@ -692,7 +692,7 @@ private static final long serialVersionUID = 0L;
     private int returnedRecordCount_ ;
     /**
      * <pre>
-     * The total number of records returned by the query ({&#64;link EvitaResponse#getRecordData()} size)
+     * The number of records actually returned by the query, i.e. the size of the fetched data chunk after pagination.
      * </pre>
      *
      * <code>int32 returnedRecordCount = 2;</code>
@@ -704,7 +704,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The total number of records returned by the query ({&#64;link EvitaResponse#getRecordData()} size)
+     * The number of records actually returned by the query, i.e. the size of the fetched data chunk after pagination.
      * </pre>
      *
      * <code>int32 returnedRecordCount = 2;</code>
@@ -720,7 +720,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The total number of records returned by the query ({&#64;link EvitaResponse#getRecordData()} size)
+     * The number of records actually returned by the query, i.e. the size of the fetched data chunk after pagination.
      * </pre>
      *
      * <code>int32 returnedRecordCount = 2;</code>
@@ -736,7 +736,7 @@ private static final long serialVersionUID = 0L;
     private int totalRecordCount_ ;
     /**
      * <pre>
-     * The total number of records calculated by the query ({&#64;link EvitaResponse#getTotalRecordCount()})
+     * The total number of records matching the query, before pagination is applied.
      * </pre>
      *
      * <code>int32 totalRecordCount = 3;</code>
@@ -748,7 +748,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The total number of records calculated by the query ({&#64;link EvitaResponse#getTotalRecordCount()})
+     * The total number of records matching the query, before pagination is applied.
      * </pre>
      *
      * <code>int32 totalRecordCount = 3;</code>
@@ -764,7 +764,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The total number of records calculated by the query ({&#64;link EvitaResponse#getTotalRecordCount()})
+     * The total number of records matching the query, before pagination is applied.
      * </pre>
      *
      * <code>int32 totalRecordCount = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficSourceQueryStatisticsContainerOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTrafficSourceQueryStatisticsContainerOrBuilder.java
@@ -60,7 +60,7 @@ public interface GrpcTrafficSourceQueryStatisticsContainerOrBuilder extends
 
   /**
    * <pre>
-   * The total number of records returned by the query ({&#64;link EvitaResponse#getRecordData()} size)
+   * The number of records actually returned by the query, i.e. the size of the fetched data chunk after pagination.
    * </pre>
    *
    * <code>int32 returnedRecordCount = 2;</code>
@@ -70,7 +70,7 @@ public interface GrpcTrafficSourceQueryStatisticsContainerOrBuilder extends
 
   /**
    * <pre>
-   * The total number of records calculated by the query ({&#64;link EvitaResponse#getTotalRecordCount()})
+   * The total number of records matching the query, before pagination is applied.
    * </pre>
    *
    * <code>int32 totalRecordCount = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTransactionResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTransactionResponse.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request for opening a transaction.
+ * Response to GetTransactionId request, returned after a new transaction is opened.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcTransactionResponse}
@@ -296,7 +296,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request for opening a transaction.
+   * Response to GetTransactionId request, returned after a new transaction is opened.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcTransactionResponse}

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpdateAndFetchCatalogSchemaResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpdateAndFetchCatalogSchemaResponse.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request for updating the catalog schema and its afterwards fetching.
+ * Response to UpdateAndFetchCatalogSchema request, which updates the catalog schema and returns the
+ * resulting schema in one round trip.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcUpdateAndFetchCatalogSchemaResponse}
@@ -71,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema_;
   /**
    * <pre>
-   * Modified catalog schema.
+   * The catalog schema after the requested mutations were applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -83,7 +84,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Modified catalog schema.
+   * The catalog schema after the requested mutations were applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -95,7 +96,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Modified catalog schema.
+   * The catalog schema after the requested mutations were applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -269,7 +270,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request for updating the catalog schema and its afterwards fetching.
+   * Response to UpdateAndFetchCatalogSchema request, which updates the catalog schema and returns the
+   * resulting schema in one round trip.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcUpdateAndFetchCatalogSchemaResponse}
@@ -461,7 +463,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema, io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema.Builder, io.evitadb.externalApi.grpc.generated.GrpcCatalogSchemaOrBuilder> catalogSchemaBuilder_;
     /**
      * <pre>
-     * Modified catalog schema.
+     * The catalog schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -472,7 +474,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified catalog schema.
+     * The catalog schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -487,7 +489,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified catalog schema.
+     * The catalog schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -507,7 +509,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified catalog schema.
+     * The catalog schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -525,7 +527,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified catalog schema.
+     * The catalog schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -550,7 +552,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified catalog schema.
+     * The catalog schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -567,7 +569,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified catalog schema.
+     * The catalog schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -579,7 +581,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified catalog schema.
+     * The catalog schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -594,7 +596,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified catalog schema.
+     * The catalog schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpdateAndFetchCatalogSchemaResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpdateAndFetchCatalogSchemaResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcUpdateAndFetchCatalogSchemaResponseOrBuilder extends
 
   /**
    * <pre>
-   * Modified catalog schema.
+   * The catalog schema after the requested mutations were applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcUpdateAndFetchCatalogSchemaResponseOrBuilder extends
   boolean hasCatalogSchema();
   /**
    * <pre>
-   * Modified catalog schema.
+   * The catalog schema after the requested mutations were applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcUpdateAndFetchCatalogSchemaResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema getCatalogSchema();
   /**
    * <pre>
-   * Modified catalog schema.
+   * The catalog schema after the requested mutations were applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcCatalogSchema catalogSchema = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpdateAndFetchEntitySchemaResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpdateAndFetchEntitySchemaResponse.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request for updating the entity schema and its afterwards fetching.
+ * Response to UpdateAndFetchEntitySchema request, which updates an entity type's schema and returns the
+ * resulting schema in one round trip.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcUpdateAndFetchEntitySchemaResponse}
@@ -71,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema_;
   /**
    * <pre>
-   * Modified entity schema.
+   * The entity schema after the requested mutations were applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -83,7 +84,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Modified entity schema.
+   * The entity schema after the requested mutations were applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -95,7 +96,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Modified entity schema.
+   * The entity schema after the requested mutations were applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -269,7 +270,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Request for updating the entity schema and its afterwards fetching.
+   * Response to UpdateAndFetchEntitySchema request, which updates an entity type's schema and returns the
+   * resulting schema in one round trip.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcUpdateAndFetchEntitySchemaResponse}
@@ -461,7 +463,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEntitySchema, io.evitadb.externalApi.grpc.generated.GrpcEntitySchema.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaOrBuilder> entitySchemaBuilder_;
     /**
      * <pre>
-     * Modified entity schema.
+     * The entity schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -472,7 +474,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified entity schema.
+     * The entity schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -487,7 +489,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified entity schema.
+     * The entity schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -507,7 +509,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified entity schema.
+     * The entity schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -525,7 +527,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified entity schema.
+     * The entity schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -550,7 +552,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified entity schema.
+     * The entity schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -567,7 +569,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified entity schema.
+     * The entity schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -579,7 +581,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified entity schema.
+     * The entity schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -594,7 +596,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Modified entity schema.
+     * The entity schema after the requested mutations were applied.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpdateAndFetchEntitySchemaResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpdateAndFetchEntitySchemaResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcUpdateAndFetchEntitySchemaResponseOrBuilder extends
 
   /**
    * <pre>
-   * Modified entity schema.
+   * The entity schema after the requested mutations were applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcUpdateAndFetchEntitySchemaResponseOrBuilder extends
   boolean hasEntitySchema();
   /**
    * <pre>
-   * Modified entity schema.
+   * The entity schema after the requested mutations were applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcUpdateAndFetchEntitySchemaResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEntitySchema getEntitySchema();
   /**
    * <pre>
-   * Modified entity schema.
+   * The entity schema after the requested mutations were applied.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntitySchema entitySchema = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpsertEntityRequest.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpsertEntityRequest.java
@@ -29,7 +29,8 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Request for upserting an entity that should return an entity with required richness.
+ * Request for upserting (inserting/updating) an entity and returning it fetched in the richness
+ * described by `require`.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcUpsertEntityRequest}
@@ -85,7 +86,7 @@ private static final long serialVersionUID = 0L;
   private io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation_;
   /**
    * <pre>
-   * Either Upsert or Delete entity mutation.
+   * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -97,7 +98,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Either Upsert or Delete entity mutation.
+   * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -109,7 +110,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Either Upsert or Delete entity mutation.
+   * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -124,7 +125,10 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object require_ = "";
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`)
+   * describing how richly to fetch the entity back after the mutation is applied. `?`/`&#64;name` placeholders
+   * are bound the same way as `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there
+   * for the full binding contract.
    * </pre>
    *
    * <code>string require = 2;</code>
@@ -145,7 +149,10 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`)
+   * describing how richly to fetch the entity back after the mutation is applied. `?`/`&#64;name` placeholders
+   * are bound the same way as `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there
+   * for the full binding contract.
    * </pre>
    *
    * <code>string require = 2;</code>
@@ -171,7 +178,8 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcQueryParam> positionalQueryParams_;
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -182,7 +190,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -194,7 +203,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -205,7 +215,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -216,7 +227,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -255,7 +267,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -276,7 +289,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -287,7 +301,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -305,7 +320,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -531,7 +547,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
   }
   /**
    * <pre>
-   * Request for upserting an entity that should return an entity with required richness.
+   * Request for upserting (inserting/updating) an entity and returning it fetched in the richness
+   * described by `require`.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcUpsertEntityRequest}
@@ -835,7 +852,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
         io.evitadb.externalApi.grpc.generated.GrpcEntityMutation, io.evitadb.externalApi.grpc.generated.GrpcEntityMutation.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntityMutationOrBuilder> entityMutationBuilder_;
     /**
      * <pre>
-     * Either Upsert or Delete entity mutation.
+     * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -846,7 +863,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Either Upsert or Delete entity mutation.
+     * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -861,7 +878,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Either Upsert or Delete entity mutation.
+     * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -881,7 +898,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Either Upsert or Delete entity mutation.
+     * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -899,7 +916,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Either Upsert or Delete entity mutation.
+     * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -924,7 +941,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Either Upsert or Delete entity mutation.
+     * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -941,7 +958,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Either Upsert or Delete entity mutation.
+     * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -953,7 +970,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Either Upsert or Delete entity mutation.
+     * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -968,7 +985,7 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * Either Upsert or Delete entity mutation.
+     * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -990,7 +1007,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     private java.lang.Object require_ = "";
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`)
+     * describing how richly to fetch the entity back after the mutation is applied. `?`/`&#64;name` placeholders
+     * are bound the same way as `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there
+     * for the full binding contract.
      * </pre>
      *
      * <code>string require = 2;</code>
@@ -1010,7 +1030,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`)
+     * describing how richly to fetch the entity back after the mutation is applied. `?`/`&#64;name` placeholders
+     * are bound the same way as `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there
+     * for the full binding contract.
      * </pre>
      *
      * <code>string require = 2;</code>
@@ -1031,7 +1054,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`)
+     * describing how richly to fetch the entity back after the mutation is applied. `?`/`&#64;name` placeholders
+     * are bound the same way as `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there
+     * for the full binding contract.
      * </pre>
      *
      * <code>string require = 2;</code>
@@ -1048,7 +1074,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`)
+     * describing how richly to fetch the entity back after the mutation is applied. `?`/`&#64;name` placeholders
+     * are bound the same way as `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there
+     * for the full binding contract.
      * </pre>
      *
      * <code>string require = 2;</code>
@@ -1062,7 +1091,10 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The string part of the parametrised query require part.
+     * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`)
+     * describing how richly to fetch the entity back after the mutation is applied. `?`/`&#64;name` placeholders
+     * are bound the same way as `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there
+     * for the full binding contract.
      * </pre>
      *
      * <code>string require = 2;</code>
@@ -1093,7 +1125,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
 
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1107,7 +1140,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1121,7 +1155,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1135,7 +1170,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1156,7 +1192,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1174,7 +1211,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1194,7 +1232,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1215,7 +1254,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1233,7 +1273,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1251,7 +1292,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1270,7 +1312,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1287,7 +1330,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1304,7 +1348,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1315,7 +1360,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1329,7 +1375,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1344,7 +1391,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1355,7 +1403,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1367,7 +1416,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The positional query parameters.
+     * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+     * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -1428,7 +1478,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -1449,7 +1500,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -1460,7 +1512,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -1477,7 +1530,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -1499,7 +1553,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -1522,7 +1577,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -1539,7 +1595,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -1558,7 +1615,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue) {
     }
     /**
      * <pre>
-     * The named query parameters.
+     * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+     * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
      * </pre>
      *
      * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpsertEntityRequestOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpsertEntityRequestOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * Either Upsert or Delete entity mutation.
+   * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
   boolean hasEntityMutation();
   /**
    * <pre>
-   * Either Upsert or Delete entity mutation.
+   * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEntityMutation getEntityMutation();
   /**
    * <pre>
-   * Either Upsert or Delete entity mutation.
+   * The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityMutation entityMutation = 1;</code>
@@ -60,7 +60,10 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`)
+   * describing how richly to fetch the entity back after the mutation is applied. `?`/`&#64;name` placeholders
+   * are bound the same way as `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there
+   * for the full binding contract.
    * </pre>
    *
    * <code>string require = 2;</code>
@@ -69,7 +72,10 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
   java.lang.String getRequire();
   /**
    * <pre>
-   * The string part of the parametrised query require part.
+   * The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`)
+   * describing how richly to fetch the entity back after the mutation is applied. `?`/`&#64;name` placeholders
+   * are bound the same way as `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there
+   * for the full binding contract.
    * </pre>
    *
    * <code>string require = 2;</code>
@@ -80,7 +86,8 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -89,7 +96,8 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
       getPositionalQueryParamsList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -97,7 +105,8 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcQueryParam getPositionalQueryParams(int index);
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -105,7 +114,8 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
   int getPositionalQueryParamsCount();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -114,7 +124,8 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
       getPositionalQueryParamsOrBuilderList();
   /**
    * <pre>
-   * The positional query parameters.
+   * Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+   * `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcQueryParam positionalQueryParams = 3;</code>
@@ -124,7 +135,8 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
 
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -132,7 +144,8 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
   int getNamedQueryParamsCount();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -147,7 +160,8 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
   getNamedQueryParams();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -156,7 +170,8 @@ public interface GrpcUpsertEntityRequestOrBuilder extends
   getNamedQueryParamsMap();
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>
@@ -168,7 +183,8 @@ io.evitadb.externalApi.grpc.generated.GrpcQueryParam getNamedQueryParamsOrDefaul
 io.evitadb.externalApi.grpc.generated.GrpcQueryParam defaultValue);
   /**
    * <pre>
-   * The named query parameters.
+   * Values for the `&#64;name` named placeholders in `require`, keyed by name (without the `&#64;` prefix) - see
+   * `GrpcEntityRequest.namedQueryParams` for the full binding contract.
    * </pre>
    *
    * <code>map&lt;string, .io.evitadb.externalApi.grpc.generated.GrpcQueryParam&gt; namedQueryParams = 4;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpsertEntityResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpsertEntityResponse.java
@@ -29,7 +29,7 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Response to UpsertEntity request. The used field is decided by the require block in the query.
+ * Response to UpsertEntity request.
  * </pre>
  *
  * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcUpsertEntityResponse}
@@ -113,7 +113,7 @@ private static final long serialVersionUID = 0L;
   public static final int ENTITYREFERENCE_FIELD_NUMBER = 1;
   /**
    * <pre>
-   * The upserted entity reference.
+   * The upserted entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -125,7 +125,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upserted entity reference.
+   * The upserted entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -140,7 +140,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upserted entity reference.
+   * The upserted entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -156,7 +156,7 @@ private static final long serialVersionUID = 0L;
   public static final int ENTITY_FIELD_NUMBER = 2;
   /**
    * <pre>
-   * The upserted entity.
+   * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -168,7 +168,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upserted entity.
+   * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -183,7 +183,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upserted entity.
+   * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -199,7 +199,8 @@ private static final long serialVersionUID = 0L;
   public static final int ENTITYREFERENCEWITHASSIGNEDPRIMARYKEYS_FIELD_NUMBER = 3;
   /**
    * <pre>
-   * The upserted entity reference with reassigned primary keys
+   * The upserted entity reference together with any reference primary keys that were reassigned as a
+   * side effect of the upsert.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -211,7 +212,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upserted entity reference with reassigned primary keys
+   * The upserted entity reference together with any reference primary keys that were reassigned as a
+   * side effect of the upsert.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -226,7 +228,8 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * The upserted entity reference with reassigned primary keys
+   * The upserted entity reference together with any reference primary keys that were reassigned as a
+   * side effect of the upsert.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -441,7 +444,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Response to UpsertEntity request. The used field is decided by the require block in the query.
+   * Response to UpsertEntity request.
    * </pre>
    *
    * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcUpsertEntityResponse}
@@ -685,7 +688,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEntityReference, io.evitadb.externalApi.grpc.generated.GrpcEntityReference.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceOrBuilder> entityReferenceBuilder_;
     /**
      * <pre>
-     * The upserted entity reference.
+     * The upserted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -697,7 +700,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference.
+     * The upserted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -719,7 +722,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference.
+     * The upserted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -739,7 +742,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference.
+     * The upserted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -757,7 +760,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference.
+     * The upserted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -784,7 +787,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference.
+     * The upserted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -807,7 +810,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference.
+     * The upserted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -817,7 +820,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference.
+     * The upserted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -835,7 +838,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference.
+     * The upserted entity as a reference (type + primary key only).
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -863,7 +866,7 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcSealedEntity, io.evitadb.externalApi.grpc.generated.GrpcSealedEntity.Builder, io.evitadb.externalApi.grpc.generated.GrpcSealedEntityOrBuilder> entityBuilder_;
     /**
      * <pre>
-     * The upserted entity.
+     * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -875,7 +878,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity.
+     * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -897,7 +900,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity.
+     * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -917,7 +920,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity.
+     * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -935,7 +938,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity.
+     * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -962,7 +965,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity.
+     * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -985,7 +988,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity.
+     * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -995,7 +998,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity.
+     * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -1013,7 +1016,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity.
+     * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -1041,7 +1044,8 @@ private static final long serialVersionUID = 0L;
         io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys, io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys.Builder, io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeysOrBuilder> entityReferenceWithAssignedPrimaryKeysBuilder_;
     /**
      * <pre>
-     * The upserted entity reference with reassigned primary keys
+     * The upserted entity reference together with any reference primary keys that were reassigned as a
+     * side effect of the upsert.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -1053,7 +1057,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference with reassigned primary keys
+     * The upserted entity reference together with any reference primary keys that were reassigned as a
+     * side effect of the upsert.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -1075,7 +1080,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference with reassigned primary keys
+     * The upserted entity reference together with any reference primary keys that were reassigned as a
+     * side effect of the upsert.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -1095,7 +1101,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference with reassigned primary keys
+     * The upserted entity reference together with any reference primary keys that were reassigned as a
+     * side effect of the upsert.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -1113,7 +1120,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference with reassigned primary keys
+     * The upserted entity reference together with any reference primary keys that were reassigned as a
+     * side effect of the upsert.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -1140,7 +1148,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference with reassigned primary keys
+     * The upserted entity reference together with any reference primary keys that were reassigned as a
+     * side effect of the upsert.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -1163,7 +1172,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference with reassigned primary keys
+     * The upserted entity reference together with any reference primary keys that were reassigned as a
+     * side effect of the upsert.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -1173,7 +1183,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference with reassigned primary keys
+     * The upserted entity reference together with any reference primary keys that were reassigned as a
+     * side effect of the upsert.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -1191,7 +1202,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The upserted entity reference with reassigned primary keys
+     * The upserted entity reference together with any reference primary keys that were reassigned as a
+     * side effect of the upsert.
      * </pre>
      *
      * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpsertEntityResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpsertEntityResponseOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcUpsertEntityResponseOrBuilder extends
 
   /**
    * <pre>
-   * The upserted entity reference.
+   * The upserted entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcUpsertEntityResponseOrBuilder extends
   boolean hasEntityReference();
   /**
    * <pre>
-   * The upserted entity reference.
+   * The upserted entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -51,7 +51,7 @@ public interface GrpcUpsertEntityResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEntityReference getEntityReference();
   /**
    * <pre>
-   * The upserted entity reference.
+   * The upserted entity as a reference (type + primary key only).
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReference entityReference = 1;</code>
@@ -60,7 +60,7 @@ public interface GrpcUpsertEntityResponseOrBuilder extends
 
   /**
    * <pre>
-   * The upserted entity.
+   * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -69,7 +69,7 @@ public interface GrpcUpsertEntityResponseOrBuilder extends
   boolean hasEntity();
   /**
    * <pre>
-   * The upserted entity.
+   * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -78,7 +78,7 @@ public interface GrpcUpsertEntityResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcSealedEntity getEntity();
   /**
    * <pre>
-   * The upserted entity.
+   * The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcSealedEntity entity = 2;</code>
@@ -87,7 +87,8 @@ public interface GrpcUpsertEntityResponseOrBuilder extends
 
   /**
    * <pre>
-   * The upserted entity reference with reassigned primary keys
+   * The upserted entity reference together with any reference primary keys that were reassigned as a
+   * side effect of the upsert.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -96,7 +97,8 @@ public interface GrpcUpsertEntityResponseOrBuilder extends
   boolean hasEntityReferenceWithAssignedPrimaryKeys();
   /**
    * <pre>
-   * The upserted entity reference with reassigned primary keys
+   * The upserted entity reference together with any reference primary keys that were reassigned as a
+   * side effect of the upsert.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>
@@ -105,7 +107,8 @@ public interface GrpcUpsertEntityResponseOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys getEntityReferenceWithAssignedPrimaryKeys();
   /**
    * <pre>
-   * The upserted entity reference with reassigned primary keys
+   * The upserted entity reference together with any reference primary keys that were reassigned as a
+   * side effect of the upsert.
    * </pre>
    *
    * <code>.io.evitadb.externalApi.grpc.generated.GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpsertPriceMutation.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpsertPriceMutation.java
@@ -393,11 +393,12 @@ private static final long serialVersionUID = 0L;
    * entity but won't be considered when evaluating search query. These prices may be
    * used for "informational" prices such as reference price (the crossed out price often found on e-commerce sites
    * as "usual price") but are not considered as the "selling" price.
+   * RENAMED TO "indexed"
    * </pre>
    *
    * <code>bool sellable = 9 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcUpsertPriceMutation.sellable is deprecated.
-   *     See GrpcPriceMutations.proto;l=51
+   *     See GrpcPriceMutations.proto;l=52
    * @return The sellable.
    */
   @java.lang.Override
@@ -2219,11 +2220,12 @@ private static final long serialVersionUID = 0L;
      * entity but won't be considered when evaluating search query. These prices may be
      * used for "informational" prices such as reference price (the crossed out price often found on e-commerce sites
      * as "usual price") but are not considered as the "selling" price.
+     * RENAMED TO "indexed"
      * </pre>
      *
      * <code>bool sellable = 9 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcUpsertPriceMutation.sellable is deprecated.
-     *     See GrpcPriceMutations.proto;l=51
+     *     See GrpcPriceMutations.proto;l=52
      * @return The sellable.
      */
     @java.lang.Override
@@ -2236,11 +2238,12 @@ private static final long serialVersionUID = 0L;
      * entity but won't be considered when evaluating search query. These prices may be
      * used for "informational" prices such as reference price (the crossed out price often found on e-commerce sites
      * as "usual price") but are not considered as the "selling" price.
+     * RENAMED TO "indexed"
      * </pre>
      *
      * <code>bool sellable = 9 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcUpsertPriceMutation.sellable is deprecated.
-     *     See GrpcPriceMutations.proto;l=51
+     *     See GrpcPriceMutations.proto;l=52
      * @param value The sellable to set.
      * @return This builder for chaining.
      */
@@ -2257,11 +2260,12 @@ private static final long serialVersionUID = 0L;
      * entity but won't be considered when evaluating search query. These prices may be
      * used for "informational" prices such as reference price (the crossed out price often found on e-commerce sites
      * as "usual price") but are not considered as the "selling" price.
+     * RENAMED TO "indexed"
      * </pre>
      *
      * <code>bool sellable = 9 [deprecated = true];</code>
      * @deprecated io.evitadb.externalApi.grpc.generated.GrpcUpsertPriceMutation.sellable is deprecated.
-     *     See GrpcPriceMutations.proto;l=51
+     *     See GrpcPriceMutations.proto;l=52
      * @return This builder for chaining.
      */
     @java.lang.Deprecated public Builder clearSellable() {

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpsertPriceMutationOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUpsertPriceMutationOrBuilder.java
@@ -256,11 +256,12 @@ public interface GrpcUpsertPriceMutationOrBuilder extends
    * entity but won't be considered when evaluating search query. These prices may be
    * used for "informational" prices such as reference price (the crossed out price often found on e-commerce sites
    * as "usual price") but are not considered as the "selling" price.
+   * RENAMED TO "indexed"
    * </pre>
    *
    * <code>bool sellable = 9 [deprecated = true];</code>
    * @deprecated io.evitadb.externalApi.grpc.generated.GrpcUpsertPriceMutation.sellable is deprecated.
-   *     See GrpcPriceMutations.proto;l=51
+   *     See GrpcPriceMutations.proto;l=52
    * @return The sellable.
    */
   @java.lang.Deprecated boolean getSellable();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUuid.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUuid.java
@@ -70,7 +70,7 @@ private static final long serialVersionUID = 0L;
   private long mostSignificantBits_ = 0L;
   /**
    * <pre>
-   * Value that supports storing a UUID.
+   * The most significant 64 bits of the UUID, as returned by `UUID#getMostSignificantBits()`.
    * </pre>
    *
    * <code>int64 mostSignificantBits = 1;</code>
@@ -84,6 +84,10 @@ private static final long serialVersionUID = 0L;
   public static final int LEASTSIGNIFICANTBITS_FIELD_NUMBER = 2;
   private long leastSignificantBits_ = 0L;
   /**
+   * <pre>
+   * The least significant 64 bits of the UUID, as returned by `UUID#getLeastSignificantBits()`.
+   * </pre>
+   *
    * <code>int64 leastSignificantBits = 2;</code>
    * @return The leastSignificantBits.
    */
@@ -449,7 +453,7 @@ private static final long serialVersionUID = 0L;
     private long mostSignificantBits_ ;
     /**
      * <pre>
-     * Value that supports storing a UUID.
+     * The most significant 64 bits of the UUID, as returned by `UUID#getMostSignificantBits()`.
      * </pre>
      *
      * <code>int64 mostSignificantBits = 1;</code>
@@ -461,7 +465,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID.
+     * The most significant 64 bits of the UUID, as returned by `UUID#getMostSignificantBits()`.
      * </pre>
      *
      * <code>int64 mostSignificantBits = 1;</code>
@@ -477,7 +481,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID.
+     * The most significant 64 bits of the UUID, as returned by `UUID#getMostSignificantBits()`.
      * </pre>
      *
      * <code>int64 mostSignificantBits = 1;</code>
@@ -492,6 +496,10 @@ private static final long serialVersionUID = 0L;
 
     private long leastSignificantBits_ ;
     /**
+     * <pre>
+     * The least significant 64 bits of the UUID, as returned by `UUID#getLeastSignificantBits()`.
+     * </pre>
+     *
      * <code>int64 leastSignificantBits = 2;</code>
      * @return The leastSignificantBits.
      */
@@ -500,6 +508,10 @@ private static final long serialVersionUID = 0L;
       return leastSignificantBits_;
     }
     /**
+     * <pre>
+     * The least significant 64 bits of the UUID, as returned by `UUID#getLeastSignificantBits()`.
+     * </pre>
+     *
      * <code>int64 leastSignificantBits = 2;</code>
      * @param value The leastSignificantBits to set.
      * @return This builder for chaining.
@@ -512,6 +524,10 @@ private static final long serialVersionUID = 0L;
       return this;
     }
     /**
+     * <pre>
+     * The least significant 64 bits of the UUID, as returned by `UUID#getLeastSignificantBits()`.
+     * </pre>
+     *
      * <code>int64 leastSignificantBits = 2;</code>
      * @return This builder for chaining.
      */

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUuidArray.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUuidArray.java
@@ -72,7 +72,7 @@ private static final long serialVersionUID = 0L;
   private java.util.List<io.evitadb.externalApi.grpc.generated.GrpcUuid> value_;
   /**
    * <pre>
-   * Value that supports storing a UUID array.
+   * The individual UUID elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -83,7 +83,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a UUID array.
+   * The individual UUID elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -95,7 +95,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a UUID array.
+   * The individual UUID elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -106,7 +106,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a UUID array.
+   * The individual UUID elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -117,7 +117,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * Value that supports storing a UUID array.
+   * The individual UUID elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -520,7 +520,7 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -534,7 +534,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -548,7 +548,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -562,7 +562,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -583,7 +583,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -601,7 +601,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -621,7 +621,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -642,7 +642,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -660,7 +660,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -678,7 +678,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -697,7 +697,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -714,7 +714,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -731,7 +731,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -742,7 +742,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -756,7 +756,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -771,7 +771,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -782,7 +782,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -794,7 +794,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Value that supports storing a UUID array.
+     * The individual UUID elements, in their original order.
      * </pre>
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUuidArrayOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUuidArrayOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcUuidArrayOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a UUID array.
+   * The individual UUID elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -42,7 +42,7 @@ public interface GrpcUuidArrayOrBuilder extends
       getValueList();
   /**
    * <pre>
-   * Value that supports storing a UUID array.
+   * The individual UUID elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -50,7 +50,7 @@ public interface GrpcUuidArrayOrBuilder extends
   io.evitadb.externalApi.grpc.generated.GrpcUuid getValue(int index);
   /**
    * <pre>
-   * Value that supports storing a UUID array.
+   * The individual UUID elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -58,7 +58,7 @@ public interface GrpcUuidArrayOrBuilder extends
   int getValueCount();
   /**
    * <pre>
-   * Value that supports storing a UUID array.
+   * The individual UUID elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>
@@ -67,7 +67,7 @@ public interface GrpcUuidArrayOrBuilder extends
       getValueOrBuilderList();
   /**
    * <pre>
-   * Value that supports storing a UUID array.
+   * The individual UUID elements, in their original order.
    * </pre>
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcUuid value = 1;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUuidOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcUuidOrBuilder.java
@@ -33,7 +33,7 @@ public interface GrpcUuidOrBuilder extends
 
   /**
    * <pre>
-   * Value that supports storing a UUID.
+   * The most significant 64 bits of the UUID, as returned by `UUID#getMostSignificantBits()`.
    * </pre>
    *
    * <code>int64 mostSignificantBits = 1;</code>
@@ -42,6 +42,10 @@ public interface GrpcUuidOrBuilder extends
   long getMostSignificantBits();
 
   /**
+   * <pre>
+   * The least significant 64 bits of the UUID, as returned by `UUID#getLeastSignificantBits()`.
+   * </pre>
+   *
    * <code>int64 leastSignificantBits = 2;</code>
    * @return The leastSignificantBits.
    */

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcCatalogSchema.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcCatalogSchema.proto
@@ -8,6 +8,10 @@ import "GrpcEnums.proto";
 import "GrpcEvitaDataTypes.proto";
 import "google/protobuf/wrappers.proto";
 
+// Represents the schema of a single catalog - the top-level container that groups related entity collections
+// together (analogous to a database / schema in a relational system). Holds the catalog name, its schema version,
+// optional description, evolution mode settings, catalog-wide (global) attributes shared across entity types,
+// name variants and the conflict resolution policy inherited by entity schemas that don't override it.
 message GrpcCatalogSchema {
   // Contains unique name of the catalog. Case-sensitive. Distinguishes one catalog item from another
   // within single entity instance.
@@ -54,6 +58,8 @@ message GrpcCatalogSchema {
 //
 // Attributes are not recommended for bigger data as they are all loaded at once when requested.
 message GrpcGlobalAttributeSchema {
+  // Contains unique name of the attribute. Case-sensitive. Distinguishes one attribute from another within
+  // a single entity type or, for global attributes, within the entire catalog.
   string name = 1;
   // optional description of the attribute
   google.protobuf.StringValue description = 2;
@@ -97,8 +103,8 @@ message GrpcGlobalAttributeSchema {
   // non-null checks even if no attributes of such name are specified.
   GrpcEvitaValue defaultValue = 11;
   // Determines how many fractional places are important when entities are compared during filtering or sorting. It is
-  // significant to know that all values of this attribute will be converted to {@link java.lang.Integer}, so the attribute
-  // number must not ever exceed maximum limits of {@link java.lang.Integer} type when scaling the number by the power
+  // significant to know that all values of this attribute will be converted to `Integer`, so the attribute
+  // number must not ever exceed maximum limits of `Integer` type when scaling the number by the power
   // of ten using `indexedDecimalPlaces` as exponent.
   int32 indexedDecimalPlaces = 12;
   // When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcChangeCapture.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcChangeCapture.proto
@@ -13,12 +13,16 @@ import "GrpcInfrastrutureMutation.proto";
 import "GrpcEvitaDataTypes.proto";
 import "GrpcEnums.proto";
 
-// Record for the criteria of the capture request allowing to limit mutations to specific area of interest an its
+// Record for the criteria of the capture request allowing to limit mutations to specific area of interest and its
 // properties.
 message GrpcChangeCaptureCriteria {
-  // The area of capture - either schema or data (correlates with the site)
+  // The area of capture - SCHEMA, DATA or INFRASTRUCTURE. If `schemaSite`/`dataSite` below is set, it determines
+  // the effective area and this field is ignored; this field is only consulted when neither site is set, which
+  // is also the only way to select INFRASTRUCTURE (it has no site message of its own).
   GrpcChangeCaptureArea area = 1;
-  // The specific requirements for the designated area
+  // At most one of `schemaSite`/`dataSite` may be set. If neither is set, every mutation matching `area` passes
+  // without further site-level filtering; each set field on the chosen site message narrows the match further
+  // (see that message's field comments for what an unset field means).
   oneof site {
     // Criteria for schema capture
     GrpcChangeCaptureSchemaSite schemaSite = 2;
@@ -28,36 +32,57 @@ message GrpcChangeCaptureCriteria {
 }
 
 // Record describing the location and form of the CDC schema event in the evitaDB that should be captured.
+// Every field below is an independent, optional filter (logically ANDed together when several are set); an
+// unset/empty field imposes no restriction on that dimension.
 message GrpcChangeCaptureSchemaSite {
-  // The name of intercepted entity
+  // Restricts capture to schema mutations of the named entity type. If `null`, matches schema mutations for any
+  // entity type, including catalog-level schema changes (which carry no entity type of their own).
   google.protobuf.StringValue entityType = 1;
-  // The intercepted type of operation
+  // Restricts capture to the listed operation types. If empty, matches any operation.
   repeated GrpcChangeCaptureOperation operation = 2;
-  // the name of the intercepted container type
+  // Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+  // matches any container type.
   repeated GrpcChangeCaptureContainerType containerType = 3;
-  // the name of the container (e.g. attribute name, associated data name, reference name)
+  // Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+  // reference name). If empty, matches containers of any name.
   repeated string containerName = 4;
 }
 
 // Record describing the location and form of the CDC data event in the evitaDB that should be captured.
+// Every field below is an independent, optional filter (logically ANDed together when several are set); an
+// unset/empty field imposes no restriction on that dimension.
 message GrpcChangeCaptureDataSite {
-  // the name of the intercepted entity type
+  // Restricts capture to mutations of the named entity type. If `null`, matches data mutations for any entity
+  // type.
   google.protobuf.StringValue entityType = 1;
-  // the primary key of the intercepted entity
+  // Restricts capture to mutations of the entity with this primary key. If `null`, matches any primary key
+  // within the entity type filter above.
   google.protobuf.Int32Value entityPrimaryKey = 2;
-  // the intercepted type of operation
+  // Restricts capture to the listed operation types. If empty, matches any operation.
   repeated GrpcChangeCaptureOperation operation = 3;
-  // the name of the intercepted container type
+  // Restricts capture to the listed container types (e.g. attribute, associated data, reference). If empty,
+  // matches any container type.
   repeated GrpcChangeCaptureContainerType containerType = 4;
-  // the name of the container (e.g. attribute name, associated data name, reference name)
+  // Restricts capture to containers with one of the listed names (e.g. attribute name, associated data name,
+  // reference name). If empty, matches containers of any name.
   repeated string containerName = 5;
 }
 
 // Record represents a catalog CDC event that is sent to the subscriber if it matches to the request he made.
 message GrpcChangeCatalogCapture {
-  // the version of the catalog where the operation was performed
+  // The catalog version the operation was committed in. Strictly monotonic across the stream: ascending in a
+  // forward stream, descending in a reverse stream. See issue #1349 for the full analysis of stream ordering.
   google.protobuf.Int64Value version = 1;
-  // the index of the event within the enclosed transaction, index 0 is the transaction lead event
+  // A direction-stable physical position of the underlying WAL record within its transaction, not a delivery
+  // counter: a forward stream assigns `1..mutationCount` ascending, a reverse stream assigns `mutationCount..1`
+  // descending, so the same physical record gets the same index regardless of direction - but indices are
+  // therefore NOT monotonic within a transaction when read in reverse (the transaction header is emitted at
+  // index `0`, then indices count down from `mutationCount`). Nested local mutations do not get their own
+  // index: they inherit the `(version, index)` pair of the entity mutation record they belong to, so
+  // `(version, index)` identifies a WAL record, not an individual emitted capture - an entity upsert with 5
+  // local mutations produces 6 captures that all share the same pair. The index is advanced before criteria
+  // filtering is applied, so it stays stable and comparable across requests using different filters. See issue
+  // #1349 for the full analysis.
   google.protobuf.Int32Value index = 2;
   // the area of the operation
   GrpcChangeCaptureArea area = 3;
@@ -67,13 +92,25 @@ message GrpcChangeCatalogCapture {
   // the primary key of the entity that was affected by the operation
   // (null for schema operations)
   google.protobuf.Int32Value entityPrimaryKey = 5;
-  // the operation that was performed
+  // The kind of change that produced this capture. Together with `area`, it determines which arm of `body` (if
+  // present) carries the payload - see the `body` oneof comment for the mapping.
   GrpcChangeCaptureOperation operation = 6;
-  // optional body of the operation when it is requested by the GrpcContent
+  // Payload of the operation. Present only when the request's content mode is `CHANGE_BODY` (see
+  // `GrpcChangeCaptureContent`); a `CHANGE_HEADER` request - the proto3 default when `content` is left unset -
+  // always leaves every arm of this oneof unset. When present, exactly one arm is set, chosen by
+  // `area`/`operation`: `schemaMutation` for a SCHEMA area mutation, `entityMutation` for the top-level DATA
+  // area entity mutation, `localMutation` for a DATA area field-level mutation nested inside an entity upsert
+  // (it shares the parent entity mutation's `(version, index)` - see the `index` field comment above),
+  // `infrastructureMutation` for the INFRASTRUCTURE area transaction header.
   oneof body {
+    // Set for a SCHEMA area mutation. See the `body` comment above for the full arm-selection mapping.
     GrpcEntitySchemaMutation schemaMutation = 7;
+    // Set for the top-level DATA area entity mutation. See the `body` comment above.
     GrpcEntityMutation entityMutation = 8;
+    // Set for a DATA area field-level mutation nested inside an entity upsert. See the `body`
+    // comment above and the `index` field comment for how it shares its parent's `(version, index)`.
     GrpcLocalMutation localMutation = 9;
+    // Set for the INFRASTRUCTURE area transaction header. See the `body` comment above.
     GrpcInfrastructureMutation infrastructureMutation = 10;
   }
   // Represents the timestamp of the commit.
@@ -104,6 +141,7 @@ message GrpcChangeSystemCapture {
 // Host CDC event. Carried as the body of GrpcChangeSystemCapture
 // when the subscriber explicitly opted in to HOST.
 message GrpcHostSystemEvent {
+  // Exactly one of the following event kinds is set.
   oneof event {
     // Fires when a catalog's local reference settles into a non-transient state on this host.
     GrpcCatalogInstalledIntoLiveView catalogInstalled = 1;

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEntitySchema.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEntitySchema.proto
@@ -49,7 +49,7 @@ message GrpcEntitySchema {
   // Each entity must be part of at most single hierarchy (tree).
   //
   // Hierarchy can limit returned entities by using filtering constraints. It's also used for
-  // computation of extra data - such as `hierarchyParentsOfSelf`. It can also invert type of returned entities in case extra result
+  // computation of extra data - such as the `parents` requirement. It can also invert type of returned entities in case extra result
   // `hierarchyOfSelf` is requested.
   bool withHierarchy = 6;
   // Contains `true` when entities of this type holds price information.
@@ -134,7 +134,7 @@ message GrpcEntitySchema {
 	// can define its price), but it is not possible to work with the price information in any other way (calculating
 	// price histogram, filtering, sorting by price, etc.).
 	//
-	// Prices can be also set as non-indexed individually by setting {@link PriceContract#indexed()} to false.
+	// Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
   repeated GrpcEntityScope priceIndexedInScopes = 18;
   // Contains current version of the catalog schema this entity schema belongs to.
   int64 catalogSchemaVersion = 19;
@@ -181,8 +181,8 @@ message GrpcAttributeSchema {
   // deprecated in favor of `uniqueInScopes`
   GrpcAttributeUniquenessType unique = 5 [deprecated = true];
   // When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-  // entity having certain value of this attribute in entire {@link CatalogContract}.
-  // {@link AttributeSchemaContract#getType() Type} of the unique attribute must implement {@link Comparable} interface.
+  // entity having certain value of this attribute in the entire catalog.
+  // The type of the unique attribute must implement the `Comparable` interface.
   //
   // As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
   // better to have this ensured by the database engine.
@@ -207,7 +207,7 @@ message GrpcAttributeSchema {
   // non-null checks upon upserting of the entity.
   bool nullable = 10;
   // Representative flag marks the attribute as one of the most important attributes in the entity, or when used
-  // on reference level in the {@link ReferenceSchemaContract} it marks attributes distinguishing duplicated
+  // on a reference-level attribute schema, it marks attributes distinguishing duplicated
   // references to the same entity and is a key attribute for creating distinct indexes for such references.
   //
   // In overall, representative attributes should be used in developer tools along with the entity's primary key to
@@ -237,8 +237,8 @@ message GrpcAttributeSchema {
   // better to have this ensured by the database engine.
   repeated GrpcScopedAttributeUniquenessType uniqueInScopes = 17;
   // When attribute is unique globally it is automatically filterable, and it is ensured there is exactly one single
-  // entity having certain value of this attribute in entire {@link CatalogContract}.
-  // {@link AttributeSchemaContract#getType() Type} of the unique attribute must implement {@link Comparable} interface.
+  // entity having certain value of this attribute in the entire catalog.
+  // The type of the unique attribute must implement the `Comparable` interface.
   //
   // As an example of unique attribute can be URL - there is no sense in having two entities with same URL, and it's
   // better to have this ensured by the database engine.
@@ -271,6 +271,8 @@ message GrpcAssociatedDataSchema {
   // Contains unique name of the model. Case-sensitive. Distinguishes one model item from another
   // within single entity instance.
   string name = 1;
+  // Contains description of the model is optional but helps authors of the schema / client API to better
+  // explain the original purpose of the model to the consumers.
   google.protobuf.StringValue description = 2;
   // Deprecation notice contains information about planned removal of this entity from the model / client API.
   // This allows to plan and evolve the schema allowing clients to adapt early to planned breaking changes.

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEntitySchemaMutations.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEntitySchemaMutations.proto
@@ -144,6 +144,6 @@ message GrpcSetEntitySchemaWithPriceMutation {
   // can define its price), but it is not possible to work with the price information in any other way (calculating
   // price histogram, filtering, sorting by price, etc.).
   //
-  // Prices can be also set as non-indexed individually by setting {@link PriceContract#indexed()} to false.
+  // Prices can be also set as non-indexed individually via the individual price's own `indexed` flag.
   repeated GrpcEntityScope indexedInScopes = 3;
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEnums.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEnums.proto
@@ -26,7 +26,7 @@ enum GrpcCatalogState {
   // State signalizing that evitaDB engine didn't load this catalog from the file system, but is present in
   // the persistence storage. Catalog might be loaded into memory later on demand and start to process requests.
   INACTIVE = 4;
-  // State signalizing that evitaDB engine is transitioning catalog from {@link #WARMING_UP} to {@link #ALIVE} state.
+  // State signalizing that evitaDB engine is transitioning catalog from `WARMING_UP` to `ALIVE` state.
   // Until the transition is fully completed, the catalog is not able to serve any requests.
   GOING_ALIVE = 5;
   // State signalizing that evitaDB engine is loading catalog from the file system to the memory and performing
@@ -34,7 +34,7 @@ enum GrpcCatalogState {
   // completed.
   BEING_ACTIVATED = 6;
   // State signalizing that evitaDB engine is deactivating the catalog. When the operation is completed, the catalog
-  // is moved to {@link #INACTIVE} state.
+  // is moved to `INACTIVE` state.
   BEING_DEACTIVATED = 7;
   // State signalizing that evitaDB engine is creating a new catalog. The catalog is not able to serve any requests
   // until the creation is fully completed.
@@ -57,7 +57,7 @@ enum GrpcCatalogState {
   UNKNOWN_CATALOG_STATE = 2;
 }
 
-// This enum represents the uniqueness type of an {@link AttributeSchema}. It is used to determine whether the attribute
+// This enum represents the uniqueness type of an `AttributeSchema`. It is used to determine whether the attribute
 // value must be unique among all the entity attributes of this type or whether it must be unique only among attributes
 // of the same locale.
 enum GrpcAttributeUniquenessType {
@@ -65,22 +65,22 @@ enum GrpcAttributeUniquenessType {
   NOT_UNIQUE = 0;
   // The attribute value must be unique among all the entities of the same collection.
   UNIQUE_WITHIN_COLLECTION = 1;
-  // The localized attribute value must be unique among all values of the same {@link Locale} among all the entities
+  // The localized attribute value must be unique among all values of the same `Locale` among all the entities
   // using of the same collection.
   UNIQUE_WITHIN_COLLECTION_LOCALE = 2;
 }
 
-// This enum represents the uniqueness type of an {@link GlobalAttributeSchema}. It is used to determine whether
-// the attribute value must be unique among all the entities using this {@link GlobalAttributeSchema} or whether it
+// This enum represents the uniqueness type of a `GlobalAttributeSchema`. It is used to determine whether
+// the attribute value must be unique among all the entities using this `GlobalAttributeSchema` or whether it
 // must be unique only among entities of the same locale.
 enum GrpcGlobalAttributeUniquenessType {
   // The attribute is not unique (default).
   NOT_GLOBALLY_UNIQUE = 0;
   // The attribute value (either localized or non-localized) must be unique among all values among all the entities
-  // using this {@link GlobalAttributeSchema} in the entire catalog.
+  // using this `GlobalAttributeSchema` in the entire catalog.
   UNIQUE_WITHIN_CATALOG = 1;
-  // The localized attribute value must be unique among all values of the same {@link Locale} among all the entities
-  // using this {@link GlobalAttributeSchema} in the entire catalog.
+  // The localized attribute value must be unique among all values of the same `Locale` among all the entities
+  // using this `GlobalAttributeSchema` in the entire catalog.
   UNIQUE_WITHIN_CATALOG_LOCALE = 2;
 }
 
@@ -198,10 +198,10 @@ enum GrpcHistogramBehavior {
   EQUALIZED_OPTIMIZED = 3;
 }
 
-// This enumeration controls behavior of the {@link ReferenceContent} related to managed entities.
-// If the target entity is not (yet) present in the database and {@link ManagedReferencesBehaviour#EXISTING} is set,
+// This enumeration controls behavior of the `ReferenceContent` related to managed entities.
+// If the target entity is not (yet) present in the database and `EXISTING` is set,
 // the reference will not be returned as if it does not exist.
-// If {@link ManagedReferencesBehaviour#ANY} is set (default behavior), the reference will be returned if defined regardless
+// If `ANY` is set (default behavior), the reference will be returned if defined regardless
 // of its target entity existence.
 enum GrpcManagedReferencesBehaviour {
   // The reference to managed entity will always be returned regardless of the target entity existence.
@@ -408,6 +408,8 @@ enum GrpcEvitaDataType {
 
 // This enum contains all supported data types of AssociatedData.
 message GrpcEvitaAssociatedDataDataType {
+  // Enumerates the value types evitaDB supports for associated data (both scalar and array variants) - a subset
+  // of the general query data types plus `ComplexDataObject` for arbitrary nested structures.
   enum GrpcEvitaDataType {
     // Represents string data type.
     STRING = 0;
@@ -569,7 +571,7 @@ enum GrpcCommitBehavior {
   // Changes performed in the transaction are passed to evitaDB server, checked for conflicts and if no conflict
   // is found, they are written to Write Ahead Log (WAL) and transaction waits until the WAL is persisted on disk
   // (fsynced). After that the transaction is marked as completed and commit is finished. This behaviour is
-  // slower than {@link #NO_WAIT} but guarantees that the changes are persisted on disk and durable. The server
+  // slower than `WAIT_FOR_CONFLICT_RESOLUTION` but guarantees that the changes are persisted on disk and durable. The server
   // may decide to fsync changes from multiple transactions at once, so the transaction may wait longer than
   // necessary. This behaviour still does not guarantee that the changes will be visible immediately after
   // the commit - because they still need to be propagated to indexes in order new data can be found by queries.
@@ -697,12 +699,12 @@ enum GrpcTaskSimplifiedState {
 // Enum specifies different modes for reference attributes inheritance in reflected schema.
 enum GrpcAttributeInheritanceBehavior {
   /**
-   * Inherit all attributes by default except those listed in the {@link #getAttributeInheritanceFilter()} array.
+   * Inherit all attributes by default except those listed in the attribute inheritance filter array.
    */
   INHERIT_ALL_EXCEPT = 0;
 
   /**
-   * Do not inherit any attributes by default except those listed in the {@link #getAttributeInheritanceFilter()} array.
+   * Do not inherit any attributes by default except those listed in the attribute inheritance filter array.
    */
   INHERIT_ONLY_SPECIFIED = 1;
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaAPI.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaAPI.proto
@@ -21,7 +21,10 @@ message GrpcReadyResponse {
 message GrpcEvitaSessionRequest {
   // The name of the catalog for which the session is to be created.
   string catalogName = 1;
-  // Commit behaviour
+  // Default commit behaviour applied when the session is closed implicitly via `close()` - determines how far a
+  // transaction must be durably persisted before the close is considered complete. Can be overridden per call by
+  // closing the session explicitly with a specific behaviour instead. See `GrpcCommitBehavior` for the available
+  // durability/performance trade-offs.
   GrpcCommitBehavior commitBehavior = 2;
   // For testing purposes. Flag indicating that all changes by the session should be rollbacked after the session is closed.
   bool dryRun = 3;
@@ -31,9 +34,11 @@ message GrpcEvitaSessionRequest {
 message GrpcEvitaSessionResponse {
   // UUID of the created session.
   string sessionId = 1;
-  // Type of the created session.
+  // Type of the created session - read-only vs. read-write, and whether fetched entities are returned in binary
+  // form for the Java driver (`BINARY_*` variants). See `GrpcSessionType`.
   GrpcSessionType sessionType = 2;
-  // Commit behaviour
+  // Effective commit behaviour of the created session, applied when the session is closed implicitly via
+  // `close()`. See `GrpcCommitBehavior` for the available durability/performance trade-offs.
   GrpcCommitBehavior commitBehaviour = 3;
   // State of the catalog after the session was created.
   GrpcCatalogState catalogState = 4;
@@ -67,7 +72,7 @@ message GrpcGetCatalogStateRequest {
 
 // Response to a get catalog state request.
 message GrpcGetCatalogStateResponse {
-  // State of the catalog.
+  // State of the catalog. Unset if no catalog with the requested name exists.
   optional GrpcCatalogState catalogState = 1;
 }
 
@@ -99,9 +104,13 @@ message GrpcRenameCatalogResponse {
 
 // Request to replace a catalog.
 message GrpcReplaceCatalogRequest {
-  // Name of the catalog that will become the successor of the original catalog (old name)
+  // Name of the source catalog whose content takes over. After a successful replace, this name no longer exists -
+  // the catalog is consumed and its content is now served under `catalogNameToBeReplaced`. If the operation fails,
+  // the state of this catalog is unknown and must be treated as damaged.
   string catalogNameToBeReplacedWith = 1;
-  // Name of the catalog that will be replaced and dropped (new name)
+  // Name of the target catalog to replace. Its existing content is dropped and replaced by the content of
+  // `catalogNameToBeReplacedWith`, while the name itself is preserved and keeps serving requests under it. If the
+  // operation fails, this catalog is guaranteed to remain untouched.
   string catalogNameToBeReplaced = 2;
 }
 
@@ -208,21 +217,32 @@ message GrpcApplyMutationResponse {
 
 }
 
-// Response to apply mutation on engine level.
+// Streamed progress report for any of evitaDB's long-running catalog-lifecycle operations that support progress
+// tracking (apply mutation, rename, replace, make mutable/immutable/alive, duplicate, activate, deactivate - see
+// the `*WithProgress` RPCs on `EvitaService`). One or more intermediate messages are streamed as the operation
+// advances, followed by exactly one final message with `progressInPercent` set to 100.
 message GrpcApplyMutationWithProgressResponse {
-  // The progress of the go live operation in percents.
+  // Progress of the tracked operation (percent, 0-100). Intermediate updates are throttled (only sent on an
+  // increase, at most once per second); the final message of the stream always carries 100.
   int32 progressInPercent = 1;
-  // Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+  // Catalog version reached by the operation. Set only on the final message (`progressInPercent` = 100), and only
+  // if the operation produced a catalog version (i.e. relates to a catalog rather than being purely engine-level);
+  // unset on every intermediate update.
   google.protobuf.Int64Value catalogVersion = 2;
-  // Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+  // Catalog schema version reached by the operation. Set only on the final message (`progressInPercent` = 100),
+  // and only if the operation produced a catalog schema version (i.e. relates to a catalog rather than being
+  // purely engine-level); unset on every intermediate update.
   google.protobuf.Int32Value catalogSchemaVersion = 3;
 }
 
 // Request to register a system change capture.
 message GrpcRegisterSystemChangeCaptureRequest {
-  // Starting point for the search (engine version)
+  // Starting point for the search (engine version). If `null`, the capture starts live-tailing from the most
+  // recent / greatest available engine version rather than replaying history from the beginning.
   google.protobuf.Int64Value sinceVersion = 1;
-  // Starting point for the search (index of the mutation within engine version - currently each engine level transaction contains only one mutation)
+  // Continuation point within `sinceVersion` (index of the mutation within the engine version - currently each
+  // engine level transaction contains only one mutation). If `null`, the capture starts at the beginning of
+  // `sinceVersion` rather than resuming mid-transaction.
   google.protobuf.Int32Value sinceIndex = 2;
   // Requested content of the capture - i.e. whether client wants to receive only the simple notification about the change
   // or whether he wants to receive the full content of the change
@@ -235,14 +255,18 @@ message GrpcRegisterSystemChangeCaptureRequest {
 
 // Response to GrpcRegisterSystemChangeCapture request.
 message GrpcRegisterSystemChangeCaptureResponse {
-  // Identification of the registered capture
+  // Identification of the registered subscription. Set on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses (when a
+  // subscription id is available), unset on `CHANGE` responses.
   GrpcUuid uuid = 1;
-  // The list of mutations (CDC events) that match the criteria
+  // A single captured CDC event that matched the subscription's criteria - each stream message carries at most
+  // one event, not a batch. Set only when `responseType` is `CHANGE`; unset on `ACKNOWLEDGEMENT` and `HEARTBEAT`
+  // responses.
   GrpcChangeSystemCapture capture = 2;
-  // The type of the response - when subscription is set-up, acknowledgement is sent
-  // Then with each capture event, the type is set to `change`
+  // The kind of this response: `ACKNOWLEDGEMENT` is sent exactly once, when the subscription is set up; `CHANGE`
+  // is sent for each matching capture event; `HEARTBEAT` is sent periodically as a keep-alive while no matching
+  // event has occurred.
   GrpcCaptureResponseType responseType = 3;
-  // Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+  // Heartbeat information. Set only on `ACKNOWLEDGEMENT` and `HEARTBEAT` responses, unset on `CHANGE` responses.
   GrpcHeartBeat heartBeat = 4;
 }
 
@@ -255,15 +279,23 @@ message GrpcGetProgressRequest {
 
 // Response to GrpcGetProgressRequest.
 message GrpcGetProgressResponse {
-  // contains information whether the progress was found or not
+  // True when a mutation progress was being tracked for `catalogName` at the moment this call was received. If
+  // `false`, none of the fields below carry information - either no mutation is currently in flight for this
+  // catalog, or a previously tracked one already finished (and its progress entry was cleared) before this call
+  // arrived; the call must be made while the operation is still running in order to observe it.
   bool found = 1;
-  // The progress of the top-level engine mutation in percents.
+  // Current progress of the tracked mutation (percent, 0-100). Unset iff `found` is `false`. The final streamed
+  // message carries 100; intermediate updates are throttled (only sent on an increase, at most once per second).
   google.protobuf.Int32Value progressInPercent = 2;
-  // Contains catalog name copied from the request (if the progress is related to a catalog)
+  // Catalog name copied from the request. Empty when `found` is `false`.
   string catalogName = 3;
-  // Contains catalog version when operation finishes (only if the mutation relates to a catalog)
+  // Catalog version reached by the operation. Set only on the final streamed message (`progressInPercent` = 100),
+  // and only if the operation produced a catalog version (i.e. relates to a catalog rather than being purely
+  // engine-level); unset on every intermediate update.
   google.protobuf.Int64Value catalogVersion = 4;
-  // Contains catalog schema version when operation finishes (only if the mutation relates to a catalog)
+  // Catalog schema version reached by the operation. Set only on the final streamed message
+  // (`progressInPercent` = 100), and only if the operation produced a catalog schema version (i.e. relates to a
+  // catalog rather than being purely engine-level); unset on every intermediate update.
   google.protobuf.Int32Value catalogSchemaVersion = 5;
 }
 

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaDataTypes.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaDataTypes.proto
@@ -8,70 +8,98 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 import "GrpcEnums.proto";
 
-// Representation of IntegerNumberRange structures with optional from and to values.
+// Representation of IntegerNumberRange structures. At least one of `from`/`to` should be set; if
+// both are absent, the range decodes to the degenerate range `[0,0]` rather than being unbounded
+// in both directions.
 message GrpcIntegerNumberRange {
-  // The lower bound of the range.
+  // The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+  // below.
   google.protobuf.Int32Value from = 1;
-  // The upper bound of the range.
+  // The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+  // above.
   google.protobuf.Int32Value to = 2;
 }
 
-// Representation of LongNumberRange structures with optional from and to values.
+// Representation of LongNumberRange structures. At least one of `from`/`to` should be set; if
+// both are absent, the range decodes to the degenerate range `[0,0]` rather than being unbounded
+// in both directions.
 message GrpcLongNumberRange {
-  // The lower bound of the range.
+  // The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+  // below.
   google.protobuf.Int64Value from = 1;
-  // The upper bound of the range.
+  // The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+  // above.
   google.protobuf.Int64Value to = 2;
 }
 
-// Representation of BigDecimalNumberRange structures with optional from and to values.
+// Representation of BigDecimalNumberRange structures. At least one of `from`/`to` should be set;
+// if both are absent, the range decodes to the degenerate range `[0,0]` rather than being
+// unbounded in both directions.
 message GrpcBigDecimalNumberRange {
-  // The lower bound of the range.
+  // The inclusive lower bound of the range. If unset (while `to` is set), the range is unbounded
+  // below.
   GrpcBigDecimal from = 1;
-  // The upper bound of the range.
+  // The inclusive upper bound of the range. If unset (while `from` is set), the range is unbounded
+  // above.
   GrpcBigDecimal to = 2;
-  // The number of decimal places to compare.
+  // The number of fractional digits retained (rounded half-up) when comparing values against this
+  // range: both bounds and the compared value are scaled to this precision first, so digits beyond
+  // it are ignored for range-membership comparisons.
   int32 decimalPlacesToCompare = 3;
 }
 
-// Representation of DateTimeRange structures with optional from and to values.
+// Representation of DateTimeRange structures. At least one of `from`/`to` should be set; if both
+// are absent, the range decodes to a degenerate range anchored at the Unix epoch
+// (1970-01-01T00:00:00Z) rather than being unbounded in both directions.
 message GrpcDateTimeRange {
-  // The lower bound of the range.
+  // The inclusive lower bound (start) of the range. If unset (while `to` is set), the range is
+  // unbounded below (open start).
   GrpcOffsetDateTime from = 1;
-  // The upper bound of the range.
+  // The inclusive upper bound (end) of the range. If unset (while `from` is set), the range is
+  // unbounded above (open end).
   GrpcOffsetDateTime to = 2;
 }
 
 // Representation of Java's BigDecimal class with arbitrary precision.
 message GrpcBigDecimal {
-  // The string serialized value.
+  // The decimal value serialized as a string in the canonical form produced by
+  // `BigDecimal#toString()`, with the exponent marker lower-cased and its `+` sign stripped
+  // (e.g. `2.5e8` rather than `2.5E+8`). Preserves the original scale so the value round-trips
+  // exactly.
   string valueString = 1;
 }
 
 // Structure for representing Locale objects specified by language tag.
 message GrpcLocale {
-  // The language tag of the locale.
+  // IETF BCP 47 language tag (e.g. `en-US`, `cs-CZ`), resolved server-side via
+  // `Locale#forLanguageTag(String)`.
   string languageTag = 1;
 }
 
 // Structure for representing Currency objects specified by currency code.
 message GrpcCurrency {
-  // The currency code of the currency.
+  // ISO 4217 three-letter currency code (e.g. `USD`, `EUR`), resolved via
+  // `Currency#getInstance(String)`.
   string code = 1;
 }
 
 // Structure for representing UUID objects.
 message GrpcUuid {
-  // Value that supports storing a UUID.
+  // The most significant 64 bits of the UUID, as returned by `UUID#getMostSignificantBits()`.
   int64 mostSignificantBits = 1;
+  // The least significant 64 bits of the UUID, as returned by `UUID#getLeastSignificantBits()`.
   int64 leastSignificantBits = 2;
 }
 
-// Structure for representing Predecessor objects.
+// Structure for representing Predecessor objects, used to express a manually maintained ordering
+// of sibling entities/references by pointing each one at the primary key of the item that precedes
+// it.
 message GrpcPredecessor {
-  // true if predecessor is a head, false otherwise
+  // If `true`, this is the first item in the ordering (no predecessor) and `predecessorId` is not
+  // set. If `false`, this item has a predecessor and `predecessorId` must be set.
   bool head = 1;
-  // Value that supports storing a Predecessor.
+  // The primary key of the entity/reference that precedes this one in the ordering. Unset when
+  // `head` is `true`; must be set when `head` is `false`.
   google.protobuf.Int32Value predecessorId = 2;
 }
 
@@ -95,270 +123,311 @@ message GrpcOffsetDateTime {
   string offset = 2;
 }
 
-// Wrapper for representing an array of strings.
+// Wrapper for representing an array of strings. Also used to carry a Character array — each
+// element is then a single-character string; which Java array type applies is determined by the
+// accompanying GrpcEvitaDataType (STRING_ARRAY vs CHARACTER_ARRAY).
 message GrpcStringArray {
-  // Value that supports storing a string array.
+  // The individual string (or, for a character array, single-character) elements, in their
+  // original order.
   repeated string value = 1;
 }
 
-// Wrapper for representing an array of integers.
+// Wrapper for representing an array of integers. Also used to carry Byte and Short arrays,
+// narrowed/widened to int32 on the wire; which Java array type applies is determined by the
+// accompanying GrpcEvitaDataType (BYTE_ARRAY, SHORT_ARRAY or INTEGER_ARRAY).
 message GrpcIntegerArray {
-  // Value that supports storing an integer array.
+  // The individual integer elements, in their original order.
   repeated int32 value = 1;
 }
 
 // Wrapper for representing an array of longs.
 message GrpcLongArray {
-  // Value that supports storing a long array.
+  // The individual long elements, in their original order.
   repeated int64 value = 1;
 }
 
 // Wrapper for representing an array of booleans.
 message GrpcBooleanArray {
-  // Value that supports storing a boolean array.
+  // The individual boolean elements, in their original order.
   repeated bool value = 1;
 }
 
 // Wrapper for representing an array of BigDecimals.
 message GrpcBigDecimalArray {
-  // Value that supports storing a BigDecimal array.
+  // The individual BigDecimal elements, in their original order.
   repeated GrpcBigDecimal value = 1;
 }
 
 // Wrapper for representing an array of DateTimeRanges.
 message GrpcDateTimeRangeArray {
-  // Value that supports storing a DateTimeRange array.
+  // The individual DateTimeRange elements, in their original order.
   repeated GrpcDateTimeRange value = 1;
 }
 
-// Wrapper for representing an array of IntegerNumberRanges.
+// Wrapper for representing an array of IntegerNumberRanges. Also used to carry ByteNumberRange
+// and ShortNumberRange arrays; which Java array type applies is determined by the accompanying
+// GrpcEvitaDataType (BYTE_NUMBER_RANGE_ARRAY, SHORT_NUMBER_RANGE_ARRAY or
+// INTEGER_NUMBER_RANGE_ARRAY).
 message GrpcIntegerNumberRangeArray {
-  // Value that supports storing an IntegerNumberRange array.
+  // The individual IntegerNumberRange elements, in their original order.
   repeated GrpcIntegerNumberRange value = 1;
 }
 
 // Wrapper for representing an array of LongNumberRanges.
 message GrpcLongNumberRangeArray {
-  // Value that supports storing a LongNumberRange array.
+  // The individual LongNumberRange elements, in their original order.
   repeated GrpcLongNumberRange value = 1;
 }
 
 // Wrapper for representing an array of BigDecimalNumberRanges.
 message GrpcBigDecimalNumberRangeArray {
-  // Value that supports storing a BigDecimalNumberRange array.
+  // The individual BigDecimalNumberRange elements, in their original order.
   repeated GrpcBigDecimalNumberRange value = 1;
 }
 
-// Wrapper for representing an array of OffsetDateTimes.
+// Wrapper for representing an array of OffsetDateTimes. Also used to carry LocalDateTime,
+// LocalDate and LocalTime arrays; which Java array type applies is determined by the accompanying
+// GrpcEvitaDataType (OFFSET_DATE_TIME_ARRAY, LOCAL_DATE_TIME_ARRAY, LOCAL_DATE_ARRAY or
+// LOCAL_TIME_ARRAY).
 message GrpcOffsetDateTimeArray {
-  // Value that supports storing an OffsetDateTime array.
+  // The individual date/time elements, in their original order.
   repeated GrpcOffsetDateTime value = 1;
 }
 
 // Wrapper for representing an array of Locales.
 message GrpcLocaleArray {
-  // Value that supports storing a Locale array.
+  // The individual Locale elements, in their original order.
   repeated GrpcLocale value = 1;
 }
 
 // Wrapper for representing an array of Currencies.
 message GrpcCurrencyArray {
-  // Value that supports storing a Currency array.
+  // The individual Currency elements, in their original order.
   repeated GrpcCurrency value = 1;
 }
 
 // Wrapper for representing an array of UUIDs.
 message GrpcUuidArray {
-  // Value that supports storing a UUID array.
+  // The individual UUID elements, in their original order.
   repeated GrpcUuid value = 1;
 }
 
 // Wrapper for representing an array of FacetStatisticsDepth enums.
 message GrpcFacetStatisticsDepthArray {
-  // Value that supports storing a FacetStatisticsDepth array.
+  // The individual FacetStatisticsDepth values, in their original order.
   repeated GrpcFacetStatisticsDepth value = 1;
 }
 
 // Wrapper for representing an array of QueryPriceModeArray enums.
 message GrpcQueryPriceModeArray {
-  // Value that supports storing a QueryPriceMode array.
+  // The individual QueryPriceMode values, in their original order.
   repeated GrpcQueryPriceMode value = 1;
 }
 
 // Wrapper for representing an array of PriceContentMode enums.
 message GrpcPriceContentModeArray {
-  // Value that supports storing a PriceContentMode array.
+  // The individual PriceContentMode values, in their original order.
   repeated GrpcPriceContentMode value = 1;
 }
 
 // Wrapper for representing an array of AttributeSpecialValue enums.
 message GrpcAttributeSpecialValueArray {
-  // Value that supports storing an AttributeSpecialValue array.
+  // The individual AttributeSpecialValue values, in their original order.
   repeated GrpcAttributeSpecialValue value = 1;
 }
 
 // Wrapper for representing an array of OrderDirection enums.
 message GrpcOrderDirectionArray {
-  // Value that supports storing an OrderDirection array.
+  // The individual OrderDirection values, in their original order.
   repeated GrpcOrderDirection value = 1;
 }
 
 // Wrapper for representing an array of EmptyHierarchicalEntityBehaviour enums.
 message GrpcEmptyHierarchicalEntityBehaviourArray {
-  // Value that supports storing an EmptyHierarchicalEntityBehaviour array.
+  // The individual EmptyHierarchicalEntityBehaviour values, in their original order.
   repeated GrpcEmptyHierarchicalEntityBehaviour value = 1;
 }
 
 // Wrapper for representing an array of StatisticsBase enums.
 message GrpcStatisticsBaseArray {
-  // Value that supports storing a StatisticsBase array.
+  // The individual StatisticsBase values, in their original order.
   repeated GrpcStatisticsBase value = 1;
 }
 
 // Wrapper for representing an array of StatisticsType enums.
 message GrpcStatisticsTypeArray {
-  // Value that supports storing a StatisticsType array.
+  // The individual StatisticsType values, in their original order.
   repeated GrpcStatisticsType value = 1;
 }
 
 // Wrapper for representing an array of HistogramBehavior enums.
 message GrpcHistogramBehaviorTypeArray {
-  // Value that supports storing a HistogramBehavior array.
+  // The individual HistogramBehavior values, in their original order.
   repeated GrpcHistogramBehavior value = 1;
 }
 
 // Wrapper for representing an array of Scope enums.
 message GrpcEntityScopeArray {
-  // Value that supports storing a Scope array.
+  // The individual Scope values, in their original order.
   repeated GrpcEntityScope value = 1;
 }
 
-// Structure that holds one of the supported data type values, its type and version of stored value.
+// Structure that holds a single attribute/default-value value together with its declared Evita
+// data type and optimistic-locking version.
 message GrpcEvitaValue {
-  // The stored value. May by only one of the following at the time.
+  // The stored value in its wire representation; which Evita/Java type it actually represents is
+  // given by `type` below — several narrower Evita types share the same wire arm (see individual
+  // field comments). Exactly one of these fields is set when the value is non-null. When this
+  // `GrpcEvitaValue` represents an absent/null value (e.g. no default value defined for an
+  // attribute schema), none of these fields are set and `type` is left at its enum default
+  // (`STRING`), which callers must not interpret as an actual empty string value.
   oneof value {
-    // String value.
+    // String value (Java `String`). Also carries a `Character` value, as a single-character
+    // string, when `type` is `CHARACTER`.
     string stringValue = 1;
-    // Integer value.
+    // Integer value (Java `int`). Also carries `Byte` and `Short` values, widened to int32, when
+    // `type` is `BYTE` or `SHORT`.
     int32 integerValue = 2;
-    // Long value.
+    // Long value (Java `long`).
     int64 longValue = 3;
-    // Boolean value.
+    // Boolean value (Java `boolean`).
     bool booleanValue = 4;
-    // BigDecimal value.
+    // BigDecimal value (Java `BigDecimal`).
     GrpcBigDecimal bigDecimalValue = 5;
-    // DateTimeRange value.
+    // DateTimeRange value (evitaDB `DateTimeRange`).
     GrpcDateTimeRange dateTimeRangeValue = 6;
-    // IntegerNumberRange value.
+    // IntegerNumberRange value (evitaDB `IntegerNumberRange`). Also carries `ByteNumberRange` and
+    // `ShortNumberRange` values when `type` is `BYTE_NUMBER_RANGE` or `SHORT_NUMBER_RANGE`.
     GrpcIntegerNumberRange integerNumberRangeValue = 7;
-    // LongNumberRange value.
+    // LongNumberRange value (evitaDB `LongNumberRange`).
     GrpcLongNumberRange longNumberRangeValue = 8;
-    // BigDecimalNumberRange value.
+    // BigDecimalNumberRange value (evitaDB `BigDecimalNumberRange`).
     GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;
-    // OffsetDateTime value.
+    // Date/time value (Java `OffsetDateTime`). Also carries `LocalDateTime`, `LocalDate` and
+    // `LocalTime` values when `type` is `LOCAL_DATE_TIME`, `LOCAL_DATE` or `LOCAL_TIME`
+    // respectively.
     GrpcOffsetDateTime offsetDateTimeValue = 10;
-    // Locale value.
+    // Locale value (Java `Locale`).
     GrpcLocale localeValue = 11;
-    // Currency value.
+    // Currency value (Java `Currency`).
     GrpcCurrency currencyValue = 12;
-    // UUID value.
+    // UUID value (Java `UUID`).
     GrpcUuid uuidValue = 13;
-    // Predecessor value.
+    // Predecessor value (evitaDB `Predecessor`). Also carries a `ReferencedEntityPredecessor`
+    // value when `type` is `REFERENCED_ENTITY_PREDECESSOR`.
     GrpcPredecessor predecessorValue = 14;
 
-    // Array of string values.
+    // String array value (Java `String[]`). Also carries a `Character[]` value, each element a
+    // single-character string, when `type` is `CHARACTER_ARRAY`.
     GrpcStringArray stringArrayValue = 50;
-    // Array of integer values.
+    // Integer array value (Java `Integer[]`). Also carries `Byte[]` and `Short[]` values when
+    // `type` is `BYTE_ARRAY` or `SHORT_ARRAY`.
     GrpcIntegerArray integerArrayValue = 51;
-    // Array of long values.
+    // Long array value (Java `Long[]`).
     GrpcLongArray longArrayValue = 52;
-    // Array of boolean values.
+    // Boolean array value (Java `Boolean[]`).
     GrpcBooleanArray booleanArrayValue = 53;
-    // Array of BigDecimal values.
+    // BigDecimal array value (Java `BigDecimal[]`).
     GrpcBigDecimalArray bigDecimalArrayValue = 54;
-    // Array of DateTimeRange values.
+    // DateTimeRange array value (evitaDB `DateTimeRange[]`).
     GrpcDateTimeRangeArray dateTimeRangeArrayValue = 55;
-    // Array of IntegerNumberRange values.
+    // IntegerNumberRange array value (evitaDB `IntegerNumberRange[]`). Also carries
+    // `ByteNumberRange[]` and `ShortNumberRange[]` values when `type` is
+    // `BYTE_NUMBER_RANGE_ARRAY` or `SHORT_NUMBER_RANGE_ARRAY`.
     GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 56;
-    // Array of LongNumberRange values.
+    // LongNumberRange array value (evitaDB `LongNumberRange[]`).
     GrpcLongNumberRangeArray longNumberRangeArrayValue = 57;
-    // Array of BigDecimalNumberRange values.
+    // BigDecimalNumberRange array value (evitaDB `BigDecimalNumberRange[]`).
     GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 58;
-    // Array of OffsetDateTime values.
+    // Date/time array value (Java `OffsetDateTime[]`). Also carries `LocalDateTime[]`,
+    // `LocalDate[]` and `LocalTime[]` values when `type` is `LOCAL_DATE_TIME_ARRAY`,
+    // `LOCAL_DATE_ARRAY` or `LOCAL_TIME_ARRAY` respectively.
     GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 59;
-    // Array of Locale values.
+    // Locale array value (Java `Locale[]`).
     GrpcLocaleArray localeArrayValue = 60;
-    // Array of Currency values.
+    // Currency array value (Java `Currency[]`).
     GrpcCurrencyArray currencyArrayValue = 61;
-    // Array of UUID values.
+    // UUID array value (Java `UUID[]`).
     GrpcUuidArray uuidArrayValue = 62;
   }
-  // The type of the stored value.
+  // The concrete Evita/Java data type represented by the `value` oneof above (see each arm's
+  // comment for which narrower types it also stands in for).
   GrpcEvitaDataType type = 100;
   // Contains version of this value and gets increased with any entity type update. Allows to execute
   // optimistic locking i.e. avoiding parallel modifications. May be null if value is used within larger complex object.
   google.protobuf.Int32Value version = 101;
 }
 
-// Structure that holds AssociatedData value. Might be one of the supported data types or a JSON string that will be
-// internally converted into ComplexDataObject.
+// Structure that holds a single associated-data value, which is either one of the primitive/array
+// Evita data types (wrapped by `GrpcEvitaValue`) or a complex (structured) object.
 message GrpcEvitaAssociatedDataValue {
-  // The stored value. May by only one of the following at the time.
+  // Exactly one of these fields is set, identifying how the associated data value is encoded.
   oneof value {
-    // Primitive value.
+    // A primitive or array Evita value (see `GrpcEvitaValue`), used whenever the associated data
+    // is not a complex/structured object.
     GrpcEvitaValue primitiveValue = 1;
-    // JSON string value, this old approach led to data type loss and is deprecated.
+    // JSON-encoded `ComplexDataObject` value.
+    // deprecated in favor of `root`: this legacy JSON encoding loses precise data type information.
+    // TOBEDONE #538: remove once no client older than 2025.4 remains in use
+    // (https://github.com/FgForrest/evitaDB/issues/538)
     string jsonValue = 2 [deprecated = true];
-    // The array of values.
+    // The root node of a complex (structured) object's tree, recursively described by
+    // `GrpcDataItem`. Used as the modern replacement for the deprecated `jsonValue` encoding.
     GrpcDataItem root = 4;
   }
-  // The type of the stored value.
+  // The concrete Evita data type of the stored value, including `COMPLEX_DATA_OBJECT` when the
+  // value is a structured object described via `root` (or the deprecated `jsonValue`).
   GrpcEvitaAssociatedDataDataType.GrpcEvitaDataType type = 100;
-  // Contains version of this value and gets increased with any entity type update. Allows to execute
-  //			optimistic locking i.e. avoiding parallel modifications.
+  // Version of this associated data value; increases on every update to enable optimistic locking
+  // (concurrent-modification detection). May be null if this value is nested within a larger
+  // complex object.
   google.protobuf.Int32Value version = 3;
 }
 
-// Structure that holds a complex object. It can be either a map or an array of values.
+// Structure that holds one node of a complex (structured) associated data value's recursive tree.
+// A node is either a leaf primitive value, an array of child nodes, or a map of named child nodes.
 message GrpcDataItem {
-  // The stored value. May by only one of the following at the time.
+  // Exactly one of these is set, identifying which kind of node this is.
   oneof value {
-    // Primitive value.
+    // Leaf node: the primitive value at this position of the tree (evitaDB `DataItemValue`).
     GrpcEvitaValue primitiveValue = 1;
-    // The array of values.
+    // Array node: the ordered child nodes at this position of the tree (evitaDB `DataItemArray`).
     GrpcDataItemArray arrayValue = 4;
-    // The map of values.
+    // Map node: the named child nodes at this position of the tree (evitaDB `DataItemMap`).
     DataItemMap mapValue = 5;
   }
 }
 
-// Structure that holds a array of values stored inside array of the complex object.
+// Structure that holds an array-typed node of a complex associated data value's tree.
 message GrpcDataItemArray {
-  // The stored array of values.
+  // The ordered child nodes of this array node, in their original order.
   repeated GrpcDataItem children = 1;
 }
 
-// Structure that holds a map of values stored inside map of the complex object.
+// Structure that holds a map-typed node of a complex associated data value's tree.
 message DataItemMap {
-  // The stored named fields with associated values.
+  // The child nodes of this map node, keyed by property name.
   map<string, GrpcDataItem> data = 1;
 }
 
-// identification of the file available for fetching
+// Identification of a file available for fetching from the server (e.g. a backup archive or an
+// export produced by an asynchronous task).
 message GrpcFile {
-  // Identification of the file
+  // Unique identifier of the file, used to reference it in fetch/download requests.
   GrpcUuid fileId = 1;
-  // File name
+  // File name, including extension.
   string name = 2;
-  // Detailed description of the file
+  // Human-readable description of the file's purpose or contents. Unset when no description was
+  // provided.
   google.protobuf.StringValue description = 3;
-  // Content type of the file
+  // MIME content type of the file (e.g. `application/zip`).
   string contentType = 4;
-  // Size of the file in bytes
+  // Size of the file on disk (bytes).
   int64 totalSizeInBytes = 5;
-  // Date and time when the file was created
+  // Date and time when the file was created.
   GrpcOffsetDateTime created = 6;
-  // Origin of the file (usually the taskType)
+  // Comma-separated identifiers of what produced the file — usually the `taskType` (see
+  // `GrpcTaskStatus.taskType`) of the task that created it. Unset when the origin wasn't recorded.
   google.protobuf.StringValue origin = 7;
 }
 
@@ -373,46 +442,58 @@ message GrpcTaskStatus {
   string taskType = 1;
   // Longer, human-readable name of the task
   string taskName = 2;
-  // Identification of the task
+  // Unique identifier of this task instance; use it to reference this task in status lookups or
+  // cancellation requests.
   GrpcUuid taskId = 3;
-  // Name of the catalog the task is related to (optional)
+  // Name of the catalog this task operates on. Unset for tasks that are not scoped to a single
+  // catalog (e.g. server-wide/system tasks).
   google.protobuf.StringValue catalogName = 4;
-  // Date and time when the task was issued
+  // Date and time when the task was issued for execution (queued to run). Unset while the task is
+  // still pending and has not yet been issued.
   GrpcOffsetDateTime issued = 5;
-  // Date and time when the task was started
+  // Date and time when the task started executing. Unset before execution begins.
   GrpcOffsetDateTime started = 6;
-  // Date and time when the task was finished
+  // Date and time when the task finished executing, successfully or with an error. Unset while
+  // the task is still running.
   GrpcOffsetDateTime finished = 7;
-  // Simplified state of the status
+  // Coarse-grained lifecycle state of the task (queued, running, finished or failed), derived
+  // from the task's more detailed internal state.
   GrpcTaskSimplifiedState simplifiedState = 8;
   // Progress of the task (0-100)
   int32 progress = 9;
-  // Configuration settings of the task
+  // String representation (`toString()`) of the task's configuration settings. Read back as an
+  // empty string if unset.
   google.protobuf.StringValue settings = 10;
-  // Result of the task
+  // The task's result, once it has produced one. At most one of these is set; neither is set
+  // while the task has not finished or produced no result.
   oneof result {
-    // Textual result of the task
+    // String representation (`toString()`) of the task's result object, used for any result other
+    // than a fetchable file.
     google.protobuf.StringValue text = 11;
-    // File that was created by the task and is available for fetching
+    // The file produced by the task (e.g. a backup archive), available for fetching by `fileId`.
     GrpcFile file = 12;
   }
-  // Exception that occurred during the task execution
+  // Public-safe error message if the task failed. Unset while the task is running or if it
+  // completed without error.
   google.protobuf.StringValue exception = 13;
-  // List of task traits
+  // Capabilities available for this task instance (e.g. whether it can be manually started,
+  // cancelled, or must be explicitly stopped).
   repeated GrpcTaskTrait trait = 14;
-  // Date and time when the task was created
+  // Date and time when this task status record was created; always set, and precedes `issued`.
   GrpcOffsetDateTime created = 15;
 }
 
 // Aggregates basic data about the catalog and entity types stored in it.
 message GrpcCatalogStatistics {
-  // name of the catalog
+  // unique identifier of the catalog
   GrpcUuid catalogId = 1;
-  // name of the catalog
+  // The catalog's unique name, used to address it via the API.
   string catalogName = 2;
   // true if the catalog is corrupted (other data will be not available)
+  // deprecated in favor of `catalogState` (compare against `CORRUPTED`)
   bool corrupted = 3 [deprecated = true];
-  // current state of the catalog, null for corrupted catalog
+  // Current lifecycle state of the catalog. Reflects `CORRUPTED` when the catalog failed to load
+  // consistently, or `UNKNOWN_CATALOG_STATE` if the state could not be determined.
   GrpcCatalogState catalogState = 4;
   // version of the catalog, -1 for corrupted catalog
   int64 catalogVersion = 5;
@@ -444,9 +525,9 @@ message GrpcEntityCollectionStatistics {
 
 // Structure for representing a name in a particular naming convention.
 message GrpcNameVariant {
-  // naming convention the name is in
+  // The naming convention this variant is rendered in (e.g. camelCase, kebab-case, PascalCase).
   GrpcNamingConvention namingConvention = 1;
-  // the name in the particular naming convention
+  // The entity/attribute/reference name transformed into the given naming convention.
   string name = 2;
 }
 

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaManagementAPI.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaManagementAPI.proto
@@ -23,11 +23,15 @@ message GrpcEvitaServerStatusResponse {
   int32 catalogsCorrupted = 5;
   // Number of catalogs that are active and has been successfully loaded, renamed to `catalogsActive`
   int32 catalogsOk = 6 [deprecated = true];
-  // Health problems
+  // Health problems currently detected by any of the server's health probes, deduplicated. Empty
+  // means no problems were detected.
   repeated GrpcHealthProblem healthProblems = 7;
   // Overall readiness of the evitaDB server
   GrpcReadiness readiness = 8;
-  // Information about all available APIs
+  // Status keyed by API code, for every external API registered on the classpath - including ones
+  // that are disabled (`GrpcApiStatus.enabled == false`) or have no registered provider (in which
+  // case `baseUrl` and `endpoints` are empty). Presence in this map does not imply the API is
+  // enabled or reachable; check `GrpcApiStatus.enabled`/`ready`.
   map<string, GrpcApiStatus> api = 9;
   // Flag indicating that the server is in read-only mode
   bool readOnly = 10;
@@ -35,7 +39,10 @@ message GrpcEvitaServerStatusResponse {
   int32 catalogsActive = 11;
   // Number of inactive catalogs
   int32 catalogsInactive = 12;
-  // The version of the current evitaDB server engine state (change in engine state).
+  // Monotonically increasing version number of the engine's own state, distinct from any single
+  // catalog's version - incremented once for each committed engine-level change (e.g. a catalog
+  // being created, removed, renamed, or having its format upgraded or read-only mode toggled).
+  // Ordinary data mutations within a catalog do not advance it.
   int64 engineVersion = 13;
   // The date and time when the current engine version was introduced (last engine level change occurred).
   GrpcOffsetDateTime introducedAt = 14;
@@ -43,26 +50,37 @@ message GrpcEvitaServerStatusResponse {
 
 // Status of the external API
 message GrpcApiStatus {
-  // True if the API is enabled
+  // True when this API is turned on in the server configuration. An enabled API can still be
+  // briefly not ready while the server is starting up - see `ready`.
   bool enabled = 1;
-  // API readiness status
+  // True when the API has finished initialization and is actually able to serve requests.
+  // Always false when `enabled` is false.
   bool ready = 2;
-  // list of base url of the web API
+  // Base URLs the API is reachable on - one per configured host binding (`host`, plus the
+  // `exposeOn` override if set), so this commonly holds more than one URL even though the field
+  // name is singular.
   repeated string baseUrl = 3;
-  // list of specific endpoints of particular API
-  // currently only system API provides list of endpoints
+  // Notable endpoints exposed by this API in addition to its base URLs, each entry naming the
+  // endpoint and giving its URL(s). Currently only the system API populates this list; every
+  // other API reports it empty.
   repeated GrpcEndpoint endpoints = 4;
 }
 
-// Information about a system endpoint of particular purpose derived from name
+// A named endpoint exposed by an external API, distinct from the API's own base URL(s) (see
+// `GrpcApiStatus.endpoints`).
 message GrpcEndpoint {
-  // logical name of the endpoint
+  // Logical name identifying what the endpoint serves. For the system API - currently the only API
+  // that populates `GrpcApiStatus.endpoints` - this is one of `serverNameUrl`,
+  // `serverCertificateUrl`, `clientCertificateUrl`, `clientPrivateKeyUrl`.
   string name = 1;
-  // absolute URL of the endpoint
+  // Absolute URL(s) the endpoint is reachable on - one per configured host binding, so this
+  // commonly holds more than one URL even though the field name is singular.
   repeated string url = 2;
 }
 
-// Response to an evitaDB configuration request.
+// Response to an evitaDB configuration request. This RPC (and therefore this response) is
+// unavailable while the engine runs in read-only mode - see GrpcEvitaEngineSettingsResponse for
+// the smaller, always-available subset of configuration.
 message GrpcEvitaConfigurationResponse {
   // Current configuration of the server in YAML format with evaluated values.
   string configuration = 1;
@@ -100,95 +118,131 @@ message GrpcEvitaEngineSettingsResponse {
 
 // Response to a server catalog statistics request.
 message GrpcEvitaCatalogStatisticsResponse {
-  // Collection of catalog statistics for all catalogs
+  // Per-catalog statistics for every catalog known to the server, including corrupted ones (see
+  // `GrpcCatalogStatistics.unusable`, where most other fields fall back to a placeholder value).
   repeated GrpcCatalogStatistics catalogStatistics = 1;
 }
 
-// Request to restore a catalog.
+// One chunk of a streamed catalog restore. The client sends a sequence of these messages over the
+// same gRPC client stream, each carrying one slice of the backup archive; the server concatenates
+// `backupFile` across all messages, in arrival order, into a single ZIP file. `catalogName` is
+// expected to be identical on every chunk - only the value from the last message in the stream is
+// actually used to name the restored catalog.
 message GrpcRestoreCatalogRequest {
-  // Name of the catalog where the backup will be restored
-  // The name must not clash with any of existing catalogs
+  // Name of the target catalog into which the backup will be restored.
+  // Must not clash with the name of any existing catalog.
   string catalogName = 1;
-  // Binary contents of the backup file.
+  // One chunk of the binary backup ZIP archive; concatenate `backupFile` from all messages in the
+  // stream, in order, to reconstruct the full archive.
   bytes backupFile = 2;
 }
 
-// Request to restore a catalog.
+// One chunk of a catalog restore uploaded via repeated unary calls, used where true client-side
+// streaming (as in `GrpcRestoreCatalogRequest`) is unavailable, e.g. gRPC-Web. The client calls
+// `RestoreCatalogUnary` once per chunk, feeding back the `fileId` it received in the previous
+// response so the server appends to the same upload; see `GrpcRestoreCatalogUnaryResponse`.
 message GrpcRestoreCatalogUnaryRequest {
-  // Name of the catalog where the backup will be restored
-  // The name must not clash with any of existing catalogs
+  // Name of the target catalog into which the backup will be restored.
+  // Must not clash with the name of any existing catalog.
   string catalogName = 1;
-  // Binary contents of the backup file.
+  // One chunk of the binary backup ZIP archive; the server appends it to the chunks already
+  // received for this upload (identified by `fileId`).
   bytes backupFile = 2;
-  // Identification of the task (for continuation purpose)
+  // Identifies the upload this chunk continues.
+  //
+  // If unset, this is the first chunk of a new upload: the server allocates a new upload id and
+  // returns it as `fileId` in the response. If set, it must be a `fileId` previously returned for
+  // this same upload, and this chunk is appended to it.
   GrpcUuid fileId = 3;
-  // Total size of uploaded file in Bytes, when the size is reached, restore automatically starts
+  // Total size of the complete backup file (bytes), as expected once all chunks have been
+  // received; sent with every chunk. Once the bytes received so far reach exactly this size, the
+  // restore starts automatically. If more bytes are received than this, the server still returns
+  // a normal response for that (final) chunk and only afterwards discards the partial upload - an
+  // overshoot is not guaranteed to surface to the client as an error, so do not exceed it.
   int64 totalSizeInBytes = 4;
 }
 
-// Request to restore a catalog.
+// Request to restore a catalog from a backup file that already exists on the server (e.g. produced
+// by a prior backup task, or a previous restore upload) - in contrast to
+// `GrpcRestoreCatalogRequest` and `GrpcRestoreCatalogUnaryRequest`, which upload a new backup file
+// as part of the call.
 message GrpcRestoreCatalogFromServerFileRequest {
-  // Name of the catalog where the backup will be restored
-  // The name must not clash with any of existing catalogs
+  // Name of the target catalog into which the backup will be restored.
+  // Must not clash with the name of any existing catalog.
   string catalogName = 1;
-  // The identification of the file on the server that should be restored
+  // Identification of the backup file already stored on the server that should be restored.
   GrpcUuid fileId = 2;
 }
 
-// Response to a catalog restore request.
+// Response to a catalog restore request. Returned by both `RestoreCatalog` and
+// `RestoreCatalogFromServerFile`.
 message GrpcRestoreCatalogResponse {
-  // returns the number of bytes read from the backup file
+  // Total number of bytes read from the backup file (bytes). Only meaningful for `RestoreCatalog`,
+  // where it reports the cumulative size of the uploaded stream; always 0 for
+  // `RestoreCatalogFromServerFile`, which does not populate this field.
   int64 read = 1;
-  // the task that is used to restore the catalog and getting its progress
+  // The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+  // progress.
   GrpcTaskStatus task = 3;
 }
 
 // Response to a catalog restore request (unary variant). This is used for gRPC/web.
 // We need to explicitly handle the fileId, because it gets repeatedly updated (appended) from the client.
 message GrpcRestoreCatalogUnaryResponse {
-  // returns the number of bytes read from the backup file
+  // Cumulative number of bytes received for this upload so far, across this and all preceding
+  // chunks (bytes).
   int64 read = 1;
-  // The identification of the file on the server that should be restored
+  // Identifies this upload. Echo this value back as `fileId` in the next
+  // `GrpcRestoreCatalogUnaryRequest` chunk so the server appends to the same upload; on the first
+  // chunk of an upload the server allocates this id and returns it here for the first time.
   GrpcUuid fileId = 2;
-  // the task that is used to restore the catalog and getting its progress
+  // The task tracking the restore operation; poll its status (`GetTaskStatus`) to observe restore
+  // progress.
   GrpcTaskStatus task = 3;
 }
 
 // Request to list task statuses in paginated form.
 message GrpcTaskStatusesRequest {
-  // Page number of the task statuses to be listed.
+  // Page number of the task statuses to be listed. Page-based paging: 1-indexed, page 1 is the
+  // first page (see `io.evitadb.dataType.PaginatedList#getPageNumber`).
   int32 pageNumber = 1;
-  // Number of task statuses per page.
+  // Number of task statuses per page. No server-side maximum is enforced.
   int32 pageSize = 2;
-  // Optional taskType of the listed task, passing non-null value
-  // in this argument filters the returned status to only those that are related to the tasks of specified type
+  // Task type names to filter by (matched against `GrpcTaskStatus.taskType`); a task matches if
+  // its type is any of the listed values. Empty (the default) means no filtering by type.
   repeated google.protobuf.StringValue taskType = 3;
-  // Optional set of simplified task states, passing list of enums in this argument
-  // filters the returned statuses to only those that match this simplified status
+  // Simplified task states to filter by; a task matches if its state is any of the listed values.
+  // Empty (the default) means no filtering by state. When both `taskType` and `simplifiedState`
+  // are non-empty, a task must satisfy both filters.
   repeated GrpcTaskSimplifiedState simplifiedState = 4;
 }
 
 // Response to a task statuses request.
 message GrpcTaskStatusesResponse {
-  // The size of the page.
+  // The page size that was actually applied (echoes the request's `pageSize`).
   int32 pageSize = 1;
-  // The number of the page.
+  // The page number that was actually applied (echoes the request's `pageNumber`); 1-indexed, see
+  // `GrpcTaskStatusesRequest.pageNumber` for the paging model.
   int32 pageNumber = 2;
-  // Collection of task statuses.
+  // Task statuses on this page, matching the filters from the request.
   repeated GrpcTaskStatus taskStatus = 3;
-  // Total number of task statuses.
+  // Total number of task statuses matching the request's filters across all pages, not just this
+  // one.
   int32 totalNumberOfRecords = 4;
 }
 
 // Request to get multiple task statuses.
 message GrpcSpecifiedTaskStatusesRequest {
-  // set of task ids to be listed
+  // Identifications of the tasks whose statuses should be returned. Ids that don't match any
+  // known task are silently omitted from the response - see
+  // `GrpcSpecifiedTaskStatusesResponse.taskStatus`.
   repeated GrpcUuid taskIds = 1;
 }
 
 // Response to a multiple task statuses request.
 message GrpcSpecifiedTaskStatusesResponse {
-  // Collection of task statuses.
+  // Statuses of the requested tasks that were found, in no particular order; ids from the request
+  // that don't match any known task are simply absent here, no error is raised for them.
   repeated GrpcTaskStatus taskStatus = 1;
 }
 
@@ -200,96 +254,116 @@ message GrpcTaskStatusRequest {
 
 // Response to a task status request.
 message GrpcTaskStatusResponse {
-  // Task status if found
+  // Status of the requested task. If no task exists for the given id, the server currently does
+  // not send this response message at all, rather than sending it with this field unset - for
+  // this unary call, that means the call does not complete normally rather than yielding an empty
+  // result (the bundled Java driver, for one, surfaces this as a `StatusRuntimeException` with
+  // status `INTERNAL`). Prefer `GetTaskStatuses` (plural) if an unknown id must not surface as an
+  // error, since it returns a normal (possibly empty) response instead.
   GrpcTaskStatus taskStatus = 1;
 }
 
-// Request to get cancel task status by id
+// Request to cancel a task by id
 message GrpcCancelTaskRequest {
   // Identification of the task
   GrpcUuid taskId = 1;
 }
 
-// Request to get cancel task status by id
+// Response to a cancel task request.
 message GrpcCancelTaskResponse {
-  // true if the task was found and canceled
+  // True if a task with the given id existed and was successfully canceled; false if no such task
+  // exists, or the task could no longer be canceled (e.g. it had already finished).
   bool success = 1;
 }
 
-// Request to list files to fetch in paginated form.
+// Request to list files available for fetching, in paginated form.
 message GrpcFilesToFetchRequest {
-  // Page number of the task statuses to be listed.
+  // Page number of the files to be listed. Page-based paging: 1-indexed, page 1 is the first page
+  // (see `io.evitadb.dataType.PaginatedList#getPageNumber`).
   int32 pageNumber = 1;
-  // Number of task statuses per page.
+  // Number of files per page. No server-side maximum is enforced.
   int32 pageSize = 2;
-  // Optional origin of the files (derived from taskType), passing non-null value
-  // in this argument filters the returned files to only those that are related to the specified origin
+  // File origins to filter by (see `GrpcFile.origin` - usually the `taskType` of the task that
+  // produced the file, e.g. `BackupTask`); a file matches if its origin is any of the listed
+  // values. Empty (the default) means no filtering - files of all origins are returned.
   repeated google.protobuf.StringValue origin = 3;
 }
 
-// Response to a get files to fetch request.
+// Response to a request to list files available for fetching.
 message GrpcFilesToFetchResponse {
-  // The size of the page.
+  // The page size that was actually applied (echoes the request's `pageSize`).
   int32 pageSize = 1;
-  // The number of the page.
+  // The page number that was actually applied (echoes the request's `pageNumber`); 1-indexed, see
+  // `GrpcFilesToFetchRequest.pageNumber` for the paging model.
   int32 pageNumber = 2;
-  // Collection of files to fetch.
+  // Files on this page, matching the origin filter from the request.
   repeated GrpcFile filesToFetch = 3;
-  // Total number of files to fetch.
+  // Total number of files matching the request's origin filter across all pages, not just this
+  // one.
   int32 totalNumberOfRecords = 4;
 }
 
-// Request to list task statuses in paginated form.
+// Request to get a single file available for fetching, by its id.
 message GrpcFileToFetchRequest {
   // Identification of the file
   GrpcUuid fileId = 1;
 }
 
-// Response to a task statuses request.
+// Response to a request for a single file available for fetching. If no file exists for the given
+// id, the call fails with an error instead of returning this message.
 message GrpcFileToFetchResponse {
-  // File to fetch.
+  // Descriptor of the requested file.
   GrpcFile fileToFetch = 1;
 }
 
-// Request to get single file by id
+// Request to stream the contents of a single file available for fetching, by its id.
 message GrpcFetchFileRequest {
   // Identification of the file
   GrpcUuid fileId = 1;
 }
 
-// Response to a task status request.
+// One chunk of a file's contents, streamed back to the client. The server sends a sequence of
+// these messages; concatenate `fileContents` from all of them, in arrival order, to reconstruct
+// the full file.
 message GrpcFetchFileResponse {
-  // chunk of the file content
+  // One chunk of the file's binary contents.
   bytes fileContents = 1;
-  // total size of the file
+  // Total size of the complete file (bytes); the same value is repeated on every chunk in the
+  // stream, not just the size of this chunk.
   int64 totalSizeInBytes = 2;
 }
 
-// Request to list task statuses in paginated form.
+// Request to delete a file available for fetching, by its id.
 message GrpcDeleteFileToFetchRequest {
   // Identification of the file
   GrpcUuid fileId = 1;
 }
 
-// Response to a task statuses request.
+// Response to a file deletion request.
 message GrpcDeleteFileToFetchResponse {
-  // true if the file was found and deleted
+  // True if the file existed and was deleted; false if no file exists for the given id. Any other
+  // failure during deletion is reported as a gRPC error rather than `false`.
   bool success = 1;
 }
 
-// Single reserved keyword
+// A single reserved keyword that cannot be used as a classifier of the given type (e.g. as an
+// entity type, attribute name, or reference name) - client-side validation of user-supplied
+// classifiers can use this list to reject collisions early, before the server does.
 message GrpcReservedKeyword {
-  // Type of the keyword
+  // The kind of classifier this keyword is reserved against (e.g. entity type, attribute name).
   GrpcClassifierType classifierType = 1;
-  // Reserved keyword
+  // The reserved keyword in its normalized (camelCase) form. A candidate classifier is considered
+  // colliding if it matches this value in any of evitaDB's supported naming conventions
+  // (camelCase, PascalCase, snake_case, UPPER_SNAKE_CASE, kebab-case), not just this exact form.
   string classifier = 2;
-  // List of words that are part of the keyword
+  // The individual words `classifier` is composed of, used to detect a collision across the
+  // supported naming conventions regardless of separator or case.
   repeated string words = 3;
 }
 
 // Response that returns information about reserved keywords.
 message GrpcReservedKeywordsResponse {
-  // List of reserved keywords
+  // All reserved keywords, across all classifier types.
   repeated GrpcReservedKeyword keywords = 1;
 }
 
@@ -306,11 +380,14 @@ service EvitaManagementService {
   rpc GetEngineSettings(google.protobuf.Empty) returns (GrpcEvitaEngineSettingsResponse);
   // Procedure used to obtain catalog statistics.
   rpc GetCatalogStatistics(google.protobuf.Empty) returns (GrpcEvitaCatalogStatisticsResponse);
-  // Procedure used to restore a catalog from backup.
+  // Procedure used to restore a catalog from a client-uploaded backup via true gRPC client
+  // streaming; see `RestoreCatalogUnary` for the chunked-unary alternative.
   rpc RestoreCatalog(stream GrpcRestoreCatalogRequest) returns (GrpcRestoreCatalogResponse);
-  // Procedure used to restore a catalog from backup (unary version for gRPC/web).
+  // Procedure used to restore a catalog from a client-uploaded backup, one chunk per call (unary
+  // version for gRPC/web, where true client streaming as in `RestoreCatalog` is unavailable).
   rpc RestoreCatalogUnary(GrpcRestoreCatalogUnaryRequest) returns (GrpcRestoreCatalogUnaryResponse);
-  // Procedure used to restore a catalog from backup.
+  // Procedure used to restore a catalog from a backup file already stored on the server, without
+  // re-uploading it.
   rpc RestoreCatalogFromServerFile(GrpcRestoreCatalogFromServerFileRequest) returns (GrpcRestoreCatalogResponse);
   // Procedure used to get listing of task statuses.
   rpc ListTaskStatuses(GrpcTaskStatusesRequest) returns (GrpcTaskStatusesResponse);
@@ -324,7 +401,7 @@ service EvitaManagementService {
   rpc ListFilesToFetch(GrpcFilesToFetchRequest) returns (GrpcFilesToFetchResponse);
   // Procedure used to get single file by its id available for fetching.
   rpc GetFileToFetch(GrpcFileToFetchRequest) returns (GrpcFileToFetchResponse);
-  // Procedure used to get file contents
+  // Procedure used to get file contents, streamed back to the client in chunks.
   rpc FetchFile(GrpcFetchFileRequest) returns (stream GrpcFetchFileResponse);
   // Procedure used to delete file contents
   rpc DeleteFile(GrpcDeleteFileToFetchRequest) returns (GrpcDeleteFileToFetchResponse);

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaSessionAPI.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaSessionAPI.proto
@@ -44,69 +44,120 @@ message GrpcCatalogVersionAtResponse {
   GrpcOffsetDateTime introducedAt = 3;
 }
 
-// Request to GetMutationsHistoryPage request.
+// Request for GetMutationsHistoryPage, a paged, reverse-chronological read of past mutations (catalog
+// schema changes and entity mutations) that match the given criteria. Traversal is always reverse
+// (newest first); there is currently no forward-traversal RPC (tracked in #1349).
 message GetMutationsHistoryPageRequest {
-  // The page number starting with 1
+  // The requested page number (1-indexed: page 1 is the newest/first page). If unset, defaults to 1.
+  // Not rejected when it lands past the last available page - the response is simply empty; see the
+  // message-level note on `GetMutationsHistoryPageResponse` about the lack of a total-count/`hasMore` signal.
   google.protobuf.Int32Value page = 1;
-  // The size of the page to return
+  // The number of mutations to return per page. If unset, defaults to 20. Not rejected or capped when it
+  // exceeds the number of available mutations; the last page is simply shorter.
   google.protobuf.Int32Value pageSize = 2;
-  // Starting point for the search (catalog version)
+  // Catalog version to anchor the search at (inclusive). If unset, defaults to the upper bound implied by
+  // the request - the version resolved from `timeFrame`'s upper bound when `timeFrame` is set, otherwise
+  // the session's current catalog version. If set beyond that bound, it is silently clamped to it rather
+  // than rejected.
+  //
+  // Known defect (tracked in #1349): when this field is set but `sinceIndex` is left unset, the server
+  // does not apply the usual reverse-direction default for `sinceIndex` (see below) and instead treats it
+  // as 0 - the index reserved for the transaction header - which filters the entire anchor version out of
+  // the result whenever `criteria` restricts content to `DATA` or `SCHEMA`. Until this is fixed, always
+  // set `sinceIndex` explicitly together with `sinceVersion`.
   google.protobuf.Int64Value sinceVersion = 3;
-  // Starting point for the search (index of the mutation within catalog version)
+  // Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+  // are numbered from 1 upward; the transaction header itself occupies index 0. If unset, defaults to
+  // `Integer.MAX_VALUE`, i.e. "start from the newest mutation of that version" - but see the defect noted
+  // on `sinceVersion` above for the (common) case where this default currently does not apply.
   google.protobuf.Int32Value sinceIndex = 4;
-  // The time range within which the mutations should be found
+  // Restricts the search to mutations committed within this time range. The lower bound (`from`) is
+  // exclusive - the version resolved from it is excluded from the result, even though the underlying
+  // version-resolution lookup it uses is itself inclusive of that moment.
   GrpcDateTimeRange timeFrame = 5;
-  // The criteria of the capture, allows to define constraints on the returned mutations
+  // Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+  // applies no criteria-based filtering.
   repeated GrpcChangeCaptureCriteria criteria = 6;
-  // The scope of the returned data - either header of the mutation, or the whole mutation
+  // Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+  // when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+  // enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+  // received in full.
   GrpcChangeCaptureContent content = 7;
 }
 
-// Response to GetMutationsHistoryPage request.
+// Response to GetMutationsHistoryPage request. Carries only the page's mutations - there is currently no
+// total record count, `hasMore`, or `isLast` field (a pagination contract gap tracked in #1349), unlike
+// `GrpcPaginatedList`/`GrpcDataChunk` elsewhere in this API. A client cannot reliably tell whether another
+// page follows without requesting it and checking whether it comes back empty.
 message GetMutationsHistoryPageResponse {
-  // The list of mutations that match the criteria
+  // The mutations on this page, newest first. Can be shorter than the requested page size - including
+  // empty - without that implying it is the last page; see the message-level note above.
   repeated GrpcChangeCatalogCapture changeCapture = 1;
 }
 
-// Request to GetMutationsHistoryPage request.
+// Request for GetMutationsHistory, a streamed, reverse-chronological read of past mutations that match
+// the given criteria - the unpaged sibling of GetMutationsHistoryPage. Traversal is always reverse
+// (newest first); there is currently no forward-traversal RPC (tracked in #1349).
 message GetMutationsHistoryRequest {
-  // Starting point for the search (catalog version)
+  // Catalog version to anchor the search at (inclusive). If unset, defaults to the engine's last applied
+  // catalog version. Note this default differs from the paged RPC's, which anchors on the session's
+  // current catalog version instead - the two can diverge under concurrent writes.
   google.protobuf.Int64Value sinceVersion = 1;
-  // Starting point for the search (index of the mutation within catalog version)
+  // Index of the mutation within `sinceVersion` to anchor the search at (inclusive). A version's mutations
+  // are numbered from 1 upward; the transaction header itself occupies index 0. If unset, no index-based
+  // filtering is applied within `sinceVersion` - all of that version's mutations are included.
   google.protobuf.Int32Value sinceIndex = 2;
-  // The criteria of the capture, allows to define constraints on the returned mutations
+  // Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+  // applies no criteria-based filtering.
   repeated GrpcChangeCaptureCriteria criteria = 3;
-  // The scope of the returned data - either header of the mutation, or the whole mutation
+  // Whether the response carries only mutation headers (`CHANGE_HEADER`, the default - proto3 zero value -
+  // when this field is left unset) or full mutation bodies (`CHANGE_BODY`). Only `CHANGE_BODY` carries
+  // enough information (e.g. `mutationCount` on the transaction header) to verify a transaction was
+  // received in full.
   GrpcChangeCaptureContent content = 4;
 }
 
-// Response to GetMutationsHistory request.
+// Response to GetMutationsHistory request. The server sends one such message per mutation - each carries
+// exactly one `changeCapture` entry, not a batch (see the RPC's streaming semantics).
 message GetMutationsHistoryResponse {
-  // The list of mutations that match the criteria
+  // The single mutation delivered by this stream message.
   repeated GrpcChangeCatalogCapture changeCapture = 1;
 }
 
-// Request to RegisterChangeCatalogCapture request.
+// Request to open a live subscription (RegisterChangeCatalogCapture) that streams mutations as they
+// commit, optionally preceded by a historical replay starting at `sinceVersion`/`sinceIndex`.
 message GrpcRegisterChangeCatalogCaptureRequest {
-  // Starting point for the search (catalog version)
+  // Catalog version from which to start the historical replay portion of the subscription (inclusive).
+  // If unset, defaults to the current catalog version plus one, i.e. only mutations committed after the
+  // subscription is registered are delivered, with no historical replay.
   google.protobuf.Int64Value sinceVersion = 1;
-  // Starting point for the search (index of the mutation within catalog version)
+  // Index of the mutation within `sinceVersion` from which to start the historical replay (inclusive).
+  // A version's mutations are numbered from 1 upward; the transaction header itself occupies index 0.
+  // If unset, defaults to 0, i.e. starting from that version's transaction header.
   google.protobuf.Int32Value sinceIndex = 2;
-  // The criteria of the capture, allows to define constraints on the returned mutations
+  // Criteria mutations must match to be included (entity type, mutation kind, area, etc.). An empty list
+  // applies no criteria-based filtering.
   repeated GrpcChangeCaptureCriteria criteria = 3;
-  // The scope of the returned data - either header of the mutation, or the whole mutation
+  // Whether delivered captures carry only mutation headers (`CHANGE_HEADER`, the default - proto3 zero
+  // value - when this field is left unset) or full mutation bodies (`CHANGE_BODY`).
   GrpcChangeCaptureContent content = 4;
 }
 
 // Request to GetTransactionOverview request.
 message GetTransactionOverviewRequest {
-  // The catalog version for which the transaction overview should be returned
+  // The catalog versions to return the transaction overview for. See `GetTransactionOverviewResponse`
+  // for the ordering and completeness contract of the response.
   repeated int64 catalogVersion = 1;
 }
 
-// Response to GetTransactionOverview request.
+// Response to GetTransactionOverview request. Entries are ordered the same way as the requested
+// `catalogVersion` list. The intended contract (per the underlying Java API) is that a version unknown
+// to history is silently omitted rather than padded with an empty entry, so the response can be shorter
+// than the request - but this is currently not honored: a single unknown/purged version makes the whole
+// RPC fail instead of being omitted (known defect, tracked in #1349).
 message GetTransactionOverviewResponse {
-  // The list of transaction overviews that match the requested catalog versions
+  // The transaction overviews for the requested catalog versions, in request order - see the
+  // message-level note above for the current gap between the intended and actual completeness contract.
   repeated GrpcTransactionOverview transactionOverviews = 1;
 }
 
@@ -143,6 +194,7 @@ message GrpcTransactionChanges {
 
 // Structure that holds changes in a specific entity collection within a transaction.
 message GrpcEntityCollectionChanges {
+  // The name (entity type) of the entity collection these counts apply to.
   string entityName = 1;
   // The number of schema altering mutations.
   int32 schemaChanges = 2;
@@ -152,16 +204,22 @@ message GrpcEntityCollectionChanges {
   int32 removed = 4;
 }
 
-// Response to RegisterChangeCatalogCapture request.
+// One message of the RegisterChangeCatalogCapture stream. `responseType` selects which payload is
+// meaningful: `ACKNOWLEDGEMENT` (subscription set up; `heartBeat` populated, `capture` is not),
+// `CHANGE` (`capture` populated, `heartBeat` is not), or `HEARTBEAT` (`heartBeat` populated, `capture`
+// is not) - the periodic keep-alive sent while no matching mutation has occurred.
 message GrpcRegisterChangeCatalogCaptureResponse {
-  // Identification of the registered capture
+  // Identification of the registered subscription. Present on every message, not just the initial
+  // acknowledgement.
   GrpcUuid uuid = 1;
-  // The list of mutations (CDC events) that match the criteria
+  // The single mutation (CDC event) delivered by this message. Populated only when `responseType` is
+  // `CHANGE`; unset otherwise.
   GrpcChangeCatalogCapture capture = 2;
-  // The type of the response - when subscription is set-up, acknowledgement is sent
-  // Then with each capture event, the type is set to `change`
+  // Which payload field (`capture` or `heartBeat`) is populated on this message - see the message-level
+  // comment above.
   GrpcCaptureResponseType responseType = 3;
-  // Optional heartbeat information, is non-null only if the response is a heartbeat or acknowledgement
+  // Heartbeat information. Populated when `responseType` is `ACKNOWLEDGEMENT` or `HEARTBEAT`; unset when
+  // `responseType` is `CHANGE`.
   GrpcHeartBeat heartBeat = 4;
 }
 
@@ -210,9 +268,10 @@ message GrpcUpdateCatalogSchemaResponse {
   int32 version = 1;
 }
 
-// Request for updating the catalog schema and its afterwards fetching.
+// Response to UpdateAndFetchCatalogSchema request, which updates the catalog schema and returns the
+// resulting schema in one round trip.
 message GrpcUpdateAndFetchCatalogSchemaResponse {
-  // Modified catalog schema.
+  // The catalog schema after the requested mutations were applied.
   GrpcCatalogSchema catalogSchema = 1;
 }
 
@@ -240,81 +299,111 @@ message GrpcUpdateEntitySchemaResponse {
   int32 version = 1;
 }
 
-// Request for updating the entity schema and its afterwards fetching.
+// Response to UpdateAndFetchEntitySchema request, which updates an entity type's schema and returns the
+// resulting schema in one round trip.
 message GrpcUpdateAndFetchEntitySchemaResponse {
-  // Modified entity schema.
+  // The entity schema after the requested mutations were applied.
   GrpcEntitySchema entitySchema = 1;
 }
 
-// Request for acquiring an entity.
+// Request for acquiring a single entity by primary key, in the richness described by `require`.
 message GrpcEntityRequest {
-  // The primary key of the entity.
+  // The primary key of the entity to fetch.
   int32 primaryKey = 1;
-  // The entity type of the entity.
+  // The entity type (collection name) the primary key belongs to.
   string entityType = 2;
-  // The string part of the parametrised query require part.
+  // The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`),
+  // parsed on the server. Parameter values are not embedded in this string but supplied separately via
+  // `positionalQueryParams`/`namedQueryParams` below. A `?` placeholder in this string is a positional
+  // parameter, an `@name` placeholder is a named parameter - see `positionalQueryParams`/`namedQueryParams`
+  // below for the full binding contract, which applies identically here.
   string require = 3;
-  // The positional query parameters.
+  // Values for the `?` positional placeholders in `require`, bound in encounter order: the first `?` in
+  // the parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and
+  // so on (FIFO). Supplying fewer values than there are `?` placeholders fails the request with
+  // "Missing argument of index N."; extra values are ignored.
   repeated GrpcQueryParam positionalQueryParams = 4;
-  // The named query parameters.
+  // Values for the `@name` named placeholders in `require`, keyed by the name used after `@` in the
+  // string (without the `@` prefix). An `@name` placeholder with no matching map entry fails the request
+  // with "Missing argument of name `name`."; extra map entries are ignored.
   map<string, GrpcQueryParam> namedQueryParams = 5;
-  // The set of scopes to search for the entity.
+  // Scopes to search for the entity in. An empty list defaults to searching only the `LIVE` scope -
+  // `ARCHIVED` entities are not matched unless `ARCHIVED_ENTITY` is explicitly included here.
   repeated GrpcEntityScope scopes = 6;
 }
 
 // Response to GetEntity request.
 message GrpcEntityResponse {
-  // The found entity.
+  // The found entity. Unset (not an error) if no entity with the requested primary key exists in
+  // `entityType` within the requested `scopes`.
   GrpcSealedEntity entity = 1;
 }
 
-// Structure that represents a pagination within a data chunk.
+// Page-based pagination descriptor for a `GrpcDataChunk`, reporting the page actually returned. The
+// desired page is requested via the query's `page()` require constraint, not a field on this response
+// structure - see `io.evitadb.api.query.require.Page` for the full contract. `pageNumber` is 1-indexed
+// (page 1 is the first page) - see `io.evitadb.dataType.PaginatedList#getPageNumber`. A requested page
+// number of 0 or less is rejected by the server; a requested page number beyond `lastPageNumber` is not
+// rejected - the engine returns the first page instead, so `pageNumber` here can differ from what was
+// requested.
 message GrpcPaginatedList {
-  // The size of the page.
+  // Number of records requested per page, echoed back from the query's `page()` require constraint.
+  // Zero is valid and yields an empty page while `totalRecordCount`/`lastPageNumber` are still reported.
   int32 pageSize = 1;
-  // The number of the page.
+  // The page actually returned (1-indexed) - see the message-level comment for how this can differ from
+  // the requested page number.
   int32 pageNumber = 2;
-  // The number of the last page.
+  // The number of the last available page, given `pageSize` and the total record count.
   int32 lastPageNumber = 3;
 }
 
-// Structure that represents a strip within a data chunk.
+// Strip/offset-based pagination descriptor for a `GrpcDataChunk` - the alternative to `GrpcPaginatedList`
+// used when the query's `require` block specifies a `strip()` requirement instead of `page()`.
 message GrpcStripList {
-  // The size of the strip.
+  // Maximum number of records returned in this strip.
   int32 limit = 1;
-  // The offset of the strip - count of records from the beginning to skip.
+  // Number of records skipped from the beginning of the result set before this strip starts. 0-indexed:
+  // an offset of 0 starts at the very first record - unlike `GrpcPaginatedList.pageNumber`, this is not a
+  // page number.
   int32 offset = 2;
 }
 
-// Structure that represents a data chunk of entities. Only one of the entity fields should be set in one response.
-// That is decided by require block in a query, so as the pagination method used.
+// A page or strip of entities, in one of three representations (references, full sealed entities, or
+// binary entities) depending on what the query's `require` block asked for. Only one representation is
+// populated per response and only one of the two pagination descriptors below is set, matching whichever
+// paging requirement (`page()`/`strip()`) the query used.
 message GrpcDataChunk {
-  // Collection of entity references.
+  // Entity references (type + primary key only, no content). Populated when the query's `require` block
+  // has no `entityFetch` requirement; `sealedEntities`/`binaryEntities` are then both empty.
   repeated GrpcEntityReference entityReferences = 1;
-  // Collection of sealed entities.
+  // Fully fetched entities in structured (non-binary) form. Populated when `require` has an `entityFetch`
+  // requirement and the session is not using the binary storage format; `entityReferences`/`binaryEntities`
+  // are then both empty.
   repeated GrpcSealedEntity sealedEntities = 2;
-  // Collection of binary entities.
+  // Fully fetched entities in the server's binary storage format, for clients that decode entities
+  // themselves. Populated when `require` has an `entityFetch` requirement and the session uses the binary
+  // storage format; `entityReferences`/`sealedEntities` are then both empty.
   repeated GrpcBinaryEntity binaryEntities = 3;
-  // Chunk of the data.
+  // Exactly one of these is set, matching which paging requirement (`page()`/`strip()`) the query used.
   oneof chunk {
-    // The paginated list.
+    // Set when the query used page-based paging (`page()`).
     GrpcPaginatedList paginatedList = 4;
-    // The strip list.
+    // Set when the query used strip/offset-based paging (`strip()`).
     GrpcStripList stripList = 5;
   }
-  // The total number of records.
+  // Total number of records matching the query across all pages/strips, not just this chunk's size.
   int32 totalRecordCount = 6;
-  // True, if this is the first page.
+  // True if this chunk is the first page/strip of the result set.
   bool isFirst = 7;
-  // True, if this is the last page.
+  // True if this chunk is the last page/strip of the result set.
   bool isLast = 8;
-  // True, if there is a previous page.
+  // True if a preceding page/strip exists.
   bool hasPrevious = 9;
-  // True, if there is a next page.
+  // True if a following page/strip exists.
   bool hasNext = 10;
-  // True, if this is a single page.
+  // True if the entire result set fits within this single chunk.
   bool isSinglePage = 11;
-  // True, if this is an empty page.
+  // True if this chunk (and the entire result set) contains no records.
   bool isEmpty = 12;
 }
 
@@ -344,10 +433,16 @@ message GrpcRenameCollectionResponse {
   bool renamed = 1;
 }
 
+// Request for replacing an entity collection's contents with those of another collection. On success,
+// `entityTypeToBeReplaced` is purged and its name is taken over by the (dropped) `entityTypeToBeReplacedWith`
+// collection. If an error occurs mid-operation, both collections are guaranteed to be left untouched under
+// their original names.
 message GrpcReplaceCollectionRequest {
-  // Name of the entity collection that will be replaced and dropped (new name)
+  // Name of the collection that will be replaced: its current contents are dropped, and it will end up
+  // holding the contents of `entityTypeToBeReplacedWith` under this same name.
   string entityTypeToBeReplaced = 1;
-  // Name of the entity collection that will become the successor of the original collection (old name)
+  // Name of the collection whose contents become the new contents of `entityTypeToBeReplaced`. This
+  // collection itself no longer exists under its own name once the replacement completes.
   string entityTypeToBeReplacedWith = 2;
 }
 
@@ -359,7 +454,7 @@ message GrpcReplaceCollectionResponse {
 
 // Request for acquiring the size of an entity collection.
 message GrpcEntityCollectionSizeRequest {
-  // The entity type of the collection - (count of entities stored).
+  // The entity type (collection name) whose size (count of entities stored) should be returned.
   string entityType = 1;
 }
 
@@ -369,7 +464,7 @@ message GrpcEntityCollectionSizeResponse {
   int32 size = 1;
 }
 
-// Response for Close request that commits or rollbacks the changes in the session.
+// Request for Close, which commits or rollbacks the changes in the session and terminates it.
 message GrpcCloseRequest {
   // Contains the requested commit behaviour
   GrpcCommitBehavior commitBehaviour = 1;
@@ -425,221 +520,330 @@ message GrpcGoLiveAndCloseResponse {
   int32 catalogSchemaVersion = 3;
 }
 
+// One message of the GoLiveAndCloseWithProgress stream. Intermediate messages report only
+// `progressInPercent` (throttled to at most once per second, and only when the percentage has
+// increased); `catalogVersion`/`catalogSchemaVersion` are left at their zero default on those messages
+// since they are not yet meaningful. The final message always carries `progressInPercent == 100` together
+// with a populated `catalogVersion`/`catalogSchemaVersion`, and ends the stream.
 message GrpcGoLiveAndCloseWithProgressResponse {
-  // Contains next catalog version
+  // Contains next catalog version. Only populated on the final message (`progressInPercent == 100`); left
+  // at its default (`0`) on intermediate progress-only messages.
   int64 catalogVersion = 1;
   // Contains the version of the catalog schema that will be valid at the moment of closing the session.
   // If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
-  // version (i.e. the one that is returned in the response) becomes visible.
+  // version (i.e. the one that is returned in the response) becomes visible. Only populated on the final
+  // message (`progressInPercent == 100`); left at its default (`0`) on intermediate progress-only messages.
   int32 catalogSchemaVersion = 2;
-  // The progress of the go live operation in percents.
+  // Progress of the go-live operation, 0-100. Monotonically increasing across messages; the final message
+  // in the stream always carries 100.
   int32 progressInPercent = 3;
 }
 
-// Response to a catalog backup request.
+// Request to back up a catalog and stream the backup file to the client.
 message GrpcBackupCatalogRequest {
-  // The moment in time to which the catalog should be backed up. Might be null for current time.
+  // The moment in time to back up the catalog's state to. If unset, defaults to the current moment
+  // (subject to being overridden by `catalogVersion`, see below).
   GrpcOffsetDateTime pastMoment = 1;
   // True, if the WAL should be included in the backup. Use false if you want to restore catalog in exact state as
   // it was at the pastMoment.
   bool includingWAL = 2;
-  // precise catalog version to create backup for, or null to create backup for the latest version,
-  // when set not null, the pastMoment parameter is ignored
+  // Precise catalog version to create the backup for. If unset, defaults to the latest version - or, when
+  // `pastMoment` is set, the version resolved from `pastMoment`. When this field is set, `pastMoment` is
+  // ignored regardless of whether it is also set.
   google.protobuf.Int64Value catalogVersion = 3;
 }
 
 // Response to a catalog backup request.
 message GrpcBackupCatalogResponse {
-  // the task that is used to backup the catalog and getting its progress
+  // Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+  // finished, retrieve the resulting backup file.
   GrpcTaskStatus taskStatus = 1;
 }
 
-// Response to a catalog full backup request.
+// Response to a catalog full backup request (a backup that includes the entire catalog history, not just
+// the current state).
 message GrpcFullBackupCatalogResponse {
-  // the task that is used to backup the catalog and getting its progress
+  // Handle to the asynchronous backup task; use it to poll or stream the task's progress and, once
+  // finished, retrieve the resulting backup file.
   GrpcTaskStatus taskStatus = 1;
 }
 
-// Request for acquiring the list of all entity types.
+// Response to GetAllEntityTypes request.
 message GrpcEntityTypesResponse {
-  // The list of all entity types.
+  // Names of all entity collections (entity types) defined in the catalog.
   repeated string entityTypes = 1;
 }
 
-// Request for specifying a query to be executed.
+// Request for specifying a full EvitaQL query (filter, order and require blocks) to be executed.
 message GrpcQueryRequest {
-  // The string part of the parametrised query.
+  // The string part of the parametrised query, e.g. `query(collection('Product'), filterBy(entityPrimaryKeyInSet(?)))`.
+  // Parameter values are not embedded in this string but supplied separately via `positionalQueryParams`/
+  // `namedQueryParams` below. A `?` placeholder is a positional parameter, an `@name` placeholder is a
+  // named parameter - see `positionalQueryParams` for the full binding contract, which applies identically here.
   string query = 1;
-  // The positional query parameters.
+  // Values for the `?` positional placeholders in `query`, bound in encounter order: the first `?` in the
+  // parsed string binds to `positionalQueryParams[0]`, the second to `positionalQueryParams[1]`, and so on
+  // (FIFO). Supplying fewer values than there are `?` placeholders fails the request with "Missing argument
+  // of index N."; extra values are ignored.
   repeated GrpcQueryParam positionalQueryParams = 2;
-  // The named query parameters.
+  // Values for the `@name` named placeholders in `query`, keyed by the name used after `@` in the string
+  // (without the `@` prefix). An `@name` placeholder with no matching map entry fails the request with
+  // "Missing argument of name `name`."; extra map entries are ignored.
   map<string, GrpcQueryParam> namedQueryParams = 3;
 }
 
-// Request for specifying a query to be executed.
+// Request for specifying a full EvitaQL query with parameter values embedded directly in the string (no
+// separate positional/named parameter binding). Internal/unsafe use only - see the `QueryUnsafe` RPC
+// comment: applications should use `GrpcQueryRequest` instead.
 message GrpcQueryUnsafeRequest {
-  // The string part of the parametrised query.
+  // The complete query string, with any parameter values already embedded (no `?`/`@name` placeholders
+  // to resolve).
   string query = 1;
 }
 
 // Response to Query request.
 message GrpcQueryResponse {
-  // The fetched record page with entities.
+  // The fetched page or strip of entities (in whichever of the three representations the query's
+  // `require` block asked for - see `GrpcDataChunk`).
   GrpcDataChunk recordPage = 1;
-  // The computed extra results.
+  // Extra results computed by `require` constraints beyond the entity page itself (facet summary,
+  // hierarchy statistics, price histograms, etc.). Unset (default) if the query's `require` block
+  // requested none of these.
   GrpcExtraResults extraResults = 2;
 }
 
-// Response for query request executed when searched for exactly one entity. The used field is decided by the require block in the query.
+// Response for a query executed via QueryOne, i.e. expecting zero or one matching entity. At most one of
+// `entityReference`/`sealedEntity`/`binaryEntity` is populated. If an entity matched, which one is chosen
+// the same way as in `GrpcDataChunk`: no `entityFetch` requirement in the query's `require` block yields
+// `entityReference`; an `entityFetch` requirement yields `sealedEntity` (structured form) or `binaryEntity`
+// (binary storage form), depending on whether the session uses the binary storage format. If no entity
+// matched the query, all three fields are left unset - this is not an error.
 message GrpcQueryOneResponse {
-  // Entity reference of the found entity.
+  // The matched entity as a reference (type + primary key only). See the message-level comment for when
+  // this field (vs. the other two) is populated.
   GrpcEntityReference entityReference = 1;
-  // Sealed entity of the found entity.
+  // The matched entity, fully fetched in structured (non-binary) form. See the message-level comment for
+  // when this field (vs. the other two) is populated.
   GrpcSealedEntity sealedEntity = 2;
-  // Binary entity of the found entity.
+  // The matched entity, fully fetched in the server's binary storage format. See the message-level comment
+  // for when this field (vs. the other two) is populated.
   GrpcBinaryEntity binaryEntity = 3;
 }
 
-// Response for query request executed when searched for a list of entities. The used field is decided by the require block in the query.
+// Response for a query executed via QueryList, i.e. expecting a flat list of matching entities (no paging
+// metadata - use plain `Query` via `GrpcQueryResponse` if paging is needed). Exactly one of
+// `entityReferences`/`sealedEntities`/`binaryEntities` is the active field, chosen the same way as in
+// `GrpcDataChunk`: no `entityFetch` requirement in the query's `require` block selects `entityReferences`;
+// an `entityFetch` requirement selects `sealedEntities` (structured form) or `binaryEntities` (binary
+// storage form), depending on whether the session uses the binary storage format. The other two fields are
+// always left empty; note the active field is itself also empty when zero entities matched.
 message GrpcQueryListResponse {
+  // Matched entities as references (type + primary key only). See the message-level comment for when this
+  // field (vs. the other two) is the active one.
   repeated GrpcEntityReference entityReferences = 1;
+  // Matched entities, fully fetched in structured (non-binary) form. See the message-level comment for
+  // when this field (vs. the other two) is the active one.
   repeated GrpcSealedEntity sealedEntities = 2;
+  // Matched entities, fully fetched in the server's binary storage format. See the message-level comment
+  // for when this field (vs. the other two) is the active one.
   repeated GrpcBinaryEntity binaryEntities = 3;
 }
 
-// Request for upserting an entity that should return an entity with required richness.
+// Request for upserting (inserting/updating) an entity and returning it fetched in the richness
+// described by `require`.
 message GrpcUpsertEntityRequest {
-  // Either Upsert or Delete entity mutation.
+  // The mutation to apply - either an upsert (insert/update) or a delete mutation for the entity.
   GrpcEntityMutation entityMutation = 1;
-  // The string part of the parametrised query require part.
+  // The string part of a parametrised `require` query fragment (e.g. `entityFetch(attributeContentAll())`)
+  // describing how richly to fetch the entity back after the mutation is applied. `?`/`@name` placeholders
+  // are bound the same way as `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there
+  // for the full binding contract.
   string require = 2;
-  // The positional query parameters.
+  // Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+  // `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
   repeated GrpcQueryParam positionalQueryParams = 3;
-  // The named query parameters.
+  // Values for the `@name` named placeholders in `require`, keyed by name (without the `@` prefix) - see
+  // `GrpcEntityRequest.namedQueryParams` for the full binding contract.
   map<string, GrpcQueryParam> namedQueryParams = 4;
 }
 
-// Request for deleting an entity that should return the deleted entity with required richness.
+// Request for deleting a single entity by primary key and returning it fetched in the richness described
+// by `require` before deletion.
 message GrpcDeleteEntityRequest {
-  // Entity type of the entity to be deleted.
+  // Entity type (collection name) the entity to delete belongs to.
   string entityType = 1;
-  // Primary key of the entity to be deleted.
+  // Primary key of the entity to delete. Effectively mandatory despite the wrapper type: the server reads
+  // its value directly without checking presence, so an unset value is treated identically to an explicit
+  // `0` rather than as "no primary key" - always set this field explicitly.
   google.protobuf.Int32Value primaryKey = 2;
-  // The string part of the parametrised query require part.
+  // The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+  // back before it is deleted. `?`/`@name` placeholders are bound the same way as
+  // `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+  // contract.
   string require = 3;
-  // The positional query parameters.
+  // Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+  // `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
   repeated GrpcQueryParam positionalQueryParams = 4;
-  // The named query parameters.
+  // Values for the `@name` named placeholders in `require`, keyed by name (without the `@` prefix) - see
+  // `GrpcEntityRequest.namedQueryParams` for the full binding contract.
   map<string, GrpcQueryParam> namedQueryParams = 5;
 }
 
-// Request for deleting an entity that should return the archived entity with required richness.
+// Request for archiving a single entity by primary key and returning it fetched in the richness described
+// by `require`.
 message GrpcArchiveEntityRequest {
-  // Entity type of the entity to be archived.
+  // Entity type (collection name) the entity to archive belongs to.
   string entityType = 1;
-  // Primary key of the entity to be archived.
+  // Primary key of the entity to archive. Effectively mandatory despite the wrapper type: the server reads
+  // its value directly without checking presence, so an unset value is treated identically to an explicit
+  // `0` rather than as "no primary key" - always set this field explicitly.
   google.protobuf.Int32Value primaryKey = 2;
-  // The string part of the parametrised query require part.
+  // The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+  // back after it is archived. `?`/`@name` placeholders are bound the same way as
+  // `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+  // contract.
   string require = 3;
-  // The positional query parameters.
+  // Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+  // `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
   repeated GrpcQueryParam positionalQueryParams = 4;
-  // The named query parameters.
+  // Values for the `@name` named placeholders in `require`, keyed by name (without the `@` prefix) - see
+  // `GrpcEntityRequest.namedQueryParams` for the full binding contract.
   map<string, GrpcQueryParam> namedQueryParams = 5;
 }
 
-// Request for deleting an entity that should return the restored entity with required richness.
+// Request for restoring a single previously archived entity by primary key and returning it fetched in
+// the richness described by `require`.
 message GrpcRestoreEntityRequest {
-  // Entity type of the entity to be restored.
+  // Entity type (collection name) the entity to restore belongs to.
   string entityType = 1;
-  // Primary key of the entity to be restored.
+  // Primary key of the entity to restore. Effectively mandatory despite the wrapper type: the server reads
+  // its value directly without checking presence, so an unset value is treated identically to an explicit
+  // `0` rather than as "no primary key" - always set this field explicitly.
   google.protobuf.Int32Value primaryKey = 2;
-  // The string part of the parametrised query require part.
+  // The string part of a parametrised `require` query fragment describing how richly to fetch the entity
+  // back after it is restored. `?`/`@name` placeholders are bound the same way as
+  // `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+  // contract.
   string require = 3;
-  // The positional query parameters.
+  // Values for the `?` positional placeholders in `require`, bound in encounter order (FIFO) - see
+  // `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
   repeated GrpcQueryParam positionalQueryParams = 4;
-  // The named query parameters.
+  // Values for the `@name` named placeholders in `require`, keyed by name (without the `@` prefix) - see
+  // `GrpcEntityRequest.namedQueryParams` for the full binding contract.
   map<string, GrpcQueryParam> namedQueryParams = 5;
 }
 
-// Request for deleting a collection of entities specified by a query.
+// Request for deleting all entities matched by a query. Beware: without a `page()`/`strip()` requirement
+// in the query's `require` block to bound the result, at most 20 entities are deleted (the engine's
+// default page size) - add an explicit `page()`/`strip()` requirement to remove more.
 message GrpcDeleteEntitiesRequest {
-  // The string part of the parametrised query.
+  // The string part of the parametrised query. `?`/`@name` placeholders are bound the same way as
+  // `positionalQueryParams`/`namedQueryParams` on `GrpcEntityRequest` - see there for the full binding
+  // contract.
   string query = 1;
-  // The positional query parameters.
+  // Values for the `?` positional placeholders in `query`, bound in encounter order (FIFO) - see
+  // `GrpcEntityRequest.positionalQueryParams` for the full binding contract.
   repeated GrpcQueryParam positionalQueryParams = 2;
-  // The named query parameters.
+  // Values for the `@name` named placeholders in `query`, keyed by name (without the `@` prefix) - see
+  // `GrpcEntityRequest.namedQueryParams` for the full binding contract.
   map<string, GrpcQueryParam> namedQueryParams = 3;
 }
 
-// Response to UpsertEntity request. The used field is decided by the require block in the query.
+// Response to UpsertEntity request.
 message GrpcUpsertEntityResponse {
-  // The upserted entity.
+  // Exactly one of these is set. `entity` is set when `GrpcUpsertEntityRequest.require` has an
+  // `entityFetch` requirement. Otherwise a reference is returned: `entityReferenceWithAssignedPrimaryKeys`
+  // when the upsert caused reference primary keys to be reassigned (e.g. due to reflected reference
+  // schemas), or plain `entityReference` otherwise.
   oneof response {
-    // The upserted entity reference.
+    // The upserted entity as a reference (type + primary key only).
     GrpcEntityReference entityReference = 1;
-    // The upserted entity.
+    // The upserted entity, fully fetched per `GrpcUpsertEntityRequest.require`.
     GrpcSealedEntity entity = 2;
-    // The upserted entity reference with reassigned primary keys
+    // The upserted entity reference together with any reference primary keys that were reassigned as a
+    // side effect of the upsert.
     GrpcEntityReferenceWithAssignedPrimaryKeys entityReferenceWithAssignedPrimaryKeys = 3;
   }
 }
 
 // Response to DeleteEntity request.
 message GrpcDeleteEntityResponse {
-  // The deleted entity. The used field is decided by the require block in the query.
+  // At most one of these is set. If an entity with the requested primary key existed and was deleted,
+  // which field is chosen by whether `GrpcDeleteEntityRequest.require` has an `entityFetch` requirement:
+  // `entity` (fully fetched, as it was immediately before deletion) if it does, `entityReference`
+  // otherwise. Neither is set if no entity with the requested primary key existed to delete.
   oneof response {
-    // The deleted entity reference.
+    // The deleted entity as a reference (type + primary key only).
     GrpcEntityReference entityReference = 1;
-    // The deleted entity.
+    // The deleted entity, fully fetched (as it was immediately before deletion) per
+    // `GrpcDeleteEntityRequest.require`.
     GrpcSealedEntity entity = 2;
   }
 }
 
 // Response to ArchiveEntity request.
 message GrpcArchiveEntityResponse {
-  // The archived entity. The used field is decided by the require block in the query.
+  // At most one of these is set. If an entity with the requested primary key existed and was archived,
+  // which field is chosen by whether `GrpcArchiveEntityRequest.require` has an `entityFetch` requirement:
+  // `entity` (fully fetched) if it does, `entityReference` otherwise. Neither is set if no entity with the
+  // requested primary key existed to archive.
   oneof response {
-    // The archived entity reference.
+    // The archived entity as a reference (type + primary key only).
     GrpcEntityReference entityReference = 1;
-    // The archived entity.
+    // The archived entity, fully fetched per `GrpcArchiveEntityRequest.require`.
     GrpcSealedEntity entity = 2;
   }
 }
 
 // Response to RestoreEntity request.
 message GrpcRestoreEntityResponse {
-  // The restored entity. The used field is decided by the require block in the query.
+  // At most one of these is set. If an entity with the requested primary key existed and was restored,
+  // which field is chosen by whether `GrpcRestoreEntityRequest.require` has an `entityFetch` requirement:
+  // `entity` (fully fetched) if it does, `entityReference` otherwise. Neither is set if no archived entity
+  // with the requested primary key existed to restore.
   oneof response {
-    // The restored entity reference.
+    // The restored entity as a reference (type + primary key only).
     GrpcEntityReference entityReference = 1;
-    // The restored entity.
+    // The restored entity, fully fetched per `GrpcRestoreEntityRequest.require`.
     GrpcSealedEntity entity = 2;
   }
 }
 
-// Response to DeleteEntity request when hierarchy has been specified in filter.
+// Response to DeleteEntityAndItsHierarchy, which removes a hierarchical root entity together with every
+// entity of the same type that transitively references it as a parent.
 message GrpcDeleteEntityAndItsHierarchyResponse {
-  // Count of deleted entities.
+  // Total number of entities deleted (the root plus its whole nested hierarchy).
   int32 deletedEntities = 1;
+  // At most one of these is set. Unlike the equivalent oneof on `GrpcDeleteEntityResponse`, this RPC
+  // always fetches the root entity's body - even when `GrpcDeleteEntityRequest.require` is empty - so in
+  // practice `deletedRootEntity` is the field that gets populated; `deletedRootEntityReference` is
+  // currently unreachable in the server implementation. Neither is set if no entity with the requested
+  // primary key existed to delete. Covers only the root entity - the rest of the deleted hierarchy is
+  // available solely as primary keys via `deletedEntityPrimaryKeys` below.
   oneof response {
-    // The deleted root entity reference.
+    // The deleted root entity as a reference (type + primary key only). Currently never populated by the
+    // server - see the message-level comment above.
     GrpcEntityReference deletedRootEntityReference = 2;
-    // The deleted root entity.
+    // The deleted root entity, fully fetched (as it was immediately before deletion) per
+    // `GrpcDeleteEntityRequest.require`.
     GrpcSealedEntity deletedRootEntity = 3;
   }
-  // Deleted entity primary keys.
+  // Primary keys of every entity deleted as part of the hierarchy removal, including the root entity's
+  // own primary key.
   repeated int32 deletedEntityPrimaryKeys = 4;
 }
 
-// Response to DeleteEntities request that deletes all entities that match the sent query..
+// Response to DeleteEntities request that deletes all entities matched by the sent query.
 message GrpcDeleteEntitiesResponse {
-  // Count of deleted entities.
+  // Total number of entities deleted.
   int32 deletedEntities = 1;
-  // The deleted entity bodies.
+  // The deleted entities' bodies, fully fetched (as they were immediately before deletion) per the
+  // `require` block of the query in `GrpcDeleteEntitiesRequest`. Empty if that `require` block had no
+  // `entityFetch` requirement.
   repeated GrpcSealedEntity deletedEntityBodies = 2;
 }
 
-// Request for opening a transaction.
+// Response to GetTransactionId request, returned after a new transaction is opened.
 message GrpcTransactionResponse {
   // The current version of the catalog the transaction is bound to.
   int64 catalogVersion = 1;

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaTrafficRecordingAPI.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaTrafficRecordingAPI.proto
@@ -8,74 +8,89 @@ import "GrpcEvitaDataTypes.proto";
 import "google/protobuf/wrappers.proto";
 import "GrpcTrafficRecording.proto";
 
-// Request to GetTrafficHistoryList request.
+// Request for a single bounded batch of past traffic records matching the given criteria.
 message GetTrafficHistoryListRequest {
-  // The limit of records to return
+  // Maximum number of matching traffic records to return in this response. This is a plain result cap - not
+  // page-based or offset-based pagination - and the server enforces no upper bound of its own beyond it. To
+  // continue fetching beyond this limit, issue a new request with `criteria.sinceSessionSequenceId` and
+  // `criteria.sinceRecordSessionOffset` set to the position right after the last record already received.
   int32 limit = 1;
-  // The criteria of the traffic recording, allows to define constraints on the returned records
+  // The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+  // are applied and all recorded traffic (up to `limit`) is eligible.
   GrpcTrafficRecordingCaptureCriteria criteria = 2;
 }
 
 // Response to GetTrafficHistoryList request.
 message GetTrafficHistoryListResponse {
-  // The list of traffic records that match the criteria
+  // The matching traffic records, up to the requested `limit`.
   repeated GrpcTrafficRecord trafficRecord = 1;
 }
 
-// Request to GetTrafficHistory request.
+// Request for the streaming variant of the traffic history query; unlike GetTrafficHistoryListRequest, all
+// matching records are streamed back without a result cap.
 message GetTrafficHistoryRequest {
-  // The criteria of the traffic recording, allows to define constraints on the returned records
+  // The criteria of the traffic recording, allowing constraints on the returned records. If unset, no filters
+  // are applied and all recorded traffic is streamed back.
   GrpcTrafficRecordingCaptureCriteria criteria = 1;
 }
 
-// Response to GetTrafficHistory request.
+// A single streamed response frame carrying traffic records.
 message GetTrafficHistoryResponse {
-  // The list of traffic records that match the criteria
+  // The traffic records carried by this streamed frame (the current server implementation emits exactly one
+  // record per frame).
   repeated GrpcTrafficRecord trafficRecord = 1;
 }
 
-// Response to GetTrafficRecordingLabelsNamesOrderedByCardinality request.
+// Request to GetTrafficRecordingLabelsNamesOrderedByCardinality request.
 message GetTrafficRecordingLabelNamesRequest {
-  // The limit of records to return
+  // Maximum number of label names to return, ordered by descending cardinality (most frequently used labels
+  // first). This is a plain result cap, not page-based or offset-based pagination; repeated calls do not support
+  // continuation.
   int32 limit = 1;
-  // Allows to filter the returned labels by the name prefix
+  // Only label names starting with this prefix are returned. If unset, no prefix filter is applied.
   google.protobuf.StringValue nameStartsWith = 2;
 }
 
-// Response to GetTrafficRecordingLabelsNamesOrderedByCardinality response.
+// Response to GetTrafficRecordingLabelsNamesOrderedByCardinality request.
 message GetTrafficRecordingLabelNamesResponse {
-  // The list of labels names that match the criteria
+  // The label names that match the criteria, ordered by descending cardinality (most frequently used labels first).
   repeated string labelName = 1;
 }
 
-// Response to GetTrafficRecordingLabelsValuesOrderedByCardinality request.
+// Request to GetTrafficRecordingLabelsValuesOrderedByCardinality request.
 message GetTrafficRecordingValuesNamesRequest {
-  // The limit of records to return
+  // Maximum number of label values to return, ordered by descending cardinality (most frequently used values
+  // first). This is a plain result cap, not page-based or offset-based pagination; repeated calls do not support
+  // continuation.
   int32 limit = 1;
   // The name of the label to get the values for
   string labelName = 2;
-  // Allows to filter the returned labels by the name prefix
+  // Only label values starting with this prefix are returned. If unset, no prefix filter is applied.
   google.protobuf.StringValue valueStartsWith = 3;
 }
 
-// Response to GetTrafficRecordingLabelsValuesOrderedByCardinality response.
+// Response to GetTrafficRecordingLabelsValuesOrderedByCardinality request.
 message GetTrafficRecordingValuesNamesResponse {
-  // The list of labels values that match the criteria
+  // The label values that match the criteria, ordered by descending cardinality (most frequently used values first).
   repeated string labelValue = 1;
 }
 
-// Request to StartTrafficRecording request.
+// Request to start a new traffic recording session. Only one recording may be in progress at a time; starting a
+// new one while another is still running fails.
 message GrpcStartTrafficRecordingRequest {
   // The sampling rate of the traffic recording (100 means all records will be recorded, 1 means 1% of records will be recorded)
   int32 samplingRate = 1;
   // If true the recording will be exported to a file, otherwise only internal ring buffer will be made available for
   // the time the traffic recording is running.
   bool exportFile = 2;
-  // The duration of the recording in milliseconds, after this time the recording will be stopped automatically.
+  // The maximum duration of the recording (milliseconds); the recording stops automatically once this much time
+  // has elapsed. If unset, the recording keeps running until explicitly stopped via StopTrafficRecording.
   google.protobuf.Int64Value maxDurationInMilliseconds = 3;
-  // The size of the recording in bytes, after this size the recording will be stopped automatically.
+  // The maximum size of the recorded traffic data (bytes); the recording stops automatically once this much data
+  // has been captured. If unset, no size-based automatic stop is applied.
   google.protobuf.Int64Value maxFileSizeInBytes = 4;
-  // The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+  // The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+  // of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
   google.protobuf.Int64Value chunkFileSizeInBytes = 5;
 }
 
@@ -87,16 +102,20 @@ message GrpcStopTrafficRecordingRequest {
 
 // Request to ExportTrafficRecording request.
 message GrpcExportTrafficRecordingRequest {
-  // The size of the chunk file in bytes. Individual files in the export file will be approximately this size.
+  // The target size of each individual chunk file within the export (bytes); exported files are split into chunks
+  // of approximately this size. If unset, or set to zero, the server-configured default chunk size is used.
   google.protobuf.Int64Value chunkFileSizeInBytes = 1;
 }
 
-// Response to StartTrafficRecording and  request.
+// Response to StartTrafficRecording, StopTrafficRecording, and ExportTrafficRecording requests.
 message GetTrafficRecordingStatusResponse {
   // The status of the recording task
   GrpcTaskStatus taskStatus = 1;
 }
 
+// This service contains RPCs that could be called by gRPC clients on evitaDB's catalog by usage of a before created
+// session. Main purpose of this service is to provide a way to query and manage recorded traffic (queries, mutations,
+// session lifecycle events) captured for diagnostics.
 service GrpcEvitaTrafficRecordingService {
 
   // Procedure that returns requested list of past traffic records with limited size that match the request criteria.
@@ -115,7 +134,8 @@ service GrpcEvitaTrafficRecordingService {
   rpc GetTrafficRecordingLabelsNamesOrderedByCardinality(GetTrafficRecordingLabelNamesRequest) returns (GetTrafficRecordingLabelNamesResponse);
   // Procedure returns a list of top unique label values ordered by cardinality of their values present in the traffic recording.
   rpc GetTrafficRecordingLabelValuesOrderedByCardinality(GetTrafficRecordingValuesNamesRequest) returns (GetTrafficRecordingValuesNamesResponse);
-  // Procedure that starts the traffic recording for the given criteria and settings
+  // Procedure that starts the traffic recording for the given criteria and settings. Fails if a recording is
+  // already in progress - only one recording may run at a time.
   rpc StartTrafficRecording(GrpcStartTrafficRecordingRequest) returns (GetTrafficRecordingStatusResponse);
   // Procedure that stops the traffic recording
   rpc StopTrafficRecording(GrpcStopTrafficRecordingRequest) returns (GetTrafficRecordingStatusResponse);

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcExtraResults.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcExtraResults.proto
@@ -75,7 +75,8 @@ message GrpcReferenceGroupStatistics {
 }
 
 // This DTO contains information about single facet group and statistics of the facets that relates to it.
-// TOBEDONE: remove when FacetSummary constraint is removed
+// deprecated in favor of `GrpcReferenceGroupStatistics`, produced by the `referenceSummary` requirement
+// TOBEDONE: remove when FacetSummary constraint is removed (https://github.com/FgForrest/evitaDB/issues/538)
 message GrpcFacetGroupStatistics {
   option deprecated = true;
 

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcPrice.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcPrice.proto
@@ -31,9 +31,9 @@ message GrpcPrice {
   google.protobuf.Int32Value innerRecordId = 4;
   // Price without tax.
   GrpcBigDecimal priceWithoutTax = 5;
-  // Price with tax.
-  GrpcBigDecimal taxRate = 6;
   // Tax rate percentage (i.e. for 19% it'll be 19.00)
+  GrpcBigDecimal taxRate = 6;
+  // Price with tax.
   GrpcBigDecimal priceWithTax = 7;
   // Date and time interval for which the price is valid (inclusive).
   GrpcDateTimeRange validity = 8;

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcPriceMutations.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcPriceMutations.proto
@@ -49,6 +49,7 @@ message GrpcUpsertPriceMutation {
   // entity but won't be considered when evaluating search query. These prices may be
   // used for "informational" prices such as reference price (the crossed out price often found on e-commerce sites
   // as "usual price") but are not considered as the "selling" price.
+  // RENAMED TO "indexed"
   bool sellable = 9 [deprecated = true];
   // Controls whether price is subject to filtering / sorting logic, non-indexed prices will be fetched along with
   // entity but won't be considered when evaluating search query. These prices may be
@@ -57,6 +58,7 @@ message GrpcUpsertPriceMutation {
   bool indexed = 10;
 }
 
+// This mutation allows to remove an existing `price` of the entity, identified by price ID, price list and currency.
 message GrpcRemovePriceMutation {
   // Contains identification of the price in the external systems. This id is expected to be used for the synchronization
   // of the price in relation with the primary source of the prices.

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcQueryParam.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcQueryParam.proto
@@ -9,106 +9,168 @@ import "GrpcEnums.proto";
 
 // Structure that supports storing all possible parameters that could be used within query.
 message GrpcQueryParam {
-  // The value of the parameter.
+  // Exactly one of the following arms must be set. An unset `queryParam` is a client error:
+  // `QueryConverter.convertQueryParam` dispatches on the set arm and throws
+  // `EvitaInvalidUsageException` if none matches.
+  //
+  // Positional parameters (query strings using `?` placeholders) bind to entries of the enclosing
+  // message's `positionalQueryParams` list in the order the `?` placeholders are encountered in the
+  // query text — the first `?` binds to index 0, and so on. A query with more `?` placeholders than
+  // available entries fails with `EvitaInvalidUsageException("Missing argument of index N.")`.
+  //
+  // Named parameters (query strings using `@name` placeholders) bind to entries of the enclosing
+  // message's `namedQueryParams` map by the name embedded in the query text. A placeholder with no
+  // matching key fails with `EvitaInvalidUsageException("Missing argument of name `name`.")`.
   oneof queryParam {
-    // The string value.
+    // Binds a string parameter into the query, e.g. a string literal compared by `attributeEquals`,
+    // `attributeContains` or similar constraints, or a classifier name (entity type, attribute name).
     string stringValue = 1;
-    // The integer value.
+    // Binds an `int32` parameter into the query, typically used for primary keys or numeric literals.
     int32 integerValue = 2;
-    // The long value.
+    // Binds a `long` parameter into the query, typically used for primary keys or numeric literals
+    // that exceed the `int32` range.
     int64 longValue = 3;
-    // The boolean value.
+    // Binds a boolean parameter into the query.
     bool booleanValue = 4;
-    // The big decimal value.
+    // Binds an arbitrary-precision decimal parameter into the query, typically used for price or
+    // other monetary/decimal literals.
     GrpcBigDecimal bigDecimalValue = 5;
-    // The date time range value.
+    // Binds a date-time range parameter into the query, e.g. used with `entityValidIn`/`priceValidIn`
+    // style constraints that test whether a given instant falls within a validity range.
     GrpcDateTimeRange dateTimeRangeValue = 6;
-    // The integer number range value.
+    // Binds an `int32` range parameter into the query, e.g. used with `between`-style range constraints.
     GrpcIntegerNumberRange integerNumberRangeValue = 7;
-    // The long number range value.
+    // Binds a `long` range parameter into the query, e.g. used with `between`-style range constraints.
     GrpcLongNumberRange longNumberRangeValue = 8;
-    // The big decimal number range value.
+    // Binds an arbitrary-precision decimal range parameter into the query, e.g. used with `between`-
+    // style range constraints over prices or other decimal values.
     GrpcBigDecimalNumberRange bigDecimalNumberRangeValue = 9;
-    // The offset date time value.
+    // Binds a single point-in-time parameter (date, time and offset) into the query, e.g. used with
+    // `priceValidIn` to test price validity at a specific instant.
     GrpcOffsetDateTime offsetDateTimeValue = 10;
-    // The locale value.
+    // Binds a `Locale` parameter into the query, e.g. used with `entityLocaleEquals`.
     GrpcLocale localeValue = 11;
-    // The currency value.
+    // Binds a `Currency` parameter into the query, e.g. used with `priceInCurrency`.
     GrpcCurrency currencyValue = 12;
-    // The facet statistics depth enum value.
+    // Binds a `GrpcFacetStatisticsDepth` enum parameter into the query, e.g. used with the
+    // `facetSummary` requirement to select whether only counts or also selection impact is computed.
     GrpcFacetStatisticsDepth facetStatisticsDepthValue = 13;
-    // The query price mode enum value.
+    // Binds a `GrpcQueryPriceMode` enum parameter into the query, used by price-related filtering
+    // constraints to select whether tax-inclusive or tax-exclusive prices are considered. Field name
+    // is a legacy typo ("Model" instead of "Mode"); kept as-is because renaming would break generated
+    // accessors and JSON field mapping for existing clients.
     GrpcQueryPriceMode queryPriceModelValue = 14;
-    // The price content mode enum value.
+    // Binds a `GrpcPriceContentMode` enum parameter into the query, e.g. used with the `priceContent`
+    // requirement to select which prices are fetched along with the entity.
     GrpcPriceContentMode priceContentModeValue = 15;
-    // The attribute special value enum value.
+    // Binds a `GrpcAttributeSpecialValue` enum parameter into the query, e.g. used with `attributeIs`
+    // to test whether an attribute value is `NULL` or `NOT_NULL`.
     GrpcAttributeSpecialValue attributeSpecialValue = 16;
-    // The order direction enum value.
+    // Binds a `GrpcOrderDirection` enum parameter into the query, e.g. used with `attributeNatural`
+    // and other ordering constraints to select ascending or descending order.
     GrpcOrderDirection orderDirectionValue = 17;
-    // The empty hierarchical entity behaviour enum value.
+    // Binds a `GrpcEmptyHierarchicalEntityBehaviour` enum parameter into the query, used by hierarchy
+    // statistics requirements to select whether hierarchy nodes with no referring entities are kept
+    // in or removed from the result tree.
     GrpcEmptyHierarchicalEntityBehaviour emptyHierarchicalEntityBehaviour = 18;
-    // The statistics base enum value.
+    // Binds a `GrpcStatisticsBase` enum parameter into the query, used by hierarchy statistics
+    // requirements to select which part of the `filterBy` constraint is considered when computing
+    // cardinalities.
     GrpcStatisticsBase statisticsBase = 19;
-    // The statistics type enum value.
+    // Binds a `GrpcStatisticsType` enum parameter into the query, used by hierarchy statistics
+    // requirements to select whether children counts or queried-entity counts are produced.
     GrpcStatisticsType statisticsType = 20;
-    // The histogram behavior enum value.
+    // Binds a `GrpcHistogramBehavior` enum parameter into the query, used by histogram requirements
+    // to select whether the histogram always has exactly the requested bucket count or an optimized,
+    // more compact bucket layout.
     GrpcHistogramBehavior histogramBehavior = 21;
-    // The managed references behaviour
+    // Binds a `GrpcManagedReferencesBehaviour` enum parameter into the query, used by the
+    // `referenceContent` requirement to select whether references to a managed entity that no longer
+    // exists are still returned.
     GrpcManagedReferencesBehaviour managedReferencesBehaviour = 22;
-    // The expression
+    // Binds a raw EvitaQL expression string into the query, evaluated via `ExpressionFactory` — e.g.
+    // used as the size argument of the `gap` requirement to compute spacing between paginated results.
     string expressionValue = 23;
-    // The scope enum value.
+    // Binds a `GrpcEntityScope` enum parameter into the query, used by scope-aware constraints to
+    // select whether live or archived entities are considered.
     GrpcEntityScope scope = 24;
-    // The facetRelationType enum value.
+    // Binds a `GrpcFacetRelationType` enum parameter into the query, used by facet summary impact
+    // calculation to select the logical relation (disjunction, conjunction, negation, exclusivity)
+    // applied between facets.
     GrpcFacetRelationType facetRelationType = 25;
-    // The facetGroupRelationLevel enum value.
+    // Binds a `GrpcFacetGroupRelationLevel` enum parameter into the query, used by facet summary
+    // impact calculation to select whether the relation applies between facets in the same group or
+    // across different groups/references.
     GrpcFacetGroupRelationLevel facetGroupRelationLevel = 26;
-    // The facet traversal mode enum value.
+    // Binds a `GrpcTraversalMode` enum parameter into the query, used by the
+    // `traverseByEntityProperty` ordering constraint to select depth-first or breadth-first traversal.
     GrpcTraversalMode traversalMode = 27;
 
-    // The string array value.
+    // Binds a list of string parameters into the query, e.g. used with `inSet`-style constraints such
+    // as `attributeInSet` over string-typed attributes.
     GrpcStringArray stringArrayValue = 101;
-    // The integer array value.
+    // Binds a list of `int32` parameters into the query, e.g. used with `entityPrimaryKeyInSet` or
+    // `attributeInSet` over integer-typed attributes.
     GrpcIntegerArray integerArrayValue = 102;
-    // The long array value.
+    // Binds a list of `long` parameters into the query, e.g. used with `inSet`-style constraints over
+    // long-typed values that exceed the `int32` range.
     GrpcLongArray longArrayValue = 103;
-    // The boolean array value.
+    // Binds a list of boolean parameters into the query, e.g. used with `inSet`-style constraints over
+    // boolean-typed attributes.
     GrpcBooleanArray booleanArrayValue = 104;
-    // The big decimal array value.
+    // Binds a list of arbitrary-precision decimal parameters into the query, e.g. used with
+    // `inSet`-style constraints over decimal-typed attributes.
     GrpcBigDecimalArray bigDecimalArrayValue = 105;
-    // The date time range array value.
+    // Binds a list of date-time range parameters into the query, e.g. used with `inSet`-style
+    // constraints over range-typed attributes.
     GrpcDateTimeRangeArray dateTimeRangeArrayValue = 106;
-    // The integer number range array value.
+    // Binds a list of `int32` range parameters into the query, e.g. used with `inSet`-style
+    // constraints over integer-range-typed attributes.
     GrpcIntegerNumberRangeArray integerNumberRangeArrayValue = 107;
-    // The long number range array value.
+    // Binds a list of `long` range parameters into the query, e.g. used with `inSet`-style constraints
+    // over long-range-typed attributes.
     GrpcLongNumberRangeArray longNumberRangeArrayValue = 108;
-    // The big decimal number range array value.
+    // Binds a list of arbitrary-precision decimal range parameters into the query, e.g. used with
+    // `inSet`-style constraints over decimal-range-typed attributes.
     GrpcBigDecimalNumberRangeArray bigDecimalNumberRangeArrayValue = 109;
-    // The offset date time array value.
+    // Binds a list of point-in-time parameters into the query, e.g. used with `inSet`-style
+    // constraints over date-time-typed attributes.
     GrpcOffsetDateTimeArray offsetDateTimeArrayValue = 110;
-    // The locale array value.
+    // Binds a list of `Locale` parameters into the query, e.g. used to enumerate multiple locales in
+    // a single constraint or requirement.
     GrpcLocaleArray localeArrayValue = 111;
-    // The currency array value.
+    // Binds a list of `Currency` parameters into the query, e.g. used to enumerate multiple currencies
+    // in a single constraint or requirement.
     GrpcCurrencyArray currencyArrayValue = 112;
-    // The facet statistics depth array value.
+    // Binds a list of `GrpcFacetStatisticsDepth` enum parameters into the query, used where the
+    // placeholder resolves to a list rather than a single value.
     GrpcFacetStatisticsDepthArray facetStatisticsDepthArrayValue = 113;
-    // The query price mode array value.
+    // Binds a list of `GrpcQueryPriceMode` enum parameters into the query, used where the placeholder
+    // resolves to a list rather than a single value.
     GrpcQueryPriceModeArray queryPriceModelArrayValue = 114;
-    // The price content mode array value.
+    // Binds a list of `GrpcPriceContentMode` enum parameters into the query, used where the
+    // placeholder resolves to a list rather than a single value.
     GrpcPriceContentModeArray priceContentModeArrayValue = 115;
-    // The attribute special value array value.
+    // Binds a list of `GrpcAttributeSpecialValue` enum parameters into the query, used where the
+    // placeholder resolves to a list rather than a single value.
     GrpcAttributeSpecialValueArray attributeSpecialArrayValue = 116;
-    // The order direction array value.
+    // Binds a list of `GrpcOrderDirection` enum parameters into the query, used where the placeholder
+    // resolves to a list rather than a single value.
     GrpcOrderDirectionArray orderDirectionArrayValue = 117;
-    // The empty hierarchical entity behaviour array value.
+    // Binds a list of `GrpcEmptyHierarchicalEntityBehaviour` enum parameters into the query, used
+    // where the placeholder resolves to a list rather than a single value.
     GrpcEmptyHierarchicalEntityBehaviourArray emptyHierarchicalEntityBehaviourArrayValue = 118;
-    // The statistics base array value.
+    // Binds a list of `GrpcStatisticsBase` enum parameters into the query, used where the placeholder
+    // resolves to a list rather than a single value.
     GrpcStatisticsBaseArray statisticsBaseArrayValue = 119;
-    // The statistics type array value.
+    // Binds a list of `GrpcStatisticsType` enum parameters into the query, used where the placeholder
+    // resolves to a list rather than a single value.
     GrpcStatisticsTypeArray statisticsTypeArrayValue = 120;
-    // The histogram behavior enum value.
+    // Binds a list of `GrpcHistogramBehavior` enum parameters into the query, used where the
+    // placeholder resolves to a list rather than a single value.
     GrpcHistogramBehaviorTypeArray histogramBehaviorTypeArrayValue = 121;
-    // The scope enum value.
+    // Binds a list of `GrpcEntityScope` enum parameters into the query, e.g. used with constraints
+    // that accept multiple scopes (live, archived) at once.
     GrpcEntityScopeArray scopeArrayValue = 122;
   }
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcSortableAttributeCompoundSchemaMutations.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcSortableAttributeCompoundSchemaMutations.proto
@@ -71,13 +71,23 @@ message GrpcRemoveSortableAttributeCompoundSchemaMutation {
   string name = 1;
 }
 
+// Mutation of a sortable attribute compound schema.
 message GrpcSortableAttributeCompoundSchemaMutation {
+  // Type of the mutation. Exactly one of the following must be set.
   oneof mutation {
+    // Mutation is responsible for setting up a new `SortableAttributeCompoundSchema` in the `EntitySchema`.
     GrpcCreateSortableAttributeCompoundSchemaMutation createSortableAttributeCompoundSchemaMutation = 1;
+    // Mutation is responsible for modifying a deprecation notice of an existing `SortableAttributeCompoundSchema`
+    // in the `EntitySchema`.
     GrpcModifySortableAttributeCompoundSchemaDeprecationNoticeMutation modifySortableAttributeCompoundSchemaDeprecationNoticeMutation = 2;
+    // Mutation is responsible for modifying a description of an existing `SortableAttributeCompoundSchema`
+    // in the `EntitySchema`.
     GrpcModifySortableAttributeCompoundSchemaDescriptionMutation modifySortableAttributeCompoundSchemaDescriptionMutation = 3;
+    // Mutation is responsible for renaming an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
     GrpcModifySortableAttributeCompoundSchemaNameMutation modifySortableAttributeCompoundSchemaNameMutation = 4;
+    // Mutation is responsible for removing an existing `SortableAttributeCompoundSchema` in the `EntitySchema`.
     GrpcRemoveSortableAttributeCompoundSchemaMutation removeSortableAttributeCompoundSchemaMutation = 5;
+    // Mutation is responsible for setting value `SortableAttributeCompoundSchema.indexedInScopes` in the `EntitySchema`.
     GrpcSetSortableAttributeCompoundIndexedMutation setSortableAttributeCompoundIndexedMutation = 6;
   }
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcTrafficRecording.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcTrafficRecording.proto
@@ -9,29 +9,34 @@ import "GrpcEvitaDataTypes.proto";
 import "GrpcEntityMutation.proto";
 import "GrpcEntitySchemaMutation.proto";
 
-// Record for the criteria of the capture request allowing to limit mutations to specific area of interest an its
+// Record for the criteria of the capture request allowing to limit mutations to specific area of interest and its
 // properties.
 message GrpcTrafficRecordingCaptureCriteria {
-  // content determines whether only basic information about the traffic recording is returned or the actual content
+  // Determines whether only basic information about the traffic recording is returned, or the actual event
+  // content as well (see the `body` oneof on `GrpcTrafficRecord`).
   GrpcTrafficRecordingContent content = 1;
-  // since specifies the time from which the traffic recording should be returned
+  // The lower time bound (inclusive) for returned traffic records. If unset, no time-based lower bound is applied.
   GrpcOffsetDateTime since = 2;
-  // sinceSessionSequenceId specifies the session sequence ID from which the traffic recording should be returned
+  // The session sequence ID (see `GrpcTrafficRecord#sessionSequenceOrder`) from which the traffic recording should
+  // be returned (inclusive). If unset, no session-sequence lower bound is applied.
   google.protobuf.Int64Value sinceSessionSequenceId = 3;
-  // sinceRecordSessionOffset specifies the record session offset from which the traffic recording should be returned
-  //                          (the offset is relative to the session sequence ID and starts from 0), offset allows
-  //                          to continue fetching the traffic recording from the last fetched record when session
-  //                          was not fully fetched
+  // The record offset within the session identified by `sinceSessionSequenceId` from which the traffic recording
+  // should be returned (the offset is relative to the session sequence ID and starts from 0); allows continuing to
+  // fetch a session's traffic recording from the last fetched record when the session was not fully fetched in a
+  // previous call. If unset, records are returned from the start of the session.
   google.protobuf.Int32Value sinceRecordSessionOffset = 4;
-  // type specifies the types of traffic recording to be returned
+  // The types of traffic recording to be returned. If empty, records of all types are returned.
   repeated GrpcTrafficRecordingType type = 5;
-  // sessionId specifies the session ID from which the traffic recording should be returned
+  // The session IDs to limit the returned traffic recording to. If empty, records from all sessions are considered.
   repeated GrpcUuid sessionId = 6;
-  // longerThan specifies the minimum duration in milliseconds of the traffic recording to be returned
+  // The minimum duration (milliseconds) the traffic recording operation must have taken to be returned. If unset,
+  // no minimum-duration filter is applied.
   google.protobuf.Int32Value longerThanMilliseconds = 7;
-  // fetchingMoreBytesThan specifies the minimum number of bytes that record should have fetched from the disk
+  // The minimum number of bytes the record must have fetched from the permanent storage to be returned. If unset,
+  // no minimum-size filter is applied.
   google.protobuf.Int32Value fetchingMoreBytesThan = 8;
-  // labels specifies the client labels that the traffic recording must have (both name and value must match)
+  // The client labels the traffic recording must have (both name and value must match). If empty, no label filter
+  // is applied.
   repeated GrpcQueryLabel labels = 9;
 }
 
@@ -57,24 +62,37 @@ message GrpcTrafficRecord {
   int32 ioFetchedSizeBytes = 8;
   // The number of objects fetched from the permanent storage.
   int32 ioFetchCount = 9;
-  // Returns non-null error message if the action the recording relates to finished with an error.
+  // The error message the operation this record represents finished with. If unset, the operation completed
+  // without error.
   google.protobuf.StringValue finishedWithError = 10;
-  // optional body of the traffic recording when it is requested by the GrpcTrafficCaptureContent
+  // The body of the traffic recording, present only when body content was requested via the capture criteria's
+  // `content` field (`TRAFFIC_RECORDING_BODY`); entirely absent when only headers were requested
+  // (`TRAFFIC_RECORDING_HEADER`). When present, exactly one of the following members is set, matching this
+  // record's `type`.
   oneof body {
+    // Present when `type` is `TRAFFIC_RECORDING_MUTATION` - the entity or schema mutation that was executed.
     GrpcTrafficMutationContainer mutation = 101;
+    // Present when `type` is `TRAFFIC_RECORDING_QUERY` - the internal evitaDB query (evitaQL) that was executed.
     GrpcTrafficQueryContainer query = 102;
+    // Present when `type` is `TRAFFIC_RECORDING_ENRICHMENT` - the entity enrichment call that was executed.
     GrpcTrafficEntityEnrichmentContainer enrichment = 103;
+    // Present when `type` is `TRAFFIC_RECORDING_FETCH` - the single entity fetch call that was executed.
     GrpcTrafficEntityFetchContainer fetch = 104;
+    // Present when `type` is `TRAFFIC_RECORDING_SESSION_FINISH` - statistics collected over the closed session.
     GrpcTrafficSessionCloseContainer sessionClose = 105;
+    // Present when `type` is `TRAFFIC_RECORDING_SESSION_START` - metadata about the newly opened session.
     GrpcTrafficSessionStartContainer sessionStart = 106;
+    // Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY` - the raw, unparsed query as received from the client.
     GrpcTrafficSourceQueryContainer sourceQuery = 107;
+    // Present when `type` is `TRAFFIC_RECORDING_SOURCE_QUERY_STATISTICS` - statistics aggregated over all
+    // operations related to a single source query.
     GrpcTrafficSourceQueryStatisticsContainer sourceQueryStatistics = 108;
   }
 }
 
 // This container holds a mutation and its metadata.
 message GrpcTrafficMutationContainer {
-  // The mutation operation.
+  // The mutation operation; exactly one of the following is set.
   oneof mutation {
     // The entity mutation operation.
     GrpcEntityMutation entityMutation = 1;
@@ -150,9 +168,9 @@ message GrpcTrafficSourceQueryContainer {
 message GrpcTrafficSourceQueryStatisticsContainer {
   // The source query id
   GrpcUuid sourceQueryId = 1;
-  // The total number of records returned by the query ({@link EvitaResponse#getRecordData()} size)
+  // The number of records actually returned by the query, i.e. the size of the fetched data chunk after pagination.
   int32 returnedRecordCount = 2;
-  // The total number of records calculated by the query ({@link EvitaResponse#getTotalRecordCount()})
+  // The total number of records matching the query, before pagination is applied.
   int32 totalRecordCount = 3;
 }
 
@@ -176,7 +194,7 @@ enum GrpcTrafficRecordingContent {
 enum GrpcTrafficRecordingType {
   // evitaDB session opened.
   TRAFFIC_RECORDING_SESSION_START = 0;
-  //* evitaDB session closed.
+  // evitaDB session closed.
   TRAFFIC_RECORDING_SESSION_FINISH = 1;
   // Query received via. API from the client - container contains original string of the client query.
   // API might call multiple queries related to the same source query.

--- a/tools/lint-proto.sh
+++ b/tools/lint-proto.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+#
+#
+#                         _ _        ____  ____
+#               _____   _(_) |_ __ _|  _ \| __ )
+#              / _ \ \ / / | __/ _` | | | |  _ \
+#             |  __/\ V /| | || (_| | |_| | |_) |
+#              \___| \_/ |_|\__\__,_|____/|____/
+#
+#   Copyright (c) 2026
+#
+#   Licensed under the Business Source License, Version 1.1 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Lints the gRPC shared module's .proto files with `buf lint` (config:
+# evita_external_api/evita_external_api_grpc/shared/buf.yaml). That file is kept at the Maven
+# module root, NOT under src/main/resources - everything under that tree is packaged as-is into
+# the shipped JAR (alongside the .proto sources themselves, for downstream non-Java clients), and
+# a lint config has no business shipping to consumers of the JAR. `buf.yaml`'s own `modules[].path`
+# points at the actual proto directory a few levels down.
+#
+# Uses the official `bufbuild/buf` Docker image so a local `buf` install isn't required, matching
+# the pattern of the other schema-diff scripts in this directory (diff-openapi-schemas.sh,
+# diff-graphql-schemas.sh).
+#
+# Works on Linux and macOS. Requires: bash, docker.
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration (overridable via environment variables)
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MODULE_DIR="${MODULE_DIR:-${PROJECT_DIR}/evita_external_api/evita_external_api_grpc/shared}"
+
+DOCKER_IMAGE="${DOCKER_IMAGE:-bufbuild/buf:1.72.0}"
+
+# ============================================================================
+# CLI parsing
+# ============================================================================
+
+usage() {
+	cat <<EOF
+Usage: $(basename "$0") [--module-dir DIR]
+
+Runs 'buf lint' against the gRPC shared module, using the buf.yaml at its root (which in turn
+points at the actual .proto directory a few levels down via modules[].path).
+
+Options:
+  --module-dir DIR   Maven module directory containing buf.yaml.
+                      Defaults to: ${MODULE_DIR}
+  -h, --help          Show this help.
+
+Environment overrides: MODULE_DIR, DOCKER_IMAGE.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--module-dir) MODULE_DIR="$2"; shift 2 ;;
+		-h|--help)    usage; exit 0 ;;
+		*) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+	esac
+done
+
+# ============================================================================
+# Prerequisite checks
+# ============================================================================
+
+if ! command -v docker >/dev/null 2>&1; then
+	echo "error: required command 'docker' is not available on PATH" >&2
+	echo "       (alternatively, install buf locally: https://buf.build/docs/cli/installation)" >&2
+	exit 1
+fi
+
+if [[ ! -f "${MODULE_DIR}/buf.yaml" ]]; then
+	echo "error: no buf.yaml found in ${MODULE_DIR}" >&2
+	exit 1
+fi
+
+# ============================================================================
+# Run buf lint via Docker
+# ============================================================================
+
+echo "==> Linting ${MODULE_DIR} (docker image: ${DOCKER_IMAGE})"
+
+set +e
+docker run --rm \
+	--volume "${MODULE_DIR}:/workspace:ro" \
+	--workdir /workspace \
+	"${DOCKER_IMAGE}" \
+	lint
+LINT_EXIT=$?
+set -e
+
+echo "==> buf lint exit code: ${LINT_EXIT} (non-zero means lint violations were found)"
+
+exit "${LINT_EXIT}"


### PR DESCRIPTION
## Summary

Documentation-quality audit of evitaDB's `.proto` surface per #1350: rewrites ~387 weak or
tautological comments across 16 `.proto` files (fields, messages, enums, RPCs) so they hold up
as the primary API reference for non-Java gRPC clients, and adds tooling so the standard is
enforced going forward rather than just this once.

- Establishes `.claude/rules/proto-documentation.md`: conventions for wrapper-type
  (`google.protobuf.*Value`) nullability, units, the two paging models in use (1-indexed
  `pageNumber` vs. 0-indexed `offset`/skip), `oneof` exclusivity, deprecation phrasing, and
  `TOBEDONE #issue (url)` markers instead of bare `TODO`.
- Regenerates the 294 affected generated Java files (comment-only; protoc 3.25.8 via
  `protobuf-maven-plugin`), and fixes the matching hand-written doc on
  `EntitySchemaDescriptor.java#withHierarchy`.
- Also documents `GrpcEvitaAPI.proto`, which the issue's own "worst offenders" table flagged
  but never assigned to a chunk.
- Adds `buf lint` (`evita_external_api_grpc/shared/buf.yaml`, `COMMENTS` ruleset only - the
  broader `STANDARD` ruleset would force renaming ~1000 established camelCase fields that
  mirror the generated Java accessors) via a Docker-based `tools/lint-proto.sh` wrapper, wired
  into `ci-dev.yml` as the first step (before JDK setup/build). `evita*/**/*.proto` was added to
  the workflow's `paths` filter so a proto-only push actually triggers it - note this also means
  a proto-only push now runs the *entire* `ci-dev` pipeline, not just the lint step.
- Adds a Claude Code `PostToolUse` hook (`.claude/hooks/`, `.claude/settings.json`, team-wide)
  that runs the same `buf lint` immediately after Claude edits/writes a `.proto` file, so
  violations surface mid-turn instead of only at CI time. Soft-fails (no block) if Docker isn't
  on `PATH`.

Six real, non-documentation bugs surfaced while tracing semantics for accurate docs were left
unfixed here and posted to #1349 instead, since they're outside this issue's scope.

Closes #1350
Related: #1349

## Test plan

- [x] `mvn generate-sources` regeneration confirmed deterministic (byte-identical baseline
      before any comment edits)
- [x] Full reactor compile clean (`evita_external_api_grpc/shared`, `/server`, `/client`,
      `evita_external_api_core`)
- [x] Field/message/enum/rpc declaration counts diffed before/after per `.proto` file - zero
      structural drift despite ~800 comment lines changed
- [x] `buf lint` (`COMMENTS` ruleset) passes clean (0 violations) across all 33 `.proto` files
- [x] `tools/lint-proto.sh` re-verified against a simulated fresh checkout (`rm -rf target`)
- [x] Confirmed `buf.yaml` is not packaged into the built JAR (`jar tf` after `mvn clean package`)
- [x] Claude Code hook verified through live dispatch: introduced a real violation via the
      `Edit` tool, confirmed it blocked with buf's output, reverted, confirmed silent pass
- [ ] `ci-dev.yml`'s new lint step has not yet run on GitHub Actions (first run happens on this PR)