### PR TITLE
fix: log discovery-phase readiness probe failures at DEBUG, not ERROR

### DIFF
--- a/documentation/adr/2026-08-03-readiness-discovery-log-level.md
+++ b/documentation/adr/2026-08-03-readiness-discovery-log-level.md
@@ -1,0 +1,127 @@
+---
+title: Readiness discovery-phase probe failures log at DEBUG; only a known-good endpoint failing logs ERROR
+date: 2026-08-03
+updated: 2026-08-03 08:45
+status: proposed
+kind: fix
+issues: [1364]
+prs: []
+areas: [evita_external_api/evita_external_api_core, evita_external_api/evita_external_api_rest, evita_external_api/evita_external_api_graphql, evita_external_api/evita_external_api_system, evita_external_api/evita_external_api_observability, evita_external_api/evita_external_api_lab, evita_external_api/evita_external_api_grpc]
+supersedes: []
+superseded-by: []
+relates: []
+---
+
+# Readiness discovery-phase probe failures log at DEBUG; only a known-good endpoint failing logs ERROR
+
+Every external API provider (`RestProvider`, `GraphQLProvider`, `SystemProvider`,
+`ObservabilityProvider`, `LabProvider`, `GrpcProvider`) tries several candidate URLs on boot until one
+answers, then caches it. Individual candidate failures during that discovery phase now log at `DEBUG`
+instead of `ERROR`; a full discovery round that stays empty for more than a 60s grace period logs one
+consolidated `WARN` and then goes quiet. Once a provider has a known-good URL, a failure there still
+logs `ERROR` immediately — that part is unchanged.
+
+## Why
+
+`AbstractApiOptions#getBaseUrls()` lists the `exposeOn` hostname (a publicly exposed hostname, e.g.
+`demo.evitadb.io`) *before* the actual bind addresses. On every boot, the first candidate(s) predictably
+fail — the public hostname doesn't route back to the container that just started — before the loop
+reaches the working local address seconds later. Each failed candidate logged at `ERROR` with a raw
+`Failed to connect to demo.evitadb.io/[...]` message, producing several alarming lines on every single
+boot of an otherwise healthy server. Docker's `HEALTHCHECK` (and any other readiness poller) re-triggers
+the same discovery loop on every probe until the catalog finishes loading, so a slower boot compounds
+the noise across multiple rounds.
+
+### Previous state
+
+All six providers logged `ERROR` unconditionally from inside the `NetworkUtils.fetchContent` /
+`isReachable` failure callbacks, with no distinction between "trying candidates, some are expected to
+fail" and "the endpoint I already proved reachable just went dark".
+
+## Options considered
+
+### Option A — DEBUG during discovery, WARN once after a grace period, ERROR unchanged in steady state (chosen)
+
+Individual candidate failures are DEBUG while a provider has never found a reachable URL. If an entire
+round exhausts and a 60s grace period has elapsed since the first attempt, log one `WARN` summarizing
+all attempted URLs and their failure reasons, then suppress further warnings (edge-triggered). Once
+`reachableUrl` is set, a failure there logs `ERROR` immediately, exactly as before.
+
+- **Pros:** silences the expected noise without hiding a genuinely stuck server; a stuck server still
+  produces exactly one clear signal instead of zero.
+- **Cons:** introduces an invented grace-period constant with no natural home in existing config.
+
+### Option B — DEBUG only, no escalation, rely on `/system/readiness` and Docker/k8s health status
+
+- **Pros:** no magic number to justify; readiness/liveness endpoints already exist for exactly this
+  purpose.
+- **Rejected because:** relies entirely on an operator (or Docker) actively watching the HTTP endpoint;
+  it removes the only in-log signal that a server is stuck, and Johnny asked for exactly that signal to
+  stay.
+
+### Option C — log one ERROR the first time an entire discovery round is exhausted
+
+The initial, simpler design: downgrade per-candidate logs to DEBUG but log `ERROR` as soon as one full
+round comes back empty.
+
+- **Pros:** simplest possible change, no timer needed.
+- **Rejected because:** it doesn't fix the reported symptom. The example boot log showed the discovery
+  round failing completely three times (07:xx, 09:xx, 12:xx) before the catalog finished loading at
+  15:xx — a perfectly healthy boot. Logging on the first exhausted round still produces an alarming
+  `ERROR` during ordinary startup.
+
+## Decision
+
+**Chosen: Option A.** A time-based grace period is the only frequency-independent way to distinguish
+"still booting" from "genuinely stuck" — round-counting doesn't work because `isReady()`'s call
+frequency is driven entirely by external callers (Docker's `HEALTHCHECK --interval`, k8s probes,
+evitaLab), not by the provider itself.
+
+A shared full probing abstraction across the 6 providers was considered and declined: they differ in
+HTTP method, content type, request body and success predicate, so a shared `probe()` signature would
+carry all of that as parameters for little savings. Only the genuinely identical piece — the grace-period
+timer and edge-triggered warn — was extracted into `ReadinessDiscoveryStallTracker`
+(`evita_external_api_core`); each provider keeps its own local `probe()`/`checkReachable()` helper.
+
+## Key technical details
+
+- `io.evitadb.externalApi.http.ReadinessDiscoveryStallTracker` — holds the 60s `GRACE_PERIOD` constant
+  and `shouldWarnAboutStall()`, which records the first-attempt timestamp and returns `true` exactly
+  once per instance, the first time the grace period has elapsed. A one-arg constructor overrides the
+  grace period (used by the unit test to avoid a real 60s wait).
+- Each provider's `isReady()` branches on `reachableUrl == null` (discovery) vs `!= null` (steady
+  state); both branches call the same local `probe(url, Consumer<String> failureLogger)` /
+  `checkReachable(uri, failureLogger)` helper, differing only in what the failure callback does
+  (`log.debug` + collect vs `log.warn` summary vs `log.error`).
+- `GrpcProvider` doesn't use `getBaseUrls()`/`exposeOn` (only `getHost()`), so it never hit the original
+  bug, but got the same DEBUG/WARN/ERROR treatment for consistency. It also already re-tries the other
+  configured hosts when the cached `reachableUrl` fails in steady state (a pre-existing self-healing
+  fallback the other five providers don't have) — preserved as-is, not extended to the others.
+- `reachableUrl` is still never reset to `null` once set, in any of the six providers (pre-existing).
+  A provider that goes from ready to permanently unreachable keeps re-testing the same dead URL and
+  logging `ERROR` forever rather than re-discovering an alternate — except `GrpcProvider`, which already
+  falls back. Left as-is; out of scope for this change (see follow-ups).
+- `ReadinessEvent.finish(Result.ERROR/TIMEOUT/READY)` fires identically in every branch — this is a
+  logging-only change, the readiness metrics/telemetry are untouched.
+
+## Verification
+
+`mvn compile` on each touched module (`evita_external_api_core`, `_rest`, `_graphql`, `_system`,
+`_observability`, `_lab`, `_grpc/server`) succeeds. New unit test
+`ReadinessDiscoveryStallTrackerTest` (`evita_test/evita_functional_tests`) covers both cases: no warning
+before the grace period, exactly one warning after it elapses — 2/2 passing.
+
+## Consequences & open follow-ups
+
+- A provider whose known-good URL goes permanently dark logs `ERROR` on every subsequent poll forever
+  (unchanged pre-existing behavior for Rest/GraphQL/System/Observability/Lab). Re-discovering an
+  alternate host the way `GrpcProvider` already does would need `reachableUrl` reset semantics
+  reconsidered — a genuine fork, deliberately left untouched here since it wasn't part of the reported
+  symptom.
+- The 60s grace period is a single named constant (`ReadinessDiscoveryStallTracker.GRACE_PERIOD`); if a
+  deployment's catalog load routinely exceeds it, the only symptom is one extra (calm) `WARN` line, not
+  a functional regression.
+
+## Timeline
+
+- **2026-08-03** — reported, designed (with advisor review), implemented, ADR written.

--- a/documentation/adr/2026-08-03-readiness-discovery-log-level.md
+++ b/documentation/adr/2026-08-03-readiness-discovery-log-level.md
@@ -1,11 +1,11 @@
 ---
 title: Readiness discovery-phase probe failures log at DEBUG; only a known-good endpoint failing logs ERROR
 date: 2026-08-03
-updated: 2026-08-03 08:45
+updated: 2026-08-03 09:17
 status: proposed
 kind: fix
 issues: [1364]
-prs: []
+prs: [1366]
 areas: [evita_external_api/evita_external_api_core, evita_external_api/evita_external_api_rest, evita_external_api/evita_external_api_graphql, evita_external_api/evita_external_api_system, evita_external_api/evita_external_api_observability, evita_external_api/evita_external_api_lab, evita_external_api/evita_external_api_grpc]
 supersedes: []
 superseded-by: []
@@ -88,7 +88,10 @@ timer and edge-triggered warn — was extracted into `ReadinessDiscoveryStallTra
 - `io.evitadb.externalApi.http.ReadinessDiscoveryStallTracker` — holds the 60s `GRACE_PERIOD` constant
   and `shouldWarnAboutStall()`, which records the first-attempt timestamp and returns `true` exactly
   once per instance, the first time the grace period has elapsed. A one-arg constructor overrides the
-  grace period (used by the unit test to avoid a real 60s wait).
+  grace period (used by the unit test to avoid a real 60s wait). State is held in `AtomicLong`/
+  `AtomicBoolean` with `compareAndSet` rather than plain fields, since a single tracker instance is
+  shared by its provider across concurrent readiness probes (e.g. an overlapping Docker health check
+  and Kubernetes readiness probe) and the exactly-once guarantee must hold under that concurrency.
 - Each provider's `isReady()` branches on `reachableUrl == null` (discovery) vs `!= null` (steady
   state); both branches call the same local `probe(url, Consumer<String> failureLogger)` /
   `checkReachable(uri, failureLogger)` helper, differing only in what the failure callback does
@@ -107,9 +110,10 @@ timer and edge-triggered warn — was extracted into `ReadinessDiscoveryStallTra
 ## Verification
 
 `mvn compile` on each touched module (`evita_external_api_core`, `_rest`, `_graphql`, `_system`,
-`_observability`, `_lab`, `_grpc/server`) succeeds. New unit test
-`ReadinessDiscoveryStallTrackerTest` (`evita_test/evita_functional_tests`) covers both cases: no warning
-before the grace period, exactly one warning after it elapses — 2/2 passing.
+`_observability`, `_lab`, `_grpc/server`) succeeds. `ReadinessDiscoveryStallTrackerTest`
+(`evita_test/evita_functional_tests`) covers: no warning before the grace period, exactly one warning
+after it elapses, and exactly one winner among 16 threads calling `shouldWarnAboutStall()` concurrently
+past the grace period — 3/3 passing.
 
 ## Consequences & open follow-ups
 

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-03 | [Readiness discovery-phase probe failures log at DEBUG; only a known-good endpoint failing logs ERROR](2026-08-03-readiness-discovery-log-level.md) | fix | proposed | #1364 |
 | 2026-08-02 | [Route release cuts through workflow_dispatch on the release_* branch, not workflow_run from master](2026-08-02-ci-release-pipeline-patch-versioning-fix.md) | infrastructure | accepted | #1359 |
 | 2026-08-02 | [Keep IDEA and Claude formatting in step with a shared .editorconfig and a diff-scoped hook, not Spotless](2026-08-02-editorconfig-formatting-parity.md) | infrastructure | accepted | #1119 |
 | 2026-08-01 | [Answer the B+ tree insert-boundary asserts from the descent instead of a captured cursor path](2026-08-01-bplustree-cursor-free-insert-path.md) | optimization | accepted | #1333, PR #1356 |

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ReadinessDiscoveryStallTracker.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ReadinessDiscoveryStallTracker.java
@@ -54,6 +54,9 @@ public class ReadinessDiscoveryStallTracker {
 	private final AtomicLong firstAttemptMillis = new AtomicLong(-1L);
 	private final AtomicBoolean stalledWarningLogged = new AtomicBoolean(false);
 
+	/**
+	 * Uses the default {@link #GRACE_PERIOD}.
+	 */
 	public ReadinessDiscoveryStallTracker() {
 		this(GRACE_PERIOD);
 	}

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ReadinessDiscoveryStallTracker.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ReadinessDiscoveryStallTracker.java
@@ -1,0 +1,81 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.http;
+
+import javax.annotation.Nonnull;
+import java.time.Duration;
+
+/**
+ * Helper used by {@link ExternalApiProvider#isReady()} implementations that probe several candidate URLs before
+ * settling on the one that actually works. Individual candidate failures are expected while none of them has been
+ * proven reachable yet (e.g. a publicly exposed hostname that doesn't route back to the container that just booted),
+ * so they are not worth an alarming log line on their own. This tracker instead recognizes the case where an entire
+ * discovery round has failed for longer than a reasonable grace period, and reports it exactly once so that a server
+ * that never becomes ready produces a single warning instead of flooding the log on every subsequent probe.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class ReadinessDiscoveryStallTracker {
+
+	/**
+	 * How long a discovery phase (no candidate URL proven reachable yet) may run before it's considered stalled
+	 * rather than merely still starting up.
+	 */
+	public static final Duration GRACE_PERIOD = Duration.ofSeconds(60);
+
+	private final long gracePeriodMillis;
+	private long firstAttemptMillis = -1L;
+	private boolean stalledWarningLogged;
+
+	public ReadinessDiscoveryStallTracker() {
+		this(GRACE_PERIOD);
+	}
+
+	/**
+	 * Allows callers (and tests) to use a different grace period than the default {@link #GRACE_PERIOD}.
+	 */
+	public ReadinessDiscoveryStallTracker(@Nonnull Duration gracePeriod) {
+		this.gracePeriodMillis = gracePeriod.toMillis();
+	}
+
+	/**
+	 * Call once after an entire discovery round has exhausted all candidate URLs without success. Returns TRUE
+	 * exactly once - the first time the grace period has elapsed since the first recorded exhausted round - so the
+	 * caller can log a single consolidated warning instead of repeating it on every subsequent round.
+	 *
+	 * @return TRUE if the caller should log a stalled-discovery warning now
+	 */
+	public boolean shouldWarnAboutStall() {
+		final long now = System.currentTimeMillis();
+		if (this.firstAttemptMillis < 0) {
+			this.firstAttemptMillis = now;
+		}
+		if (!this.stalledWarningLogged && now - this.firstAttemptMillis >= this.gracePeriodMillis) {
+			this.stalledWarningLogged = true;
+			return true;
+		}
+		return false;
+	}
+
+}

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ReadinessDiscoveryStallTracker.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ReadinessDiscoveryStallTracker.java
@@ -25,6 +25,8 @@ package io.evitadb.externalApi.http;
 
 import javax.annotation.Nonnull;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Helper used by {@link ExternalApiProvider#isReady()} implementations that probe several candidate URLs before
@@ -33,6 +35,10 @@ import java.time.Duration;
  * so they are not worth an alarming log line on their own. This tracker instead recognizes the case where an entire
  * discovery round has failed for longer than a reasonable grace period, and reports it exactly once so that a server
  * that never becomes ready produces a single warning instead of flooding the log on every subsequent probe.
+ *
+ * Instances are shared by a single provider across concurrent readiness probes (e.g. an overlapping Docker health
+ * check and Kubernetes readiness probe), so state is held in atomics rather than plain fields to keep the
+ * exactly-once guarantee correct under concurrent calls.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
@@ -45,8 +51,8 @@ public class ReadinessDiscoveryStallTracker {
 	public static final Duration GRACE_PERIOD = Duration.ofSeconds(60);
 
 	private final long gracePeriodMillis;
-	private long firstAttemptMillis = -1L;
-	private boolean stalledWarningLogged;
+	private final AtomicLong firstAttemptMillis = new AtomicLong(-1L);
+	private final AtomicBoolean stalledWarningLogged = new AtomicBoolean(false);
 
 	public ReadinessDiscoveryStallTracker() {
 		this(GRACE_PERIOD);
@@ -68,12 +74,9 @@ public class ReadinessDiscoveryStallTracker {
 	 */
 	public boolean shouldWarnAboutStall() {
 		final long now = System.currentTimeMillis();
-		if (this.firstAttemptMillis < 0) {
-			this.firstAttemptMillis = now;
-		}
-		if (!this.stalledWarningLogged && now - this.firstAttemptMillis >= this.gracePeriodMillis) {
-			this.stalledWarningLogged = true;
-			return true;
+		this.firstAttemptMillis.compareAndSet(-1L, now);
+		if (now - this.firstAttemptMillis.get() >= this.gracePeriodMillis) {
+			return this.stalledWarningLogged.compareAndSet(false, true);
 		}
 		return false;
 	}

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/GraphQLProvider.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/GraphQLProvider.java
@@ -29,13 +29,16 @@ import io.evitadb.externalApi.event.ReadinessEvent.Prospective;
 import io.evitadb.externalApi.event.ReadinessEvent.Result;
 import io.evitadb.externalApi.graphql.configuration.GraphQLOptions;
 import io.evitadb.externalApi.http.ExternalApiProvider;
+import io.evitadb.externalApi.http.ReadinessDiscoveryStallTracker;
+import io.evitadb.utils.CollectionUtils;
 import io.evitadb.utils.NetworkUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
 import java.util.Optional;
-import java.util.function.Predicate;
+import java.util.function.Consumer;
 
 import static io.evitadb.externalApi.graphql.io.GraphQLRouter.SYSTEM_PREFIX;
 
@@ -69,6 +72,12 @@ public class GraphQLProvider implements ExternalApiProvider<GraphQLOptions> {
      */
     private String reachableUrl;
 
+	/**
+	 * Tracks how long the readiness discovery phase (see {@link #reachableUrl}) has been running, so a server that
+	 * never becomes reachable on any candidate URL is reported once instead of on every single probe.
+	 */
+	private final ReadinessDiscoveryStallTracker stallTracker = new ReadinessDiscoveryStallTracker();
+
 	public GraphQLProvider(
 		@Nonnull GraphQLOptions configuration,
 		@Nonnull GraphQLManager graphQLManager,
@@ -99,43 +108,64 @@ public class GraphQLProvider implements ExternalApiProvider<GraphQLOptions> {
 	}
 
 	@Override
-    public boolean isReady() {
-        final Predicate<String> isReady = url -> {
-	        final ReadinessEvent readinessEvent = new ReadinessEvent(CODE, Prospective.CLIENT);
-			final Optional<String> post = NetworkUtils.fetchContent(
-				url,
-				"POST",
-				"application/json",
-				"{\"query\":\"{liveness}\"}",
-				this.requestTimeout,
-				error -> {
-					log.error("Error while checking readiness of GraphQL API: {}", error);
-					readinessEvent.finish(Result.ERROR);
-				},
-				timeouted -> {
-					log.error("{}", timeouted);
-					readinessEvent.finish(Result.TIMEOUT);
+	public boolean isReady() {
+		if (this.reachableUrl == null) {
+			// discovery phase: some candidate URLs (e.g. a publicly exposed hostname) are expected to fail until
+			// the reachable one is found, so individual failures are only worth a DEBUG line here
+			final String[] baseUrls = this.configuration.getBaseUrls();
+			final Map<String, String> failures = CollectionUtils.createLinkedHashMap(baseUrls.length);
+			for (String baseUrl : baseUrls) {
+				final String url = baseUrl + SYSTEM_PREFIX;
+				if (probe(url, message -> {
+					failures.put(url, message);
+					log.debug("Error while checking readiness of GraphQL API: {}", message);
+				})) {
+					this.reachableUrl = url;
+					return true;
 				}
-			);
-			final Boolean result = post.map(content -> content.contains("true")).orElse(false);
-			if (result) {
-				readinessEvent.finish(Result.READY);
 			}
-			return result;
-        };
-        final String[] baseUrls = this.configuration.getBaseUrls();
-        if (this.reachableUrl == null) {
-	        for (String baseUrl : baseUrls) {
-		        final String url = baseUrl + SYSTEM_PREFIX;
-		        if (isReady.test(url)) {
-			        this.reachableUrl = url;
-			        return true;
-		        }
-	        }
-            return false;
-        } else {
-            return isReady.test(this.reachableUrl);
-        }
-    }
+			if (this.stallTracker.shouldWarnAboutStall()) {
+				log.warn(
+					"GraphQL API has not become reachable on any of the {} configured URL(s) for over {}s " +
+						"(this can be normal while the server is still starting up): {}",
+					baseUrls.length, ReadinessDiscoveryStallTracker.GRACE_PERIOD.toSeconds(), failures
+				);
+			}
+			return false;
+		} else {
+			// steady state: this URL was reachable before, so a failure now is a genuine regression
+			return probe(
+				this.reachableUrl,
+				message -> log.error("Error while checking readiness of GraphQL API: {}", message)
+			);
+		}
+	}
+
+	/**
+	 * Performs a single readiness probe against the given URL, reporting any failure message via {@code failureLogger}.
+	 */
+	private boolean probe(@Nonnull String url, @Nonnull Consumer<String> failureLogger) {
+		final ReadinessEvent readinessEvent = new ReadinessEvent(CODE, Prospective.CLIENT);
+		final Optional<String> post = NetworkUtils.fetchContent(
+			url,
+			"POST",
+			"application/json",
+			"{\"query\":\"{liveness}\"}",
+			this.requestTimeout,
+			error -> {
+				failureLogger.accept(error);
+				readinessEvent.finish(Result.ERROR);
+			},
+			timeouted -> {
+				failureLogger.accept(timeouted);
+				readinessEvent.finish(Result.TIMEOUT);
+			}
+		);
+		final Boolean result = post.map(content -> content.contains("true")).orElse(false);
+		if (result) {
+			readinessEvent.finish(Result.READY);
+		}
+		return result;
+	}
 
 }

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/GrpcProvider.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/GrpcProvider.java
@@ -38,12 +38,16 @@ import io.evitadb.externalApi.event.ReadinessEvent.Result;
 import io.evitadb.externalApi.grpc.configuration.GrpcOptions;
 import io.evitadb.externalApi.grpc.generated.EvitaServiceGrpc.EvitaServiceBlockingStub;
 import io.evitadb.externalApi.http.ExternalApiProvider;
+import io.evitadb.externalApi.http.ReadinessDiscoveryStallTracker;
+import io.evitadb.utils.CollectionUtils;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Descriptor of external API provider that provides gRPC API.
@@ -64,8 +68,8 @@ public class GrpcProvider implements ExternalApiProvider<GrpcOptions> {
 	@Getter
 	private final HttpService apiHandler;
 	/**
-	 * Timeout taken from {@link ApiOptions#requestTimeoutInMillis()} that will be used in {@link #checkReachable(String)}
-	 * method.
+	 * Timeout taken from {@link ApiOptions#requestTimeoutInMillis()} that will be used in
+	 * {@link #checkReachable(String, Consumer)} method.
 	 */
 	private final long requestTimeout;
 	/**
@@ -76,6 +80,11 @@ public class GrpcProvider implements ExternalApiProvider<GrpcOptions> {
 	 * Builder for gRPC client factory.
 	 */
 	private final ClientFactory clientFactory;
+	/**
+	 * Tracks how long the readiness discovery phase (see {@link #reachableUrl}) has been running, so a server that
+	 * never becomes reachable on any candidate URL is reported once instead of on every single probe.
+	 */
+	private final ReadinessDiscoveryStallTracker stallTracker = new ReadinessDiscoveryStallTracker();
 
 	public GrpcProvider(@Nonnull GrpcOptions configuration, @Nonnull HttpService apiHandler, long requestTimeout, long idleTimeout) {
 		this.configuration = configuration;
@@ -122,29 +131,62 @@ public class GrpcProvider implements ExternalApiProvider<GrpcOptions> {
 
 	@Override
 	public boolean isReady() {
-		if (this.reachableUrl != null) {
-			if (checkReachable(this.reachableUrl)) {
+		if (this.reachableUrl == null) {
+			// discovery phase: individual host failures are expected until the reachable one is found (e.g. the
+			// server socket isn't bound yet), so they're only worth a DEBUG line here
+			final HostDefinition[] hosts = this.configuration.getHost();
+			final Map<String, String> failures = CollectionUtils.createLinkedHashMap(hosts.length);
+			for (HostDefinition hostDefinition : hosts) {
+				final String uri = toUri(hostDefinition);
+				if (checkReachable(uri, message -> {
+					failures.put(uri, message);
+					log.debug("Error while checking readiness of gRPC API: {}", message);
+				})) {
+					return true;
+				}
+			}
+			if (this.stallTracker.shouldWarnAboutStall()) {
+				log.warn(
+					"gRPC API has not become reachable on any of the {} configured URL(s) for over {}s " +
+						"(this can be normal while the server is still starting up): {}",
+					hosts.length, ReadinessDiscoveryStallTracker.GRACE_PERIOD.toSeconds(), failures
+				);
+			}
+			return false;
+		} else {
+			// steady state: this URL was reachable before, so a failure now is a genuine regression; fall back to
+			// the other configured hosts in case the service moved rather than went down
+			final Consumer<String> failureLogger =
+				message -> log.error("Error while checking readiness of gRPC API: {}", message);
+			if (checkReachable(this.reachableUrl, failureLogger)) {
 				return true;
 			}
-		}
-
-		for (HostDefinition hostDefinition : this.configuration.getHost()) {
-			final String uriScheme = this.configuration.getTlsMode() != TlsMode.FORCE_NO_TLS ? "https" : "http";
-
-			final String uri = uriScheme + "://" + hostDefinition.hostAddressWithPort() + "/";
-			if (!uri.equals(this.reachableUrl) && checkReachable(uri)) {
-				return true;
+			for (HostDefinition hostDefinition : this.configuration.getHost()) {
+				final String uri = toUri(hostDefinition);
+				if (!uri.equals(this.reachableUrl) && checkReachable(uri, failureLogger)) {
+					return true;
+				}
 			}
+			return false;
 		}
-		return false;
 	}
 
 	/**
-	 * Check if the given URI is reachable via gRPC client.
+	 * Assembles the gRPC endpoint URI for the given host, honoring the configured TLS mode.
+	 */
+	@Nonnull
+	private String toUri(@Nonnull HostDefinition hostDefinition) {
+		final String uriScheme = this.configuration.getTlsMode() != TlsMode.FORCE_NO_TLS ? "https" : "http";
+		return uriScheme + "://" + hostDefinition.hostAddressWithPort() + "/";
+	}
+
+	/**
+	 * Check if the given URI is reachable via gRPC client, reporting any failure message via {@code failureLogger}.
 	 * @param uri URI to check
+	 * @param failureLogger callback receiving the failure message, if the URI turns out unreachable
 	 * @return true if the URI is reachable, false otherwise
 	 */
-	public boolean checkReachable(@Nonnull String uri) {
+	public boolean checkReachable(@Nonnull String uri, @Nonnull Consumer<String> failureLogger) {
 		final ReadinessEvent readinessEvent = new ReadinessEvent(CODE, Prospective.CLIENT);
 		try {
 			final EvitaServiceBlockingStub evitaService = GrpcClients.builder(uri)
@@ -158,21 +200,21 @@ public class GrpcProvider implements ExternalApiProvider<GrpcOptions> {
 				return true;
 			} else {
 				readinessEvent.finish(Result.ERROR);
-				log.error("gRPC API is not ready at: {}", uri);
+				failureLogger.accept("gRPC API is not ready at: " + uri);
 				return false;
 			}
 		} catch (StatusRuntimeException e) {
 			if (e.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
 				readinessEvent.finish(Result.TIMEOUT);
-				log.error("Timeout while checking readiness of gRPC API at: {}", uri);
+				failureLogger.accept("Timeout while checking readiness of gRPC API at: " + uri);
 			} else {
 				readinessEvent.finish(Result.ERROR);
-				log.error("Error while checking readiness of gRPC API: {}", e.getMessage());
+				failureLogger.accept("Error while checking readiness of gRPC API: " + e.getMessage());
 			}
 			return false;
 		} catch (Exception e) {
 			readinessEvent.finish(Result.ERROR);
-			log.error("Error while checking readiness of gRPC API: {}", e.getMessage());
+			failureLogger.accept("Error while checking readiness of gRPC API: " + e.getMessage());
 			return false;
 		}
 	}

--- a/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/LabProvider.java
+++ b/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/LabProvider.java
@@ -29,13 +29,16 @@ import io.evitadb.externalApi.event.ReadinessEvent;
 import io.evitadb.externalApi.event.ReadinessEvent.Prospective;
 import io.evitadb.externalApi.event.ReadinessEvent.Result;
 import io.evitadb.externalApi.http.ProxyingEndpointProvider;
+import io.evitadb.externalApi.http.ReadinessDiscoveryStallTracker;
 import io.evitadb.externalApi.lab.configuration.LabOptions;
+import io.evitadb.utils.CollectionUtils;
 import io.evitadb.utils.NetworkUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
-import java.util.function.Predicate;
+import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Descriptor of provider of lab API and GUI.
@@ -66,6 +69,12 @@ public class LabProvider implements ProxyingEndpointProvider<LabOptions> {
 	 */
 	private String reachableUrl;
 
+	/**
+	 * Tracks how long the readiness discovery phase (see {@link #reachableUrl}) has been running, so a server that
+	 * never becomes reachable on any candidate URL is reported once instead of on every single probe.
+	 */
+	private final ReadinessDiscoveryStallTracker stallTracker = new ReadinessDiscoveryStallTracker();
+
 	public LabProvider(@Nonnull LabOptions configuration, @Nonnull HttpService apiHandler, long requestTimeout) {
 		this.configuration = configuration;
 		this.apiHandler = apiHandler;
@@ -88,44 +97,65 @@ public class LabProvider implements ProxyingEndpointProvider<LabOptions> {
 
 	@Override
 	public boolean isReady() {
-		final Predicate<String> isReady = url -> {
-			final ReadinessEvent readinessEvent = new ReadinessEvent(CODE, Prospective.CLIENT);
-			return NetworkUtils.fetchContent(
-					url,
-					null,
-					"text/html",
-					null,
-					this.requestTimeout,
-					error -> {
-						log.error("Error while checking readiness of Lab API: {}", error);
-						readinessEvent.finish(Result.ERROR);
-					},
-					timeouted -> {
-						log.error("{}", timeouted);
-						readinessEvent.finish(Result.TIMEOUT);
-					}
-				)
-				.map(content -> {
-					final boolean result = content.contains("evitaLab app");
-					if (result) {
-						readinessEvent.finish(Result.READY);
-					}
-					return result;
-				})
-				.orElse(false);
-		};
-		final String[] baseUrls = this.configuration.getBaseUrls();
 		if (this.reachableUrl == null) {
+			// discovery phase: some candidate URLs (e.g. a publicly exposed hostname) are expected to fail until
+			// the reachable one is found, so individual failures are only worth a DEBUG line here
+			final String[] baseUrls = this.configuration.getBaseUrls();
+			final Map<String, String> failures = CollectionUtils.createLinkedHashMap(baseUrls.length);
 			for (String baseUrl : baseUrls) {
-				if (isReady.test(baseUrl)) {
+				if (probe(baseUrl, message -> {
+					failures.put(baseUrl, message);
+					log.debug("Error while checking readiness of Lab API: {}", message);
+				})) {
 					this.reachableUrl = baseUrl;
 					return true;
 				}
 			}
+			if (this.stallTracker.shouldWarnAboutStall()) {
+				log.warn(
+					"Lab API has not become reachable on any of the {} configured URL(s) for over {}s " +
+						"(this can be normal while the server is still starting up): {}",
+					baseUrls.length, ReadinessDiscoveryStallTracker.GRACE_PERIOD.toSeconds(), failures
+				);
+			}
 			return false;
 		} else {
-			return isReady.test(this.reachableUrl);
+			// steady state: this URL was reachable before, so a failure now is a genuine regression
+			return probe(
+				this.reachableUrl,
+				message -> log.error("Error while checking readiness of Lab API: {}", message)
+			);
 		}
+	}
+
+	/**
+	 * Performs a single readiness probe against the given URL, reporting any failure message via {@code failureLogger}.
+	 */
+	private boolean probe(@Nonnull String url, @Nonnull Consumer<String> failureLogger) {
+		final ReadinessEvent readinessEvent = new ReadinessEvent(CODE, Prospective.CLIENT);
+		return NetworkUtils.fetchContent(
+				url,
+				null,
+				"text/html",
+				null,
+				this.requestTimeout,
+				error -> {
+					failureLogger.accept(error);
+					readinessEvent.finish(Result.ERROR);
+				},
+				timeouted -> {
+					failureLogger.accept(timeouted);
+					readinessEvent.finish(Result.TIMEOUT);
+				}
+			)
+			.map(content -> {
+				final boolean result = content.contains("evitaLab app");
+				if (result) {
+					readinessEvent.finish(Result.READY);
+				}
+				return result;
+			})
+			.orElse(false);
 	}
 
 }

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/ObservabilityProvider.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/ObservabilityProvider.java
@@ -28,13 +28,16 @@ import io.evitadb.externalApi.event.ReadinessEvent;
 import io.evitadb.externalApi.event.ReadinessEvent.Prospective;
 import io.evitadb.externalApi.event.ReadinessEvent.Result;
 import io.evitadb.externalApi.http.ExternalApiProvider;
+import io.evitadb.externalApi.http.ReadinessDiscoveryStallTracker;
 import io.evitadb.externalApi.observability.configuration.ObservabilityOptions;
+import io.evitadb.utils.CollectionUtils;
 import io.evitadb.utils.NetworkUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
-import java.util.function.Predicate;
+import java.util.Map;
+import java.util.function.Consumer;
 
 import static io.evitadb.externalApi.observability.ObservabilityManager.LIVENESS_SUFFIX;
 
@@ -71,6 +74,12 @@ public class ObservabilityProvider implements ExternalApiProvider<ObservabilityO
 	 */
 	private String reachableUrl;
 
+	/**
+	 * Tracks how long the readiness discovery phase (see {@link #reachableUrl}) has been running, so a server that
+	 * never becomes reachable on any candidate URL is reported once instead of on every single probe.
+	 */
+	private final ReadinessDiscoveryStallTracker stallTracker = new ReadinessDiscoveryStallTracker();
+
 	public ObservabilityProvider(
 		@Nonnull ObservabilityOptions configuration,
 		@Nonnull ObservabilityManager observabilityManager,
@@ -101,45 +110,66 @@ public class ObservabilityProvider implements ExternalApiProvider<ObservabilityO
 
 	@Override
 	public boolean isReady() {
-		final Predicate<String> isReady = url -> {
-			final ReadinessEvent readinessEvent = new ReadinessEvent(CODE, Prospective.CLIENT);
-			return NetworkUtils.fetchContent(
-					url,
-					"GET",
-					"text/plain",
-					null,
-					this.requestTimeout,
-					error -> {
-						log.error("Error while checking readiness of Observability API: {}", error);
-						readinessEvent.finish(Result.ERROR);
-					},
-					timeouted -> {
-						log.error("{}", timeouted);
-						readinessEvent.finish(Result.TIMEOUT);
-					}
-				)
-				.map(content -> {
-					final boolean result = !content.isEmpty();
-					if (result) {
-						readinessEvent.finish(Result.READY);
-					}
-					return result;
-				})
-				.orElse(false);
-		};
-		final String[] baseUrls = this.configuration.getBaseUrls();
 		if (this.reachableUrl == null) {
+			// discovery phase: some candidate URLs (e.g. a publicly exposed hostname) are expected to fail until
+			// the reachable one is found, so individual failures are only worth a DEBUG line here
+			final String[] baseUrls = this.configuration.getBaseUrls();
+			final Map<String, String> failures = CollectionUtils.createLinkedHashMap(baseUrls.length);
 			for (String baseUrl : baseUrls) {
 				final String url = baseUrl + LIVENESS_SUFFIX;
-				if (isReady.test(url)) {
+				if (probe(url, message -> {
+					failures.put(url, message);
+					log.debug("Error while checking readiness of Observability API: {}", message);
+				})) {
 					this.reachableUrl = url;
 					return true;
 				}
 			}
+			if (this.stallTracker.shouldWarnAboutStall()) {
+				log.warn(
+					"Observability API has not become reachable on any of the {} configured URL(s) for over {}s " +
+						"(this can be normal while the server is still starting up): {}",
+					baseUrls.length, ReadinessDiscoveryStallTracker.GRACE_PERIOD.toSeconds(), failures
+				);
+			}
 			return false;
 		} else {
-			return isReady.test(this.reachableUrl);
+			// steady state: this URL was reachable before, so a failure now is a genuine regression
+			return probe(
+				this.reachableUrl,
+				message -> log.error("Error while checking readiness of Observability API: {}", message)
+			);
 		}
+	}
+
+	/**
+	 * Performs a single readiness probe against the given URL, reporting any failure message via {@code failureLogger}.
+	 */
+	private boolean probe(@Nonnull String url, @Nonnull Consumer<String> failureLogger) {
+		final ReadinessEvent readinessEvent = new ReadinessEvent(CODE, Prospective.CLIENT);
+		return NetworkUtils.fetchContent(
+				url,
+				"GET",
+				"text/plain",
+				null,
+				this.requestTimeout,
+				error -> {
+					failureLogger.accept(error);
+					readinessEvent.finish(Result.ERROR);
+				},
+				timeouted -> {
+					failureLogger.accept(timeouted);
+					readinessEvent.finish(Result.TIMEOUT);
+				}
+			)
+			.map(content -> {
+				final boolean result = !content.isEmpty();
+				if (result) {
+					readinessEvent.finish(Result.READY);
+				}
+				return result;
+			})
+			.orElse(false);
 	}
 
 }

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/RestProvider.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/RestProvider.java
@@ -28,15 +28,18 @@ import io.evitadb.externalApi.event.ReadinessEvent;
 import io.evitadb.externalApi.event.ReadinessEvent.Prospective;
 import io.evitadb.externalApi.event.ReadinessEvent.Result;
 import io.evitadb.externalApi.http.ExternalApiProvider;
+import io.evitadb.externalApi.http.ReadinessDiscoveryStallTracker;
 import io.evitadb.externalApi.rest.api.openApi.OpenApiSystemEndpoint;
 import io.evitadb.externalApi.rest.api.system.model.LivenessDescriptor;
 import io.evitadb.externalApi.rest.configuration.RestOptions;
+import io.evitadb.utils.CollectionUtils;
 import io.evitadb.utils.NetworkUtils;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
-import java.util.function.Predicate;
+import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Descriptor of external API provider that provides REST API.
@@ -65,6 +68,12 @@ public class RestProvider implements ExternalApiProvider<RestOptions> {
 	 */
 	private String reachableUrl;
 
+	/**
+	 * Tracks how long the readiness discovery phase (see {@link #reachableUrl}) has been running, so a server that
+	 * never becomes reachable on any candidate URL is reported once instead of on every single probe.
+	 */
+	private final ReadinessDiscoveryStallTracker stallTracker = new ReadinessDiscoveryStallTracker();
+
 	@Nonnull
 	@Override
 	public String getCode() {
@@ -92,45 +101,66 @@ public class RestProvider implements ExternalApiProvider<RestOptions> {
 
 	@Override
 	public boolean isReady() {
-		final Predicate<String> isReady = url -> {
-			final ReadinessEvent readinessEvent = new ReadinessEvent(CODE, Prospective.CLIENT);
-			return NetworkUtils.fetchContent(
-					url,
-					"GET",
-					"application/json",
-					null,
-					this.requestTimeout,
-					error -> {
-						log.error("Error while checking readiness of REST API: {}", error);
-						readinessEvent.finish(Result.ERROR);
-					},
-					timeouted -> {
-						log.error("{}", timeouted);
-						readinessEvent.finish(Result.TIMEOUT);
-					}
-				)
-				.map(content -> {
-					final boolean result = content.contains("true");
-					if (result) {
-						readinessEvent.finish(Result.READY);
-					}
-					return result;
-				})
-				.orElse(false);
-		};
-		final String[] baseUrls = this.configuration.getBaseUrls();
 		if (this.reachableUrl == null) {
+			// discovery phase: some candidate URLs (e.g. a publicly exposed hostname) are expected to fail until
+			// the reachable one is found, so individual failures are only worth a DEBUG line here
+			final String[] baseUrls = this.configuration.getBaseUrls();
+			final Map<String, String> failures = CollectionUtils.createLinkedHashMap(baseUrls.length);
 			for (String baseUrl : baseUrls) {
 				final String url = baseUrl + OpenApiSystemEndpoint.URL_PREFIX + "/" + LivenessDescriptor.LIVENESS_SUFFIX;
-				if (isReady.test(url)) {
+				if (probe(url, message -> {
+					failures.put(url, message);
+					log.debug("Error while checking readiness of REST API: {}", message);
+				})) {
 					this.reachableUrl = url;
 					return true;
 				}
 			}
+			if (this.stallTracker.shouldWarnAboutStall()) {
+				log.warn(
+					"REST API has not become reachable on any of the {} configured URL(s) for over {}s " +
+						"(this can be normal while the server is still starting up): {}",
+					baseUrls.length, ReadinessDiscoveryStallTracker.GRACE_PERIOD.toSeconds(), failures
+				);
+			}
 			return false;
 		} else {
-			return isReady.test(this.reachableUrl);
+			// steady state: this URL was reachable before, so a failure now is a genuine regression
+			return probe(
+				this.reachableUrl,
+				message -> log.error("Error while checking readiness of REST API: {}", message)
+			);
 		}
+	}
+
+	/**
+	 * Performs a single readiness probe against the given URL, reporting any failure message via {@code failureLogger}.
+	 */
+	private boolean probe(@Nonnull String url, @Nonnull Consumer<String> failureLogger) {
+		final ReadinessEvent readinessEvent = new ReadinessEvent(CODE, Prospective.CLIENT);
+		return NetworkUtils.fetchContent(
+				url,
+				"GET",
+				"application/json",
+				null,
+				this.requestTimeout,
+				error -> {
+					failureLogger.accept(error);
+					readinessEvent.finish(Result.ERROR);
+				},
+				timeouted -> {
+					failureLogger.accept(timeouted);
+					readinessEvent.finish(Result.TIMEOUT);
+				}
+			)
+			.map(content -> {
+				final boolean result = content.contains("true");
+				if (result) {
+					readinessEvent.finish(Result.READY);
+				}
+				return result;
+			})
+			.orElse(false);
 	}
 
 }

--- a/evita_external_api/evita_external_api_system/src/main/java/io/evitadb/externalApi/system/SystemProvider.java
+++ b/evita_external_api/evita_external_api_system/src/main/java/io/evitadb/externalApi/system/SystemProvider.java
@@ -30,8 +30,10 @@ import io.evitadb.externalApi.event.ReadinessEvent.Prospective;
 import io.evitadb.externalApi.event.ReadinessEvent.Result;
 import io.evitadb.externalApi.http.ExternalApiProviderWithConsoleOutput;
 import io.evitadb.externalApi.http.ExternalApiServer;
+import io.evitadb.externalApi.http.ReadinessDiscoveryStallTracker;
 import io.evitadb.externalApi.system.configuration.SystemOptions;
 import io.evitadb.utils.ArrayUtils;
+import io.evitadb.utils.CollectionUtils;
 import io.evitadb.utils.ConsoleWriter;
 import io.evitadb.utils.ConsoleWriter.ConsoleColor;
 import io.evitadb.utils.ConsoleWriter.ConsoleDecoration;
@@ -43,7 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nonnull;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.function.Predicate;
+import java.util.function.Consumer;
 
 import static io.evitadb.externalApi.system.SystemProviderRegistrar.ENDPOINT_SERVER_NAME;
 
@@ -83,6 +85,12 @@ public class SystemProvider implements ExternalApiProviderWithConsoleOutput<Syst
 	 */
 	private String reachableUrl;
 
+	/**
+	 * Tracks how long the readiness discovery phase (see {@link #reachableUrl}) has been running, so a server that
+	 * never becomes reachable on any candidate URL is reported once instead of on every single probe.
+	 */
+	private final ReadinessDiscoveryStallTracker stallTracker = new ReadinessDiscoveryStallTracker();
+
 	public SystemProvider(
 		@Nonnull SystemOptions configuration,
 		@Nonnull HttpService apiHandler,
@@ -114,38 +122,59 @@ public class SystemProvider implements ExternalApiProviderWithConsoleOutput<Syst
 
 	@Override
 	public boolean isReady() {
-		final Predicate<String> isReady = url -> {
-			final ReadinessEvent readinessEvent = new ReadinessEvent(CODE, Prospective.CLIENT);
-			final boolean reachable = NetworkUtils.isReachable(
-				url,
-				this.requestTimeout,
-				error -> {
-					log.error("Error while checking readiness of System API: {}", error);
-					readinessEvent.finish(Result.ERROR);
-				},
-				timeouted -> {
-					log.error("{}", timeouted);
-					readinessEvent.finish(Result.TIMEOUT);
-				}
-			);
-			if (reachable) {
-				readinessEvent.finish(Result.READY);
-			}
-			return reachable;
-		};
-		final String[] baseUrls = this.configuration.getBaseUrls();
 		if (this.reachableUrl == null) {
+			// discovery phase: some candidate URLs (e.g. a publicly exposed hostname) are expected to fail until
+			// the reachable one is found, so individual failures are only worth a DEBUG line here
+			final String[] baseUrls = this.configuration.getBaseUrls();
+			final Map<String, String> failures = CollectionUtils.createLinkedHashMap(baseUrls.length);
 			for (String baseUrl : baseUrls) {
 				final String nameUrl = baseUrl + ENDPOINT_SERVER_NAME;
-				if (isReady.test(nameUrl)) {
+				if (probe(nameUrl, message -> {
+					failures.put(nameUrl, message);
+					log.debug("Error while checking readiness of System API: {}", message);
+				})) {
 					this.reachableUrl = nameUrl;
 					return true;
 				}
 			}
+			if (this.stallTracker.shouldWarnAboutStall()) {
+				log.warn(
+					"System API has not become reachable on any of the {} configured URL(s) for over {}s " +
+						"(this can be normal while the server is still starting up): {}",
+					baseUrls.length, ReadinessDiscoveryStallTracker.GRACE_PERIOD.toSeconds(), failures
+				);
+			}
 			return false;
 		} else {
-			return isReady.test(this.reachableUrl);
+			// steady state: this URL was reachable before, so a failure now is a genuine regression
+			return probe(
+				this.reachableUrl,
+				message -> log.error("Error while checking readiness of System API: {}", message)
+			);
 		}
+	}
+
+	/**
+	 * Performs a single readiness probe against the given URL, reporting any failure message via {@code failureLogger}.
+	 */
+	private boolean probe(@Nonnull String url, @Nonnull Consumer<String> failureLogger) {
+		final ReadinessEvent readinessEvent = new ReadinessEvent(CODE, Prospective.CLIENT);
+		final boolean reachable = NetworkUtils.isReachable(
+			url,
+			this.requestTimeout,
+			error -> {
+				failureLogger.accept(error);
+				readinessEvent.finish(Result.ERROR);
+			},
+			timeouted -> {
+				failureLogger.accept(timeouted);
+				readinessEvent.finish(Result.TIMEOUT);
+			}
+		);
+		if (reachable) {
+			readinessEvent.finish(Result.READY);
+		}
+		return reachable;
 	}
 
 	@Nonnull

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/http/ReadinessDiscoveryStallTrackerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/http/ReadinessDiscoveryStallTrackerTest.java
@@ -28,9 +28,15 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.evitadb.test.TestTags.EXTERNAL_API;
 import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -63,6 +69,43 @@ class ReadinessDiscoveryStallTrackerTest {
 		assertTrue(tracker.shouldWarnAboutStall());
 		assertFalse(tracker.shouldWarnAboutStall());
 		assertFalse(tracker.shouldWarnAboutStall());
+	}
+
+	@Test
+	@DisplayName("warns exactly once when called concurrently past the grace period")
+	void shouldWarnExactlyOnceUnderConcurrentAccess() throws InterruptedException {
+		final ReadinessDiscoveryStallTracker tracker = new ReadinessDiscoveryStallTracker(Duration.ofMillis(20));
+		assertFalse(tracker.shouldWarnAboutStall());
+		Thread.sleep(50);
+
+		final int threadCount = 16;
+		final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		try {
+			final CountDownLatch readyLatch = new CountDownLatch(threadCount);
+			final CountDownLatch startLatch = new CountDownLatch(1);
+			final AtomicInteger warnCount = new AtomicInteger();
+			for (int i = 0; i < threadCount; i++) {
+				executorService.submit(() -> {
+					readyLatch.countDown();
+					try {
+						startLatch.await();
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+					if (tracker.shouldWarnAboutStall()) {
+						warnCount.incrementAndGet();
+					}
+				});
+			}
+			readyLatch.await();
+			startLatch.countDown();
+			executorService.shutdown();
+			assertTrue(executorService.awaitTermination(5, TimeUnit.SECONDS));
+
+			assertEquals(1, warnCount.get(), "Exactly one concurrent caller should have won the stall warning");
+		} finally {
+			executorService.shutdownNow();
+		}
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/http/ReadinessDiscoveryStallTrackerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/http/ReadinessDiscoveryStallTrackerTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.evitadb.test.TestTags.EXTERNAL_API;
-import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static io.evitadb.test.TestTags.MANAGEMENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @DisplayName("ReadinessDiscoveryStallTracker")
 @Tag(EXTERNAL_API)
-@Tag(OBSERVABILITY)
+@Tag(MANAGEMENT)
 class ReadinessDiscoveryStallTrackerTest {
 
 	@Test
@@ -61,10 +61,10 @@ class ReadinessDiscoveryStallTrackerTest {
 	@Test
 	@DisplayName("warns exactly once after the grace period elapses")
 	void shouldWarnExactlyOnceAfterGracePeriodElapses() throws InterruptedException {
-		final ReadinessDiscoveryStallTracker tracker = new ReadinessDiscoveryStallTracker(Duration.ofMillis(20));
+		final ReadinessDiscoveryStallTracker tracker = new ReadinessDiscoveryStallTracker(Duration.ofMillis(200));
 		assertFalse(tracker.shouldWarnAboutStall());
 
-		Thread.sleep(50);
+		Thread.sleep(400);
 
 		assertTrue(tracker.shouldWarnAboutStall());
 		assertFalse(tracker.shouldWarnAboutStall());
@@ -74,9 +74,9 @@ class ReadinessDiscoveryStallTrackerTest {
 	@Test
 	@DisplayName("warns exactly once when called concurrently past the grace period")
 	void shouldWarnExactlyOnceUnderConcurrentAccess() throws InterruptedException {
-		final ReadinessDiscoveryStallTracker tracker = new ReadinessDiscoveryStallTracker(Duration.ofMillis(20));
+		final ReadinessDiscoveryStallTracker tracker = new ReadinessDiscoveryStallTracker(Duration.ofMillis(200));
 		assertFalse(tracker.shouldWarnAboutStall());
-		Thread.sleep(50);
+		Thread.sleep(400);
 
 		final int threadCount = 16;
 		final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/http/ReadinessDiscoveryStallTrackerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/http/ReadinessDiscoveryStallTrackerTest.java
@@ -1,0 +1,68 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.http;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link ReadinessDiscoveryStallTracker}.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("ReadinessDiscoveryStallTracker")
+@Tag(EXTERNAL_API)
+@Tag(OBSERVABILITY)
+class ReadinessDiscoveryStallTrackerTest {
+
+	@Test
+	@DisplayName("does not warn before the grace period elapses")
+	void shouldNotWarnBeforeGracePeriodElapses() {
+		final ReadinessDiscoveryStallTracker tracker = new ReadinessDiscoveryStallTracker(Duration.ofSeconds(60));
+		assertFalse(tracker.shouldWarnAboutStall());
+		assertFalse(tracker.shouldWarnAboutStall());
+	}
+
+	@Test
+	@DisplayName("warns exactly once after the grace period elapses")
+	void shouldWarnExactlyOnceAfterGracePeriodElapses() throws InterruptedException {
+		final ReadinessDiscoveryStallTracker tracker = new ReadinessDiscoveryStallTracker(Duration.ofMillis(20));
+		assertFalse(tracker.shouldWarnAboutStall());
+
+		Thread.sleep(50);
+
+		assertTrue(tracker.shouldWarnAboutStall());
+		assertFalse(tracker.shouldWarnAboutStall());
+		assertFalse(tracker.shouldWarnAboutStall());
+	}
+
+}


### PR DESCRIPTION
## Summary
- Discovery-phase readiness-probe failures (candidate URLs tried before a provider locks onto a working one) now log at `DEBUG` instead of `ERROR`, across all six external API providers (Rest, GraphQL, System, Observability, Lab, gRPC).
- If an entire discovery round stays empty for more than a 60s grace period, a single consolidated `WARN` is logged once via the new `ReadinessDiscoveryStallTracker`, then suppressed - a server that never becomes ready still produces exactly one signal, not a per-URL flood on every poll.
- Once a provider has a known-good URL (steady state), a failure there still logs `ERROR` immediately, unchanged.
- Logging only - `ReadinessEvent` metrics/telemetry are unaffected.

See `documentation/adr/2026-08-03-readiness-discovery-log-level.md` for the full design rationale and rejected alternatives.

Closes #1364

## Test plan
- [x] `mvn compile` succeeds on all touched modules (core, rest, graphql, system, observability, lab, grpc/server)
- [x] New `ReadinessDiscoveryStallTrackerTest` (2 tests) passes
