### PR TITLE
fix: dev merges never actually cut a release-branch patch

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -156,5 +156,20 @@ jobs:
         # workflows sets it explicitly — matching that convention here too.
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh workflow run ci-release.yml --ref "$RELEASE_BRANCH"
-        echo "Dispatched CI Release branch workflow on $RELEASE_BRANCH"
+        # On the brand-new-branch path above (as opposed to the fast-forward
+        # of an existing branch), this dispatches immediately after the
+        # branch's first-ever push — GitHub's ref index for a just-created
+        # branch could plausibly lag that push by a beat. Retry a few times
+        # rather than fail the whole release on a transient "branch not
+        # found"; this is a bounded wait on GitHub's own eventual
+        # consistency, not a poll for a long-running task.
+        for attempt in 1 2 3 4 5; do
+          if gh workflow run ci-release.yml --ref "$RELEASE_BRANCH"; then
+            echo "Dispatched CI Release branch workflow on $RELEASE_BRANCH"
+            exit 0
+          fi
+          echo "Dispatch attempt $attempt failed, retrying in 3s..."
+          sleep 3
+        done
+        echo "::error::failed to dispatch CI Release branch on $RELEASE_BRANCH after 5 attempts"
+        exit 1

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -151,6 +151,10 @@ jobs:
     - name: Dispatch release build
       env:
         RELEASE_BRANCH: ${{ steps.release_branch.outputs.branch }}
+        # gh does fall back to GITHUB_TOKEN (job-level env, above) when
+        # GH_TOKEN is unset, but every other gh-using step in this repo's
+        # workflows sets it explicitly — matching that convention here too.
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh workflow run ci-release.yml --ref "$RELEASE_BRANCH"
         echo "Dispatched CI Release branch workflow on $RELEASE_BRANCH"

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -24,6 +24,11 @@ jobs:
     permissions:
       # write permission is required to create a github release
       contents: write
+      # required to dispatch the CI Release branch workflow below — a plain
+      # push wouldn't do it: pushes authenticated with the default
+      # GITHUB_TOKEN never trigger downstream `on: push` workflows (GitHub's
+      # anti-recursion guard), `workflow_dispatch` is explicitly exempted
+      actions: write
     outputs:
       released_version: ${{ steps.release_version.outputs.version }}
       release_branch: ${{ steps.release_branch.outputs.branch }}
@@ -64,6 +69,11 @@ jobs:
       run: |
         mvn duplicate-finder:check -pl '!:evita_long_running_tests'
 
+    # Only used below to name the release branch (e.g. "2026.2" -> release_2026-2).
+    # The actual published version (including patch number) is resolved by
+    # CI Release branch itself once dispatched onto that branch — this repo's
+    # pom.xml version never carries a patch number, so it can't tell a first
+    # ".0" cut apart from the Nth hotfix on an already-released minor.
     - name: Resolve new release version
       id: release_version
       run: |
@@ -128,21 +138,19 @@ jobs:
         git push origin "$RELEASE_BRANCH"
         echo "Fast-forwarded release branch: $RELEASE_BRANCH"
 
-    # Create workflow data files for the release workflow
-    - name: Create workflow data files
+    # Dispatch the actual release build onto the release branch. A plain
+    # `git push` above (authenticated with GITHUB_TOKEN) never fires that
+    # workflow's `on: push` trigger — see the `actions: write` permission
+    # comment at the top of this job. `gh workflow run` uses the
+    # `workflow_dispatch` event, which GitHub does not suppress, so this is
+    # the only reliable way to hand off to CI Release branch from here.
+    # It resolves the next patch version itself by scanning existing tags
+    # against the branch it's dispatched onto, so a first-ever cut for a
+    # brand-new release branch and the Nth hotfix on an existing one both
+    # come out correctly versioned without this job needing to know which.
+    - name: Dispatch release build
       env:
         RELEASE_BRANCH: ${{ steps.release_branch.outputs.branch }}
-        RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
       run: |
-        echo "$RELEASE_BRANCH" > release_branch.txt
-        echo "$RELEASE_VERSION" > released_version.txt
-
-    # Upload workflow data for the release workflow
-    - name: Upload workflow data
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: workflow-data
-        path: |
-          release_branch.txt
-          released_version.txt
-        retention-days: 14
+        gh workflow run ci-release.yml --ref "$RELEASE_BRANCH"
+        echo "Dispatched CI Release branch workflow on $RELEASE_BRANCH"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -3,12 +3,17 @@
 name: CI Release branch
 
 on:
