### PR TITLE
fix: dispatch DockerHub-deploy explicitly instead of the broken workflow_run cascade

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -34,6 +34,10 @@ jobs:
     permissions:
       # write permission is required to create a github release
       contents: write
+      # required to dispatch DockerHub-deploy below — see the "Dispatch
+      # Docker publish" step's comment for why a plain workflow_run listener
+      # doesn't work here
+      actions: write
 
     outputs:
       release_id: ${{ steps.create_release.outputs.id }}
@@ -394,6 +398,40 @@ jobs:
       with:
         name: version.txt
         path: 'version.txt'
+
+    # DockerHub-deploy used to pick this run up via a `workflow_run` listener
+    # on this workflow's completion — that only fires reliably when this
+    # run's own actor is a human (e.g. a direct push to a release_* branch).
+    # When CI Master branch dispatched this very run via `gh workflow run`
+    # (GITHUB_TOKEN-authored, the standard dev -> master path), its actor is
+    # `github-actions[bot]` and GitHub's anti-recursion rule blocks that
+    # completion from cascading further — only workflow_dispatch/
+    # repository_dispatch are exempted, and only for one hop. Dispatch it
+    # explicitly instead (same mechanism as the CI Master hand-off, applied
+    # one hop further), passing this run's own id so it pulls the artifacts
+    # just uploaded above rather than the release's zip asset — the release
+    # is typically still a draft at this point (publishing happens later,
+    # separately) and a draft has no real downloadable git tag yet. Placed
+    # ahead of the enrichment tail below (not gated on it) so a Claude
+    # enrichment failure can never delay or block the Docker publish.
+    - name: Dispatch Docker publish
+      if: success()
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ steps.release_version.outputs.version }}
+        THIS_RUN_ID: ${{ github.run_id }}
+      run: |
+        for attempt in 1 2 3 4 5; do
+          if gh workflow run docker-latest.yml --repo "${{ github.repository }}" --ref master \
+               -f version="$VERSION" -f run_id="$THIS_RUN_ID" -f push_latest=auto; then
+            echo "Dispatched DockerHub-deploy for $VERSION (run $THIS_RUN_ID)"
+            exit 0
+          fi
+          echo "Dispatch attempt $attempt failed, retrying in 3s..."
+          sleep 3
+        done
+        echo "::error::failed to dispatch DockerHub-deploy for $VERSION after 5 attempts"
+        exit 1
 
     # Cache the Claude Code CLI binary so we don't re-download it on every
     # release run. The cache key is pinned to CLAUDE_CODE_VERSION below; bump

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -363,10 +363,11 @@ jobs:
     # deploy to Central + draft release both already happened above) and are
     # placed ahead of the release-notes enrichment block below on purpose:
     # enrichment is best-effort, but a hard failure anywhere still taints the
-    # job's overall conclusion, and the Docker publish workflow only triggers
-    # on a successful conclusion. Uploading the release-completing assets
-    # first means a failure in the enrichment tail can no longer prevent the
-    # release from being usable or block the Docker publish.
+    # job's overall conclusion, and the "Dispatch Docker publish" step further
+    # below is itself gated on `if: success()`. Uploading the release-
+    # completing assets first means a failure in the enrichment tail can no
+    # longer prevent the release from being usable or block the Docker
+    # publish.
     - name: Upload dist.zip to release
       uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
       if: success()

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -3,20 +3,34 @@
 name: DockerHub-deploy
 
 on:
