### PR TITLE
docs: record the configuration the #1332 ingest figures were measured at

### DIFF
--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/SortAttributeIngestBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/SortAttributeIngestBenchmark.java
@@ -103,8 +103,10 @@ import java.util.concurrent.TimeUnit;
 		"-Xmx16g"
 	}
 )
-// pinned, not merely defaulted: the state is Scope.Benchmark and its Level.Invocation fixture creates and closes a
-// whole Evita instance, so a multi-threaded run would have threads booting and closing the same catalog concurrently
+// declared, but NOT enforced: the state is Scope.Benchmark and its Level.Invocation fixture creates and closes a
+// whole Evita instance, so a multi-threaded run would have threads booting and closing the same catalog
+// concurrently. JMH's command line takes precedence over annotations, so `-t N` still overrides this - it records
+// the intent and the reason, it cannot enforce them. Never pass `-t` to this benchmark.
 @Threads(1)
 public class SortAttributeIngestBenchmark implements EvitaCatalogSetup {
 

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/state/SortAttributeIngestBenchmarkState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/state/SortAttributeIngestBenchmarkState.java
@@ -113,6 +113,14 @@ import java.util.Random;
  * the schema definition, because a *cold* WARM_UP catalog is the very thing being measured and cannot be reused
  * across invocations. That residue is what the control quantifies.
  *
+ * **Reproducing the #1332 end-to-end figures.** They were measured with `-p entityCount=5000`, **not** at the
+ * `@Param` default of 20 000 committed here - the block widths quoted alongside them (~5 and ~250) only follow from
+ * 5 000, since block width is `entityCount / distinctValues`. They also predate both the trial-scoped batch and the
+ * 16 GiB heap, each of which moves the reported figure, so they belong to that earlier harness and not to this one.
+ * Restated ingest-only - the raw figure minus the fixture measured on the harness they actually ran on - the #1332
+ * reductions are 12.92 % at `distinctValues = 1000` and 15.13 % at 20. The absolute deltas of -3.792 and
+ * -3.943 GB/op are unchanged either way, because the fixture cancels in a subtraction.
+ *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
 @State(Scope.Benchmark)


### PR DESCRIPTION
Follow-up to `950c803f9`, which closed #1335. Documentation only — no behaviour change, no measurement re-run required to review it.

## The #1332 figures cannot be reproduced from what the harness records

They were measured with `-p entityCount=5000`, **not** the committed `@Param` default of `20000`. The tell is in PR #1336's own table: the block widths quoted there (~5 and ~250) only follow from 5 000, since block width is `entityCount / distinctValues`.

Re-run at that override against the pre-`950c803f9` harness those numbers were actually taken on, they reproduce to within 1.2 % on different hardware:

| `distinctValues` | recorded (#1336) | re-measured |
|---|---|---|
| 1000 | 25.920 GB/op | 26.222 GB/op |
| 20 | 22.472 GB/op | 22.600 GB/op |

At the `20000` default the same benchmark reports 94.224 and 76.026 GB/op — 3.4–3.6× larger, and not comparable to anything in that record.

The note also states what the new control makes computable. Subtracting the fixture measured on the harness those figures ran on (0.354 and 0.351 GB/op), the #1332 reductions restate as **12.92 %** and **15.13 %**, against 12.76 % and 14.93 % raw. The absolute deltas of −3.792 and −3.943 GB/op are unchanged, because the fixture cancels in a subtraction. PR #1336's body has been updated to match.

## `@Threads(1)` is not enforced

The comment added in `950c803f9` says the annotation is "pinned, not merely defaulted". JMH resolves command-line options ahead of annotations, so `-t N` still overrides it. The hazard it describes is real — a `Scope.Benchmark` state whose `Level.Invocation` fixture boots and closes an entire Evita instance — so the comment keeps the intent and the reason, and now says plainly that it records them rather than enforcing them.

## Two observations, not addressed here

Both concern `950c803f9` and are raised for the author rather than changed in this PR:

1. **`-Xmx16g` may be a consequence of the trial-scoped batch rather than an independent requirement.** The commit reports `-Xmx8g` OOM-ing at `distinctValues=1000`; the pre-memoisation harness completed both parameter rows at 8 GiB (94.224 and 76.026 GB/op). Retaining 20 000 builders for a whole trial adds live heap on top of the ingesting catalog, which would explain the difference. Worth confirming, because the commit also notes that the heap change moves GC behaviour (136 collections at 8 GiB vs 80 at 16 GiB) and therefore breaks comparability with every earlier figure.
2. **The fixture is reported at "roughly 1.5 GB" after the batch moved to trial scope.** Measured on the previous harness, the batch was ~96 % of a 1.268 GB fixture (scaling the control from 5 000 to 20 000 entities isolates ~61 kB per builder against ~49 MB of fixed boot, schema and close). Post-memoisation the residue would be expected near ~50 MB, not 1.5 GB.
