### PR TITLE
fix: keep-alive ping/idle mismatch and always-safe retry

### DIFF
--- a/documentation/adr/2026-07-16-client-session-cancellation-cascade.md
+++ b/documentation/adr/2026-07-16-client-session-cancellation-cascade.md
@@ -1,7 +1,7 @@
 ---
 title: Fix the gRPC session-cancellation cascade, and move the test-only executor switch off public config into a per-dataset real-pool opt-in
 date: 2026-07-16
-updated: 2026-07-31 21:50
+updated: 2026-08-03 15:50
 status: accepted
 kind: fix
 issues: []
@@ -9,7 +9,7 @@ prs: [1284]
 areas: [evita_external_api_grpc/client/driver, evita_external_api_core/configuration, evita_engine/core, evita_api/exception, evita_api/configuration, evita_server, evita_test_support, evita_test/evita_functional_tests]
 supersedes: []
 superseded-by: []
-relates: []
+relates: [2026-08-03-driver-connection-resilience]
 ---
 
 # Fix the gRPC keep-alive self-kill and session-cancellation cascade
@@ -274,7 +274,11 @@ Re-checked against the current tree, not just carried from `RESULTS.md`:
 - **Resolved, not open:** CDC gate hardening (blocking-semantics Javadoc + timeout) — confirmed
   present in `ClientChangeCapturePublisher`'s Javadoc.
 - **Resolved, not open:** the inert-ping defect (client ping silently disabled by the old coupled
-  idle timeout) — confirmed fixed via the decoupled `idleTimeoutMillis` knob described above.
+  idle timeout) — confirmed fixed via the decoupled `idleTimeoutMillis` knob described above. This only
+  ever covered the *client's* half of the contract, though: the server still ignored inbound client pings
+  as connection activity (`ExternalApiServer`'s single-argument `idleTimeoutMillis` overload rode
+  Armeria's `keepAliveOnPing = false` default), an unrecognized gap in this fix, not a regression —
+  closed in `2026-08-03-driver-connection-resilience.md`.
 - Part C (bounded-wait before throwing CSAE on guard collision) was **not implemented** — the CDC
   ordering fix removed the register-then-mutate race that was the only observed source of guard
   collisions, so RESULTS.md records the decision to skip it rather than build unneeded hardening.

--- a/documentation/adr/2026-08-03-driver-connection-resilience.md
+++ b/documentation/adr/2026-08-03-driver-connection-resilience.md
@@ -5,7 +5,7 @@ updated: 2026-08-03 16:30
 status: accepted
 kind: fix
 issues: [1367, 1368]
-prs: []
+prs: [1371]
 areas: [evita_external_api_grpc/client/driver, evita_external_api_core/configuration, evita_external_api_core/http, evita_server/resources, documentation/user/en]
 supersedes: []
 superseded-by: []

--- a/documentation/adr/2026-08-03-driver-connection-resilience.md
+++ b/documentation/adr/2026-08-03-driver-connection-resilience.md
@@ -1,0 +1,219 @@
+---
+title: Align client/server keep-alive timing and always retry provably-unprocessed gRPC calls
+date: 2026-08-03
+updated: 2026-08-03 16:30
+status: accepted
+kind: fix
+issues: [1367, 1368]
+prs: []
+areas: [evita_external_api_grpc/client/driver, evita_external_api_core/configuration, evita_external_api_core/http, evita_server/resources, documentation/user/en]
+supersedes: []
+superseded-by: []
+relates: [2026-07-16-client-session-cancellation-cascade]
+---
+
+# Align client/server keep-alive timing and always retry provably-unprocessed gRPC calls
+
+Two independently-filed driver defects shared a root cause — the client/server keep-alive contract
+introduced by the 2026-07-16 cascade fix was only half-closed — so they are fixed together. #1368: the
+driver's keep-alive ping could never keep a connection alive because the server both shipped a tighter
+idle timeout than documented and ignored inbound pings as activity. #1367: the driver retries nothing by
+default, so a routine server-side connection close (a graceful restart's `GOAWAY`, or a `Connection
+refused` while the server is coming back up) hard-fails whatever the application was doing.
+
+## Why
+
+Both issues were filed from reading the shipped 2026.2.1 defaults, not a single reproduced incident, but
+the arithmetic is real: a client keep-alive ping that structurally cannot land before the server reaps
+the connection is not a tuning problem, it is dead code. And a driver whose only two responses to a lost
+connection are the default answer ("time out and blow up") and the ADR-designed answer ("say the outcome
+is indeterminate and give up") never actually gets to "retry the small class of calls that are safe to
+retry" — because nothing turns retry on by default.
+
+### Previous state
+
+- `ApiOptions.DEFAULT_IDLE_TIMEOUT` was `20000` ms in code, but the shipped `evita-configuration.yaml`
+  bound `idleTimeoutInMillis` to `${api.idleTimeoutInMillis:2K}` — `2000` ms via
+  `SpecialConfigInputFormatsHandler`'s decimal `K` suffix (confirmed by reading the parser directly, not
+  assumed). Neither issue caught this; it was found by reading the actual shipped template while
+  investigating #1368, and made the real-world mismatch an order of magnitude worse than described.
+- `ExternalApiServer` called Armeria's single-argument `.idleTimeoutMillis(millis)` overload, so the
+  server's `keepAliveOnPing` rode Armeria's global default (`false`). Verified directly against Armeria
+  1.40.0 sources: `Http2RequestDecoder.onPingRead` calls `keepAliveHandler.onPing()` on every inbound
+  client ping, but `AbstractKeepAliveHandler.onPing()` only resets the connection's idle clock
+  `if (connectionIdleTimeNanos > 0 && keepAliveOnPing)`. With the flag false, an actively-pinging client
+  connection was still reaped on schedule — the server-side half of the keep-alive contract the
+  2026-07-16 ADR believed it had closed.
+- `ClientConnectionOptions` defaulted to a `30000` ms ping against a `300000` ms client-side idle timeout
+  — internally consistent, but never checked against the server's own idle timeout, so the pair was safe
+  on paper and inert in practice against either the `20000` ms code constant or the `2000` ms shipped
+  default. The `30000` ms ping is not an arbitrary number: the 2026-07-16 ADR set it deliberately as a
+  *stall budget* — Armeria couples a ping's ack-wait deadline to the ping interval itself
+  (`AbstractKeepAliveHandler.PingWriteListener` schedules the connection's forced close after exactly
+  `pingIntervalMillis` if no ack arrives), so a shorter interval directly reintroduces the "GC pause kills
+  a live connection" self-inflicted failure that ADR fixed. Any fix here has to keep the ping at or above
+  that stall budget, not shrink it to satisfy the idle-timeout arithmetic.
+- `EvitaClientConfiguration.retry` defaulted to `false`, and `EvitaClient` only installed the
+  `RetryingClient` decorator at all when it was `true`. The installed rule set (`onTimeoutException`,
+  `onStatus(SERVICE_UNAVAILABLE, GATEWAY_TIMEOUT, UNKNOWN)`, `onStatus(TOO_MANY_REQUESTS)`) was adequate
+  for the reported failures, but simply never ran for the default caller.
+
+## Options considered
+
+### Retry scope: unconditional `onUnprocessed()` vs. flipping the whole flag (chosen: unconditional)
+
+- **Option A — always install `onUnprocessed().thenBackoff()`; keep the broader rule set behind the
+  existing `retry` flag, default unchanged (`false`) (chosen).** `UnprocessedRequestException` is
+  Armeria's own "certain the server never saw this request" signal (a refused connection, or a `GOAWAY`
+  received before the request's stream was accepted) — replaying it can never duplicate an
+  already-applied mutation, so it is safe unconditionally.
+  - **Pros:** fixes both traces in #1367 (connection-refused-during-restart, and GOAWAY before the
+    request was accepted) with zero duplicate-application risk; changes nothing for callers who chose
+    `retry=false` on purpose.
+  - **Cons:** does not, by itself, retry a request that was aborted *after* the server may have started
+    processing it (that stays behind `retry(true)`, unchanged from before).
+- **Option B — default `retry` to `true` (the issue's literal suggested fix) (declined).**
+  - **Pros:** matches the issue text exactly; simplest possible change.
+  - **Rejected because:** the existing rule set includes `onStatus(..., HttpStatus.UNKNOWN).thenBackoff()`
+    — Armeria's sentinel for *any* transport abort with no response headers, which includes a request the
+    server already processed (e.g. a mutation whose response was lost to a `GOAWAY` mid-stream). The
+    2026-07-16 ADR deliberately chose *not* to auto-retry transport failures for exactly this reason
+    (`TransportException`'s Javadoc documents the outcome as indeterminate, "a blind retry can duplicate
+    an already-applied change"). Flipping the whole flag would silently re-enable that risk for every
+    driver user by default, reopening a question that PR already closed.
+
+### Keep-alive numbers: shrink the client's ping vs. raise the server's idle timeout (chosen: raise the server)
+
+- **Option A — lower `ClientConnectionOptions` defaults (ping `30000`→`5000`, idle `300000`→`15000`);
+  leave the server's `20000` ms code constant alone; fix the two wiring bugs (declined — first choice,
+  reversed after review).**
+  - **Pros:** matches #1368's own suggested numbers at face value; a healthy connection's ping/ack traffic
+    resets both idle clocks well inside either threshold.
+  - **Rejected because:** the ping interval doubles as the ack-wait stall budget (see *Previous state*
+    above) — shrinking it to 5 s means any GC pause or event-loop stall over 5 s now self-kills the
+    connection, which is precisely the failure class the 2026-07-16 ADR widened the ping from 1 s to 30 s
+    to fix. This was caught in review, not before implementation: the first pass shipped this option, ran
+    150 tests green, and only a second look connected `PingWriteListener`'s deadline scheduling (already
+    read while investigating #1368) to the choice of number. The green tests were not evidence against
+    it — the entire dataset-based test lane runs with the ping disabled
+    (`EvitaParameterResolver.pingIntervalMillis(0)`), so nothing in the suite can stall an event loop for
+    5+ seconds while a ping is in flight to catch this.
+- **Option B — raise the server's idle timeout instead (`20000`→`60000` ms, code constant and shipped YAML
+  both) and keep the client's ping/idle defaults exactly as they were (`30000`/`300000`) (chosen).**
+  - **Pros:** the 30 s ping keeps the full production-derived stall budget; the server's new 60 s idle
+    timeout gives it 2× margin over that ping, so a healthy, actively-pinging connection is never reaped by
+    either side; with `keepAliveOnPing` now fixed on both sides, the server backstop only matters once
+    keep-alive itself has already stopped working (a genuinely dead peer) — the same case Option A also
+    only affected, just detected a little slower now (up to 60 s instead of 15 s).
+  - **Cons:** a connection that never pings at all (the driver supports `pingIntervalMillis(0)`, and
+    several test-lane clients use it) now waits up to 60 s of true silence before the server reclaims it,
+    instead of 20 s. Accepted: this was already true relative to the client's own 300 s idle default before
+    this fix, or the server's original 2 s shipped bug provided no meaningful protection either way.
+
+## Decision
+
+**Chosen: `onUnprocessed()` unconditionally (retry dimension) and raising the server's idle timeout
+(keep-alive dimension).** Unconditional `onUnprocessed()` retry closes the reported failures without
+reopening the duplicate-mutation risk the 2026-07-16 ADR deliberately avoided. Raising the server's idle
+timeout — rather than shrinking the client's ping — keeps the 30 s stall budget that same ADR chose for a
+specific, evidenced reason (production GC/event-loop stalls), while still closing the "ping never lands
+before the server reaps" gap: the fix moves to the side of the equation with no lower bound instead of
+the side with a hard lower bound.
+
+## Key technical details
+
+- `evita_external_api/evita_external_api_core/.../http/ExternalApiServer.java` — `.idleTimeoutMillis(apiOptions.idleTimeoutInMillis())`
+  changed to the two-argument `(millis, true)` overload, mirroring the comment/pattern `EvitaClient`
+  already used for the client side.
+- `evita_external_api/evita_external_api_core/.../configuration/ApiOptions.java` —
+  `DEFAULT_IDLE_TIMEOUT` `20_000` → `60_000`.
+- `evita_server/src/main/resources/evita-configuration.yaml` — `idleTimeoutInMillis` default `2K` → `60K`,
+  now matching the raised `ApiOptions.DEFAULT_IDLE_TIMEOUT`; `documentation/user/en/operate/configure.md`
+  updated to match (hand-edited; the Czech mirror regenerates via Comenius, not touched here).
+  `requestTimeoutInMillis` (`2K`) is untouched — a different Armeria setting, out of scope for either issue.
+- `evita_external_api/evita_external_api_grpc/client/.../driver/config/ClientConnectionOptions.java` —
+  `DEFAULT_PING_INTERVAL_MILLIS` (`30_000`) and `DEFAULT_IDLE_TIMEOUT_MILLIS` (`300_000`) are **unchanged**
+  from the 2026-07-16 ADR's values; only their Javadoc gained the cross-reference to the server's new
+  `60000` ms default.
+- `evita_external_api/evita_external_api_grpc/client/.../driver/EvitaClient.java` — retry-rule
+  construction extracted into `static RetryRule createRetryRule(boolean retryEnabled)`; the
+  `RetryingClient` decorator is now installed unconditionally (previously only under `if
+  (configuration.retry())`), with the `onUnprocessed()` rule always present and the broader rule set
+  appended only when `retryEnabled`. `EvitaClientConfiguration.retry` keeps its `false` default —
+  its meaning narrowed to "the broader, potentially-duplicating rule set," not "any retry at all." The
+  unconditional retry uses Armeria's default backoff and `maxTotalAttempts` (10), but the whole retry
+  sequence — attempts plus backoff delays combined — is bounded by the call's existing response timeout
+  (`ClientTimeoutOptions`, 5 s by default): `AbstractRetryingClient`'s per-attempt deadline is `min` of any
+  per-attempt override (unset here) and the *original* call's remaining deadline, so a down server fails
+  no later than today's configured per-call timeout, just with a few backoff attempts inside that budget
+  instead of one immediate failure.
+- **Invariant a future change must preserve:** the client ping must stay (a) at or above the worst
+  tolerable event-loop stall / GC pause — production evidence in the 2026-07-16 ADR put this at multiple
+  seconds, hence `30000` ms, not a much shorter probe frequency — **and** (b) strictly below the client's
+  own idle timeout (checked today, `EvitaClient`'s existing precondition warning) **and** (c) strictly
+  below the server's shipped idle timeout (not checked anywhere — no runtime handshake carries the
+  server's value to the client). Constraint (a) has a hard lower bound; (b) and (c) don't, which is why
+  this fix raised the server's idle timeout rather than lowering the ping.
+- Confirmed via Armeria 1.40.0 sources (not assumed): `Http2RequestDecoder.java:450-451`
+  (`onPingRead` → `keepAliveHandler.onPing()`), `AbstractKeepAliveHandler.java:197-213` (`onPing()` only
+  resets the idle clock when `keepAliveOnPing` is true), `AbstractKeepAliveHandler.java:320`
+  (`PingWriteListener` schedules the forced close after `pingIdleTimeNanos` — the ping interval **is** the
+  ack-wait deadline, the source of constraint (a) above), `AbstractRuleBuilder.java:287-288`
+  (`onUnprocessed()` is `onException(UnprocessedRequestException.class)`), `RuleFilter.java:98-101` (the
+  exception filter matches on the raw `cause` argument, no completed `RequestLog` required — which is what
+  makes `EvitaClient.createRetryRule` unit-testable without a network), and
+  `DefaultFlagsProvider.java:98` (`DEFAULT_MAX_TOTAL_ATTEMPTS = 10`).
+
+## Verification
+
+- `EvitaClientRetryRuleTest` (new, 3 tests): `createRetryRule(false)` retries an
+  `UnprocessedRequestException` and does not retry a bare `CANCELLED` `StatusRuntimeException`;
+  `createRetryRule(true)` still retries the unprocessed case. Built directly against
+  `ClientRequestContext.of(...)` and `RetryRule.shouldRetry(...)`, Armeria's own sanctioned unit-testing
+  seam — no network involved, so no timing dependency.
+- `ClientConnectionOptionsTest` — default-value assertions confirm `30_000`/`300_000` are unchanged; the
+  existing clamp/fallback tests (already symbolic, not literal) needed no change.
+- `EvitaServerTest` — 14/14, confirms the server still boots and answers readiness/liveness/status probes
+  with the two-argument `idleTimeoutMillis` overload and the raised `60000` ms default.
+- `ClientSessionCancellationCascadeTest` — 1/1 unchanged, confirming the always-installed `RetryingClient`
+  decorator does not interfere with a fault injected at the gRPC `ClientInterceptor` layer (that layer
+  sits above Armeria's HTTP-level decorators, including `RetryingClient`, so it was never a candidate for
+  exercising the retry rule in the first place — the reason a unit-level test was used for the retry rule
+  instead).
+- `EvitaClientReadOnlyTest` + `EvitaClientReadWriteTest` (the 2026-07-16 ADR's real-thread-pool island) —
+  150 tests, 0 failures, 1 pre-existing skip. Re-run after reverting the client ping/idle numbers to their
+  original values; note this suite runs in well under a minute per class and never stalls an event loop
+  for seconds, so it cannot by itself validate the stall-budget property discussed above — that property
+  rests on the unchanged 2026-07-16 production evidence, not on this suite.
+
+## Consequences & open follow-ups
+
+- **Still open — no cross-side precondition check.** #1368 suggested the server could advertise its idle
+  timeout during the client handshake so `EvitaClient`'s existing warning could compare against it instead
+  of only the client's own value. That is a real protocol change, not a config-default fix, and was
+  deliberately left out of this PR's scope.
+- **Still open — the server-side `keepAliveOnPing` fix has no automated regression test.** Proving it
+  end-to-end needs a real idle-timeout window to elapse, the same class of timing-sensitive test the
+  2026-07-16 ADR deliberately declined to write for the client-side stall-kill case. Verified instead by
+  direct primary-source reading of Armeria 1.40.0 (cited above under *Key technical details*).
+- The 2026-07-16 ADR's "Resolved, not open: the inert-ping defect" entry only ever covered the *client's*
+  half of the contract (Armeria silently dropping a ping whose interval isn't strictly below the client's
+  own idle timeout). It did not cover the server ignoring inbound pings as activity — that half was an
+  unrecognized gap in the original fix, not a regression; this record's `relates` link and this bullet
+  are the fix-up.
+- **Still open — a fully-silent connection (ping disabled) now waits up to 60 s before the server reclaims
+  it**, up from 20 s (or the buggy 2 s shipped default). Accepted for this PR — see the *Options
+  considered* rejection of Option A — but if connection-count pressure ever becomes a real operational
+  concern, the next lever is a shorter idle timeout specifically for connections that never negotiate a
+  ping, not a shorter ping for everyone.
+
+## Related work
+
+- Relates to `2026-07-16-client-session-cancellation-cascade.md`, which introduced the client-side
+  `pingIntervalMillis`/`idleTimeoutMillis` knobs and the transport-failure-as-session-loss design this
+  record builds directly on. That record's front matter and follow-ups are updated in the same commit to
+  point here.
+
+## Timeline
+
+- **2026-08-03** — issues #1367 and #1368 filed; root-caused, fixed and merged the same day.

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -34,7 +34,7 @@ filename date that disagrees with `date:`.
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
 | 2026-08-03 | [Readiness discovery-phase probe failures log at DEBUG; only a known-good endpoint failing logs ERROR](2026-08-03-readiness-discovery-log-level.md) | fix | proposed | #1364, PR #1366 |
-| 2026-08-03 | [Align client/server keep-alive timing and always retry provably-unprocessed gRPC calls](2026-08-03-driver-connection-resilience.md) | fix | accepted | #1367, #1368 |
+| 2026-08-03 | [Align client/server keep-alive timing and always retry provably-unprocessed gRPC calls](2026-08-03-driver-connection-resilience.md) | fix | accepted | #1367, #1368, PR #1371 |
 | 2026-08-02 | [Route release cuts through workflow_dispatch on the release_* branch, not workflow_run from master](2026-08-02-ci-release-pipeline-patch-versioning-fix.md) | infrastructure | accepted | #1359, #1362 |
 | 2026-08-02 | [Keep IDEA and Claude formatting in step with a shared .editorconfig and a diff-scoped hook, not Spotless](2026-08-02-editorconfig-formatting-parity.md) | infrastructure | accepted | #1119 |
 | 2026-08-01 | [Answer the B+ tree insert-boundary asserts from the descent instead of a captured cursor path](2026-08-01-bplustree-cursor-free-insert-path.md) | optimization | accepted | #1333, PR #1356 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,8 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-03 | [Readiness discovery-phase probe failures log at DEBUG; only a known-good endpoint failing logs ERROR](2026-08-03-readiness-discovery-log-level.md) | fix | proposed | #1364 |
+| 2026-08-03 | [Readiness discovery-phase probe failures log at DEBUG; only a known-good endpoint failing logs ERROR](2026-08-03-readiness-discovery-log-level.md) | fix | proposed | #1364, PR #1366 |
+| 2026-08-03 | [Align client/server keep-alive timing and always retry provably-unprocessed gRPC calls](2026-08-03-driver-connection-resilience.md) | fix | accepted | #1367, #1368 |
 | 2026-08-02 | [Route release cuts through workflow_dispatch on the release_* branch, not workflow_run from master](2026-08-02-ci-release-pipeline-patch-versioning-fix.md) | infrastructure | accepted | #1359, #1362 |
 | 2026-08-02 | [Keep IDEA and Claude formatting in step with a shared .editorconfig and a diff-scoped hook, not Spotless](2026-08-02-editorconfig-formatting-parity.md) | infrastructure | accepted | #1119 |
 | 2026-08-01 | [Answer the B+ tree insert-boundary asserts from the descent instead of a captured cursor path](2026-08-01-bplustree-cursor-free-insert-path.md) | optimization | accepted | #1333, PR #1356 |

--- a/documentation/user/en/operate/configure.md
+++ b/documentation/user/en/operate/configure.md
@@ -98,7 +98,7 @@ cache:                                            # [see Cache configuration](#c
 
 api:                                              # [see API configuration](#api-configuration)
   workerGroupThreads: 4
-  idleTimeoutInMillis: 2K
+  idleTimeoutInMillis: 60K
   requestTimeoutInMillis: 2K  
   maxEntitySizeInBytes: 2MB
   accessLog: false
@@ -1093,10 +1093,13 @@ This section of the configuration allows you to selectively enable, disable, and
     </dd>
     <dt>idleTimeoutInMillis</dt>
     <dd>
-        <p>**Default:** `2K`</p>
+        <p>**Default:** `60K`</p>
         <p>The amount of time a connection can be idle for before it is timed out. An idle connection is a connection 
             that has had no data transfer in the idle timeout period. Note that this is a fairly coarse grained approach,
-            and small values will cause problems for requests with a long processing time.</p>
+            and small values will cause problems for requests with a long processing time. The default sits comfortably
+            above the Java driver's default keep-alive ping interval (30 s, see
+            [Connection options](../use/connectors/java.md#connection-options)) so an actively-pinging client
+            connection is never reaped.</p>
     </dd>
     <dt>requestTimeoutInMillis</dt>
     <dd>

--- a/documentation/user/en/use/connectors/java.md
+++ b/documentation/user/en/use/connectors/java.md
@@ -137,10 +137,14 @@ Connection settings are configured via
         the client sends a PING; if the peer does not acknowledge it within the same interval, the connection is
         closed. The interval is therefore the *stall budget* — it must comfortably exceed the worst tolerable
         GC / CPU-starvation pause, not act as a probe frequency, otherwise a slow-but-alive call may be killed
-        mid-flight. Set `0` to disable the client ping entirely (the connection is then reaped by
-        `idleTimeoutMillis` alone); any other value must be at least `1000` ms. The ping must stay strictly below
-        `idleTimeoutMillis`, otherwise the underlying HTTP client silently disables it — the default pair
-        (`30000` ping, `300000` idle) satisfies this, and the client logs a warning if a custom pair does not.</p>
+        mid-flight; this is why the interval is 30 s rather than a much shorter probe frequency. Set `0` to disable
+        the client ping entirely (the connection is then reaped by `idleTimeoutMillis` alone); any other value must
+        be at least `1000` ms. The ping must also stay strictly below `idleTimeoutMillis`, otherwise the underlying
+        HTTP client silently disables it — the default pair (`30000` ping, `300000` idle) satisfies this, and the
+        client logs a warning if a custom pair does not. Separately, it must stay below the *server's* own
+        `idleTimeoutInMillis` (see [API configuration](../../operate/configure.md#api-configuration), default 60 s)
+        or the server reaps the connection before a scheduled ping ever gets a chance to run — the server's default
+        is chosen with exactly this 30 s client default in mind.</p>
     </dd>
     <dt>idleTimeoutMillis</dt>
     <dd>

--- a/documentation/user/en/use/connectors/java.md
+++ b/documentation/user/en/use/connectors/java.md
@@ -305,7 +305,12 @@ The following options are configured directly on
     <dt>retry</dt>
     <dd>
         <p>**Default: `false`**</p>
-        <p>Whether the client will retry the call in case of timeout or other network related problems.</p>
+        <p>Whether the broader, potentially-duplicating retry rule set is active: timeouts, `503`/`504`/`UNKNOWN`
+        statuses, and `429` back-off. These can match a request the server already processed (e.g. a mutation
+        whose response was lost to a transport abort), so they stay opt-in. Independently of this flag, a request
+        Armeria can prove never reached the server (a refused connection, or a GOAWAY received before the request's
+        stream was accepted) is always retried automatically with backoff, bounded by the per-call timeout, since
+        replaying it can never duplicate an already-applied mutation.</p>
     </dd>
     <dt>trackedTaskLimit</dt>
     <dd>

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/configuration/ApiOptions.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/configuration/ApiOptions.java
@@ -52,6 +52,11 @@ import static java.util.Optional.ofNullable;
  * @param idleTimeoutInMillis    The amount of time a connection can be idle for before it is timed out. An idle connection is a
  *                               connection that has had no data transfer in the idle timeout period. Note that this is a fairly coarse
  *                               grained approach, and small values will cause problems for requests with a long processing time.
+ *                               Defaults to `60000` (60 s), comfortably above the driver's default keep-alive ping
+ *                               interval (`ClientConnectionOptions.DEFAULT_PING_INTERVAL_MILLIS`, `30000` ms). An
+ *                               acknowledged inbound ping counts as activity (`ExternalApiServer`'s `keepAliveOnPing =
+ *                               true`), so an actively-pinging client is never reaped. Lowering this below the ping
+ *                               interval silently makes the keep-alive unable to keep up.
  * @param requestTimeoutInMillis The amount of time a connection can sit idle without processing a request, before it is closed by
  *                               the server.
  * @param pingIntervalMillis     The HTTP/2 keep-alive PING interval in milliseconds. When neither a read nor a write happens on a
@@ -79,7 +84,7 @@ public record ApiOptions(
 	@Nonnull Map<String, AbstractApiOptions> endpoints
 ) {
 	public static final int DEFAULT_WORKER_GROUP_THREADS = Runtime.getRuntime().availableProcessors();
-	public static final int DEFAULT_IDLE_TIMEOUT = 20 * 1000;
+	public static final int DEFAULT_IDLE_TIMEOUT = 60 * 1000;
 	public static final int DEFAULT_REQUEST_TIMEOUT = 1000;
 	public static final int DEFAULT_PING_INTERVAL = 0;
 	public static final long DEFAULT_MAX_ENTITY_SIZE = 2_097_152L;

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ExternalApiServer.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ExternalApiServer.java
@@ -594,7 +594,11 @@ public class ExternalApiServer implements AutoCloseable {
 			.decorator(TracingDecorator.newDecorator())
 			.errorHandler(LoggingServerErrorHandler.INSTANCE)
 			.gracefulShutdownTimeout(gracefulShutdown ? Duration.ofSeconds(1) : Duration.ZERO, gracefulShutdown ? Duration.ofSeconds(1) : Duration.ZERO)
-			.idleTimeoutMillis(apiOptions.idleTimeoutInMillis())
+			// keepAliveOnPing = true makes a client's inbound keep-alive ping count as connection activity, so a
+			// connection with an actively pinging client is never reaped by the idle timeout - set explicitly
+			// rather than riding Armeria's global Flags.defaultServerKeepAliveOnPing (false by default). Without
+			// this, the server ignores the driver's own keep-alive ping and reaps the connection regardless.
+			.idleTimeoutMillis(apiOptions.idleTimeoutInMillis(), true)
 			.requestTimeoutMillis(apiOptions.requestTimeoutInMillis())
 			.pingIntervalMillis(apiOptions.pingIntervalMillis())
 			.serviceWorkerGroup(workerGroup, true)

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
@@ -28,6 +28,7 @@ import com.google.protobuf.Empty;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
 import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.client.retry.RetryRule;
@@ -308,6 +309,34 @@ public class EvitaClient implements EvitaContract {
 		return false;
 	}
 
+	/**
+	 * Builds the {@link RetryRule} installed on every driver instance's gRPC client. An `onUnprocessed()` rule is
+	 * always active, regardless of {@code retryEnabled}: Armeria raises {@link UnprocessedRequestException} only
+	 * when it is certain a request never reached the server (a refused connection, or a GOAWAY received before the
+	 * request's stream was accepted), so replaying it can never duplicate an already-applied mutation. When
+	 * {@code retryEnabled} is {@code true}, the broader rule set is layered on top — timeouts, `503`/`504`/`UNKNOWN`
+	 * statuses and `429` back-off — which can also match a request the server already processed (e.g. a mutation
+	 * whose response was lost to a transport abort), so that behaviour stays opt-in.
+	 *
+	 * @param retryEnabled whether the broader, potentially-duplicating retry rule set should be active
+	 * @return the {@link RetryRule} to install on the gRPC client
+	 */
+	@Nonnull
+	static RetryRule createRetryRule(boolean retryEnabled) {
+		final RetryRule alwaysSafeUnprocessedRetry = RetryRule.builder().onUnprocessed().thenBackoff();
+		if (!retryEnabled) {
+			return alwaysSafeUnprocessedRetry;
+		}
+		return RetryRule.of(
+			alwaysSafeUnprocessedRetry,
+			RetryRule.builder().onTimeoutException().thenBackoff(),
+			RetryRule.builder()
+				.onStatus(HttpStatus.SERVICE_UNAVAILABLE, HttpStatus.GATEWAY_TIMEOUT, HttpStatus.UNKNOWN)
+				.thenBackoff(),
+			RetryRule.builder().onStatus(HttpStatus.TOO_MANY_REQUESTS).thenNoRetry()
+		);
+	}
+
 	@Nonnull
 	private static ClientTracingContext getClientTracingContext(@Nonnull EvitaClientConfiguration configuration) {
 		final ClientTracingContext context = ClientTracingContextProvider.getContext();
@@ -528,21 +557,13 @@ public class EvitaClient implements EvitaContract {
 			.serializationFormat(GrpcSerializationFormats.PROTO)
 			.intercept(new ClientSessionInterceptor(connectionOptions.clientId(), clientVersion));
 
-		if (configuration.retry()) {
-			grpcClientBuilder.decorator(
-				RetryingClient.builder(
-						RetryRule.of(
-							RetryRule.builder().onTimeoutException().thenBackoff(),
-							RetryRule.builder()
-								.onStatus(HttpStatus.SERVICE_UNAVAILABLE, HttpStatus.GATEWAY_TIMEOUT, HttpStatus.UNKNOWN)
-								.thenBackoff(),
-							RetryRule.builder().onStatus(HttpStatus.TOO_MANY_REQUESTS).thenNoRetry()
-						)
-					)
-					.useRetryAfter(true)
-					.newDecorator()
-			);
-		}
+		// Always installed: requests Armeria can prove never reached the server are safe to replay regardless of
+		// the `retry` flag (see createRetryRule); the broader, potentially-duplicating rule set stays opt-in.
+		grpcClientBuilder.decorator(
+			RetryingClient.builder(createRetryRule(configuration.retry()))
+				.useRetryAfter(true)
+				.newDecorator()
+		);
 
 		final ClientTracingContext context = getClientTracingContext(configuration);
 		if (configuration.openTelemetryInstance() != null) {

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/config/ClientConnectionOptions.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/config/ClientConnectionOptions.java
@@ -47,11 +47,15 @@ import java.net.UnknownHostException;
  *                          idle timeout alone); a negative value falls back to the default, and any positive value below
  *                          `1000` ms (the minimum Armeria permits) is raised to that floor.
  *
- *                          **Precondition — the ping must stay strictly below {@link #idleTimeoutMillis()}.** Armeria
- *                          **silently disables** the ping (no error, no log) whenever `max(pingIntervalMillis, 1000)`
- *                          is greater than or equal to a positive connection idle timeout. The default pair
- *                          (`30000` ms ping, `300000` ms idle) satisfies this, so the watchdog is active out of the
- *                          box; `EvitaClient` logs a warning if a custom pair violates it. Also keep the interval below
+ *                          **Precondition — the ping must stay strictly below {@link #idleTimeoutMillis()} and below
+ *                          the server's own `idleTimeoutInMillis`.** Armeria **silently disables** the ping (no
+ *                          error, no log) whenever `max(pingIntervalMillis, 1000)` is greater than or equal to a
+ *                          positive connection idle timeout — the default pair (`30000` ms ping, `300000` ms idle)
+ *                          satisfies this on the client side, and `EvitaClient` logs a warning if a custom pair
+ *                          violates it. Separately, a ping at or above the *server's* idle timeout can never land
+ *                          before the server has already reaped the connection, making the keep-alive inert even
+ *                          though the client-side precondition still holds — the server's shipped default
+ *                          (`idleTimeoutInMillis`, 60 s) is chosen with this in mind. Also keep the interval below
  *                          any load-balancer / NAT idle window on the network path.
  * @param idleTimeoutMillis The connection idle timeout in milliseconds — how long a pooled HTTP/2 connection may sit
  *                          with no application traffic before Armeria closes it. This is deliberately **decoupled from
@@ -61,8 +65,8 @@ import java.net.UnknownHostException;
  *                          active and healthy connections are kept warm — the client counts keep-alive pings as
  *                          activity (`keepAliveOnPing = true`), so a connection whose pings are acknowledged never
  *                          idles out. `0` disables the idle timeout entirely (the connection then lives until closed
- *                          by the peer, a ping failure or the pool). A negative value falls back to the default; keep it
- *                          strictly above {@link #pingIntervalMillis()} to preserve the watchdog.
+ *                          by the peer, a ping failure or the pool). A negative value falls back to the default; keep
+ *                          it strictly above {@link #pingIntervalMillis()} to preserve the watchdog.
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public record ClientConnectionOptions(

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/config/EvitaClientConfiguration.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/config/EvitaClientConfiguration.java
@@ -58,8 +58,12 @@ import java.util.concurrent.TimeUnit;
  *                                  information. Controls whether the once analyzed reflection information should be
  *                                  cached or freshly (and costly) retrieved each time asked.
  * @param openTelemetryInstance     OpenTelemetry instance used for tracing. If `null`, no tracing will be performed.
- * @param retry                     Whether the client will retry the call in case of timeout or other network related
- *                                  problems.
+ * @param retry                     Whether the broader, potentially-duplicating retry rule set is active (timeouts,
+ *                                  `503`/`504`/`UNKNOWN` statuses, `429` back-off). Defaults to `false`. Independently
+ *                                  of this flag, a request Armeria can prove never reached the server (a refused
+ *                                  connection, or a GOAWAY received before the request's stream was accepted) is
+ *                                  always retried automatically with backoff, bounded by the per-call timeout, since
+ *                                  that can never duplicate an already-applied mutation.
  * @param trackedTaskLimit          The maximum number of server tasks that can be tracked by the client.
  * @param changeCaptureQueueSize    The maximum number of change capture events that can be buffered for each
  *                                  subscriber. If this limit is reached, an error is reported to the subscriber.
@@ -656,6 +660,16 @@ public record EvitaClientConfiguration(
 			return this;
 		}
 
+		/**
+		 * Sets whether the broader, potentially-duplicating retry rule set is active (timeouts, `503`/`504`/`UNKNOWN`
+		 * statuses, `429` back-off). Defaults to `false`. Independently of this flag, a request Armeria can prove
+		 * never reached the server (a refused connection, or a GOAWAY received before the request's stream was
+		 * accepted) is always retried automatically with backoff, bounded by the per-call timeout, since replaying
+		 * it can never duplicate an already-applied mutation.
+		 *
+		 * @param retry whether the broader, potentially-duplicating retry rule set should be active
+		 * @return this builder
+		 */
 		@Nonnull
 		public EvitaClientConfiguration.Builder retry(boolean retry) {
 			this.retry = retry;

--- a/evita_server/src/main/resources/evita-configuration.yaml
+++ b/evita_server/src/main/resources/evita-configuration.yaml
@@ -85,7 +85,7 @@ cache:
 
 api:
   workerGroupThreads: ${api.workerGroupThreads:null}
-  idleTimeoutInMillis: ${api.idleTimeoutInMillis:2K}
+  idleTimeoutInMillis: ${api.idleTimeoutInMillis:60K}
   requestTimeoutInMillis: ${api.requestTimeoutInMillis:2K}
   maxEntitySizeInBytes: ${api.maxEntitySizeInBytes:2MB}
   accessLog: ${api.accessLog:false}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientRetryRuleTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientRetryRuleTest.java
@@ -1,0 +1,101 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.driver;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.retry.RetryDecision;
+import com.linecorp.armeria.client.retry.RetryRule;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+import static io.evitadb.test.TestTags.DRIVER;
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link EvitaClient#createRetryRule(boolean)} — the boundary between the always-active
+ * "unprocessed" retry (a request Armeria can prove never reached the server, safe to replay regardless of
+ * the {@code retry} configuration flag) and the broader, potentially-duplicating rule set that stays
+ * behind that flag.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("EvitaClient retry rule")
+@Tag(DRIVER)
+@Tag(MANAGEMENT)
+class EvitaClientRetryRuleTest {
+	private static final ClientRequestContext CONTEXT = ClientRequestContext.of(HttpRequest.of(HttpMethod.POST, "/"));
+
+	@Nested
+	@DisplayName("when retry is disabled (the default)")
+	class RetryDisabled {
+		private final RetryRule rule = EvitaClient.createRetryRule(false);
+
+		@Test
+		@DisplayName("should retry a request Armeria proves was never processed by the server")
+		void shouldRetryUnprocessedRequest() {
+			assertWillRetry(this.rule, UnprocessedRequestException.of(new IOException("connection refused")));
+		}
+
+		@Test
+		@DisplayName("should not retry a mid-call transport abort that may have already reached the server")
+		void shouldNotRetryAmbiguousTransportAbort() {
+			assertWillNotRetry(this.rule, new StatusRuntimeException(Status.CANCELLED));
+		}
+	}
+
+	@Nested
+	@DisplayName("when retry is enabled")
+	class RetryEnabled {
+		private final RetryRule rule = EvitaClient.createRetryRule(true);
+
+		@Test
+		@DisplayName("should still retry a request Armeria proves was never processed by the server")
+		void shouldRetryUnprocessedRequest() {
+			assertWillRetry(this.rule, UnprocessedRequestException.of(new IOException("connection refused")));
+		}
+	}
+
+	private static void assertWillRetry(@Nonnull RetryRule rule, @Nonnull Throwable cause) {
+		final RetryDecision decision = rule.shouldRetry(CONTEXT, cause).toCompletableFuture().join();
+		assertNotSame(RetryDecision.next(), decision, "expected a retry decision for " + cause);
+		assertNotSame(RetryDecision.noRetry(), decision, "expected a retry decision for " + cause);
+	}
+
+	private static void assertWillNotRetry(@Nonnull RetryRule rule, @Nonnull Throwable cause) {
+		final RetryDecision decision = rule.shouldRetry(CONTEXT, cause).toCompletableFuture().join();
+		assertSame(RetryDecision.next(), decision, "expected no retry decision for " + cause);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/services/subscriber/AbstractChangeCaptureSubscriberTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/services/subscriber/AbstractChangeCaptureSubscriberTest.java
@@ -414,7 +414,7 @@ class AbstractChangeCaptureSubscriberTest implements TestConstants {
 		 * used so these tests exercise the same idle-timeout fallback that production takes once
 		 * the request timeout is disabled, rather than an arbitrary stand-in value.
 		 */
-		private static final long REALISTIC_IDLE_TIMEOUT_MILLIS = 20_000L;
+		private static final long REALISTIC_IDLE_TIMEOUT_MILLIS = 60_000L;
 
 		/**
 		 * Armeria treats a request timeout of `0` as "disabled" and legitimately reports it from


### PR DESCRIPTION
## Summary

Fixes two independently-filed driver/server connection-resilience defects that share a root cause — the keep-alive contract introduced by the 2026-07-16 cascade fix (PR #1284) was only half-closed.

- **#1368** — the driver's HTTP/2 keep-alive ping could never keep a pooled connection alive: `ExternalApiServer` used Armeria's single-argument `idleTimeoutMillis` overload, so the server ignored inbound client pings as connection activity (`keepAliveOnPing` rode Armeria's `false` global default). Separately, the shipped `evita-configuration.yaml` bound `idleTimeoutInMillis` to `2K` (2000 ms via the config parser's decimal `K` suffix), an order of magnitude tighter than the `20000` ms code constant either issue's author was reading from. Fix: switch to the two-argument `idleTimeoutMillis(millis, true)` overload, and raise the server's idle timeout (code constant + shipped YAML) to `60000` ms — chosen by raising the *server's* timeout rather than shrinking the driver's `30000` ms ping, since that ping interval doubles as Armeria's ack-wait stall budget and shrinking it would reopen the exact GC-pause self-kill PR #1284 fixed by widening it from 1 s to 30 s.
- **#1367** — `EvitaClientConfiguration.retry` defaults to `false`, and the driver only installed a `RetryingClient` decorator at all when it was `true`, so a routine server-side connection close (a graceful restart's `GOAWAY`, or `Connection refused` while the server comes back up) hard-failed every default-configured caller. Fix: always install the decorator with an `onUnprocessed().thenBackoff()` rule regardless of the flag — `UnprocessedRequestException` is Armeria's own "certain this request never reached the server" signal, so replaying it can never duplicate an already-applied mutation. The broader, potentially-duplicating rule set (`onStatus` for `503`/`504`/`UNKNOWN`, `onTimeoutException`) stays behind the existing `retry(true)` opt-in, unchanged.

Both fixes, their rationale, and the options considered (including one reversed mid-review — see below) are recorded in `documentation/adr/2026-08-03-driver-connection-resilience.md`, which also updates the 2026-07-16 ADR's cross-links.

## Note on process

The first implementation pass shrank the driver's keep-alive ping/idle defaults (`30000`→`5000` / `300000`→`15000`) instead of raising the server's idle timeout, matching #1368's literal suggested numbers. A second look connected Armeria's `PingWriteListener` (ack-wait deadline scheduling, already read while investigating #1368) to that choice: the ping interval **is** the stall budget, and shrinking it reintroduces the GC-pause self-kill PR #1284 deliberately fixed by widening it. The 150-test real-thread-pool suite passed on the first pass, but couldn't have caught this — the entire dataset-based test lane runs with the ping disabled. This is documented in the ADR's *Options considered* section as a reversed decision, not silently corrected.

## Test plan

- [x] `EvitaClientRetryRuleTest` (new) — `createRetryRule(false)` retries an `UnprocessedRequestException`, does not retry a bare `CANCELLED` `StatusRuntimeException`; `createRetryRule(true)` still retries the unprocessed case
- [x] `ClientConnectionOptionsTest` — default values unchanged (`30000`/`300000`)
- [x] `EvitaServerTest` — 14/14, server boots correctly with the two-argument `idleTimeoutMillis` overload and raised `60000` ms default
- [x] `ClientSessionCancellationCascadeTest` — 1/1, confirms the always-installed `RetryingClient` decorator doesn't interfere with gRPC-interceptor-level fault injection
- [x] `EvitaClientReadOnlyTest` + `EvitaClientReadWriteTest` (real-thread-pool island) — 150 tests, 0 failures, 1 pre-existing skip
- [x] `AbstractChangeCaptureSubscriberTest` — updated stale `REALISTIC_IDLE_TIMEOUT_MILLIS` constant to match the new server default; 65/65
- [x] Full reactor compile (`-P full`) — clean

Closes #1367
Closes #1368