-  workflow_run:
-    workflows: ["CI Master branch"]
-    types:
-      - completed
-    branches:
-      - "master"
+  # Dispatched by CI Master branch once it has fast-forwarded (or created)
+  # the target release_* branch — see the "Dispatch release build" step
+  # there. There used to also be a `workflow_run` trigger fired from a
+  # successful "CI Master branch" run, but that path always minted "vX.Y.0"
+  # verbatim from pom.xml, so it could only ever cut a fresh release and
+  # errored out (after an already-completed Maven Central deploy!) on every
+  # later merge onto an already-released minor. workflow_dispatch runs the
+  # same tag-scanning version resolution used below for direct release_*
+  # pushes, so both a brand-new minor and its Nth hotfix are handled by one
+  # unified path.
+  workflow_dispatch:
   push:
     branches:
       - "release_*"
@@ -21,8 +26,10 @@ on:
 
 jobs:
   build:
-    # Run if the master workflow was successful OR if the branch is a release branch
-    if: ${{ github.event.workflow_run.conclusion == 'success' || startsWith(github.ref, 'refs/heads/release_') }}
+    # Guards against workflow_dispatch being fired against a non-release ref
+    # (e.g. manually from the Actions UI) — the version-resolution step below
+    # only makes sense for a release_* branch name.
+    if: startsWith(github.ref, 'refs/heads/release_')
 
     permissions:
       # write permission is required to create a github release
@@ -39,103 +46,92 @@ jobs:
 
     steps:
 
-    - name: Download release branch info
-      uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-      if: ${{ github.event.workflow_run.conclusion == 'success' }}
-      with:
-        workflow: ${{ github.event.workflow_run.workflow_id }}
-        run_id: ${{ github.event.workflow_run.id }}
-        name: workflow-data
-
-    - name: Read release branch name
-      id: read_branch
-      if: ${{ github.event.workflow_run.conclusion == 'success' }}
-      run: |
-        if [ -f "release_branch.txt" ]; then
-          RELEASE_BRANCH=$(cat release_branch.txt)
-          echo "branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
-          echo "Using release branch: $RELEASE_BRANCH"
-        else
-          echo "release_branch.txt not found"
-          exit 1
-        fi
-
-    - name: Read release version
-      id: read_version
-      if: ${{ github.event.workflow_run.conclusion == 'success' }}
-      run: |
-        if [ -f "released_version.txt" ]; then
-          RELEASE_VERSION=$(cat released_version.txt)
-          echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
-          echo "Using release version: $RELEASE_VERSION"
-        else
-          echo "released_version.txt not found"
-          exit 1
-        fi
-
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 checkout sources
       with:
-        ref: ${{ github.event.workflow_run.conclusion == 'success' && steps.read_branch.outputs.branch || github.ref }}
         fetch-depth: 0
         persist-credentials: false
 
     - name: Resolve new release version
       id: release_version
       env:
