### PR TITLE
fix: give ComparableArray a real natural order instead of throwing

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndex.java
@@ -1376,13 +1376,22 @@ public abstract sealed class SortIndex
 		 * reproduce that ordering — it supplies only the element-wise natural order the {@link Comparable} contract
 		 * requires, and callers that need the index's ordering must keep using the comparator.
 		 *
-		 * It must never throw. {@link java.util.HashMap} promotes a bin holding at least eight entries into a
-		 * red-black tree and then navigates that tree by the key's natural order on every hash tie — it accepts any
-		 * class declaring `Comparable` of itself, which this record does. A `ComparableArray` used as an ordinary map
-		 * key (the sparse `value → cardinality` map of a sort index storage part, for one) therefore reaches this
+		 * It must never *refuse* to answer. {@link java.util.HashMap} promotes a bin holding at least eight entries
+		 * into a red-black tree and then navigates it by the key's natural order on every hash tie — it accepts
+		 * any class declaring `Comparable` of itself, which this record does. A `ComparableArray` used as an ordinary
+		 * map key (the sparse `value → cardinality` map of a sort index storage part, for one) therefore reaches this
 		 * method from inside the JDK, with no comparator in sight; refusing to answer there turns a plain lookup — or
 		 * even the `put` that triggers the promotion — into a hard failure, and only on datasets large enough to
 		 * treeify a bin.