-  workflow_run:
-    workflows: ['CI Release branch']                     # runs after CI workflow
-    types:
-      - completed
-  # Manual recovery / re-run path. Use when the upstream CI Release run failed
-  # late (e.g. release-drafter step failed, no workflow artifacts uploaded) but
-  # you have already manually created the GitHub release with `dist.zip`. The
-  # workflow downloads `dist.zip` from the release asset, extracts the JAR,
-  # and proceeds as in the normal flow.
+  # There used to also be a `workflow_run: workflows: ['CI Release branch']`
+  # trigger here. Removed: it only fires reliably when that run's own actor
+  # is a human (e.g. a direct push to a release_* branch) — when CI Master
+  # branch dispatches CI Release branch via `gh workflow run`
+  # (GITHUB_TOKEN-authored, the standard dev -> master path), the resulting
+  # run's actor is `github-actions[bot]`, and GitHub's anti-recursion rule
+  # blocks that run's completion from cascading into further automatic
+  # triggers — only workflow_dispatch/repository_dispatch are exempted, and
+  # only for one hop. CI Release branch now explicitly dispatches this
+  # workflow itself (same mechanism, applied one hop further), passing its
+  # own run_id so this can pull evita-server.jar/version.txt as workflow
+  # artifacts instead of from the release's zip asset — the release is
+  # typically still a draft at that point (publishing happens later,
+  # separately), and a draft release has no real downloadable git tag yet.
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release tag (e.g. v2025.7.18) — must already be a published GitHub release with the evitaDB-<version>.zip asset.'
+        description: 'Release tag (e.g. v2025.7.18).'
         required: true
+        type: string
+      run_id:
+        description: >-
+          Run id of the CI Release branch run to pull evita-server.jar/version.txt
+          artifacts from. Leave empty to instead download dist.zip from the
+          (already published) GitHub release for "version" — the original
+          manual-recovery path.
+        required: false
+        default: ''
         type: string
       push_latest:
         description: 'Force the :latest decision instead of auto-computing it. "auto" (default) pushes :latest when this version is the newest known release line (by YYYY.MM); "true"/"false" override that.'
@@ -30,13 +44,11 @@ on:
 
 permissions:
   contents: read          # Required for actions/checkout to read the repository
-  actions: read           # Required to download artifacts from the triggering workflow
+  actions: read           # Required to download artifacts from the dispatching workflow's run
 
 jobs:
   on-success:
     runs-on: ubuntu-latest