-        ARTIFACT_VERSION: ${{ steps.read_version.outputs.version }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Check if version was already read from workflow artifact (before checkout wiped it)
-        if [ -n "$ARTIFACT_VERSION" ]; then
-          VERSION="$ARTIFACT_VERSION"
-          echo "Using version from master workflow artifact: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        # Extract version from branch name (e.g., release_2025-7 -> 2025.7).
+        # This runs for every trigger now (workflow_dispatch from CI Master,
+        # or a direct push to a release_* branch) — there is no longer a
+        # shortcut that trusts a pre-computed version, because the only
+        # previous source of one (the pom.xml-derived "vX.Y.0" from CI
+        # Master) can't distinguish a fresh minor from its Nth hotfix.
+        BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+        echo "Branch name: $BRANCH_NAME"
+
+        # Extract major.minor from branch name
+        MAJOR_MINOR=$(echo "$BRANCH_NAME" | sed 's/release_//' | sed 's/-/./')
+        echo "Extracted major.minor: $MAJOR_MINOR"
+
+        git fetch --tags
+
+        # Published versions — git tags on remote.
+        TAG_VERSIONS=$(git tag -l "v${MAJOR_MINOR}.*")
+
+        # Draft versions — releases that have not yet been published, so
+        # their git tag does not exist on remote. Without this, a failed
+        # partial run (draft created, but Maven deploy or asset upload
+        # failed later) would recompute the same version on the next push
+        # and collide with artefacts already deployed to Maven Central.
+        DRAFT_VERSIONS=$(gh api "/repos/${{ github.repository }}/releases?per_page=100" \
+          --jq '.[] | select(.draft == true) | .name, .tag_name' 2>/dev/null \
+          | grep -E "^v${MAJOR_MINOR}\.[0-9]+$" || true)
+
+        ALL_VERSIONS=$(printf "%s\n%s\n" "$TAG_VERSIONS" "$DRAFT_VERSIONS" \
+          | sort -V -u | grep -v '^$' || true)
+        echo "Known versions (tags + drafts):"
+        printf "%s\n" "$ALL_VERSIONS"
+
+        # Extract patch numbers and find the max
+        MAX_PATCH=-1
+        for tag in $ALL_VERSIONS; do
+          PATCH="${tag##*.}"
+          case "$PATCH" in
+            ''|*[!0-9]*) continue ;;
+          esac
+          if [ "$PATCH" -gt "$MAX_PATCH" ]; then
+            MAX_PATCH=$PATCH
+          fi
+        done
+
+        # Increment patch number
+        NEW_PATCH=$((MAX_PATCH + 1))
+        VERSION="v${MAJOR_MINOR}.${NEW_PATCH}"
+        echo "Calculated new version: $VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+        # A MAJOR release is the first (".0") cut for this major.minor — the
+        # only case with a matching GitHub milestone to pull issues from.
+        # Any later merge onto an already-released minor is a patch/hotfix,
+        # regardless of how it got here (workflow_dispatch or a direct push).
+        if [ "$NEW_PATCH" -eq 0 ]; then
+          echo "is_major=true" >> $GITHUB_OUTPUT
         else
-          # Extract version from branch name (e.g., release_2025-7 -> 2025.7)
-          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-          echo "Branch name: $BRANCH_NAME"
+          echo "is_major=false" >> $GITHUB_OUTPUT
+        fi
 
-          # Extract major.minor from branch name
-          MAJOR_MINOR=$(echo "$BRANCH_NAME" | sed 's/release_//' | sed 's/-/./')
-          echo "Extracted major.minor: $MAJOR_MINOR"
-
-          git fetch --tags
-
-          # Published versions — git tags on remote.
-          TAG_VERSIONS=$(git tag -l "v${MAJOR_MINOR}.*")
-
-          # Draft versions — releases that have not yet been published, so
-          # their git tag does not exist on remote. Without this, a failed
-          # partial run (draft created, but Maven deploy or asset upload
-          # failed later) would recompute the same version on the next push
-          # and collide with artefacts already deployed to Maven Central.
-          DRAFT_VERSIONS=$(gh api "/repos/${{ github.repository }}/releases?per_page=100" \
-            --jq '.[] | select(.draft == true) | .name, .tag_name' 2>/dev/null \
-            | grep -E "^v${MAJOR_MINOR}\.[0-9]+$" || true)
-
-          ALL_VERSIONS=$(printf "%s\n%s\n" "$TAG_VERSIONS" "$DRAFT_VERSIONS" \
-            | sort -V -u | grep -v '^$' || true)
-          echo "Known versions (tags + drafts):"
-          printf "%s\n" "$ALL_VERSIONS"
-
-          # Extract patch numbers and find the max
-          MAX_PATCH=-1
-          for tag in $ALL_VERSIONS; do
-            PATCH="${tag##*.}"
-            case "$PATCH" in
-              ''|*[!0-9]*) continue ;;
-            esac
-            if [ "$PATCH" -gt "$MAX_PATCH" ]; then
-              MAX_PATCH=$PATCH
-            fi
-          done
-
-          # Increment patch number
-          NEW_PATCH=$((MAX_PATCH + 1))
-          VERSION="v${MAJOR_MINOR}.${NEW_PATCH}"
-          echo "Calculated new version: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        # Whether this major.minor is the highest one with any release at
+        # all — used below to decide the GitHub "latest" flag. Previously
+        # that was inferred from `github.ref_name == 'master'`, which only
+        # a first-ever ".0" cut (via the now-removed workflow_run path) could
+        # satisfy; a hotfix on the current line would wrongly fall back to
+        # "legacy" and stop showing as the latest release.
+        HIGHEST_MAJOR_MINOR=$(git tag -l 'v*' \
+          | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+          | sed -E 's/^v([0-9]+\.[0-9]+)\.[0-9]+$/\1/' \
+          | sort -V -u | tail -1)
+        HIGHEST_OF_BOTH=$(printf "%s\n%s\n" "$HIGHEST_MAJOR_MINOR" "$MAJOR_MINOR" | sort -V -u | tail -1)
+        if [ "$HIGHEST_OF_BOTH" = "$MAJOR_MINOR" ]; then
+          echo "is_latest_line=true" >> $GITHUB_OUTPUT
+        else
+          echo "is_latest_line=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Setup Java JDK
@@ -204,7 +200,7 @@ jobs:
       continue-on-error: true
       env:
         VERSION: ${{ steps.release_version.outputs.version }}
