### PR TITLE
test: quantify the sort-attribute ingest benchmark's fixture with a control

### DIFF
--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/SortAttributeIngestBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/SortAttributeIngestBenchmark.java
@@ -33,6 +33,7 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -60,11 +61,12 @@ import java.util.concurrent.TimeUnit;
  * measured cross-jar against the base engine. It is {@link Mode#SingleShotTime} so entities per second is
  * `entityCount / score`, but at the iteration counts it can afford the wall-clock number is far too noisy to trust
  * (this issue saw ±258 % on `ns/op` against ±0.75 % on allocation in the same run), so **read `gc.alloc.rate.norm`,
- * not the score**, and run with `-prof gc` - reading that figure the way {@link SortAttributeIngestBenchmarkState}
- * prescribes, because the per-invocation fixture's allocation is counted inside it. Note that the CPU-only changes
- * are invisible here: the retained-leaf block search alters no allocation, and resolving the thread's transaction
- * once per positional read removes a single duplicate `ThreadLocal` read that no end-to-end wall-clock measurement
- * can separate from noise - it is kept on strictly-fewer-operations grounds, not on a measured end-to-end delta.
+ * not the score**, and run with `-prof gc` - subtracting {@link #fixtureControl} from it exactly as
+ * {@link SortAttributeIngestBenchmarkState} prescribes, because the per-invocation fixture's allocation is counted
+ * inside the raw figure. Note that the CPU-only changes are invisible here: the retained-leaf block search alters no
+ * allocation, and resolving the thread's transaction once per positional read removes a single duplicate
+ * `ThreadLocal` read that no end-to-end wall-clock measurement can separate from noise - it is kept on
+ * strictly-fewer-operations grounds, not on a measured end-to-end delta.
  *
  * Heap is sized explicitly in the fork arguments on purpose. The profiled process ran without `-Xmx`, so JVM
  * ergonomics handed it 23.4 GiB and it sat at 92 % old-gen occupancy with the young generation squeezed to 320 MB;
@@ -88,6 +90,10 @@ import java.util.concurrent.TimeUnit;
 		"-Xmx8g"
 	}
 )
+// the state is Scope.Benchmark and its fixture is Level.Invocation, so under `-t N` all N threads would create and
+// close the one shared Evita instance concurrently. JMH's command line still wins over this annotation - `-t N`
+// overrides it - so treat it as the declared intent, not as an enforced guard: never pass `-t` to this benchmark.
+@Threads(1)
 public class SortAttributeIngestBenchmark implements EvitaCatalogSetup {
 
 	/**
@@ -111,6 +117,26 @@ public class SortAttributeIngestBenchmark implements EvitaCatalogSetup {
 				}
 			}
 		);
+	}
+
+	/**
+	 * Ingests nothing. This is the **control**: it takes the same state, so JMH runs the same `Level.Invocation`
+	 * fixture and the same `Level.Invocation` teardown around an empty body, and whatever `gc.alloc.rate.norm` it
+	 * reports *is* the fixture cost that {@link #warmUpIngest} also carries.
+	 *
+	 * Subtract it per `distinctValues` value, never pooled across the two - the fixture's own allocation differs
+	 * between them. See {@link SortAttributeIngestBenchmarkState} for the protocol and for what the subtraction
+	 * does and does not remove.
+	 *
+	 * Its **score is meaningless and near zero** - the body really is empty - and that is not evidence the control did
+	 * nothing: the state is `Scope.Benchmark`, so JMH runs `setUp()` and `closeEvita()` around it regardless, which is
+	 * precisely what the reported `gc.alloc.rate.norm` captures. Do not delete this method as a no-op benchmark.
+	 *
+	 * @param state the freshly booted catalog and its product source - built, then deliberately left unused
+	 */
+	@Benchmark
+	public void fixtureControl(SortAttributeIngestBenchmarkState state) {
+		// intentionally empty - the fixture is the measurement
 	}
 
 }

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/state/SortAttributeIngestBenchmarkState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/state/SortAttributeIngestBenchmarkState.java
@@ -94,14 +94,49 @@ import java.util.Random;
  * cursor path, the allocation-free unordered-array guards - so run it with `-prof gc` and compare the normalised
  * allocation rate against the base worktree.
  *