+		 *
+		 * The one case that still propagates is a {@link ClassCastException} from comparing two elements of different
+		 * types at the same position. That is deliberate and must not be swallowed: within a single compound every
+		 * value shares the element types declared by its {@link ComparatorSource} array — the write path enforces it
+		 * through the validating constructor — so mixed types mean corrupted data or a schema whose compound element
+		 * types changed without a reindex. Masking it with a fallback tie-break would trade a loud failure for a
+		 * silently wrong order. Note this differs from the refusal above: the refusal fired on perfectly valid data,
+		 * whereas this fires only on data that is genuinely broken. Arrays of *differing length* are not affected —
+		 * they never reach an element comparison past their shared prefix.
 		 *
 		 * Ordering is element-wise with `null` first, falling back to array length. That is a total order across the
 		 * values of any single compound, because they all share the element types declared by the comparator base. It

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndex.java
@@ -1370,17 +1370,51 @@ public abstract sealed class SortIndex
 		}
 
 		/**
-		 * {@link ComparableArray} carries no ordering of its own: it is always ordered through the owning
-		 * {@link SortIndex}'s configured {@link ComparableArrayComparator} (per-element comparators with direction and
-		 * NULL handling). This method exists only to satisfy the {@link Comparable} key bound of the owner value tree,
-		 * which never invokes it because a comparator is always supplied, so a direct call is a programming error and
-		 * fails fast.
+		 * {@link ComparableArray} carries no *domain* ordering of its own: the owning {@link SortIndex} always orders
+		 * it through the configured {@link ComparableArrayComparator} (per-element comparators honouring direction and
+		 * NULL handling), which the index constructor wires unconditionally. This method deliberately does NOT
+		 * reproduce that ordering — it supplies only the element-wise natural order the {@link Comparable} contract
+		 * requires, and callers that need the index's ordering must keep using the comparator.
+		 *
+		 * It must never throw. {@link java.util.HashMap} promotes a bin holding at least eight entries into a
+		 * red-black tree and then navigates that tree by the key's natural order on every hash tie — it accepts any
+		 * class declaring `Comparable` of itself, which this record does. A `ComparableArray` used as an ordinary map
+		 * key (the sparse `value → cardinality` map of a sort index storage part, for one) therefore reaches this
+		 * method from inside the JDK, with no comparator in sight; refusing to answer there turns a plain lookup — or
+		 * even the `put` that triggers the promotion — into a hard failure, and only on datasets large enough to
+		 * treeify a bin.
+		 *
+		 * Ordering is element-wise with `null` first, falling back to array length. That is a total order across the
+		 * values of any single compound, because they all share the element types declared by the comparator base. It
+		 * is intentionally NOT consistent with {@link #equals(Object)} for element types whose own `compareTo`
+		 * disagrees with `equals` ({@link java.math.BigDecimal} scale, for one); {@link java.util.HashMap} tolerates
+		 * that, resolving identity through `equals` and ties through its own fallback ordering.
 		 */
 		@Override
 		public int compareTo(@Nonnull ComparableArray o) {
-			throw new GenericEvitaInternalError(
-				"ComparableArray must be ordered through the SortIndex comparator, never its natural order!"
-			);
+			final Serializable[] left = this.array;
+			final Serializable[] right = o.array;
+			final int sharedLength = Math.min(left.length, right.length);
+			for (int i = 0; i < sharedLength; i++) {
+				final Serializable leftValue = left[i];
+				final Serializable rightValue = right[i];
+				if (leftValue == null || rightValue == null) {
+					// nulls sort first; two nulls are equal on this element and the comparison moves on
+					if (leftValue != null) {
+						return 1;
+					}
+					if (rightValue != null) {
+						return -1;
+					}
+					continue;
+				}
+				//noinspection unchecked,rawtypes
+				final int result = ((Comparable) leftValue).compareTo(rightValue);
+				if (result != 0) {
+					return result;
+				}
+			}
+			return Integer.compare(left.length, right.length);
 		}
 
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ComparableArrayHashMapKeyTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ComparableArrayHashMapKeyTest.java
@@ -30,6 +30,7 @@ import io.evitadb.index.attribute.SortIndex.ComparatorSource;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.SortIndexStoragePart;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
@@ -37,6 +38,8 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.INDEXING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -58,6 +61,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
 @DisplayName("ComparableArray survives use as a treeified HashMap key")
 class ComparableArrayHashMapKeyTest {
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ComparableArrayHashMapKeyTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ComparableArrayHashMapKeyTest.java
@@ -1,0 +1,201 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.attribute;
+
+import io.evitadb.api.query.order.OrderDirection;
+import io.evitadb.api.requestResponse.schema.OrderBehaviour;
+import io.evitadb.index.attribute.SortIndex.ComparableArray;
+import io.evitadb.index.attribute.SortIndex.ComparatorSource;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.SortIndexStoragePart;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for {@link ComparableArray} used as a {@link HashMap} key.
+ *
+ * `HashMap` converts a bin holding at least `TREEIFY_THRESHOLD` (8) entries into a red-black tree once the table has
+ * grown to at least `MIN_TREEIFY_CAPACITY` (64). Navigating that tree uses the key's **natural order** whenever two
+ * keys tie on hash — `HashMap.comparableClassFor` accepts any class declaring `Comparable<itself>`, which
+ * {@link ComparableArray} does. A `compareTo` that refuses to answer therefore turns an ordinary map lookup into
+ * a hard failure, and only on datasets large enough to treeify a bin — which is why the whole test suite stayed
+ * green while a real catalog could not be loaded at all.
+ *
+ * The sink exercised here is {@link SortIndexStoragePart}'s map-based constructor, which folds the sparse
+ * `value → cardinality` map into the persisted columns with one `Map.get` per distinct value. It is the common entry
+ * point of every de-serialization path (the current serializer plus the backward-compatible readers) and of the
+ * storage-protocol migration, so a compound (multi-element) sortable attribute with enough distinct values reaches it
+ * on a plain catalog load.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("ComparableArray survives use as a treeified HashMap key")
+class ComparableArrayHashMapKeyTest {
+
+	private static final AttributeIndexKey ATTRIBUTE_KEY =
+		new AttributeIndexKey(null, "defaultSortingCoefficientCompound", null);
+
+	/**
+	 * Two-element compound of `Integer`s, mirroring the shape that failed in production (a compound sortable attribute
+	 * whose distinct values outnumber the treeify threshold within a single hash bin).
+	 */
+	private static final ComparatorSource[] COMPARATOR_BASE = {
+		new ComparatorSource(Integer.class, OrderDirection.ASC, OrderBehaviour.NULLS_LAST),
+		new ComparatorSource(Integer.class, OrderDirection.ASC, OrderBehaviour.NULLS_LAST)
+	};
+
+	/** Number of filler values inserted first, purely to grow the table past `MIN_TREEIFY_CAPACITY`. */
+	private static final int FILLER_COUNT = 120;
+	/** Number of values sharing one identical hash — must exceed `TREEIFY_THRESHOLD` (8) to convert the bin. */
+	private static final int COLLIDING_COUNT = 10;
+
+	/**
+	 * Builds a value whose {@link java.util.Arrays#hashCode(Object[])} is `961 + 31 * first + second`. Shifting `first`
+	 * up by one while shifting `second` down by 31 therefore yields a *different* value with an *identical* hash, which
+	 * is what forces every member of the colliding family into the same bin regardless of table size.
+	 */
+	@Nonnull
+	private static ComparableArray value(int first, int second) {
+		return new ComparableArray(new Serializable[]{first, second});
+	}
+
+	/**
+	 * Reproduces the production failure: a sparse cardinality map big enough to treeify the bin holding the colliding
+	 * family, folded by the map-based {@link SortIndexStoragePart} constructor. Before the fix this throws
+	 * `ComparableArray must be ordered through the SortIndex comparator, never its natural order!` from
+	 * `HashMap.compareComparables`; afterwards the columns are folded correctly.
+	 */
+	@Test
+	@DisplayName("folding a treeified sparse cardinality map does not fail")
+	void shouldFoldCardinalityMapWithTreeifiedBin() {
+		// distinct values in ascending element-wise order, so the part is well formed; the colliding family is placed
+		// last so the fillers have already grown the table beyond MIN_TREEIFY_CAPACITY when the collisions arrive
+		final Serializable[] sortedRecordsValues = new Serializable[FILLER_COUNT + COLLIDING_COUNT];
+		final Map<Serializable, Integer> valueCardinalities = new HashMap<>();
+
+		for (int i = 0; i < FILLER_COUNT; i++) {
+			// spread across distinct buckets - these only exist to grow the table
+			final ComparableArray filler = value(i, i * 7);
+			sortedRecordsValues[i] = filler;
+			valueCardinalities.put(filler, 2);
+		}
+		for (int i = 0; i < COLLIDING_COUNT; i++) {
+			// 31 * (first + 1) + (second - 31) == 31 * first + second -> identical Arrays.hashCode
+			final ComparableArray colliding = value(1_000 + i, 50_000 - 31 * i);
+			sortedRecordsValues[FILLER_COUNT + i] = colliding;
+			valueCardinalities.put(colliding, 2);
+		}
+
+		// every distinct value is shared by exactly two records
+		final int totalRecords = sortedRecordsValues.length * 2;
+		final int[] sortedRecords = new int[totalRecords];
+		for (int i = 0; i < totalRecords; i++) {
+			sortedRecords[i] = i + 1;
+		}
+
+		// guard the test itself: without a genuinely treeified bin this exercises the plain linked-list path and would
+		// pass even against the unfixed code
+		assertTrue(
+			hasTreeifiedBin(valueCardinalities),
+			"The cardinality map has no treeified bin - the test would not exercise HashMap's comparison path!"
+		);
+
+		final SortIndexStoragePart part = new SortIndexStoragePart(
+			1, ATTRIBUTE_KEY, COMPARATOR_BASE,
+			sortedRecords, sortedRecordsValues, valueCardinalities, 0, 1L
+		);
+
+		assertArrayHasEveryValue(part.getCardinalityValues(), sortedRecordsValues);
+		for (final int cardinality : part.getCardinalities()) {
+			assertEquals(2, cardinality, "Every distinct value was shared by exactly two records!");
+		}
+	}
+
+	/**
+	 * A direct probe of the same JDK mechanism, independent of any evitaDB storage type: a lookup that *misses* on a
+	 * treeified bin traverses the whole tree and consults the natural order on every hash tie.
+	 */
+	@Test
+	@DisplayName("a missing-key lookup on a treeified bin does not fail")
+	void shouldTolerateMissingKeyLookupOnTreeifiedBin() {
+		final Map<Serializable, Integer> map = new HashMap<>();
+		for (int i = 0; i < FILLER_COUNT; i++) {
+			map.put(value(i, i * 7), 1);
+		}
+		for (int i = 0; i < COLLIDING_COUNT; i++) {
+			map.put(value(1_000 + i, 50_000 - 31 * i), 1);
+		}
+		assertTrue(hasTreeifiedBin(map), "The map has no treeified bin - the probe would not reach the tree path!");
+
+		// a key absent from the map but hashing into the treeified bin - the production probe was exactly this shape
+		assertEquals(null, map.get(value(1_000 + COLLIDING_COUNT, 50_000 - 31 * COLLIDING_COUNT)));
+	}
+
+	/**
+	 * Reports whether the map holds at least one bin converted to a red-black tree, by reflecting over the internal
+	 * table. Without this the test could silently degrade into the linked-list path and stop protecting anything.
+	 */
+	private static boolean hasTreeifiedBin(@Nonnull Map<Serializable, Integer> map) {
+		try {
+			final java.lang.reflect.Field tableField = HashMap.class.getDeclaredField("table");
+			tableField.setAccessible(true);
+			final Object[] table = (Object[]) tableField.get(map);
+			if (table == null) {
+				return false;
+			}
+			final Class<?> treeNodeType = Class.forName("java.util.HashMap$TreeNode");
+			for (final Object bin : table) {
+				if (bin != null && treeNodeType.isInstance(bin)) {
+					return true;
+				}
+			}
+			return false;
+		} catch (ReflectiveOperationException ex) {
+			throw new IllegalStateException("Cannot inspect the HashMap table layout!", ex);
+		}
+	}
+
+	/**
+	 * Asserts the folded cardinality column carries exactly the expected distinct values, in the order they appear in
+	 * `sortedRecordsValues` (the storage convention the serializer's two-pointer merge relies on).
+	 */
+	private static void assertArrayHasEveryValue(
+		@Nonnull Serializable[] actual,
+		@Nonnull Serializable[] expected
+	) {
+		assertEquals(expected.length, actual.length, "Every value had cardinality 2, so none may be dropped!");
+		for (int i = 0; i < expected.length; i++) {
+			assertEquals(expected[i], actual[i], "Cardinality columns must stay aligned with the sorted values!");
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/SortIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/SortIndexTest.java
@@ -1141,6 +1141,85 @@ class SortIndexTest {
 			assertNotEquals(null, a);
 			assertNotEquals("not-a-comparable-array", a);
 		}
+
+		/**
+		 * The natural order exists so the JDK can key a `HashMap` on a compound value (a treeified bin is navigated by
+		 * the key's natural order); it is deliberately NOT the index's domain order, which always goes through the
+		 * configured comparator. These cases pin the contract independently of `HashMap`'s treeify heuristics, so it
+		 * stays verified even if those internals change.
+		 */
+		@Test
+		@DisplayName("should order element-wise on the first differing element")
+		void shouldOrderElementWise() {
+			final ComparableArray a = new ComparableArray(new Serializable[]{"A", 2});
+			final ComparableArray b = new ComparableArray(new Serializable[]{"B", 1});
+
+			// the first element decides - the second is never consulted
+			assertTrue(a.compareTo(b) < 0);
+			assertTrue(b.compareTo(a) > 0);
+		}
+
+		@Test
+		@DisplayName("should fall through equal elements to the next position")
+		void shouldFallThroughEqualElements() {
+			final ComparableArray a = new ComparableArray(new Serializable[]{"A", 1});
+			final ComparableArray b = new ComparableArray(new Serializable[]{"A", 2});
+
+			assertTrue(a.compareTo(b) < 0);
+			assertTrue(b.compareTo(a) > 0);
+		}
+
+		@Test
+		@DisplayName("should report equal arrays as equal")
+		void shouldReportEqualArraysAsEqual() {
+			final ComparableArray a = new ComparableArray(new Serializable[]{"A", 1});
+			final ComparableArray b = new ComparableArray(new Serializable[]{"A", 1});
+
+			assertEquals(0, a.compareTo(b));
+			assertEquals(0, b.compareTo(a));
+		}
+
+		@Test
+		@DisplayName("should sort a null element before a non-null one")
+		void shouldSortNullElementFirst() {
+			final ComparableArray nullFirst = new ComparableArray(new Serializable[]{"A", null});
+			final ComparableArray nonNull = new ComparableArray(new Serializable[]{"A", 1});
+
+			assertTrue(nullFirst.compareTo(nonNull) < 0);
+			assertTrue(nonNull.compareTo(nullFirst) > 0);
+		}
+
+		@Test
+		@DisplayName("should treat two null elements as equal on that position")
+		void shouldTreatTwoNullElementsAsEqual() {
+			final ComparableArray a = new ComparableArray(new Serializable[]{"A", null, 1});
+			final ComparableArray b = new ComparableArray(new Serializable[]{"A", null, 2});
+
+			// both nulls cancel out, so the decision falls to the third element
+			assertTrue(a.compareTo(b) < 0);
+			assertEquals(
+				0,
+				new ComparableArray(new Serializable[]{null, null})
+					.compareTo(new ComparableArray(new Serializable[]{null, null}))
+			);
+		}
+
+		@Test
+		@DisplayName("should break a tie on the shared prefix by array length")
+		void shouldBreakTieByLength() {
+			final ComparableArray shorter = new ComparableArray(new Serializable[]{"A"});
+			final ComparableArray longer = new ComparableArray(new Serializable[]{"A", 1});
+
+			assertTrue(shorter.compareTo(longer) < 0);
+			assertTrue(longer.compareTo(shorter) > 0);
+
+			// an empty array never reaches an element comparison - it is ordered purely by length, which is what keeps
+			// the empty sentinel used by the reference compound comparators safe against any other value
+			final ComparableArray empty = new ComparableArray(new Serializable[0]);
+			assertTrue(empty.compareTo(longer) < 0);
+			assertTrue(longer.compareTo(empty) > 0);
+			assertEquals(0, empty.compareTo(new ComparableArray(new Serializable[0])));
+		}
 	}
 
 	@Nested


### PR DESCRIPTION
Closes #1372

## Problem

A catalog holding a compound sortable attribute with enough distinct values could not be loaded at
all. `SortIndex.ComparableArray` implements `Comparable<ComparableArray>` with a `compareTo` that
**always threw** — a deliberate fail-fast enforcing that compound values are ordered through the
index's `ComparableArrayComparator`, justified by "the owner value tree never invokes it because a
comparator is always supplied".

That premise is false: **`java.util.HashMap` invokes it.** `HashMap` promotes a bin holding at least
`TREEIFY_THRESHOLD` (8) entries into a red-black tree once the table reaches `MIN_TREEIFY_CAPACITY`
(64), then navigates that tree by the key's **natural order** on every hash tie —
`comparableClassFor` accepts any class declaring `Comparable` of itself. The guard fired from inside
the JDK, where no comparator could possibly be supplied.

The sink is `SortIndexStoragePart`'s map-based constructor (`sparseCardinalityColumns`), the common
entry point of the current serializer, both backward-compatible readers, and
`Migration_2026_2.rekeySortOnlyIndex` — so this broke ordinary catalog loads, not only migrations.

## Fix

`compareTo` returns an element-wise natural order (nulls first, then array length), with a JavaDoc
stating plainly that it is **not** the domain sort order and must never throw. Safe because
`SortIndex`'s constructor wires the comparator unconditionally (`createComparatorFor` for a single
element, `createCombinedComparatorFor` for a compound) — the guard had no reachable true positive.

Alternatives rejected:

- **Comparison-free lookup at the sink** — does not fix it. The map is *built* in the serializers,
  and `HashMap.treeify` / `putTreeVal` call `compareComparables` too; the new test fails inside
  `treeify` during `put`. This would have turned a reproducible crash into a rarer, data-dependent one.
- **Drop `Comparable` entirely** — `InvertedIndex` casts values to raw `Comparable` throughout, so
  this converts the error into a `ClassCastException` at the same depth. Viable only if the inverted
  index is re-typed to carry its comparator.
- **Declare `Comparable<Object>` to defeat `comparableClassFor`** — depends on an unspecified
  `HashMap` implementation detail, and leaves every non-`HashMap` ordering path still armed.

## Verification

- **`ComparableArrayHashMapKeyTest`** (new) — engineers identical `Arrays.hashCode` values
  (`[x, y]` and `[x+1, y-31]` collide), inserts fillers first so the table has already grown past 64,
  and **asserts the bin actually treeified** by reflecting over `HashMap.table` so it cannot silently
  decay into the linked-list path. Red before the fix (in `HashMap.treeify`, during `put`), green after.
- Sort-index regression sweep — `SortIndexTest`, `SortIndexStoragePartSerializerTest`,
  `SortIndexViewModeTest`, `SortIndexOwnerPagingRoundTripTest`, `SortIndexLeafPagePartSerializerTest`,
  `AttributeIndexTest`, `AttributeIndexLoaderTest`, `EntityIndexRoundTripTest`: **234 tests green**.
- **End-to-end on a real ~1.8 GB production catalog**: full v4 → v5 → v6 storage-protocol upgrade
  completed (17 collections re-keyed; `Product` alone 5010 indexes and 57752 manifests evicted),
  catalog loaded in 4s with zero errors. Post-migration the catalog is genuinely usable — querying
  returns 7157 products, and sorting by `defaultSortingCoefficientCompound` (the exact compound
  attribute that was crashing) works in both directions. The same catalog failed the v5 → v6 step
  before the change.

## Notes

- The ordering is intentionally **not consistent with `equals`** for element types whose `compareTo`
  disagrees with `equals` (`BigDecimal` scale). `HashMap` tolerates exactly this — identity by
  `equals`, ties by its own fallback. Please do not "fix" it by routing `equals` through `compareTo`.
- Known follow-up, deliberately out of scope: `SortIndexStoragePartSerializer.read` rebuilds a
  `HashMap` only to fold it straight back into the ascending columns it was read from, while the
  write path already uses the allocation-free two-pointer `computeBlockLengths` overload. It must
  **not** be extended to the `_2025_5` / `_2026_1` readers — their on-disk cardinality section was
  written in `HashMap` iteration order and is not guaranteed ascending.