-        IS_MAJOR: ${{ github.event.workflow_run.conclusion == 'success' }}
+        IS_MAJOR: ${{ steps.release_version.outputs.is_major }}
       run: |
         # Highest v* tag strictly less than VERSION, by semantic version sort.
         PREV=$( (git tag -l 'v*'; printf "%s\n" "$VERSION") \
@@ -215,8 +211,8 @@ jobs:
         echo "prev_tag=$PREV" >> $GITHUB_OUTPUT
         echo "Resolved previous tag: ${PREV:-<none>}"
 
-        # Milestone is only set for MAJOR releases (triggered by workflow_run
-        # from CI Master); patch releases use commit-only mode.
+        # Milestone is only set for MAJOR releases (the first ".0" cut of a
+        # major.minor); patch/hotfix releases use commit-only mode.
         if [ "$IS_MAJOR" = "true" ]; then
           MILESTONE="${VERSION#v}"
           MILESTONE="${MILESTONE%.0}"
@@ -263,8 +259,8 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         VERSION: ${{ steps.release_version.outputs.version }}
-        COMMITISH: ${{ github.event.workflow_run.conclusion == 'success' && steps.read_branch.outputs.branch || github.ref }}
-        MAKE_LATEST: ${{ github.ref_name == 'master' && 'true' || 'legacy' }}
+        COMMITISH: ${{ github.ref }}
+        MAKE_LATEST: ${{ steps.release_version.outputs.is_latest_line == 'true' && 'true' || 'legacy' }}
         SKELETON_OK: ${{ steps.skeleton.outcome == 'success' }}
       run: |
         # GitHub API wants a plain branch name, not a full `refs/heads/*` ref.

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -80,9 +80,19 @@ jobs:
         # partial run (draft created, but Maven deploy or asset upload
         # failed later) would recompute the same version on the next push
         # and collide with artefacts already deployed to Maven Central.
-        DRAFT_VERSIONS=$(gh api "/repos/${{ github.repository }}/releases?per_page=100" \
-          --jq '.[] | select(.draft == true) | .name, .tag_name' 2>/dev/null \
-          | grep -E "^v${MAJOR_MINOR}\.[0-9]+$" || true)
+        # The `gh api` call is intentionally allowed to fail the step (no
+        # `2>/dev/null`/`|| true` around it) — a silent API error here would
+        # otherwise look identical to "no drafts exist" and risk exactly the
+        # collision this is meant to prevent. Only the grep's own "no match"
+        # exit (1, when there are legitimately no matching drafts) is
+        # tolerated, and separately from the API call.
+        DRAFT_VERSIONS_RAW=$(gh api "/repos/${{ github.repository }}/releases?per_page=100" \
+          --jq '.[] | select(.draft == true) | .name, .tag_name')
+        # MAJOR_MINOR's dot is escaped for regex use — unescaped, it matches
+        # any character, so e.g. "2026.2" would also match a stray tag like
+        # "v2026X2.5".
+        DRAFT_VERSIONS=$(printf '%s\n' "$DRAFT_VERSIONS_RAW" \
+          | grep -E "^v${MAJOR_MINOR//./\\.}\.[0-9]+$" || true)
 
         ALL_VERSIONS=$(printf "%s\n%s\n" "$TAG_VERSIONS" "$DRAFT_VERSIONS" \
           | sort -V -u | grep -v '^$' || true)

--- a/documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md
+++ b/documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md
@@ -1,7 +1,7 @@
 ---
 title: Route release cuts through workflow_dispatch on the release_* branch, not workflow_run from master
 date: 2026-08-02
-updated: 2026-08-02 21:30
+updated: 2026-08-02 21:25
 status: accepted
 kind: infrastructure
 issues: [1359]
@@ -109,6 +109,11 @@ exactly what made the `workflow_run` side silently wrong (it never scanned tags)
   and no release is cut. This was already true before this change; it now matters more because the
   dispatch path is the *only* route to a release. Left as-is — a docs-only or tooling-only merge
   genuinely doesn't warrant a release — but recorded here so it reads as a decision, not an oversight.
+- `tools/list-commits.sh` was silently dropping `perf:`-prefixed conventional commits from patch-mode
+  release notes — they matched its type regex but the categorisation `case` statement had no branch
+  for them (major-mode releases never noticed, since `list-issues.sh` catches performance work via
+  the `performance` issue label instead). Found while curating this hotfix's own release notes by
+  hand; fixed alongside this change by routing `perf` into the same bucket as `feat`.
 
 ### The `MAKE_LATEST` bug this also fixes
 
@@ -140,11 +145,6 @@ published `v*` tags instead of trusting the ref name.
 
 - The first `dev` → `master` merge after this lands is the first real exercise of the new path;
   watch its `CI Master branch` and `CI Release branch` runs directly rather than assuming success.
-- `tools/list-commits.sh` silently drops `perf:`-prefixed conventional commits — they match its type
-  regex but the categorisation `case` statement has no branch for them, so they vanish from patch-mode
-  release notes entirely (major-mode releases don't notice because `list-issues.sh` catches
-  performance work via the `performance` issue label instead). Found while curating this hotfix's
-  release notes by hand; not fixed here — reported separately.
 
 ## Timeline
 

--- a/documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md
+++ b/documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md
@@ -1,0 +1,152 @@
+---
+title: Route release cuts through workflow_dispatch on the release_* branch, not workflow_run from master
+date: 2026-08-02
+updated: 2026-08-02 21:30
+status: accepted
+kind: infrastructure
+issues: [1359]
+prs: []
+areas: [.github/workflows]
+supersedes: []
+superseded-by: []
+relates: []
+---
+
+# Route release cuts through workflow_dispatch on the release_* branch, not workflow_run from master
+
+`CI Master branch` no longer hands off to `CI Release branch` via a `workflow_run` trigger. It now
+fast-forwards (or creates) the target `release_*` branch as before, then explicitly dispatches
+`CI Release branch` on that branch with `gh workflow run`. The dispatched run resolves its own
+version by scanning existing tags for that major.minor — the same logic that already handled direct
+hotfix pushes to a release branch — so both a brand-new minor and the Nth patch on an
+already-released one are versioned correctly by one unified path.
+
+## Why
+
+Investigating whether merging `dev` → `master` would produce a `2026.2.1` hotfix (`dev`'s `pom.xml`
+was still `2026.2-SNAPSHOT`, unchanged since `v2026.2.0` shipped) surfaced that the answer was no —
+and that the pipeline had **no working mechanism at all** for cutting a patch release from a
+`dev` → `master` merge. It only ever looked like one existed because every `v2026.1.x` hotfix
+(twenty of them) was actually produced by a human merging a fix PR **directly onto**
+`release_2026-1`, never through `master`.
+
+### Previous state
+
+`ci-master.yml` fast-forwarded (or created) the release branch with a plain `git push`, authenticated
+by the default `GITHUB_TOKEN` (no `persist-credentials: false` override). GitHub does not trigger
+downstream `on: push` workflows from `GITHUB_TOKEN`-authored pushes — an anti-recursion guard — so
+that push never fired `ci-release.yml`'s `push: branches: [release_*]` trigger. The only trigger that
+*did* fire, `workflow_run` (from a successful `CI Master branch` run), computed the release version
+by stripping `-SNAPSHOT` off `pom.xml` and always appending `.0` — never scanning existing tags. That
+path could only ever mint a fresh `.0` cut; any second merge onto an already-released minor would
+recompute the same already-published version and hit the "release already exists — refusing to
+overwrite" guard, but only *after* `mvn deploy` had already re-attempted publishing that version to
+Maven Central.
+
+**Falsifying evidence** (this is what overturned the initial "it'll just make v2026.2.1" read):
+- `v2026.1.5` is reachable from `origin/release_2026-1` but not from `origin/master`
+  (`git branch -r --contains v2026.1.5`) — proof the 2026.1.x hotfixes never touched master.
+- `gh run list --workflow="CI Release branch"` shows **zero** `push`-triggered runs against
+  `release_2026-2`, ever — proof the fast-forward push never fired anything.
+- `release_2026-2`, `origin/master`, and tag `v2026.2.0` were all still the same commit days after
+  two further PRs (#1329, #1331) merged to master — proof nothing re-triggered after the first cut.
+
+## Options considered
+
+### Option A — dispatch `workflow_dispatch` from `ci-master.yml` onto the release branch (chosen)
+
+`workflow_dispatch` (and `repository_dispatch`) are explicitly exempted from GitHub's
+`GITHUB_TOKEN` anti-recursion suppression, so `gh workflow run ci-release.yml --ref <branch>` reaches
+the target workflow reliably without any new credentials. It also lets `ci-release.yml` collapse to a
+single version-resolution path (tag-scan by branch name) instead of the previous dual-path
+(trusted-artifact vs. tag-scan), removing the class of bug this ADR fixes.
+
+- **Pros:** no new secret to provision; unifies first-cut and hotfix under one code path; keeps the
+  release branch as the sole thing being built (no artifact hand-off to trust).
+- **Cons:** requires `permissions: actions: write` on the `CI Master branch` job; the repository's
+  default branch must carry the `workflow_dispatch:` trigger definition for `gh workflow run` to
+  find it at all — true here since `dev` (this repo's default branch) always merges into `dev` before
+  reaching `master`.
+
+### Option B — authenticate the fast-forward push with a real token (declined)
+
+Store a PAT or GitHub App installation token as a secret and use it for `actions/checkout`/`git push`
+in `ci-master.yml`, so the existing `push: branches: [release_*]` trigger fires normally.
+
+- **Pros:** no change needed to `ci-release.yml` at all.
+- **Rejected because:** requires provisioning and rotating a new credential outside version control
+  — Claude Code cannot create repository secrets, only the repository owner can. `workflow_dispatch`
+  achieves the same result with zero new secrets.
+
+## Decision
+
+**Chosen: Option A.** It fixes the trigger gap with a workflow-only change, and forces
+`ci-release.yml`'s version resolution down to one path instead of two — the two-path version was
+exactly what made the `workflow_run` side silently wrong (it never scanned tags) while the
+`push`-triggered side was silently unreachable from `master`.
+
+## Key technical details
+
+- `.github/workflows/ci-master.yml` — `Resolve new release version` still computes `vX.Y.0` from
+  `pom.xml`, but purely to derive the release branch name (`Determine release branch name`); it is no
+  longer read anywhere as the actual version to publish. `Dispatch release build` is the new final
+  step.
+- `.github/workflows/ci-release.yml` — `on:` is now `workflow_dispatch` + the pre-existing `push:
+  branches: [release_*]`; the job-level `if` is just `startsWith(github.ref, 'refs/heads/release_')`.
+  `Resolve new release version` always tag-scans; it now also emits `is_major` (true only when the
+  resolved patch is `0`) and `is_latest_line` (true when this major.minor is the highest of any
+  published release).
+- `IS_MAJOR` (gates whether `list-issues.sh` pulls from a GitHub milestone) now reads
+  `steps.release_version.outputs.is_major` instead of the removed `workflow_run` check.
+- `MAKE_LATEST` now reads `steps.release_version.outputs.is_latest_line` instead of
+  `github.ref_name == 'master'` — see below, this is a second, related bug fix riding along.
+- `docker-latest.yml`'s `workflow_run: workflows: ['CI Release branch']` trigger is unaffected: it
+  subscribes to that workflow's completion regardless of what triggered it, so it still fires whether
+  `ci-release.yml` ran via `push` or `workflow_dispatch`.
+- **Known limitation, kept deliberately:** `ci-master.yml`'s `push` trigger still carries a `paths:`
+  filter (`evita*/**/*.java`, `evita*/**/pom.xml`, …). A `dev` → `master` merge touching only
+  `documentation/**` or `tools/**` will not trigger `CI Master branch` at all, so nothing dispatches
+  and no release is cut. This was already true before this change; it now matters more because the
+  dispatch path is the *only* route to a release. Left as-is — a docs-only or tooling-only merge
+  genuinely doesn't warrant a release — but recorded here so it reads as a decision, not an oversight.
+
+### The `MAKE_LATEST` bug this also fixes
+
+`MAKE_LATEST` used to be `github.ref_name == 'master' && 'true' || 'legacy'`. That was only ever true
+via the (broken) `workflow_run` path, whose `github.ref_name` mirrors the run that triggered it
+(`push` to `master`). Once release cuts run against a `release_*` ref instead, `github.ref_name` is
+never literally `master`, so every future release — including a hotfix on the *current* line, e.g.
+`v2026.2.1` — would have been marked `legacy` and stopped showing as the GitHub-visible latest
+release. Fixed by comparing this release's major.minor against the highest major.minor among all
+published `v*` tags instead of trusting the ref name.
+
+## Verification
+
+- `documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md` fixture scripts (not
+  committed — ad hoc bash extracted from the workflow's own tag-scan logic) exercised: a hotfix onto
+  an already-`.0`-tagged minor → correct `N+1` patch, `is_major=false`; a brand-new minor with no
+  prior tags → `.0`, `is_major=true`; a second hotfix on top of the first → `N+2`; the pre-existing
+  direct-push-to-`release_2026-1` path → unchanged `v2026.1.21`; a draft-but-untagged patch left by a
+  failed prior run → correctly skipped over.
+- `is_latest_line` fixture-tested against the repo's real tag set: `release_2026-2` (current line) →
+  `true`; `release_2026-1` (superseded) → `false`; a hypothetical new `release_2026-3` → `true`; an
+  old `release_2025-3` → `false`.
+- Both workflow YAML files parse (`yaml.safe_load`); `actionlint` was not available locally to
+  validate GitHub Actions expression semantics beyond plain YAML syntax.
+- Not verified end-to-end against live GitHub Actions (would require pushing and observing a real
+  dispatch) — the first real release cut after this merges is the actual integration test.
+
+## Consequences & open follow-ups
+
+- The first `dev` → `master` merge after this lands is the first real exercise of the new path;
+  watch its `CI Master branch` and `CI Release branch` runs directly rather than assuming success.
+- `tools/list-commits.sh` silently drops `perf:`-prefixed conventional commits — they match its type
+  regex but the categorisation `case` statement has no branch for them, so they vanish from patch-mode
+  release notes entirely (major-mode releases don't notice because `list-issues.sh` catches
+  performance work via the `performance` issue label instead). Found while curating this hotfix's
+  release notes by hand; not fixed here — reported separately.
+
+## Timeline
+
+- **2026-08-02** — investigated why `dev` → `master` wouldn't produce `2026.2.1`; found the trigger
+  gap; implemented and verified the `workflow_dispatch` fix.

--- a/documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md
+++ b/documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md
@@ -1,7 +1,7 @@
 ---
 title: Route release cuts through workflow_dispatch on the release_* branch, not workflow_run from master
 date: 2026-08-02
-updated: 2026-08-02 21:25
+updated: 2026-08-02 21:35
 status: accepted
 kind: infrastructure
 issues: [1359]
@@ -114,6 +114,16 @@ exactly what made the `workflow_run` side silently wrong (it never scanned tags)
   for them (major-mode releases never noticed, since `list-issues.sh` catches performance work via
   the `performance` issue label instead). Found while curating this hotfix's own release notes by
   hand; fixed alongside this change by routing `perf` into the same bucket as `feat`.
+- Two review-caught fixes to pre-existing code this PR moved but didn't originally introduce, both in
+  `Resolve new release version`: the draft-release regex match on `MAJOR_MINOR` treated its literal
+  `.` as a regex wildcard (now escaped, so a stray tag can't false-positive-match); and a `gh api`
+  failure listing draft releases was silently swallowed (`2>/dev/null ... || true` around the whole
+  pipeline) and would have looked identical to "no drafts exist" — now only the grep's own
+  legitimate no-match case is tolerated, and a real API failure aborts the step. Both mattered more
+  once this became the sole release-resolution path.
+- `Dispatch release build` retries `gh workflow run` a few times on failure — for a genuinely new
+  release branch (not the fast-forward case), GitHub's API index for the just-pushed ref could
+  plausibly lag by a beat, so this guards against a spurious "branch not found" on that path.
 
 ### The `MAKE_LATEST` bug this also fixes
 

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,8 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-02 | [Keep IDEA and Claude formatting in step with a shared .editorconfig and a diff-scoped hook, not Spotless](2026-08-02-editorconfig-formatting-parity.md) | infrastructure | accepted | — |
+| 2026-08-02 | [Route release cuts through workflow_dispatch on the release_* branch, not workflow_run from master](2026-08-02-ci-release-pipeline-patch-versioning-fix.md) | infrastructure | accepted | #1359 |
+| 2026-08-02 | [Keep IDEA and Claude formatting in step with a shared .editorconfig and a diff-scoped hook, not Spotless](2026-08-02-editorconfig-formatting-parity.md) | infrastructure | accepted | #1119 |
 | 2026-08-01 | [Answer the B+ tree insert-boundary asserts from the descent instead of a captured cursor path](2026-08-01-bplustree-cursor-free-insert-path.md) | optimization | accepted | #1333, PR #1356 |
 | 2026-07-31 | [Take the four contained bulk-ingest wins, reject the two that trade an invariant or add complexity, and defer the one worth more than all of them](2026-07-31-bulk-ingest-write-path.md) | optimization | accepted | #1342, PR #1348 |
 | 2026-07-27 | [Cut commit-merge latency and write-path allocation by pruning the trunk merge, not inverting it](2026-07-27-write-path-performance-tuning/) | optimization | accepted | #760, PR #1317, PR #1298 |

--- a/tools/list-commits.sh
+++ b/tools/list-commits.sh
@@ -109,7 +109,9 @@ while IFS='|||' read -r subject body; do
 
     # Store in appropriate array (using description as key for deduplication)
     case "$commit_type" in
-      feat)
+      feat|perf)
+        # perf: shares the Features bucket with feat: — matches list-issues.sh,
+        # where issues labeled "performance" also land under Features.
         feat_commits["$commit_desc"]="$entry"
         ;;
       fix)


### PR DESCRIPTION
## Summary

Investigating whether merging `dev` → `master` would produce a `v2026.2.1` hotfix found that the
release pipeline has **no working mechanism** for cutting a patch release from a `dev` → `master`
merge — every `v2026.1.x` hotfix (twenty of them) was actually produced by merging a fix PR directly
onto `release_2026-1`, never through `master`. Full investigation and decision: `documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md`.

- `CI Master branch`'s fast-forward push to the release branch is authenticated with the default
  `GITHUB_TOKEN`, which GitHub never lets trigger downstream `on: push` workflows. The only trigger
  that did fire, `workflow_run`, always minted `vX.Y.0` verbatim from `pom.xml` without scanning
  existing tags — it could only ever cut a fresh `.0`, and would fail (after an already-completed
  `mvn deploy` to Maven Central!) on any later merge onto an already-released minor.
- `CI Master branch` now explicitly dispatches `CI Release branch` onto the release branch via
  `gh workflow run` (`workflow_dispatch` is exempt from the `GITHUB_TOKEN` anti-recursion
  suppression). `CI Release branch` collapses to one tag-scanning version-resolution path that
  correctly handles both a fresh `.0` cut and the Nth hotfix.
- Also fixes a related latent bug: `MAKE_LATEST` depended on `github.ref_name == 'master'`, which
  would have wrongly marked every future hotfix on the current release line as `legacy` instead of
  the visible latest release, once cuts run against `release_*` refs instead.
- Fixes `tools/list-commits.sh` silently dropping `perf:`-prefixed commits from patch-mode release
  notes (matched by its type regex but uncaught by the categorization `case`), found while curating
  this hotfix's own release notes by hand.

## Test plan

- [x] Fixture-tested the tag-scanning version resolution against the real repo's tag set (fresh
      minor, hotfix on an already-`.0`-tagged minor, second hotfix, unchanged direct-push-to-branch
      path, draft-but-untagged partial-run recovery)
- [x] Fixture-tested `is_latest_line` against the real tag set (current line, superseded line,
      hypothetical new minor, old line)
- [x] Both workflow YAML files parse (`yaml.safe_load`)
- [x] `tools/list-commits.sh` re-run against `dev` since `v2026.2.0` — all 15 `perf:` commits now
      appear under Features
- [ ] Not verified end-to-end against live GitHub Actions — the first real `dev` → `master` merge
      after this lands is the actual integration test; watch its `CI Master branch` /
      `CI Release branch` runs directly

Closes #1359