-    # workflow_dispatch always runs; workflow_run only runs on upstream success.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -54,32 +66,32 @@ jobs:
       - name: Resolve build inputs
         id: inputs
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSION: ${{ inputs.version }}
+          INPUT_RUN_ID: ${{ inputs.run_id }}
           INPUT_PUSH_LATEST: ${{ inputs.push_latest }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "source=release_asset" >> "$GITHUB_OUTPUT"
-            echo "version_tag=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
-            echo "push_latest_override=$INPUT_PUSH_LATEST" >> "$GITHUB_OUTPUT"
-          else
+          echo "version_tag=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "push_latest_override=$INPUT_PUSH_LATEST" >> "$GITHUB_OUTPUT"
+          if [ -n "$INPUT_RUN_ID" ]; then
             echo "source=workflow_artifact" >> "$GITHUB_OUTPUT"
-            echo "push_latest_override=auto" >> "$GITHUB_OUTPUT"
+            echo "run_id=$INPUT_RUN_ID" >> "$GITHUB_OUTPUT"
+          else
+            echo "source=release_asset" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Download a JAR file to deploy # download `evita-server.jar` artifact if the workflow we react to was successful
+      - name: Download a JAR file to deploy # download `evita-server.jar` artifact from the dispatching run
         if: steps.inputs.outputs.source == 'workflow_artifact'
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
-          run_id: ${{ github.event.workflow_run.id }}
+          run_id: ${{ steps.inputs.outputs.run_id }}
           name: evita-server.jar
           path: docker
 
-      - name: Download a version information # download `version.txt` artifact if the workflow we react to was successful
+      - name: Download a version information # download `version.txt` artifact from the dispatching run
         if: steps.inputs.outputs.source == 'workflow_artifact'
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
-          run_id: ${{ github.event.workflow_run.id }}
+          run_id: ${{ steps.inputs.outputs.run_id }}
           name: version.txt
 
       # Recovery path: pull dist.zip from the release, extract evita-server.jar

--- a/documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md
+++ b/documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md
@@ -1,10 +1,10 @@
 ---
 title: Route release cuts through workflow_dispatch on the release_* branch, not workflow_run from master
 date: 2026-08-02
-updated: 2026-08-02 21:35
+updated: 2026-08-02 22:50
 status: accepted
 kind: infrastructure
-issues: [1359]
+issues: [1359, 1362]
 prs: []
 areas: [.github/workflows]
 supersedes: []
@@ -100,9 +100,9 @@ exactly what made the `workflow_run` side silently wrong (it never scanned tags)
   `steps.release_version.outputs.is_major` instead of the removed `workflow_run` check.
 - `MAKE_LATEST` now reads `steps.release_version.outputs.is_latest_line` instead of
   `github.ref_name == 'master'` — see below, this is a second, related bug fix riding along.
-- `docker-latest.yml`'s `workflow_run: workflows: ['CI Release branch']` trigger is unaffected: it
-  subscribes to that workflow's completion regardless of what triggered it, so it still fires whether
-  `ci-release.yml` ran via `push` or `workflow_dispatch`.
+- `docker-latest.yml`'s `workflow_run: workflows: ['CI Release branch']` trigger turned out **not**
+  to be unaffected — see "The DockerHub-deploy cascade this also breaks" below. First assumed
+  harmless here; the first live run proved otherwise the same day.
 - **Known limitation, kept deliberately:** `ci-master.yml`'s `push` trigger still carries a `paths:`
   filter (`evita*/**/*.java`, `evita*/**/pom.xml`, …). A `dev` → `master` merge touching only
   `documentation/**` or `tools/**` will not trigger `CI Master branch` at all, so nothing dispatches
@@ -135,6 +135,36 @@ never literally `master`, so every future release — including a hotfix on the 
 release. Fixed by comparing this release's major.minor against the highest major.minor among all
 published `v*` tags instead of trusting the ref name.
 
+### The DockerHub-deploy cascade this also breaks (and fixes)
+
+`docker-latest.yml` listens via `workflow_run: workflows: ['CI Release branch']`. The first live
+`dev` → `master` merge under this fix (run `30764447267`, produced `v2026.2.1`) proved the ADR's own
+"unaffected" claim above wrong: no `DockerHub-deploy` run was ever created for it.
+
+The same GITHUB_TOKEN anti-recursion rule that motivated this whole ADR applies one hop further than
+first assumed: a `workflow_dispatch` dispatched by a `GITHUB_TOKEN`-authored action *is* exempted
+(that's the mechanism this ADR relies on for `ci-master.yml` → `ci-release.yml`), but the exemption
+is one-hop — the *completion* of that resulting run does not itself cascade into further automatic
+triggers like `workflow_run`, only into another `workflow_dispatch`/`repository_dispatch`. Confirmed
+via `actor`/`triggering_actor`: run `30764447267` (dispatched by `ci-master.yml`) is
+`github-actions[bot]`; the last genuine `.0` cut (run `30331814919`, triggered by a real push from
+`novoj`) is `novoj` — and only the latter has a matching `DockerHub-deploy` run.
+
+**Fix:** `ci-release.yml` now explicitly dispatches `docker-latest.yml` itself (`Dispatch Docker
+publish` step, same retry pattern as `Dispatch release build`), rather than relying on the
+`workflow_run` listener at all. The `workflow_run` trigger is removed from `docker-latest.yml`
+entirely — keeping both would double-publish for a direct push to a release branch (still a human
+actor, so `workflow_run` would still fire there too).
+
+This also required a second change: `docker-latest.yml`'s existing `workflow_dispatch` inputs
+(originally a manual-recovery path only) download `dist.zip` from the *published* GitHub release —
+but the release is typically still a **draft** at the point `ci-release.yml` would dispatch this,
+and a draft release has no real downloadable git tag yet. Added an optional `run_id` input: when
+given, `docker-latest.yml` pulls `evita-server.jar`/`version.txt` as workflow artifacts from that
+specific run (uploaded by `ci-release.yml` just before dispatching) instead of the release asset.
+The original release-asset path still works unchanged when `run_id` is omitted (manual recovery,
+unchanged contract).
+
 ## Verification
 
 - `documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md` fixture scripts (not
@@ -146,17 +176,29 @@ published `v*` tags instead of trusting the ref name.
 - `is_latest_line` fixture-tested against the repo's real tag set: `release_2026-2` (current line) →
   `true`; `release_2026-1` (superseded) → `false`; a hypothetical new `release_2026-3` → `true`; an
   old `release_2025-3` → `false`.
-- Both workflow YAML files parse (`yaml.safe_load`); `actionlint` was not available locally to
-  validate GitHub Actions expression semantics beyond plain YAML syntax.
-- Not verified end-to-end against live GitHub Actions (would require pushing and observing a real
-  dispatch) — the first real release cut after this merges is the actual integration test.
+- All three workflow YAML files (`ci-master.yml`, `ci-release.yml`, `docker-latest.yml`) parse
+  (`yaml.safe_load`); `actionlint` was not available locally to validate GitHub Actions expression
+  semantics beyond plain YAML syntax.
+- **Live end-to-end run**: PR #1361 (`dev` → `master`) exercised the real path. `CI Master branch`
+  fast-forwarded `release_2026-2` and dispatched `CI Release branch` (run `30764447267`), which
+  correctly resolved and published `v2026.2.1` — the primary bug this ADR fixes is confirmed working.
+  It also surfaced the DockerHub-deploy cascade break documented above (no `DockerHub-deploy` run was
+  created), which is fixed here.
+- `evitadb/evitadb:2026.2.1` and `evitadb/evitadb:latest` published manually (`gh workflow run
+  docker-latest.yml -f version=v2026.2.1 -f push_latest=auto`, run `30765917444`, `success`) while
+  the `Dispatch Docker publish` fix was being written; confirmed via DockerHub API that both tags
+  share the identical image digest (`sha256:f9d89b9e...`), pushed 3 seconds apart.
 
 ## Consequences & open follow-ups
 
-- The first `dev` → `master` merge after this lands is the first real exercise of the new path;
-  watch its `CI Master branch` and `CI Release branch` runs directly rather than assuming success.
+- The first live `dev` → `master` merge under this fix (PR #1361) has already run — the release-cut
+  half worked as designed; the DockerHub-deploy gap it exposed is fixed in this same record. The
+  *next* merge is the first real exercise of the Docker-dispatch fix specifically; watch its
+  `DockerHub-deploy` run rather than assuming success.
 
 ## Timeline
 
 - **2026-08-02** — investigated why `dev` → `master` wouldn't produce `2026.2.1`; found the trigger
-  gap; implemented and verified the `workflow_dispatch` fix.
+  gap; implemented and verified the `workflow_dispatch` fix; PR #1361 exercised it live, producing
+  `v2026.2.1` but exposing the DockerHub-deploy cascade break; fixed by dispatching
+  `docker-latest.yml` explicitly.

--- a/documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md
+++ b/documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md
@@ -1,7 +1,7 @@
 ---
 title: Route release cuts through workflow_dispatch on the release_* branch, not workflow_run from master
 date: 2026-08-02
-updated: 2026-08-02 22:50
+updated: 2026-08-02 23:05
 status: accepted
 kind: infrastructure
 issues: [1359, 1362]
@@ -194,7 +194,14 @@ unchanged contract).
 - The first live `dev` → `master` merge under this fix (PR #1361) has already run — the release-cut
   half worked as designed; the DockerHub-deploy gap it exposed is fixed in this same record. The
   *next* merge is the first real exercise of the Docker-dispatch fix specifically; watch its
-  `DockerHub-deploy` run rather than assuming success.
+  `DockerHub-deploy` run rather than assuming success — in particular, whether `Download a JAR file
+  to deploy`/`Download a version information` find the artifacts. Unlike the old `workflow_run`
+  listener (which only started after `CI Release branch`'s entire job had finished), the new
+  dispatch fires right after the two upload steps, before the enrichment tail — narrower, but still
+  padded by `docker-latest.yml`'s own runner-allocation and checkout time before it reaches the
+  download steps. Reviewer-flagged risk (PR #1363); no failure observed yet, but not proven absent
+  either — if the download step ever fails on a fresh dispatch, add a short retry/backoff there
+  rather than assuming it's unrelated.
 
 ## Timeline
 

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-02 | [Route release cuts through workflow_dispatch on the release_* branch, not workflow_run from master](2026-08-02-ci-release-pipeline-patch-versioning-fix.md) | infrastructure | accepted | #1359 |
+| 2026-08-02 | [Route release cuts through workflow_dispatch on the release_* branch, not workflow_run from master](2026-08-02-ci-release-pipeline-patch-versioning-fix.md) | infrastructure | accepted | #1359, #1362 |
 | 2026-08-02 | [Keep IDEA and Claude formatting in step with a shared .editorconfig and a diff-scoped hook, not Spotless](2026-08-02-editorconfig-formatting-parity.md) | infrastructure | accepted | #1119 |
 | 2026-08-01 | [Answer the B+ tree insert-boundary asserts from the descent instead of a captured cursor path](2026-08-01-bplustree-cursor-free-insert-path.md) | optimization | accepted | #1333, PR #1356 |
 | 2026-07-31 | [Take the four contained bulk-ingest wins, reject the two that trade an invariant or add complexity, and defer the one worth more than all of them](2026-07-31-bulk-ingest-write-path.md) | optimization | accepted | #1342, PR #1348 |


### PR DESCRIPTION
## Summary

Follow-on to #1359. The live `dev` → `master` merge under that fix (PR #1361, produced `v2026.2.1`)
proved its own "`docker-latest.yml` is unaffected" assumption wrong: no `DockerHub-deploy` run was
ever created for it. Full write-up (including the DockerHub cascade section) added to the same ADR:
`documentation/adr/2026-08-02-ci-release-pipeline-patch-versioning-fix.md`.

- Root cause is the same anti-recursion rule, one hop further: `CI Release branch`'s run, when
  dispatched by `CI Master branch` via `gh workflow run`, has `actor: github-actions[bot]`
  (confirmed via the API). GitHub's exemption covers a `GITHUB_TOKEN`-authored `workflow_dispatch`
  dispatch itself, but not that run's *completion* cascading into further automatic triggers like
  `workflow_run`. The last genuine `.0` cut (a real push, `actor: novoj`) correctly fired
  `DockerHub-deploy`; this one didn't.
- `CI Release branch` now explicitly dispatches `docker-latest.yml` (same mechanism and retry
  pattern as the `CI Master` → `CI Release` hand-off), passing its own `run_id` so
  `docker-latest.yml` can pull `evita-server.jar`/`version.txt` as workflow artifacts instead of the
  release's zip asset — the release is typically still a draft at that point and has no downloadable
  git tag yet.
- `docker-latest.yml`'s `workflow_run` trigger is removed entirely (keeping both would double-publish
  for a direct push to a release branch, which still has a human actor and would fire both ways).
- `v2026.2.1` was published to DockerHub manually in the interim — confirmed `evitadb/evitadb:2026.2.1`
  and `evitadb/evitadb:latest` share the identical image digest.

## Test plan

- [x] Simulated `docker-latest.yml`'s `Resolve build inputs` logic for both the new automated
      (`run_id` given) and original manual-recovery (`run_id` omitted) paths
- [x] All three workflow YAML files parse (`yaml.safe_load`)
- [x] Confirmed via GitHub API: `actor`/`triggering_actor` mismatch between the broken automated run
      and the last working human-triggered one
- [x] Manually dispatched `docker-latest.yml` for `v2026.2.1` — succeeded, `:latest` and `:2026.2.1`
      verified to share the same digest on DockerHub
- [ ] Not verified end-to-end with the new `Dispatch Docker publish` step itself (would require a
      real `dev` → `master` merge) — the next one is the actual integration test

Closes #1362