- * **The reported bytes/op is `fixture + ingest`, so compare the ABSOLUTE difference.** `setUp()` is annotated
- * `@Setup(Level.Invocation)` and boots a full Evita instance, defines the schema and materialises the whole batch;
- * JMH's `GCProfiler` snapshots its counters in `beforeIteration` / `afterIteration`, bracketing the entire iteration
- * including per-invocation fixtures, so the fixture's allocation is counted inside the reported figure. The fixture
- * is identical on both sides of the A/B pair and therefore cancels in the **absolute** GB/op difference - that number
- * is trustworthy. The **percentage** is not: its denominator is diluted by fixture allocation, so it understates the
- * change and must never be read as a fraction of the ingest's own allocation. Quantifying the fixture would take a
- * control `@Benchmark` with an empty body taking this same state; no such control exists today.
+ * **Reported bytes/op is `fixture + ingest`; subtract the control to get the ingest alone.** `setUp()` is annotated
+ * `@Setup(Level.Invocation)` and boots a full Evita instance, defines the schema and materialises the whole batch,
+ * and `closeEvita()` is its matching `@TearDown(Level.Invocation)`. JMH's `GCProfiler` is an `InternalProfiler`: it
+ * snapshots the allocation counters in `beforeIteration` / `afterIteration`, which brackets the **entire** iteration
+ * including both per-invocation fixtures, so their allocation lands inside the reported figure.
+ *
+ * `SortAttributeIngestBenchmark.fixtureControl` is what makes that recoverable - it takes this same state and does
+ * nothing, so whatever it reports *is* the fixture. The protocol is
+ *
+ * ```
+ * ingest allocation = warmUpIngest[distinctValues] - fixtureControl[distinctValues]
+ * ```
+ *
+ * with three conditions that are easy to get wrong:
+ *
+ * 1. **Subtract per `distinctValues`; never pool one control across both.** The two settings do not carry the same
+ *    fixture cost. `setAttribute` boxes every low-cardinality `int` and `Integer.valueOf` caches `-128..127`, so at
+ *    `distinctValues = 20` all `entityCount * 40` values are cache hits and allocate nothing, while at 1000 only
+ *    12.8 % of them are. Measured at `entityCount = 20 000`: 1.268 GB/op against 1.257 GB/op - an 11.2 MB gap, which
+ *    is exactly the 697 600 boxes that escape the cache. Pooling would over-subtract one arm and under-subtract the
+ *    other.
+ * 2. **Take the control from the same build as the `warmUpIngest` it is subtracted from**, and say which build that
+ *    was. The fixture itself is stable across an A/B pair - it touches only `evita_api` builders and the engine's
+ *    boot path, neither of which a sort-index change moves - but the percentage's denominator is that one build's
+ *    own `warmUpIngest - fixtureControl`.
+ * 3. **The remainder is the ingest plus a teardown asymmetry.** `closeEvita()` is inside the bracket for both
+ *    methods, but the control closes an *empty* catalog while `warmUpIngest` closes one holding `entityCount`
+ *    entities, so the flush the ingest provokes stays in the remainder. That is where it belongs - the ingest caused
+ *    it - but the remainder is therefore not the `upsertEntity` loop in isolation.
+ *
+ * **Why the batch is still rebuilt every invocation.** The fixture is 1.35 % (`distinctValues = 1000`) and 1.65 %
+ * (`distinctValues = 20`) of the corresponding `warmUpIngest` at `entityCount = 20 000`, and scaling the control from
+ * 5 000 to 20 000 entities shows ~96 % of it is the batch itself (~61 kB per builder against ~49 MB of fixed boot,
+ * schema and empty-catalog close). Memoising the batch across a trial would therefore remove most of the fixture -
+ * but the subtraction above already removes *all* of it, exactly, so hoisting would buy no accuracy while costing the
+ * guarantee that each invocation ingests a batch no previous invocation has touched. The Evita boot cannot leave
+ * `Level.Invocation` at all: a catalog still holding the previous invocation's entities would start with wide sort
+ * blocks and would stop measuring a cold WARM_UP load.
+ *
+ * **Reproducing the #1332 figures.** They were taken with `-p entityCount=5000`, not at the `@Param` default of
+ * 20 000 committed here - the block widths quoted alongside them (~5 and ~250) only follow from 5 000. At that
+ * override this harness reports 26.222 and 22.600 GB/op against the 25.920 and 22.472 recorded there, so it
+ * reproduces to within 1.2 %.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */


### PR DESCRIPTION
Closes #1335

`SortAttributeIngestBenchmark` reports `gc.alloc.rate.norm` as its headline metric, but JMH's `GCProfiler` is an `InternalProfiler`: it snapshots the allocation counters in `beforeIteration` / `afterIteration`, bracketing the entire iteration **including** the `@Setup(Level.Invocation)` fixture and its teardown. The reported bytes/op was therefore `fixture + ingest` — absolute A/B deltas were exact, but percentages carried fixture allocation in the denominator.

## What changed

- **`fixtureControl`** — a second `@Benchmark` with an empty body taking the same state. JMH runs both `Level.Invocation` fixtures around it regardless, so what it reports *is* the fixture. `warmUpIngest − fixtureControl` is the ingest's own allocation.
- **`@Threads(1)`** — documented as declarative only, since JMH's `-t` still overrides an annotation.
- **JavaDoc** — the subtraction protocol, its three conditions, and reproduction instructions.

## GO/NO-GO gate

The issue prescribed running the control *before* changing anything else. Measured at `entityCount = 20 000` (JDK 21.0.11, `-Xmx8g`, `-wi 1 -i 3`, one run so both halves of each subtraction share machine state):

| `distinctValues` | `fixtureControl` | `warmUpIngest` | control share | ingest-only |
|---|---|---|---|---|
| 1000 | 1.268 GB/op | 94.224 GB/op | 1.35 % | 92.956 GB/op |
| 20 | 1.257 GB/op | 76.026 GB/op | 1.65 % | 74.769 GB/op |

The fixture is a small share, so **item 2 of the issue (memoising the entity batch) was declined**: the subtraction already removes all of the fixture, exactly, so hoisting would buy no accuracy — only churn and an uneven first iteration. That holds even though the batch turns out to be ~96 % of the fixture itself.

## Two conditions the issue didn't anticipate

**Subtract per `distinctValues`, never pooled.** `setAttribute` boxes every low-cardinality `int` and `Integer.valueOf` caches `−128..127`, so at `distinctValues = 20` all values are cache hits and allocate nothing, while at 1000 only 12.8 % are. The measured gap between the two controls is 11.165 MB against 11.16 MB predicted from the 697 600 boxes that escape the cache. A pooled control would over-subtract one arm and under-subtract the other.

**The remainder carries a teardown asymmetry.** `closeEvita()` is inside the profiler bracket for both methods, but the control closes an *empty* catalog while `warmUpIngest` closes one holding `entityCount` entities. The flush the ingest provokes stays in the remainder — the right place for it, but the remainder is not the `upsertEntity` loop in isolation.

## Reproducibility finding

The #1332 figures were taken with `-p entityCount=5000`, **not** the committed `@Param` default of 20 000 — the block widths quoted beside them (~5 and ~250) only follow from 5 000. At that override this harness reproduces them to within 1.2 %, which confirms `warmUpIngest` is unchanged by this PR and the recorded absolutes remain valid. PR #1336's body has been updated with the restated ingest-only percentages: **12.92 %** and **15.13 %** (previously 12.76 % and 14.93 % raw).

## Not changed

`SortIndexTimingBenchmark` is affected by the same `GCProfiler` mechanism at a 10:1–100:1 fixture-to-signal ratio, but its fixture cannot be coarsened without letting block widths drift off the scenario definition, so documentation is the whole fix there — and `75cf26b50` already applied it. Its JavaDoc states that only `ns/op` is trustworthy; verified, left alone.
