### PR TITLE
Report HTTP/2 connection teardowns and turn the Rapid-Reset defence off by default

### DIFF
--- a/documentation/adr/2026-07-16-client-session-cancellation-cascade.md
+++ b/documentation/adr/2026-07-16-client-session-cancellation-cascade.md
@@ -9,7 +9,7 @@ prs: [1284]
 areas: [evita_external_api_grpc/client/driver, evita_external_api_core/configuration, evita_engine/core, evita_api/exception, evita_api/configuration, evita_server, evita_test_support, evita_test/evita_functional_tests]
 supersedes: []
 superseded-by: []
-relates: [2026-08-03-driver-connection-resilience]
+relates: [2026-08-03-driver-connection-resilience, 2026-08-04-http2-connection-teardown-observability]
 ---
 
 # Fix the gRPC keep-alive self-kill and session-cancellation cascade

--- a/documentation/adr/2026-08-03-driver-connection-resilience.md
+++ b/documentation/adr/2026-08-03-driver-connection-resilience.md
@@ -9,7 +9,7 @@ prs: [1371]
 areas: [evita_external_api_grpc/client/driver, evita_external_api_core/configuration, evita_external_api_core/http, evita_server/resources, documentation/user/en]
 supersedes: []
 superseded-by: []
-relates: [2026-07-16-client-session-cancellation-cascade]
+relates: [2026-07-16-client-session-cancellation-cascade, 2026-08-04-http2-connection-teardown-observability]
 ---
 
 # Align client/server keep-alive timing and always retry provably-unprocessed gRPC calls

--- a/documentation/adr/2026-08-04-http2-connection-teardown-observability.md
+++ b/documentation/adr/2026-08-04-http2-connection-teardown-observability.md
@@ -1,0 +1,297 @@
+---
+title: Report HTTP/2 RST_STREAM floods instead of enforcing against them, and turn the Rapid-Reset defence off by default
+date: 2026-08-04
+updated: 2026-08-04 09:20
+status: accepted
+kind: fix
+issues: [1369]
+prs: []
+areas: [evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http, evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/event]
+supersedes: []
+superseded-by: []
+relates: [2026-08-03-driver-connection-resilience, 2026-07-16-client-session-cancellation-cascade]
+---
+
+# Report HTTP/2 connection-level teardowns; stop enforcing the Rapid-Reset limit by default
+
+evitaDB now watches the HTTP/2 frames of every connection and emits a throttled `WARN` plus a
+metric for three otherwise-silent connection-level events: a peer resetting streams en masse, the
+server tearing a connection down with an erroneous `GOAWAY`, and a **peer** tearing one down with
+an erroneous `GOAWAY`. At the same time Netty's Rapid-Reset defence (CVE-2023-44487), which stock
+Armeria enables at 400 resets per minute, is **disabled by default** — the flood is reported, not
+punished. Two undocumented system properties turn enforcement back on for deployments with a
+different threat model.
+
+## Why
+
+A client with an unbounded CDC re-subscription loop issued ~300 `RegisterSystemChangeCapture`
+calls per second and cancelled each one. Armeria's default Rapid-Reset limit tripped roughly every
+1.4 s, and each trip sent `GOAWAY(ENHANCE_YOUR_CALM)` and closed the connection. Because a `GOAWAY`
+is connection-level, every in-flight request on that connection died with it — including calls
+entirely unrelated to the flood. On the application side this surfaced as `TransportException`,
+`StatusRuntimeException: CANCELLED` and a 5-second timeout on a plain `getCatalogNames`, all
+against a server that was answering other traffic normally.
+
+The server logged **nothing**. The access log kept showing `200`s for the individual gRPC calls,
+because at the HTTP layer they were fine. Identifying the cause took most of a day and ultimately
+required attaching a JDWP logpoint to `Http2GoAwayHandler` **in the client JVM** — something an
+operator of an evitaDB deployment generally cannot do.
+
+Two separate problems hide behind that. The teardown was invisible, and the teardown should not
+have happened at all.
+
+### Previous state
+
+Armeria *does* log a `WARN` for this, from
+`com.linecorp.armeria.internal.common.AbstractHttp2ConnectionHandler` and
+`Http2GoAwayHandler`. evitaDB's own `logback.xml` pins `com.linecorp.armeria` (and `io.netty`) to
+`ERROR`, which is what actually produced the silence. That suppression is deliberate — those
+loggers are noisy — and it is also why "just un-suppress it" is not the fix: the Armeria line
+carries a stack trace, fires once per teardown (43 times a minute at the reporter's cadence), names
+no threshold, and would drag every other Armeria `WARN` in with it.
+
+Nothing configured the Rapid-Reset limit either. The effective threshold was whatever Armeria
+defaults to (`Flags.defaultServerHttp2MaxResetFramesPerMinute()` = 400 per 60 s), invisible and
+untunable.
+
+## Options considered
+
+### Option A — inspect the frames on the wire, report without enforcing (chosen)
+
+A per-connection Netty handler inserted between the TLS handler and the HTTP/2 connection handler.
+Inbound it walks the frame stream and counts `RST_STREAM`; outbound it recognizes erroneous
+`GOAWAY` frames. Enforcement is handed to Netty at `0` (off) by default.
+
+- **Pros:** sees every reset regardless of stream state or routing; covers gRPC, GraphQL, REST and
+  every other port identically; the report carries the peer, the count, the window and the
+  consequence; throttled per peer, so it cannot become a flood itself; detaches detection from
+  enforcement, which is what makes turning enforcement off safe.
+- **Cons:** couples to a pipeline position and to HTTP/2 framing, neither of which Armeria
+  guarantees; needs a test against a real server to stay honest.
+
+### Option B — narrow the logback suppression to the two Armeria classes (declined)
+
+- **Pros:** a three-line configuration change, ships instantly, works on existing 2026.2.1
+  installations with no upgrade.
+- **Cons:** stack trace per teardown at 43 lines/min; no threshold, no count, no throttle; the
+  logger names are Armeria-internal; and it only ever fires *after* the connection has been killed,
+  so it cannot support turning enforcement off.
+- **Rejected because:** it reports the symptom the defence causes, and this record's main decision
+  is to stop causing it. It remains the correct **workaround** for anyone on 2026.2.1 today, and is
+  documented as such on the issue.
+
+### Option C — count cancellations at the Armeria service layer (declined)
+
+Hook `ServiceRequestContext.log().whenComplete()` and count requests whose cause is a
+`ClosedStreamException`, the way `HttpMetricDecorator` already derives `Result.CANCELLED`.
+
+- **Pros:** public Armeria API only; no framing, no pipeline-position coupling; gets the request
+  path and the `clientId` header for free.
+- **Cons:** the decorator only runs for requests that were routed to a service, and the
+  cancellation classification is reliable only on the gRPC branch (`CompletableRpcResponse`).
+- **Rejected because:** a Rapid-Reset flood is precisely `HEADERS` immediately followed by
+  `RST_STREAM` — the stream dies before dispatch, which is the exact case this misses. It would
+  have been blind to the incident that prompted the issue. Revisit if Armeria ever exposes a
+  connection-level reset counter.
+
+### Option D — keep enforcement on, only make it visible and configurable (declined)
+
+- **Pros:** zero behavioural change in a patch release; the CVE mitigation stays; the smallest
+  possible diff.
+- **Cons:** leaves the amplification in place as the shipped default.
+- **Rejected because:** the defence's failure mode is worse than what it prevents on evitaDB's
+  deployment. See the Decision below.
+
+## Decision
+
+**Chosen: Option A, with enforcement off by default.**
+
+Netty counts *inbound* `RST_STREAM` frames — that is, **cancellations**, not requests. A client
+doing 50k req/s with no cancellations never comes near the limit. But a well-behaved client emits
+one `RST_STREAM` for every client-side timeout and every closed server-stream, so the defence fires
+hardest exactly when the server is already slow: requests time out → the client cancels them →
+resets accumulate → the connection is killed → every in-flight request on it dies → the client
+reconnects and retries. A slow period becomes a metastable failure. 400 cancellations per minute
+(6.7/s) is well within reach of one busy trusted client during an incident.
+
+The threat model the defence exists for is an untrusted internet-facing peer. evitaDB is a database
+that sits behind the application layer and talks to a small number of trusted clients. On that
+deployment the mitigation costs more than it buys — the reporter's outage was *caused* by the
+defence firing, not prevented by it.
+
+Turning it off is only safe because detection no longer depends on it: the flood is still counted
+and reported at the same 400-per-window threshold Armeria would have enforced at, so the operator
+learns exactly what they learned before, minus the severed connection.
+
+The knobs are **system properties, not configuration keys, and are absent from the user
+documentation** — deliberately. They are a last resort for a deployment with an unusual threat
+model. Promoting them to `ApiOptions` would advertise a dial whose safe setting is "leave it
+alone", and would add two components to a public record in a patch release.
+
+This would flip back if evitaDB were ever positioned as directly internet-facing, or if a
+connection-level reset counter appeared in Armeria's public API that made Option C viable without
+the dispatch blind spot.
+
+## Key technical details
+
+- `Http2ConnectionMonitor` — one shared instance per server, holding the thresholds and the
+  per-peer report throttle; `install(ChannelPipeline)` is handed to Armeria's
+  `childChannelPipelineCustomizer` by `ExternalApiServer`, and produces one stateful handler per
+  connection.
+- **Pipeline position is the load-bearing assumption.** The handler must sit *after* the TLS
+  handler (or it inspects ciphertext) and *before* the HTTP/2 connection handler (or it sees
+  decoded messages, not frames). **Appending it is wrong** — it lands behind everything Armeria
+  installs and sees nothing at all, which is how the first implementation failed. The measured
+  layouts are:
+  - plaintext, at customizer time: `Flush, ReadSuppressing, TrafficLogging,
+    Http2PrefaceOrHttpHandler, HttpServerHandler`
+  - TLS, at customizer time: `Flush, ReadSuppressing, HttpsConnectionAcceptHandler, TrafficLogging,
+    Http2OrHttpHandler`
+
+  In both, the protocol handler's slot is later taken in place by `Http2ServerConnectionHandler`,
+  and the TLS handler takes the accept handler's slot in front of it. Inserting immediately ahead
+  of the first handler whose class name starts with `Http2` is therefore the one position that
+  works on every port. If no such handler is found the monitor logs once and installs nothing —
+  no monitoring beats monitoring the wrong bytes.
+- **Inbound walking starts only after the 24-byte HTTP/2 connection preface.** That is what keeps
+  HTTP/1.1 traffic, a PROXY protocol header and an h2c upgrade handshake from being misread as
+  frames. A connection whose preface never arrives is simply never inspected.
+- Every buffer is read with **absolute** getters and forwarded untouched; a relative read would
+  consume bytes the codec (or the socket) still needs.
+- The walker disables itself for a connection if it ever reads a frame length above 1 MiB —
+  Armeria advertises a 16 KiB max frame size, so that only happens after losing frame boundaries.
+- The outbound `GOAWAY` check tolerates Netty's buffer layout: Netty writes the header, last stream
+  id and error code as one buffer and the debug data as a second, so the declared payload length is
+  larger than the buffer. Only the fixed part must be contiguous.
+- **Both directions are covered.** Outbound `GOAWAY` recognition is a stateless sniff of the write
+  path; inbound recognition rides the frame walker that is already there for `RST_STREAM`. The
+  inbound case is the more alarming of the two — the client is stating that *evitaDB* violated the
+  protocol, so it may point at a server-side defect rather than at a misbehaving peer — and it was
+  the last blind spot: everything Netty rejects at connection level (control-frame floods, empty-
+  frame floods, HPACK desync, oversized frames) now surfaces on one side or the other.
+- **The bound on error codes differs by direction, on purpose.** Outbound recognition only accepts
+  codes 1–13, because it inspects arbitrary write buffers and the bound is what keeps a payload
+  from being mistaken for a frame. Inbound recognition accepts any non-zero code, because the
+  walker knows the frame boundaries and an unknown extension code there is genuine.
+- Metrics: `io_evitadb_external_api_http2_rst_flood_total` and
+  `io_evitadb_external_api_http2_go_away_total` (labelled by `errorCode` and `direction`). The peer
+  address is on the JFR event but **not** a metric label — unbounded Prometheus cardinality.
+- **Monitoring can never take traffic down, by construction.** An exception escaping `channelRead` becomes a Netty
+  `exceptionCaught` that very likely closes the connection — and worse, the buffer would never be forwarded, stalling
+  the read and leaking it. Both directions are therefore wrapped: on any `Throwable` the monitor disables *itself*
+  for that connection (separately per direction), logs once, and the buffer is forwarded **outside** the guarded
+  block so it reaches the codec regardless. `install()` is wrapped for the same reason — it runs while a connection
+  is being accepted, so letting anything escape would reject the connection outright. This is a deliberate exception
+  to the project's "never silently skip an unexpected state" rule: the rule protects correctness of the engine, and
+  here the correct behaviour of an observability side-channel *is* to get out of the way. The price is paid as a
+  loud warning rather than as silence.
+- **The report says how many occurrences the throttle swallowed.** A peer that is torn down every
+  1.4 s would otherwise produce a once-a-minute line indistinguishable from a single incident.
+
+## Verification
+
+`Http2ConnectionMonitorTest` — 22 tests, all green:
+
+- frame recognition against `EmbeddedChannel`: threshold behaviour, frames split one byte at a
+  time, a DATA payload containing bytes that look exactly like a `RST_STREAM` frame (must not be
+  counted), HTTP/1.1 traffic (must never be walked), buffers forwarded with every byte intact;
+- outbound `GOAWAY` recognition for `ENHANCE_YOUR_CALM(11)`, `PROTOCOL_ERROR(1)` and
+  `COMPRESSION_ERROR(9)`, and non-recognition of a graceful `NO_ERROR` shutdown;
+- inbound `GOAWAY` recognition: an erroneous peer teardown is reported, the graceful `NO_ERROR`
+  shutdown every client sends is not, an unknown extension code is reported, and a frame delivered
+  one byte at a time is both read correctly and leaves the walker aligned on the frames that
+  follow its debug data;
+- `fromSystemProperties()`: the shipped default is enforcement `0` / window `60`, a valid pair is
+  honoured, a malformed or negative value falls back rather than enabling enforcement, and a `0`
+  window is clamped so it can never silently disable an enforcement that was asked for. This is
+  the configuration every user gets and nothing else covers it;
+- **against a real Armeria server on both a plaintext and a TLS port**: three client-side timeouts
+  on one multiplexed connection are counted as three `RST_STREAM` frames. This is the test that
+  caught the wrong pipeline position — the first implementation appended the handler and observed
+  zero inbound bytes;
+- **against a real server with enforcement switched on**: the flood is reported on the very frame
+  that trips Netty's limit, *and* the resulting `GOAWAY(ENHANCE_YOUR_CALM)` is recognized on the
+  outbound path. The inbound handler necessarily runs before the codec that throws, so the flood
+  report always wins the per-peer throttle and the (redundant) `GOAWAY` line is correctly
+  suppressed;
+- **resilience**: a monitor whose every report throws must not disturb the connection — the channel
+  stays active, no exception reaches the pipeline, and every inbound and outbound buffer is still
+  forwarded with its bytes intact, both on the failing frame and on the ones after it. A pipeline
+  with no HTTP/2 handler at all is left unmonitored rather than rejected.
+
+`EvitaServerTest` (14 tests) boots the real server through `ExternalApiServer`, exercising the
+installation path in production wiring. 67 tests green across `io.evitadb.externalApi.http` and
+`io.evitadb.server`.
+
+`Http2ConnectionMonitorBenchmark` (`evita_test/evita_performance_tests`) is the standing guard on the
+two performance claims the design rests on, each an A/B against the same pipeline without the
+handler. Full writeup and tables:
+[`Http2ConnectionMonitorBenchmark`](../performance/individual/Http2ConnectionMonitorBenchmark/README.md).
+
+- **The inbound walk is O(frames), not O(bytes).** Multiplying the bytes walked per operation by
+  48.7× (256 B → 16 KiB payloads, frame count held at 16) moved the cost from 112.4 to 114.9 ns/op —
+  **+2.2 %**, inside the error bar. **~7 ns per inbound frame**, so ~14 ns on a unary gRPC request
+  against an end-to-end cost measured in hundreds of microseconds. Response size does not matter,
+  which is what makes the handler safe on a database that returns large result sets.
+- **Neither direction allocates.** `gc.alloc.rate.norm` is identical on the outbound path
+  (152.000 B/op both arms) and within 0.002 B/op inbound — and that residual is not the handler but
+  fixed background allocation amortised over fewer operations in the slower arm (0.000 at equal
+  speed, 0.001 at 3.2× slower, 0.002 at 8.6× slower). Nothing on either path constructs an object.
+- The cancellation path costs **~24 ns per `RST_STREAM`**; the extra ~17 ns over a data frame is the
+  single `System.nanoTime()` in `recordResetFrame`'s window check. Left unoptimised on purpose —
+  Netty's own limiter pays the same clock read, and a reset means a cancelled request that already
+  cost orders of magnitude more. The outbound `GOAWAY` recognition costs **~1–3 ns per write**.
+
+Measured on JDK 21.0.11 / JMH 1.37, 8 × 2 s warm-up, 6 × 2 s measurement, 2 forks, idle 24-core
+machine. The A/B arms run sequentially, so a contended run inflates them unequally — the writeup
+records the baseline values that identify one.
+
+Netty's default (400 per 60 s) was read out of `DefaultFlagsProvider` rather than assumed, and
+matches the reporter's observation: 400 resets at ~300/s is ~1.33 s, against the ~1.4 s cadence
+they measured.
+
+## Consequences & open follow-ups
+
+- **The defence is off by default.** A pathological client can now churn streams indefinitely
+  without being disconnected. That is the intended trade — it will be reported once a minute per
+  peer and shows up in `io_evitadb_external_api_http2_rst_flood_total`. Anyone exposing evitaDB to
+  untrusted peers must set `evitadb.http2.maxRstFramesPerWindow`.
+- **The two system properties are intentionally absent from `documentation/user/`.** A future
+  contributor documenting them, or promoting them to `ApiOptions`, is reversing a decision, not
+  filling a gap.
+- **The pipeline-position coupling will break on an Armeria refactor.** It fails safe (one warning,
+  no monitoring), and `Http2ConnectionMonitorTest`'s real-server tests fail loudly. They are the
+  regression gate for any Armeria upgrade.
+- **`clientId` is not in the report.** The issue asked for it "if it is known for that connection";
+  it is not — the evitaDB client header is per-request and nothing on the server records it per
+  channel. The remote address is reported instead, and the access log (`%a`) correlates by it.
+- **Server-sent stream-level `RST_STREAM` is deliberately not reported.** It is per-request, not
+  connection-level, and is already visible through the access log and `RequestEvent` status codes.
+- **The h2c *upgrade* path is untested.** Prior-knowledge h2c and ALPN h2 are both covered; an
+  HTTP/1.1 `Upgrade: h2c` connection may place the codec elsewhere, in which case the monitor
+  silently observes nothing. evitaDB's own clients do not use it.
+- **`logback.xml` was not changed.** With enforcement off by default, Armeria's own
+  `ENHANCE_YOUR_CALM` line can no longer fire at all, so the suppression is not hiding the
+  headline case. What it still hides is Armeria's view of the *other* connection errors — which
+  this monitor now reports itself, from the outbound side, with a peer and a throttle. Narrowing
+  the suppression would therefore only duplicate lines. It becomes worth revisiting if the monitor
+  is ever removed or its pipeline hook stops working.
+
+## Related work
+
+- `2026-08-03-driver-connection-resilience` — the driver-side half of the same incident (issues
+  #1367/#1368); this record covers what the server should have said while that was happening.
+- `2026-07-16-client-session-cancellation-cascade` — the other place where a cancelled client
+  stream has server-side consequences; shares the `RST_STREAM`-as-cancellation semantics relied on
+  here.
+
+## Timeline
+
+- **2026-08-03** — issue #1369 reported, alongside the driver-side #1367/#1368
+- **2026-08-04** — implemented; first implementation appended the handler and saw nothing, the
+  real-server test caught it and the pipeline layout was measured rather than inferred
+- **2026-08-04** — scope widened from `ENHANCE_YOUR_CALM` to every erroneous `GOAWAY` in both
+  directions, enforcement flipped off by default, and the handler hardened so that no failure of
+  its own can disturb the connection it watches
+- **2026-08-04** — the two performance claims measured rather than asserted, and the numbers
+  written down so nobody has to re-measure them

--- a/documentation/adr/2026-08-04-http2-connection-teardown-observability.md
+++ b/documentation/adr/2026-08-04-http2-connection-teardown-observability.md
@@ -1,11 +1,11 @@
 ---
 title: Report HTTP/2 RST_STREAM floods instead of enforcing against them, and turn the Rapid-Reset defence off by default
 date: 2026-08-04
-updated: 2026-08-04 09:20
+updated: 2026-08-04 09:35
 status: accepted
 kind: fix
 issues: [1369]
-prs: []
+prs: [1383]
 areas: [evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http, evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/event]
 supersedes: []
 superseded-by: []

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-04 | [Report HTTP/2 RST_STREAM floods instead of enforcing against them, and turn the Rapid-Reset defence off by default](2026-08-04-http2-connection-teardown-observability.md) | fix | accepted | #1369 |
 | 2026-08-03 | [Readiness discovery-phase probe failures log at DEBUG; only a known-good endpoint failing logs ERROR](2026-08-03-readiness-discovery-log-level.md) | fix | proposed | #1364, PR #1366 |
 | 2026-08-03 | [Enforce the test-tag policy from a JUnit PostDiscoveryFilter, because listener exceptions are swallowed](2026-08-03-test-tag-policy-gate-via-post-discovery-filter.md) | fix | accepted | #1374, PR #1382 |
 | 2026-08-03 | [Align client/server keep-alive timing and always retry provably-unprocessed gRPC calls](2026-08-03-driver-connection-resilience.md) | fix | accepted | #1367, #1368, PR #1371 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-04 | [Report HTTP/2 RST_STREAM floods instead of enforcing against them, and turn the Rapid-Reset defence off by default](2026-08-04-http2-connection-teardown-observability.md) | fix | accepted | #1369 |
+| 2026-08-04 | [Report HTTP/2 RST_STREAM floods instead of enforcing against them, and turn the Rapid-Reset defence off by default](2026-08-04-http2-connection-teardown-observability.md) | fix | accepted | #1369, PR #1383 |
 | 2026-08-03 | [Readiness discovery-phase probe failures log at DEBUG; only a known-good endpoint failing logs ERROR](2026-08-03-readiness-discovery-log-level.md) | fix | proposed | #1364, PR #1366 |
 | 2026-08-03 | [Enforce the test-tag policy from a JUnit PostDiscoveryFilter, because listener exceptions are swallowed](2026-08-03-test-tag-policy-gate-via-post-discovery-filter.md) | fix | accepted | #1374, PR #1382 |
 | 2026-08-03 | [Align client/server keep-alive timing and always retry provably-unprocessed gRPC calls](2026-08-03-driver-connection-resilience.md) | fix | accepted | #1367, #1368, PR #1371 |

--- a/documentation/performance/individual/Http2ConnectionMonitorBenchmark/README.md
+++ b/documentation/performance/individual/Http2ConnectionMonitorBenchmark/README.md
@@ -1,0 +1,111 @@
+# Http2ConnectionMonitor — cost of watching every HTTP/2 connection
+
+**Benchmark source** (the executable counterpart of this document — its class JavaDoc links back here):
+`evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/Http2ConnectionMonitorBenchmark.java`
+
+The tables below are the authoritative record — raw JMH JSON is not retained. Re-run the benchmark (command below) to
+regenerate the numbers, and update this document whenever the inbound walker or the outbound recognition changes so
+the two never drift apart.
+
+## Why this benchmark exists
+
+`Http2ConnectionMonitor` (see [the ADR](../../../adr/2026-08-04-http2-connection-teardown-observability.md)) installs a
+handler into **every** child channel pipeline, between the TLS handler and the HTTP/2 codec. Every inbound and every
+outbound byte of every connection — gRPC, GraphQL, REST, system API — passes through it. That is the worst possible
+place to be wrong about cost, and the design rests on two claims that are cheap to assert and easy to break silently:
+
+1. **The inbound walk is O(frames), not O(bytes).** It reads the 9-byte frame header one byte at a time (so it survives
+   frames split across arbitrary socket reads) and then skips the entire payload in a single index jump. A regression
+   to a per-byte walk would not fail any test — it would just quietly tax every large response.
+2. **Neither direction allocates.** A per-frame allocation on the hot path would be invisible in latency and lethal in
+   GC pressure at load.
+
+Both are measured here rather than argued.
+
+## Method
+
+Every operation is an **A/B against the same pipeline**: `monitored = true` installs the monitor, `monitored = false`
+runs an otherwise identical `EmbeddedChannel`. Only the **difference** between the arms is the handler's cost — the
+absolute numbers include `EmbeddedChannel` plumbing a real connection does not have.
+
+The `payloadSize` sweep (256 B → 16 KiB) is what proves claim 1: it changes the bytes walked per operation by
+**48.7×** (2 704 → 131 728 B/op) while leaving the frame count identical at 16.
+
+| operation | shape | what it isolates |
+|---|---|---|
+| `dataFrames` | 8 × `HEADERS`(64 B) + 8 × `DATA`(`payloadSize`) | the ordinary request path |
+| `resetFrames` | 16 × `RST_STREAM`(4 B) | the cancellation storm — the only op where `recordResetFrame` runs |
+| `outboundFrames` | one write of 16 × `DATA`(`payloadSize`) | the response path's `GOAWAY` recognition |
+
+**Denominators differ by direction.** The inbound ops push 16 frames whose headers are each parsed, so they divide by
+16 for a per-frame figure. `outboundFrames` hands the whole buffer to a **single** `writeOutbound`, so the recognition
+runs **once per write** and rejects on the first frame's type byte — that figure is per-write and must not be divided.
+
+The throttled reporting path (log line + JFR event) is deliberately excluded: the monitor used here raises its
+reporting threshold out of reach, leaving exactly the code that runs on every connection all the time.
+
+Run environment: JDK 21.0.11 (OpenJDK 64-Bit Server VM, Ubuntu), JMH 1.37, no VM options, 8 × 2 s warm-up,
+6 × 2 s measurement, 2 forks, `-prof gc`, on an idle 24-core machine.
+
+## Result — the walk is per-frame, and it does not allocate
+
+### Time (`avgt`, ns/op — lower is better)
+
+| operation | payload | monitored | unmonitored | delta/op | per unit |
+|---|---|---|---|---|---|
+| `dataFrames` | 256 B | 164.60 ± 2.76 | 52.22 ± 3.47 | +112.4 | **7.0 ns / frame** |
+| `dataFrames` | 16 KiB | 167.45 ± 7.80 | 52.54 ± 2.50 | +114.9 | **7.2 ns / frame** |
+| `resetFrames` | 256 B | 437.88 ± 5.95 | 50.49 ± 0.86 | +387.4 | **24.2 ns / frame** |
+| `resetFrames` | 16 KiB | 434.40 ± 5.08 | 50.74 ± 1.43 | +383.7 | **24.0 ns / frame** |
+| `outboundFrames` | 256 B | 69.19 ± 1.26 | 67.98 ± 4.10 | +1.2 | **1.2 ns / write** |
+| `outboundFrames` | 16 KiB | 69.49 ± 0.96 | 66.48 ± 0.81 | +3.0 | **3.0 ns / write** |
+
+**Claim 1 holds.** Multiplying the bytes walked by 48.7× moves the inbound cost from 112.4 to 114.9 ns/op —
+**+2.2 %**, itself well inside the 16 KiB arm's own error bar. That bounds the per-byte component at roughly
+**0.02 ns per KiB skipped**; a per-byte walk would have shown near a 48× increase. `resetFrames` is a control: its
+frames are 4-byte-payload regardless of `payloadSize`, so its two rows are an independent repeat measurement of the
+same quantity and agree to 0.9 %.
+
+**The reset path's extra 17 ns is one `System.nanoTime()`.** Both paths parse a frame header; the only thing
+`resetFrames` does on top is `recordResetFrame`, whose sole non-trivial operation is the clock read for the window
+check — and 24.1 − 7.1 = 17.0 ns/frame is exactly that call on this machine. It is deliberately not optimised away:
+Netty's own rate limiter pays the same clock read, and a reset means a cancelled request that already cost orders of
+magnitude more.
+
+### Allocation (`gc.alloc.rate.norm`, B/op — the regression oracle)
+
+| operation | monitored | unmonitored | delta |
+|---|---|---|---|
+| `dataFrames` | 24.001 | 24.000 | +0.001 |
+| `resetFrames` | 24.002 | 24.000 | +0.002 |
+| `outboundFrames` | 152.000 | 152.000 | **identical** |
+
+**Claim 2 holds, with one honest caveat.** The handler allocates nothing — neither the walker, nor
+`recordResetFrame` (a clock read and integer arithmetic), nor the outbound recognition (absolute `ByteBuf` getters)
+constructs an object. The ≤0.002 B/op residual is **not** the handler: it tracks how much *slower* each arm is,
+because a fixed background allocation (JIT, profiler threads) is amortised over fewer operations. The ordering is
+exactly what that predicts — 0.000 where the arms run at equal speed, 0.001 at 3.2× slower, 0.002 at 8.6× slower. One
+24-byte object per ~12 000 operations is below the profiler's ability to attribute.
+
+Do **not** compare `gc.count` between arms: the monitored arm completes far fewer operations in the same wall clock, so
+its collection count is lower for reasons that have nothing to do with allocation per operation.
+
+## Conclusion
+
+The monitor costs **~7 ns per inbound frame**, **~1–3 ns per outbound write**, and allocates nothing measurable. A
+typical unary gRPC request is two inbound frames (`HEADERS` + `DATA`), so the monitor adds roughly **14 ns** to a
+request whose end-to-end cost is measured in hundreds of microseconds — on the order of 0.01 %. Response size does not
+matter, which is the property that makes the design safe on a database that returns large result sets.
+
+This benchmark is the standing guard on both claims. If someone replaces the single-jump payload skip with a per-byte
+loop, or adds an allocation to the walker, the `payloadSize` sweep and the `gc.alloc.rate.norm` column are where it
+surfaces — nothing in the functional test suite would notice either.
+
+Regenerate with:
+`java -cp evita_test/evita_performance_tests/target/benchmarks.jar org.openjdk.jmh.Main
+'io\.evitadb\.spike\.Http2ConnectionMonitorBenchmark' -prof gc`
+
+**Measure on an idle machine and validate the run before quoting it.** The A/B arms run sequentially, not
+concurrently, so background load lands on them unequally. The tell is the *unmonitored* baselines: they should come in
+near 52 / 50 / 67 ns/op (`dataFrames` / `resetFrames` / `outboundFrames`). A run whose baselines are inflated, or whose
+per-fork `rawData` drifts monotonically within a fork, is contended — discard it rather than publishing it.

--- a/documentation/performance/individual/README.md
+++ b/documentation/performance/individual/README.md
@@ -35,6 +35,10 @@ the test and its results stay discoverable from either side.
 - [`SortIndexArrayVsBPlusTreeBenchmark/`](SortIndexArrayVsBPlusTreeBenchmark/README.md) — `SortIndex` distinct-values
   backing: contiguous array vs. consolidated `TransactionalObjectBPlusTree`. Drove `SortIndex.VALUE_BLOCK_SIZE = 256`
   plus the leaf-array-caching and software-prefetch optimizations in `TransactionalObjectBPlusTree`.
+- [`Http2ConnectionMonitorBenchmark/`](Http2ConnectionMonitorBenchmark/README.md) — cost of the HTTP/2 connection
+  monitor that sits in every child channel pipeline. Proved the inbound frame walk is O(frames) rather than O(bytes)
+  (48.7× more bytes → +2.2 % time) at ~7 ns/frame, the outbound `GOAWAY` recognition ~1–3 ns/write, and neither
+  direction allocating.
 - [`BucketBPlusTreePayloadBenchmark/`](BucketBPlusTreePayloadBenchmark/README.md) — neutrality A/B for generalizing the
   `TransactionalBucketBPlusTree` single-record column from raw `int[]` to the pluggable `RecordColumn` SPI
   (`IntRecordColumn` / `LongRecordColumn`). Proved allocation- and time-neutral (deterministic `gc.alloc.rate.norm`

--- a/documentation/user/en/operate/reference/jfr-events.md
+++ b/documentation/user/en/operate/reference/jfr-events.md
@@ -3,6 +3,10 @@
 #### API
 
 <dl>
+  <dt><SourceClass>evita_engine/src/main/java/io/evitadb/externalApi/event/Http2GoAwayEvent.java</SourceClass> HTTP/2 connection closed with GOAWAY</dt>
+  <dd>Event that is fired when an HTTP/2 connection is closed by an erroneous GOAWAY frame, either sent by the server or received from the peer.</dd>
+  <dt><SourceClass>evita_engine/src/main/java/io/evitadb/externalApi/event/Http2RstFloodEvent.java</SourceClass> HTTP/2 RST_STREAM flood</dt>
+  <dd>Event that is fired when a single HTTP/2 connection sends more RST_STREAM (cancelled request) frames within one window than the reporting threshold allows.</dd>
   <dt><SourceClass>evita_engine/src/main/java/io/evitadb/externalApi/event/ReadinessEvent.java</SourceClass> Readiness probe</dt>
   <dd>Event that is fired when a readiness probe is either executed by client or invoked on the server side.</dd>
   <dt><SourceClass>evita_engine/src/main/java/io/evitadb/externalApi/event/RequestEvent.java</SourceClass> Request</dt>

--- a/documentation/user/en/operate/reference/metrics.md
+++ b/documentation/user/en/operate/reference/metrics.md
@@ -19,8 +19,12 @@
     <dd><strong>Conflict policy</strong>: The coarse conflict policy (NONE/CATALOG/COLLECTION/ENTITY) in force for the conflicting scope.</dd>
     <dt>conflictScope</dt>
     <dd><strong>Conflict scope</strong>: The granularity of the conflicting key (e.g. entity, attribute, price, reference).</dd>
+    <dt>direction</dt>
+    <dd><strong>GOAWAY direction</strong>: SENT when the server closed the connection, RECEIVED when the peer did.</dd>
     <dt>entityType</dt>
     <dd><strong>Entity type</strong>: The name of the related entity type (collection).</dd>
+    <dt>errorCode</dt>
+    <dd><strong>GOAWAY error code</strong>: The RFC 9113 error code carried by the GOAWAY frame, for example ENHANCE_YOUR_CALM(11).</dd>
     <dt>error_type</dt>
     <dd><strong>Error type</strong>: Class of the error being counted.</dd>
     <dt>fileType</dt>
@@ -95,6 +99,10 @@ duration of the probe.</dd>
 #### API
 
 <dl>
+  <dt><code>io_evitadb_external_api_http2_go_away_total</code> (COUNTER)</dt>
+  <dd>HTTP/2 connections closed with an erroneous GOAWAY total<br/><br/><strong>Labels:</strong> <Term>direction</Term>, <Term>errorCode</Term><br/></dd>
+  <dt><code>io_evitadb_external_api_http2_rst_flood_total</code> (COUNTER)</dt>
+  <dd>HTTP/2 RST_STREAM floods detected total</dd>
   <dt><code>io_evitadb_external_api_readiness_duration_milliseconds</code> (HISTOGRAM)</dt>
   <dd>Readiness probe duration<br/><br/><strong>Labels:</strong> <Term>api</Term>, <Term>probeResult</Term>, <Term>prospective</Term><br/></dd>
   <dt><code>io_evitadb_external_api_readiness_total</code> (COUNTER)</dt>

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/event/Http2GoAwayEvent.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/event/Http2GoAwayEvent.java
@@ -1,0 +1,110 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.event;
+
+import io.evitadb.api.observability.annotation.ExportInvocationMetric;
+import io.evitadb.api.observability.annotation.ExportMetricLabel;
+import jdk.jfr.Description;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+
+/**
+ * JFR event fired whenever an HTTP/2 connection is torn down by an erroneous `GOAWAY` frame - in either direction.
+ *
+ * `SENT` covers the server giving up on a connection: `ENHANCE_YOUR_CALM` from Netty's Rapid-Reset defence
+ * (CVE-2023-44487, off by default - see {@link io.evitadb.externalApi.http.Http2ConnectionMonitor}),
+ * `PROTOCOL_ERROR` or `FRAME_SIZE_ERROR` from a malformed peer, `COMPRESSION_ERROR` from an HPACK desync, and the
+ * other connection-level failures. `RECEIVED` covers the mirror image and is the more alarming one: the *client* is
+ * rejecting something the server sent, which may point at a defect in evitaDB rather than in the peer.
+ *
+ * Either way a `GOAWAY` closes the whole connection, so every in-flight request on it fails - exporting the
+ * occurrence as a metric makes the situation alertable instead of something that has to be discovered by debugging
+ * the client. Graceful `NO_ERROR` shutdowns, which accompany every ordinary connection close, are not reported.
+ *
+ * The error code and the direction are exported as metric labels - both are closed, small sets (RFC 9113 §7 defines
+ * fourteen codes), and the code is what tells a rate-limited client apart from a malformed one. The peer address is
+ * recorded on the JFR event but deliberately **not** exported as a label - it is an unbounded dimension that would
+ * blow up the Prometheus cardinality. Use the accompanying log line or the JFR recording to identify the peer.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Description(
+	"Event that is fired when an HTTP/2 connection is closed by an erroneous GOAWAY frame, either sent by the " +
+		"server or received from the peer."
+)
+@Label("HTTP/2 connection closed with GOAWAY")
+@ExportInvocationMetric(label = "HTTP/2 connections closed with an erroneous GOAWAY total")
+@Getter
+public class Http2GoAwayEvent extends AbstractExternalApiEvent {
+
+	/**
+	 * Address of the peer whose connection was closed.
+	 */
+	@Label("Peer address")
+	@Name("peerAddress")
+	@Description("The remote address of the peer whose connection was closed.")
+	final String peerAddress;
+
+	/**
+	 * Name and numeric value of the RFC 9113 §7 error code carried by the `GOAWAY` frame.
+	 */
+	@Label("GOAWAY error code")
+	@Name("errorCode")
+	@Description("The RFC 9113 error code carried by the GOAWAY frame, for example ENHANCE_YOUR_CALM(11).")
+	@ExportMetricLabel
+	final String errorCode;
+
+	/**
+	 * Whether the server sent the frame or received it from the peer.
+	 */
+	@Label("GOAWAY direction")
+	@Name("direction")
+	@Description("SENT when the server closed the connection, RECEIVED when the peer did.")
+	@ExportMetricLabel
+	final String direction;
+
+	public Http2GoAwayEvent(@Nonnull String peerAddress, @Nonnull String errorCode, @Nonnull Direction direction) {
+		this.peerAddress = peerAddress;
+		this.errorCode = errorCode;
+		this.direction = direction.name();
+	}
+
+	/**
+	 * Which side of the connection gave up.
+	 */
+	public enum Direction {
+		/**
+		 * The server closed the connection - the peer, or something between it and the server, misbehaved.
+		 */
+		SENT,
+		/**
+		 * The peer closed the connection, rejecting something the server sent.
+		 */
+		RECEIVED
+	}
+
+}

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/event/Http2RstFloodEvent.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/event/Http2RstFloodEvent.java
@@ -1,0 +1,71 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.event;
+
+import io.evitadb.api.observability.annotation.ExportInvocationMetric;
+import jdk.jfr.Description;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+
+/**
+ * JFR event fired when a single HTTP/2 connection sends more `RST_STREAM` frames within one window than the reporting
+ * threshold allows. Every such frame is a cancelled request, so a sustained flood means a client is either opening
+ * and cancelling calls in a tight loop or having all of its request timeouts fire at once - neither shows up in the
+ * access log, because the individual requests look perfectly ordinary.
+ *
+ * The event is emitted regardless of whether the Rapid-Reset defence is enforcing (it is disabled by default, see
+ * {@link io.evitadb.externalApi.http.Http2ConnectionMonitor}), which is what makes the situation alertable without
+ * having to sever the connection to find out about it.
+ *
+ * The offending peer address is recorded on the JFR event but deliberately **not** exported as a metric label - it is
+ * an unbounded dimension that would blow up the Prometheus cardinality. Use the accompanying log line or the JFR
+ * recording to identify the peer.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Description(
+	"Event that is fired when a single HTTP/2 connection sends more RST_STREAM (cancelled request) frames within " +
+		"one window than the reporting threshold allows."
+)
+@Label("HTTP/2 RST_STREAM flood")
+@ExportInvocationMetric(label = "HTTP/2 RST_STREAM floods detected total")
+@Getter
+public class Http2RstFloodEvent extends AbstractExternalApiEvent {
+
+	/**
+	 * Address of the peer that sent the frames.
+	 */
+	@Label("Peer address")
+	@Name("peerAddress")
+	@Description("The remote address of the peer that flooded the server with RST_STREAM frames.")
+	final String peerAddress;
+
+	public Http2RstFloodEvent(@Nonnull String peerAddress) {
+		this.peerAddress = peerAddress;
+	}
+
+}

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ExternalApiServer.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ExternalApiServer.java
@@ -564,6 +564,9 @@ public class ExternalApiServer implements AutoCloseable {
 			.eventLoopMetrics(workerGroup, new MeterIdPrefix("armeria.netty.worker"))
 			.bindTo(meterRegistry);
 
+		// reports RST_STREAM floods and erroneous GOAWAY teardowns that would otherwise leave no trace on the server
+		final Http2ConnectionMonitor http2ConnectionMonitor = Http2ConnectionMonitor.fromSystemProperties();
+
 		serverBuilder
 			.blockingTaskExecutor(evita.getServiceExecutor(), false)
 			// this may be changed in future versions to a limited set
@@ -601,6 +604,15 @@ public class ExternalApiServer implements AutoCloseable {
 			.idleTimeoutMillis(apiOptions.idleTimeoutInMillis(), true)
 			.requestTimeoutMillis(apiOptions.requestTimeoutInMillis())
 			.pingIntervalMillis(apiOptions.pingIntervalMillis())
+			// Netty's Rapid-Reset (CVE-2023-44487) defence, which stock Armeria enables at 400 resets per minute -
+			// evitaDB turns it OFF by default, because it kills the whole connection (and every unrelated in-flight
+			// request on it) for a client that is merely timing out a lot, and evitaDB's clients are usually trusted.
+			// The flood is reported by Http2ConnectionMonitor instead of being enforced against
+			.http2MaxResetFramesPerWindow(
+				http2ConnectionMonitor.getMaxRstFramesPerWindow(),
+				http2ConnectionMonitor.getRstFrameWindowSeconds()
+			)
+			.childChannelPipelineCustomizer(http2ConnectionMonitor::install)
 			.serviceWorkerGroup(workerGroup, true)
 			.maxRequestLength(apiOptions.maxEntitySizeInBytes())
 			.workerGroup(workerGroup, true)

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/Http2ConnectionMonitor.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/Http2ConnectionMonitor.java
@@ -314,10 +314,12 @@ public class Http2ConnectionMonitor {
 
 	public Http2ConnectionMonitor(int maxRstFramesPerWindow, int rstFrameWindowSeconds) {
 		this.maxRstFramesPerWindow = maxRstFramesPerWindow;
-		this.rstFrameWindowSeconds = rstFrameWindowSeconds;
+		// a zero or negative window would restart the count on every single frame, so the counter could never reach
+		// the threshold - enforcement asked for would be silently disabled instead of merely misconfigured
+		this.rstFrameWindowSeconds = Math.max(1, rstFrameWindowSeconds);
 		this.reportingThreshold = maxRstFramesPerWindow > 0 ?
 			maxRstFramesPerWindow : RST_FLOOD_REPORTING_THRESHOLD;
-		this.windowNanos = TimeUnit.SECONDS.toNanos(rstFrameWindowSeconds);
+		this.windowNanos = TimeUnit.SECONDS.toNanos(this.rstFrameWindowSeconds);
 	}
 
 	/**
@@ -737,9 +739,8 @@ public class Http2ConnectionMonitor {
 		}
 
 		/**
-		 * Counts one `RST_STREAM` frame into the current window and reports the connection the first time the window
-		 * exceeds the threshold. Mirrors the sliding window Netty's own limiter uses, so an enabled enforcement and
-		 * this counter agree on when the limit is reached.
+		 * Reports a `GOAWAY` the peer sent us, reading the error code out of the payload the walker captured. The
+		 * graceful `NO_ERROR` close that ends every ordinary connection is not news and is passed over.
 		 *
 		 * @param channel connection the frame arrived on
 		 */
@@ -756,6 +757,14 @@ public class Http2ConnectionMonitor {
 			}
 		}
 
+		/**
+		 * Counts one `RST_STREAM` frame into the current window and reports the connection the first time the count
+		 * passes the threshold. The window is **tumbling**, not sliding: once it elapses the count restarts at one.
+		 * That is deliberately the same shape Netty's `Http2MaxRstFrameListener` uses, so when enforcement is turned
+		 * on, this counter and Netty's limiter trip on the very same frame instead of drifting apart.
+		 *
+		 * @param channel connection the frame arrived on
+		 */
 		private void recordResetFrame(@Nonnull Channel channel) {
 			final long now = System.nanoTime();
 			if (now - this.windowStartNanos >= Http2ConnectionMonitor.this.windowNanos) {

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/Http2ConnectionMonitor.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/Http2ConnectionMonitor.java
@@ -1,0 +1,771 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.http;
+
+import io.evitadb.externalApi.event.Http2GoAwayEvent;
+import io.evitadb.externalApi.event.Http2GoAwayEvent.Direction;
+import io.evitadb.externalApi.event.Http2RstFloodEvent;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http2.Http2Error;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Makes two otherwise invisible HTTP/2 connection-level situations visible in the server log and in the metrics:
+ *
+ * 1. **a peer resetting streams en masse** - a client that opens and immediately cancels calls in a tight loop (an
+ *    unbounded re-subscription loop without a backoff is the classic one) or whose request timeouts are all firing at
+ *    once. Nothing about it shows up in the access log, because the individual requests look perfectly ordinary;
+ * 2. **the server tearing a connection down with an erroneous `GOAWAY`** - `PROTOCOL_ERROR` or `FRAME_SIZE_ERROR`
+ *    from a malformed peer or a broken intermediary, `COMPRESSION_ERROR` from an HPACK desync, `SETTINGS_TIMEOUT`,
+ *    `INADEQUATE_SECURITY`, or `ENHANCE_YOUR_CALM` when the Rapid-Reset defence below is switched on. A `GOAWAY` is
+ *    connection-level, so it kills **every** in-flight request on that connection, including ones entirely unrelated
+ *    to whatever triggered it - on the client this surfaces as an assortment of transport errors, cancellations and
+ *    timeouts against a server that is otherwise perfectly healthy. Graceful `NO_ERROR` shutdowns are ignored.
+ *
+ * **Detection is deliberately separated from enforcement.** Netty's Rapid-Reset defence (CVE-2023-44487) is
+ * *disabled by default* here, unlike in stock Armeria which allows 400 resets per minute. evitaDB is a database that
+ * sits behind the application layer and talks to a small number of trusted clients; on that deployment the defence
+ * does more harm than good, because a legitimate client emits a `RST_STREAM` for every client-side timeout and every
+ * closed server-stream. It therefore fires hardest exactly when the server is already slow - requests time out, the
+ * client cancels them, the resets accumulate, the connection is killed, every in-flight request on it dies and the
+ * client reconnects and retries. That turns a slow period into a metastable failure. Reporting the flood without
+ * killing the connection gives the operator the same information without the amplification.
+ *
+ * Anyone exposing evitaDB to untrusted peers can switch the defence back on with {@link #PROPERTY_MAX_RST_FRAMES}
+ * (and optionally {@link #PROPERTY_RST_FRAME_WINDOW_SECONDS}). These are system properties rather than configuration
+ * keys on purpose - they are a last resort for a deployment that has an unusual threat model, not something an
+ * ordinary operator should be tuning.
+ *
+ * Neither Netty nor Armeria expose an observation hook for either situation, so both are recognized directly on the
+ * wire. {@link ExternalApiServer} hands {@link #install(ChannelPipeline)} to
+ * `ServerBuilder#childChannelPipelineCustomizer`, which slots a per-connection handler in between the TLS handler and
+ * the HTTP/2 connection handler. It therefore sees inbound frames before the HTTP/2 codec does, and outbound frames
+ * after it produced them - in both cases as plain, already-decrypted HTTP/2 frame bytes.
+ *
+ * **Invariants a future change must not break:**
+ *
+ * - every inspected {@link ByteBuf} is read with absolute getters only and is forwarded untouched - a relative read
+ *   would consume bytes the HTTP/2 codec (or the socket) still needs;
+ * - inbound inspection only starts once the HTTP/2 connection preface has been seen, which is what keeps it from
+ *   misreading HTTP/1.1 traffic, a PROXY protocol header or an h2c upgrade handshake as frames. A connection whose
+ *   preface never arrives is simply never inspected;
+ * - inbound inspection disables itself for the connection if it ever loses the frame boundaries
+ *   ({@link #MAX_INBOUND_FRAME_LENGTH}); reporting nothing is always preferable to reporting nonsense;
+ * - outbound recognition must remain tolerant of buffer layout: Netty currently writes the fixed part of the
+ *   `GOAWAY` frame (header, last stream id, error code) as its own buffer and the debug data as a second one, but
+ *   the recognition only requires the fixed part to be contiguous.
+ *
+ * This object is shared by every connection and holds the reporting throttle; the per-connection parsing state lives
+ * in the handler instances it produces.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Slf4j
+public class Http2ConnectionMonitor {
+	/**
+	 * Undocumented escape hatch enabling Netty's Rapid-Reset defence - the number of `RST_STREAM` frames a connection
+	 * may send within {@link #PROPERTY_RST_FRAME_WINDOW_SECONDS} before the server closes it with
+	 * `GOAWAY(ENHANCE_YOUR_CALM)`. Defaults to `0`, which leaves the defence off. See the class documentation for why
+	 * it is off and why it is not an ordinary configuration key.
+	 */
+	public static final String PROPERTY_MAX_RST_FRAMES = "evitadb.http2.maxRstFramesPerWindow";
+	/**
+	 * Undocumented escape hatch setting the length of the window {@link #PROPERTY_MAX_RST_FRAMES} applies to, in
+	 * seconds. It is also the window the reporting threshold is measured over. Defaults to `60`.
+	 */
+	public static final String PROPERTY_RST_FRAME_WINDOW_SECONDS = "evitadb.http2.rstFrameWindowSeconds";
+	/**
+	 * Number of `RST_STREAM` frames within one window above which a connection is reported. Matches the threshold
+	 * stock Armeria enforces at, so the log line appears exactly where a default Armeria server would have severed
+	 * the connection.
+	 */
+	public static final int RST_FLOOD_REPORTING_THRESHOLD = 400;
+	/**
+	 * Length of the reporting (and, when enabled, enforcement) window in seconds.
+	 */
+	public static final int DEFAULT_RST_FRAME_WINDOW_SECONDS = 60;
+
+	/**
+	 * The HTTP/2 connection preface every client sends before its first frame (RFC 9113 §3.4). Inbound inspection
+	 * starts right behind it.
+	 */
+	private static final byte[] CONNECTION_PREFACE =
+		"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+	/**
+	 * Length of the HTTP/2 frame header - 3B payload length, 1B type, 1B flags, 4B stream identifier (RFC 9113 §4.1).
+	 */
+	private static final int FRAME_HEADER_LENGTH = 9;
+	/**
+	 * Type of the `RST_STREAM` frame (RFC 9113 §6.4).
+	 */
+	private static final int FRAME_TYPE_RST_STREAM = 0x03;
+	/**
+	 * Type of the `GOAWAY` frame (RFC 9113 §6.8).
+	 */
+	private static final int FRAME_TYPE_GO_AWAY = 0x07;
+	/**
+	 * Minimal `GOAWAY` payload - 4B last stream identifier, 4B error code, optional debug data (RFC 9113 §6.8).
+	 */
+	private static final int GO_AWAY_MIN_PAYLOAD_LENGTH = 8;
+	/**
+	 * Error code of a graceful shutdown - the only `GOAWAY` that is not worth reporting (RFC 9113 §7).
+	 */
+	private static final long ERROR_CODE_NO_ERROR = 0x00L;
+	/**
+	 * Error code Netty uses when the `RST_STREAM` rate limit is exceeded (RFC 9113 §7). It is the one reason that has
+	 * a configurable threshold and a well-known client-side cause, so it earns a more specific explanation.
+	 */
+	private static final long ERROR_CODE_ENHANCE_YOUR_CALM = 0x0BL;
+	/**
+	 * Highest error code defined by RFC 9113 §7 - used only to keep the outbound frame recognition tight, Netty and
+	 * Armeria never send anything outside this range.
+	 */
+	private static final long ERROR_CODE_MAX = 0x0DL;
+	/**
+	 * Largest inbound frame the walker considers plausible. Armeria advertises a `SETTINGS_MAX_FRAME_SIZE` of 16 KiB,
+	 * so a conforming peer stays three orders of magnitude below this; anything larger means the walker lost the
+	 * frame boundaries and must stop rather than produce made-up counts.
+	 */
+	private static final int MAX_INBOUND_FRAME_LENGTH = 1 << 20;
+	/**
+	 * How long reporting is suppressed for a peer address that has already been reported.
+	 */
+	private static final long REPORT_SUPPRESSION_INTERVAL_NANOS = TimeUnit.MINUTES.toNanos(1);
+	/**
+	 * Upper bound on the number of tracked peer addresses - reached only when many distinct peers misbehave at once,
+	 * in which case the entries that fell out of the suppression window are dropped before a new one is added.
+	 */
+	private static final int MAX_TRACKED_PEERS = 256;
+	/**
+	 * Class name prefix Armeria gives to both of its HTTP/2 protocol handlers - the one probing for the connection
+	 * preface on a plaintext port and the one negotiating ALPN behind TLS. See {@link #install(ChannelPipeline)}.
+	 */
+	private static final String HTTP2_HANDLER_NAME_PREFIX = "Http2";
+
+	/**
+	 * Number of `RST_STREAM` frames per window Netty is told to enforce - `0` (the default) leaves the Rapid-Reset
+	 * defence disabled and is what {@link ExternalApiServer} hands to Armeria.
+	 */
+	@Getter private final int maxRstFramesPerWindow;
+	/**
+	 * Length of the reporting and enforcement window, in seconds.
+	 */
+	@Getter private final int rstFrameWindowSeconds;
+	/**
+	 * Number of `RST_STREAM` frames within one window above which a connection is reported. Follows
+	 * {@link #maxRstFramesPerWindow} when enforcement is on (so the report explains the teardown that is about to
+	 * happen) and {@link #RST_FLOOD_REPORTING_THRESHOLD} when it is off.
+	 */
+	private final int reportingThreshold;
+	/**
+	 * {@link #rstFrameWindowSeconds} pre-converted, so the hot path doesn't repeat the conversion.
+	 */
+	private final long windowNanos;
+	/**
+	 * Throttling state per peer address - see {@link PeerReportState}.
+	 */
+	private final Map<String, PeerReportState> reportStateByPeer = new ConcurrentHashMap<>(16);
+	/**
+	 * Guards the "could not be installed" warning so a pipeline this monitor no longer understands reports itself
+	 * once instead of on every accepted connection.
+	 */
+	private final AtomicBoolean installationFailureReported = new AtomicBoolean();
+
+	/**
+	 * Creates a monitor configured from the undocumented system properties, falling back to reporting-only operation.
+	 *
+	 * @return monitor shared by every connection of a single server
+	 */
+	@Nonnull
+	public static Http2ConnectionMonitor fromSystemProperties() {
+		return new Http2ConnectionMonitor(
+			readNonNegativeProperty(PROPERTY_MAX_RST_FRAMES, 0),
+			Math.max(1, readNonNegativeProperty(PROPERTY_RST_FRAME_WINDOW_SECONDS, DEFAULT_RST_FRAME_WINDOW_SECONDS))
+		);
+	}
+
+	/**
+	 * Reads a non-negative integer system property, falling back to the default value when it is absent or malformed.
+	 *
+	 * @param propertyName name of the system property
+	 * @param defaultValue value to use when the property is absent or cannot be parsed
+	 * @return the resolved value
+	 */
+	private static int readNonNegativeProperty(@Nonnull String propertyName, int defaultValue) {
+		final String value = System.getProperty(propertyName);
+		if (value == null || value.isBlank()) {
+			return defaultValue;
+		}
+		try {
+			final int parsedValue = Integer.parseInt(value.trim());
+			if (parsedValue < 0) {
+				log.warn("Ignoring negative value `{}` of system property `{}`.", value, propertyName);
+				return defaultValue;
+			}
+			return parsedValue;
+		} catch (NumberFormatException ex) {
+			log.warn("Ignoring non-numeric value `{}` of system property `{}`.", value, propertyName);
+			return defaultValue;
+		}
+	}
+
+	/**
+	 * Translates the numeric error code into its RFC 9113 name so the log line doesn't force the reader to look it up.
+	 *
+	 * @param errorCode `GOAWAY` error code
+	 * @return name of the error code including its numeric value
+	 */
+	@Nonnull
+	private static String errorCodeName(long errorCode) {
+		final Http2Error error = Http2Error.valueOf(errorCode);
+		return (error == null ? "UNKNOWN" : error.name()) + "(" + errorCode + ")";
+	}
+
+	/**
+	 * Resolves the peer identification used both for the log line and for throttling it. The port is deliberately left
+	 * out - a misbehaving client reconnects on a new ephemeral port every time, so including it would defeat the
+	 * suppression entirely.
+	 *
+	 * @param remoteAddress remote address of the inspected channel
+	 * @return human-readable peer address
+	 */
+	@Nonnull
+	private static String peerAddress(@Nullable SocketAddress remoteAddress) {
+		if (remoteAddress instanceof InetSocketAddress inetSocketAddress) {
+			return inetSocketAddress.getAddress() == null ?
+				inetSocketAddress.getHostString() : inetSocketAddress.getAddress().getHostAddress();
+		} else {
+			return String.valueOf(remoteAddress);
+		}
+	}
+
+	/**
+	 * Returns the error code of the `GOAWAY` frame the passed buffer starts with, or `-1` when the buffer holds
+	 * something else or a graceful `NO_ERROR` shutdown.
+	 *
+	 * The frame type, the connection-level stream identifier, the payload length and the error code range are all
+	 * verified, which makes a false positive on an arbitrary payload buffer that happens to pass through effectively
+	 * impossible.
+	 *
+	 * @param buffer buffer to inspect, never modified
+	 * @return the `GOAWAY` error code, or `-1` when this is not an erroneous `GOAWAY` frame
+	 */
+	private static long resolveGoAwayErrorCode(@Nonnull ByteBuf buffer) {
+		final int index = buffer.readerIndex();
+		if (buffer.readableBytes() < FRAME_HEADER_LENGTH + GO_AWAY_MIN_PAYLOAD_LENGTH) {
+			return -1L;
+		}
+		if (buffer.getUnsignedByte(index + 3) != FRAME_TYPE_GO_AWAY) {
+			return -1L;
+		}
+		if (buffer.getUnsignedMedium(index) < GO_AWAY_MIN_PAYLOAD_LENGTH) {
+			return -1L;
+		}
+		// GOAWAY is a connection-level frame - its stream identifier is always zero (the top bit is reserved)
+		if ((buffer.getInt(index + 5) & 0x7FFFFFFF) != 0) {
+			return -1L;
+		}
+		// payload layout: 4B last stream identifier followed by the 4B error code
+		final long errorCode = buffer.getUnsignedInt(index + FRAME_HEADER_LENGTH + 4);
+		// NO_ERROR accompanies every ordinary connection close and carries no information worth a warning
+		return errorCode > ERROR_CODE_NO_ERROR && errorCode <= ERROR_CODE_MAX ? errorCode : -1L;
+	}
+
+	public Http2ConnectionMonitor(int maxRstFramesPerWindow, int rstFrameWindowSeconds) {
+		this.maxRstFramesPerWindow = maxRstFramesPerWindow;
+		this.rstFrameWindowSeconds = rstFrameWindowSeconds;
+		this.reportingThreshold = maxRstFramesPerWindow > 0 ?
+			maxRstFramesPerWindow : RST_FLOOD_REPORTING_THRESHOLD;
+		this.windowNanos = TimeUnit.SECONDS.toNanos(rstFrameWindowSeconds);
+	}
+
+	/**
+	 * Installs the per-connection handler into a freshly initialized child channel pipeline. Meant to be passed
+	 * directly to `ServerBuilder#childChannelPipelineCustomizer`.
+	 *
+	 * The handler has to sit **after** the TLS handler - otherwise it would inspect ciphertext - and **before** the
+	 * HTTP/2 connection handler - otherwise it would see decoded messages instead of frames. Appending it is
+	 * therefore wrong: it would land behind everything Armeria installs. At the time this runs Armeria has already
+	 * placed its protocol-detection handler (`Http2PrefaceOrHttpHandler` on a plaintext port, `Http2OrHttpHandler`
+	 * behind ALPN) and the HTTP/2 connection handler later takes exactly that slot, while the TLS handler takes the
+	 * slot of the accept handler in front of it. Inserting right ahead of the protocol handler is the single
+	 * position that satisfies both requirements on every port - see `Http2ConnectionMonitorTest`, which asserts it
+	 * against a real server on both a plaintext and a TLS port.
+	 *
+	 * @param pipeline pipeline of a freshly accepted child channel
+	 */
+	public void install(@Nonnull ChannelPipeline pipeline) {
+		try {
+			for (Entry<String, ChannelHandler> entry : pipeline) {
+				if (entry.getValue().getClass().getSimpleName().startsWith(HTTP2_HANDLER_NAME_PREFIX)) {
+					pipeline.addBefore(entry.getKey(), null, newHandler());
+					return;
+				}
+			}
+			reportInstallationFailure("no HTTP/2 protocol handler was found in the pipeline " + pipeline.names(), null);
+		} catch (Throwable ex) {
+			// this runs while a connection is being accepted - letting anything escape would reject the connection
+			// outright, so an unusable monitor must cost nothing more than the monitoring itself
+			reportInstallationFailure("the pipeline could not be instrumented", ex);
+		}
+	}
+
+	/**
+	 * Reports, exactly once per server, that monitoring could not be installed. Losing the monitor is not worth
+	 * failing a connection over, but it must not happen quietly either - an Armeria upgrade that reshapes the
+	 * pipeline would otherwise silently take the diagnostics away.
+	 *
+	 * @param reason what went wrong
+	 * @param cause  the exception behind it, if there was one
+	 */
+	private void reportInstallationFailure(@Nonnull String reason, @Nullable Throwable cause) {
+		if (this.installationFailureReported.compareAndSet(false, true)) {
+			log.warn(
+				"HTTP/2 connection monitoring could not be installed - {}. RST_STREAM floods and erroneous GOAWAY " +
+					"teardowns will not be reported; HTTP traffic itself is unaffected.",
+				reason, cause
+			);
+		}
+	}
+
+	/**
+	 * Number of `RST_STREAM` frames within one window above which a connection is reported. Follows
+	 * {@link #getMaxRstFramesPerWindow()} when enforcement is on - so the report explains the teardown that is about
+	 * to happen - and {@link #RST_FLOOD_REPORTING_THRESHOLD} when it is off.
+	 *
+	 * @return the reporting threshold
+	 */
+	protected int reportingThreshold() {
+		return this.reportingThreshold;
+	}
+
+	/**
+	 * Creates the per-connection handler. A new instance is required for every channel - it carries the frame parsing
+	 * state of that one connection.
+	 *
+	 * @return handler to be inserted into a child channel pipeline
+	 */
+	@Nonnull
+	ChannelHandler newHandler() {
+		return new MonitoringHandler();
+	}
+
+	/**
+	 * Reports that a peer exceeded the `RST_STREAM` reporting threshold within a single window.
+	 *
+	 * @param channel     connection the frames arrived on
+	 * @param resetFrames number of `RST_STREAM` frames counted within the window
+	 */
+	protected void reportRstFlood(@Nonnull Channel channel, int resetFrames) {
+		final String peerAddress = peerAddress(channel.remoteAddress());
+
+		new Http2RstFloodEvent(peerAddress).commit();
+
+		final int suppressed = suppressedSinceLastReport(peerAddress, System.nanoTime());
+		if (suppressed >= 0) {
+			if (this.maxRstFramesPerWindow > 0) {
+				log.warn(
+					"HTTP/2 peer `{}` sent {} RST_STREAM frames within {} s and reached the configured limit ({}, " +
+						"system property `{}`): the server is about to close the connection with " +
+						"GOAWAY(ENHANCE_YOUR_CALM), so every in-flight request on it - including requests unrelated " +
+						"to the flood - will fail. {}",
+					peerAddress, resetFrames, this.rstFrameWindowSeconds, this.maxRstFramesPerWindow,
+					PROPERTY_MAX_RST_FRAMES, throttleNote(suppressed)
+				);
+			} else {
+				log.warn(
+					"HTTP/2 peer `{}` sent {} RST_STREAM frames within {} s. Each of them is a cancelled request, so " +
+						"this is either a client opening and cancelling calls in a tight loop (for example a " +
+						"re-subscription loop without a backoff) or a client whose request timeouts are firing en " +
+						"masse. The connection is left intact and the requests keep being served - evitaDB does not " +
+						"rate-limit trusted clients - but the peer is doing work nobody consumes. {}",
+					peerAddress, resetFrames, this.rstFrameWindowSeconds, throttleNote(suppressed)
+				);
+			}
+		}
+	}
+
+	/**
+	 * Reports that the server is closing a connection with an erroneous `GOAWAY` frame.
+	 *
+	 * @param channel   channel that is being torn down
+	 * @param errorCode error code carried by the frame
+	 */
+	protected void reportGoAwaySent(@Nonnull Channel channel, long errorCode) {
+		final String peerAddress = peerAddress(channel.remoteAddress());
+		final String errorCodeName = errorCodeName(errorCode);
+
+		new Http2GoAwayEvent(peerAddress, errorCodeName, Direction.SENT).commit();
+
+		// an ENHANCE_YOUR_CALM teardown has already been explained in detail by reportRstFlood, which fires on the
+		// very frame that trips the limit (the inbound handler necessarily runs before the codec that throws), so
+		// repeating it here would only add noise - and must not consume the peer's throttle either
+		if (errorCode == ERROR_CODE_ENHANCE_YOUR_CALM) {
+			return;
+		}
+		final int suppressed = suppressedSinceLastReport(peerAddress, System.nanoTime());
+		if (suppressed >= 0) {
+			log.warn(
+				"HTTP/2 connection with peer `{}` is being closed by the server with GOAWAY({}), so every in-flight " +
+					"request on it - including requests unrelated to the failure - will fail. This points at a " +
+					"protocol-level problem on the connection (a malformed or misbehaving client, an intermediary " +
+					"rewriting the traffic, or an unsupported TLS configuration) rather than at an individual " +
+					"request. {}",
+				peerAddress, errorCodeName, throttleNote(suppressed)
+			);
+		}
+	}
+
+	/**
+	 * Reports that a **peer** closed the connection with an erroneous `GOAWAY` frame. This is the mirror image of
+	 * {@link #reportGoAwaySent(Channel, long)} and is the more alarming of the two: the client is stating that
+	 * *evitaDB* violated the protocol, so unlike an outbound teardown it may well point at a server-side defect
+	 * rather than a misbehaving peer. Graceful `NO_ERROR` shutdowns, which every ordinary client sends when it closes
+	 * a connection, are ignored.
+	 *
+	 * @param channel   channel the frame arrived on
+	 * @param errorCode error code carried by the frame
+	 */
+	protected void reportGoAwayReceived(@Nonnull Channel channel, long errorCode) {
+		final String peerAddress = peerAddress(channel.remoteAddress());
+		final String errorCodeName = errorCodeName(errorCode);
+
+		new Http2GoAwayEvent(peerAddress, errorCodeName, Direction.RECEIVED).commit();
+
+		final int suppressed = suppressedSinceLastReport(peerAddress, System.nanoTime());
+		if (suppressed >= 0) {
+			log.warn(
+				"HTTP/2 peer `{}` closed the connection with GOAWAY({}) - the client is rejecting something the " +
+					"server sent, so every in-flight request on that connection failed. Unlike a teardown initiated " +
+					"by the server this accuses evitaDB of the protocol violation and may point at a server-side " +
+					"defect (or at an intermediary rewriting the traffic), so it is worth investigating even when " +
+					"the client recovers by reconnecting. {}",
+				peerAddress, errorCodeName, throttleNote(suppressed)
+			);
+		}
+	}
+
+	/**
+	 * Builds the tail of a report, telling the reader how many occurrences the throttle swallowed since the previous
+	 * one. Without it a peer producing a teardown every couple of seconds is indistinguishable from a peer that
+	 * produced exactly one.
+	 *
+	 * @param suppressed number of occurrences suppressed since the last report for this peer
+	 * @return sentence to append to the log message
+	 */
+	@Nonnull
+	private static String throttleNote(int suppressed) {
+		final long seconds = TimeUnit.NANOSECONDS.toSeconds(REPORT_SUPPRESSION_INTERVAL_NANOS);
+		return suppressed == 0 ?
+			"Further reports for this peer are throttled to one per " + seconds + " s." :
+			suppressed + " further occurrence(s) for this peer were suppressed since the last report; reports are " +
+				"throttled to one per " + seconds + " s.";
+	}
+
+	/**
+	 * Decides whether the passed peer may be reported now and, if so, how many occurrences were swallowed by the
+	 * throttle since the previous report. Concurrent callers for the same peer are resolved so that exactly one wins.
+	 *
+	 * @param peerAddress peer to check
+	 * @param now         current {@link System#nanoTime()}
+	 * @return number of suppressed occurrences since the last report (`0` on the first one), or `-1` when this
+	 * occurrence itself must be suppressed
+	 */
+	private int suppressedSinceLastReport(@Nonnull String peerAddress, long now) {
+		PeerReportState state = this.reportStateByPeer.get(peerAddress);
+		if (state == null) {
+			pruneStaleEntries(now);
+			final PeerReportState fresh = new PeerReportState(now);
+			state = this.reportStateByPeer.putIfAbsent(peerAddress, fresh);
+			if (state == null) {
+				return 0;
+			}
+		}
+		final long previous = state.lastReportedNanos().get();
+		if (now - previous >= REPORT_SUPPRESSION_INTERVAL_NANOS &&
+			state.lastReportedNanos().compareAndSet(previous, now)) {
+			return state.suppressedOccurrences().getAndSet(0);
+		}
+		state.suppressedOccurrences().incrementAndGet();
+		return -1;
+	}
+
+	/**
+	 * Drops the peers whose suppression window has already elapsed once the map grew beyond {@link #MAX_TRACKED_PEERS}.
+	 * Called only when a previously unseen peer is about to be recorded, i.e. at most once per reported incident, so
+	 * the linear sweep costs nothing in practice.
+	 *
+	 * @param now current {@link System#nanoTime()}
+	 */
+	private void pruneStaleEntries(long now) {
+		if (this.reportStateByPeer.size() >= MAX_TRACKED_PEERS) {
+			this.reportStateByPeer.values()
+				.removeIf(state -> now - state.lastReportedNanos().get() >= REPORT_SUPPRESSION_INTERVAL_NANOS);
+		}
+	}
+
+	/**
+	 * Throttling state of a single peer address - when it was last reported, and how many occurrences have been
+	 * swallowed since.
+	 *
+	 * @param lastReportedNanos    time of the last report in {@link System#nanoTime()} units
+	 * @param suppressedOccurrences occurrences swallowed by the throttle since that report
+	 */
+	private record PeerReportState(
+		@Nonnull AtomicLong lastReportedNanos,
+		@Nonnull AtomicInteger suppressedOccurrences
+	) {
+
+		PeerReportState(long now) {
+			this(new AtomicLong(now), new AtomicInteger());
+		}
+
+	}
+
+	/**
+	 * Per-connection half of the monitor - walks the inbound HTTP/2 frame stream counting `RST_STREAM` frames and
+	 * recognizes erroneous outbound `GOAWAY` frames. See {@link Http2ConnectionMonitor} for the pipeline position
+	 * this relies on and for the invariants this parsing must preserve.
+	 */
+	private final class MonitoringHandler extends ChannelDuplexHandler {
+		/**
+		 * Scratch space for a frame header that arrived split across several reads.
+		 */
+		private final byte[] frameHeader = new byte[FRAME_HEADER_LENGTH];
+		/**
+		 * Scratch space for the fixed part of a `GOAWAY` payload - 4B last stream identifier, 4B error code.
+		 */
+		private final byte[] goAwayPayload = new byte[GO_AWAY_MIN_PAYLOAD_LENGTH];
+		/**
+		 * Set to FALSE once the frame boundaries are lost - inbound inspection then stops for good on this connection.
+		 */
+		private boolean inspecting = true;
+		/**
+		 * Set to FALSE if outbound recognition ever throws - like {@link #inspecting}, monitoring is sacrificed
+		 * rather than the connection.
+		 */
+		private boolean recognizingOutbound = true;
+		/**
+		 * Set to TRUE once the connection preface has been seen and the byte stream is known to be HTTP/2 frames.
+		 */
+		private boolean framing;
+		/**
+		 * Number of leading {@link #CONNECTION_PREFACE} bytes matched so far.
+		 */
+		private int prefaceMatched;
+		/**
+		 * Number of {@link #frameHeader} bytes filled in so far.
+		 */
+		private int frameHeaderBytes;
+		/**
+		 * Number of payload bytes of the current frame that still have to be skipped.
+		 */
+		private int payloadRemaining;
+		/**
+		 * Number of bytes of the fixed part of the current `GOAWAY` payload captured so far, or `-1` when no `GOAWAY`
+		 * payload is being captured.
+		 */
+		private int goAwayPayloadBytes = -1;
+		/**
+		 * Start of the current counting window, in {@link System#nanoTime()} units.
+		 */
+		private long windowStartNanos = System.nanoTime();
+		/**
+		 * Number of `RST_STREAM` frames counted within the current window.
+		 */
+		private int resetFramesInWindow;
+
+		@Override
+		public void channelRead(ChannelHandlerContext ctx, Object msg) {
+			if (this.inspecting && msg instanceof ByteBuf buffer) {
+				try {
+					inspectInbound(ctx.channel(), buffer);
+				} catch (Throwable ex) {
+					// This is an observability side-channel sitting in the middle of every connection. An exception
+					// escaping here would be caught by Netty, turned into an exceptionCaught, and would very likely
+					// close the connection - and the buffer below would never be forwarded, stalling the read and
+					// leaking it. No diagnostic is worth that, so monitoring switches itself off for this connection
+					// instead. (The project's "never silently skip an unexpected state" rule yields here, and the
+					// price is paid as a loud warning rather than as silence.)
+					this.inspecting = false;
+					reportInspectionFailure("inbound", ex);
+				}
+			}
+			// forwarded outside the guard above - the buffer must reach the codec exactly as it arrived, whatever
+			// the monitor did or failed to do with it
+			ctx.fireChannelRead(msg);
+		}
+
+		@Override
+		public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+			if (this.recognizingOutbound && msg instanceof ByteBuf buffer) {
+				try {
+					final long errorCode = resolveGoAwayErrorCode(buffer);
+					if (errorCode > 0) {
+						reportGoAwaySent(ctx.channel(), errorCode);
+					}
+				} catch (Throwable ex) {
+					// an exception here would fail the write promise and lose a frame the peer is waiting for
+					this.recognizingOutbound = false;
+					reportInspectionFailure("outbound", ex);
+				}
+			}
+			// forwarded outside the guard above, for the same reason as in channelRead
+			ctx.write(msg, promise);
+		}
+
+		/**
+		 * Reports that monitoring was switched off for this connection because it threw. Deliberately swallows its
+		 * own failure - if the logging subsystem is what broke, saying so must still not reach the traffic.
+		 *
+		 * @param direction which half of the monitor failed
+		 * @param cause     the exception it failed with
+		 */
+		private static void reportInspectionFailure(@Nonnull String direction, @Nonnull Throwable cause) {
+			try {
+				log.warn(
+					"HTTP/2 {} connection monitoring failed and has been disabled for this connection. The " +
+						"connection itself is unaffected and keeps serving requests.",
+					direction, cause
+				);
+			} catch (Throwable ignored) {
+				// nothing left to do - reporting the failure to report is not worth risking the connection over
+			}
+		}
+
+		/**
+		 * Walks the inbound bytes, counting `RST_STREAM` frames. Reads absolutely so that the buffer reaches the
+		 * HTTP/2 codec untouched, and tolerates frames split across any number of reads.
+		 *
+		 * @param channel connection the bytes arrived on
+		 * @param buffer  bytes to walk, never modified
+		 */
+		private void inspectInbound(@Nonnull Channel channel, @Nonnull ByteBuf buffer) {
+			final int end = buffer.writerIndex();
+			int index = buffer.readerIndex();
+			while (index < end) {
+				if (!this.framing) {
+					final byte current = buffer.getByte(index++);
+					if (current == CONNECTION_PREFACE[this.prefaceMatched]) {
+						if (++this.prefaceMatched == CONNECTION_PREFACE.length) {
+							this.framing = true;
+						}
+					} else {
+						// the preface has no self-overlap, so a mismatch can only restart the match from scratch
+						this.prefaceMatched = current == CONNECTION_PREFACE[0] ? 1 : 0;
+					}
+				} else if (this.payloadRemaining > 0) {
+					if (this.goAwayPayloadBytes >= 0) {
+						// the fixed part of a GOAWAY payload carries the error code and may be split across reads
+						while (index < end && this.goAwayPayloadBytes < GO_AWAY_MIN_PAYLOAD_LENGTH) {
+							this.goAwayPayload[this.goAwayPayloadBytes++] = buffer.getByte(index++);
+							this.payloadRemaining--;
+						}
+						if (this.goAwayPayloadBytes == GO_AWAY_MIN_PAYLOAD_LENGTH) {
+							this.goAwayPayloadBytes = -1;
+							recordReceivedGoAway(channel);
+						}
+					} else {
+						final int skipped = Math.min(this.payloadRemaining, end - index);
+						this.payloadRemaining -= skipped;
+						index += skipped;
+					}
+				} else {
+					this.frameHeader[this.frameHeaderBytes++] = buffer.getByte(index++);
+					if (this.frameHeaderBytes == FRAME_HEADER_LENGTH) {
+						this.frameHeaderBytes = 0;
+						final int length = ((this.frameHeader[0] & 0xFF) << 16)
+							| ((this.frameHeader[1] & 0xFF) << 8)
+							| (this.frameHeader[2] & 0xFF);
+						if (length > MAX_INBOUND_FRAME_LENGTH) {
+							// the frame boundaries are lost - stop rather than report made-up counts
+							this.inspecting = false;
+							return;
+						}
+						final int frameType = this.frameHeader[3] & 0xFF;
+						if (frameType == FRAME_TYPE_RST_STREAM) {
+							recordResetFrame(channel);
+						} else if (frameType == FRAME_TYPE_GO_AWAY && length >= GO_AWAY_MIN_PAYLOAD_LENGTH) {
+							// arm the payload capture below - the error code follows the last stream identifier
+							this.goAwayPayloadBytes = 0;
+						}
+						this.payloadRemaining = length;
+					}
+				}
+			}
+		}
+
+		/**
+		 * Counts one `RST_STREAM` frame into the current window and reports the connection the first time the window
+		 * exceeds the threshold. Mirrors the sliding window Netty's own limiter uses, so an enabled enforcement and
+		 * this counter agree on when the limit is reached.
+		 *
+		 * @param channel connection the frame arrived on
+		 */
+		private void recordReceivedGoAway(@Nonnull Channel channel) {
+			final long errorCode = ((long) (this.goAwayPayload[4] & 0xFF) << 24)
+				| ((long) (this.goAwayPayload[5] & 0xFF) << 16)
+				| ((long) (this.goAwayPayload[6] & 0xFF) << 8)
+				| (this.goAwayPayload[7] & 0xFF);
+			// NO_ERROR is what every ordinary client sends when it closes a connection - only failures are news.
+			// Unlike the outbound recognition there is no upper bound on the code here: this walker knows the frame
+			// boundaries, so an unknown (extension) code is genuine rather than a possible false positive.
+			if (errorCode != ERROR_CODE_NO_ERROR) {
+				reportGoAwayReceived(channel, errorCode);
+			}
+		}
+
+		private void recordResetFrame(@Nonnull Channel channel) {
+			final long now = System.nanoTime();
+			if (now - this.windowStartNanos >= Http2ConnectionMonitor.this.windowNanos) {
+				this.windowStartNanos = now;
+				this.resetFramesInWindow = 1;
+			} else if (++this.resetFramesInWindow == reportingThreshold() + 1) {
+				reportRstFlood(channel, this.resetFramesInWindow);
+			}
+		}
+
+	}
+
+}

--- a/evita_external_api/evita_external_api_core/src/main/java/module-info.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/module-info.java
@@ -88,6 +88,7 @@ module evita.external.api.core {
 	requires org.bouncycastle.provider;
 	requires org.bouncycastle.pkix;
 	requires com.linecorp.armeria;
+	requires io.netty.buffer;
 	requires io.netty.codec.http2;
 	requires io.netty.transport;
 	requires io.netty.handler;

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/EvitaJfrEventRegistry.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/EvitaJfrEventRegistry.java
@@ -57,6 +57,8 @@ import io.evitadb.core.metric.event.system.ScheduledExecutorStatisticsEvent;
 import io.evitadb.core.metric.event.system.TransactionThreadPoolStatisticsEvent;
 import io.evitadb.core.metric.event.transaction.*;
 import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.externalApi.event.Http2GoAwayEvent;
+import io.evitadb.externalApi.event.Http2RstFloodEvent;
 import io.evitadb.externalApi.event.ReadinessEvent;
 import io.evitadb.externalApi.event.RequestEvent;
 import io.evitadb.externalApi.grpc.metric.event.EvitaProcedureCalledEvent;
@@ -156,6 +158,8 @@ public class EvitaJfrEventRegistry {
 		AnteroomWastedEvent.class,
 
 		// api
+		Http2GoAwayEvent.class,
+		Http2RstFloodEvent.class,
 		ReadinessEvent.class,
 		RequestEvent.class,
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/http/Http2ConnectionMonitorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/http/Http2ConnectionMonitorTest.java
@@ -41,6 +41,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
@@ -306,6 +308,8 @@ class Http2ConnectionMonitorTest {
 				final ByteBuf forwarded = channel.readInbound();
 				assertNotNull(forwarded, "the buffer must reach the next handler");
 				assertEquals(payload.length, forwarded.readableBytes(), "no byte may be consumed on the way");
+				// finishAndReleaseAll() only releases what is still queued - anything read out has to be released here
+				forwarded.release();
 			} finally {
 				channel.finishAndReleaseAll();
 			}
@@ -474,6 +478,7 @@ class Http2ConnectionMonitorTest {
 				final ByteBuf forwarded = channel.readInbound();
 				assertNotNull(forwarded, "the buffer must still reach the HTTP/2 codec");
 				assertEquals(payload.length, forwarded.readableBytes(), "with every byte intact");
+				forwarded.release();
 
 				// monitoring is off for this connection now, but traffic keeps flowing through it
 				final byte[] more = rstStreamFrame(7);
@@ -481,6 +486,7 @@ class Http2ConnectionMonitorTest {
 				final ByteBuf second = channel.readInbound();
 				assertNotNull(second, "subsequent reads must keep being forwarded");
 				assertEquals(more.length, second.readableBytes());
+				second.release();
 			} finally {
 				channel.finishAndReleaseAll();
 			}
@@ -499,12 +505,14 @@ class Http2ConnectionMonitorTest {
 				final ByteBuf written = channel.readOutbound();
 				assertNotNull(written, "the frame must still reach the socket");
 				assertEquals(goAway.length, written.readableBytes());
+				written.release();
 
 				final byte[] more = frame(0x00, 1, new byte[16]);
 				channel.writeOutbound(Unpooled.wrappedBuffer(more));
 				final ByteBuf second = channel.readOutbound();
 				assertNotNull(second, "subsequent writes must keep going out");
 				assertEquals(more.length, second.readableBytes());
+				second.release();
 			} finally {
 				channel.finishAndReleaseAll();
 			}
@@ -524,6 +532,7 @@ class Http2ConnectionMonitorTest {
 				final ByteBuf forwarded = channel.readInbound();
 				assertNotNull(forwarded, "traffic must flow through an unmonitored pipeline unchanged");
 				assertEquals(payload.length, forwarded.readableBytes());
+				forwarded.release();
 			} finally {
 				channel.finishAndReleaseAll();
 			}
@@ -532,6 +541,9 @@ class Http2ConnectionMonitorTest {
 
 	@Nested
 	@DisplayName("configuration")
+	// these are the only tests here that touch JVM-global state, and the suite runs test classes concurrently -
+	// without the lock they could hand a half-set threshold to any server booting on another thread
+	@ResourceLock(Resources.SYSTEM_PROPERTIES)
 	class Configuration {
 
 		@AfterEach

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/http/Http2ConnectionMonitorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/http/Http2ConnectionMonitorTest.java
@@ -1,0 +1,722 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.http;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.RequestOptions;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link Http2ConnectionMonitor} - both the on-the-wire frame recognition in isolation and the assumption
+ * it stands on, namely that {@link Http2ConnectionMonitor#install(io.netty.channel.ChannelPipeline)} really does place
+ * the handler where it sees the HTTP/2 frames of every connection, on a plaintext and on a TLS port alike.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Http2ConnectionMonitor")
+@Tag(EXTERNAL_API)
+@Tag(OBSERVABILITY)
+class Http2ConnectionMonitorTest {
+	private static final byte[] CONNECTION_PREFACE =
+		"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+	/**
+	 * Upper bound on every wait in this class. Nothing here polls, so a generous bound costs nothing on a healthy
+	 * run and only decides how long a genuinely broken run takes to fail.
+	 */
+	private static final long AWAIT_TIMEOUT_SECONDS = 60L;
+	/**
+	 * How long a request is left hanging before the client cancels it. Only reached after the connection is already
+	 * established, so it is not racing connection setup on a loaded machine.
+	 */
+	private static final long CANCELLATION_DELAY_MILLIS = 2_000L;
+
+	/**
+	 * Fails the test unless the passed latch is counted down within {@link #AWAIT_TIMEOUT_SECONDS}.
+	 */
+	private static void awaitLatch(@Nonnull CountDownLatch latch, @Nonnull String message) throws Exception {
+		assertTrue(latch.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS), message);
+	}
+
+	/**
+	 * Builds a raw HTTP/2 frame - 3B payload length, 1B type, 1B flags, 4B stream identifier, payload.
+	 */
+	@Nonnull
+	private static byte[] frame(int type, int streamId, @Nonnull byte[] payload) {
+		final byte[] result = new byte[9 + payload.length];
+		result[0] = (byte) (payload.length >>> 16);
+		result[1] = (byte) (payload.length >>> 8);
+		result[2] = (byte) payload.length;
+		result[3] = (byte) type;
+		result[4] = 0;
+		result[5] = (byte) (streamId >>> 24);
+		result[6] = (byte) (streamId >>> 16);
+		result[7] = (byte) (streamId >>> 8);
+		result[8] = (byte) streamId;
+		System.arraycopy(payload, 0, result, 9, payload.length);
+		return result;
+	}
+
+	/**
+	 * Builds a `RST_STREAM` frame (type 0x03) carrying the `CANCEL` error code.
+	 */
+	@Nonnull
+	private static byte[] rstStreamFrame(int streamId) {
+		return frame(0x03, streamId, new byte[]{0x00, 0x00, 0x00, 0x08});
+	}
+
+	/**
+	 * Builds the fixed part of a `GOAWAY` frame (type 0x07) exactly the way Netty writes it - header, last stream
+	 * identifier and error code in one buffer, the debug data in a separate one.
+	 */
+	@Nonnull
+	private static byte[] goAwayFrame(int lastStreamId, long errorCode, int debugDataLength) {
+		final byte[] payload = new byte[]{
+			(byte) (lastStreamId >>> 24), (byte) (lastStreamId >>> 16),
+			(byte) (lastStreamId >>> 8), (byte) lastStreamId,
+			(byte) (errorCode >>> 24), (byte) (errorCode >>> 16),
+			(byte) (errorCode >>> 8), (byte) errorCode
+		};
+		final byte[] result = frame(0x07, 0, payload);
+		// the declared payload length also covers the debug data that arrives in a separate buffer
+		final int declaredLength = payload.length + debugDataLength;
+		result[0] = (byte) (declaredLength >>> 16);
+		result[1] = (byte) (declaredLength >>> 8);
+		result[2] = (byte) declaredLength;
+		return result;
+	}
+
+	@Nonnull
+	private static byte[] concat(@Nonnull byte[]... parts) {
+		int length = 0;
+		for (byte[] part : parts) {
+			length += part.length;
+		}
+		final byte[] result = new byte[length];
+		int offset = 0;
+		for (byte[] part : parts) {
+			System.arraycopy(part, 0, result, offset, part.length);
+			offset += part.length;
+		}
+		return result;
+	}
+
+	/**
+	 * Monitor that records what it would have reported instead of logging it.
+	 *
+	 * The reports arrive on a Netty event loop while the test asserts on its own thread, so the collections are
+	 * concurrent and every report also counts down a latch. Tests **await those latches** rather than polling with
+	 * sleeps - this suite runs heavily parallelized and a sleep-and-poll loop turns into a flake as soon as the box
+	 * is busy.
+	 */
+	private static class RecordingMonitor extends Http2ConnectionMonitor {
+		private final List<Integer> rstFloods = new CopyOnWriteArrayList<>();
+		private final List<Long> goAways = new CopyOnWriteArrayList<>();
+		private final List<Long> receivedGoAways = new CopyOnWriteArrayList<>();
+		private final CountDownLatch rstFloodReported = new CountDownLatch(1);
+		private final CountDownLatch goAwaySentReported = new CountDownLatch(1);
+		private final Integer reportingThresholdOverride;
+
+		RecordingMonitor(int maxRstFramesPerWindow, int rstFrameWindowSeconds) {
+			this(maxRstFramesPerWindow, rstFrameWindowSeconds, null);
+		}
+
+		/**
+		 * Lowers the reporting threshold without enabling enforcement, so a test can prove the reporting path
+		 * without waiting for the production threshold of 400 frames.
+		 */
+		RecordingMonitor(int maxRstFramesPerWindow, int rstFrameWindowSeconds, Integer reportingThresholdOverride) {
+			super(maxRstFramesPerWindow, rstFrameWindowSeconds);
+			this.reportingThresholdOverride = reportingThresholdOverride;
+		}
+
+		@Override
+		protected int reportingThreshold() {
+			return this.reportingThresholdOverride == null ?
+				super.reportingThreshold() : this.reportingThresholdOverride;
+		}
+
+		@Override
+		protected void reportRstFlood(@Nonnull Channel channel, int resetFrames) {
+			this.rstFloods.add(resetFrames);
+			// counted down last, so an awaiting thread always observes the recorded value
+			this.rstFloodReported.countDown();
+		}
+
+		@Override
+		protected void reportGoAwaySent(@Nonnull Channel channel, long errorCode) {
+			this.goAways.add(errorCode);
+			this.goAwaySentReported.countDown();
+		}
+
+		@Override
+		protected void reportGoAwayReceived(@Nonnull Channel channel, long errorCode) {
+			this.receivedGoAways.add(errorCode);
+		}
+	}
+
+	@Nested
+	@DisplayName("inbound RST_STREAM counting")
+	class InboundCounting {
+
+		@Test
+		@DisplayName("reports once the peer exceeds the threshold within a window")
+		void shouldReportRstFloodOnceThresholdIsExceeded() {
+			final RecordingMonitor monitor = new RecordingMonitor(0, 60);
+			final EmbeddedChannel channel = new EmbeddedChannel(monitor.newHandler());
+			try {
+				channel.writeInbound(Unpooled.wrappedBuffer(CONNECTION_PREFACE));
+				// with enforcement off the threshold is RST_FLOOD_REPORTING_THRESHOLD - the report fires on the next
+				for (int i = 0; i < Http2ConnectionMonitor.RST_FLOOD_REPORTING_THRESHOLD; i++) {
+					channel.writeInbound(Unpooled.wrappedBuffer(rstStreamFrame(2 * i + 1)));
+				}
+				assertEquals(List.of(), monitor.rstFloods, "must not report at or below the threshold");
+
+				channel.writeInbound(Unpooled.wrappedBuffer(rstStreamFrame(999)));
+				assertEquals(
+					List.of(Http2ConnectionMonitor.RST_FLOOD_REPORTING_THRESHOLD + 1), monitor.rstFloods,
+					"must report exactly once when the threshold is exceeded"
+				);
+
+				channel.writeInbound(Unpooled.wrappedBuffer(rstStreamFrame(1001)));
+				assertEquals(1, monitor.rstFloods.size(), "must report at most once per window");
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+
+		@Test
+		@DisplayName("counts frames that arrive split across arbitrary reads")
+		void shouldCountFramesSplitAcrossReads() {
+			final RecordingMonitor monitor = new RecordingMonitor(2, 60);
+			final EmbeddedChannel channel = new EmbeddedChannel(monitor.newHandler());
+			try {
+				final byte[] stream = concat(
+					CONNECTION_PREFACE, rstStreamFrame(1), rstStreamFrame(3), rstStreamFrame(5)
+				);
+				// hand the bytes over one at a time - the walker must not depend on read boundaries
+				for (byte singleByte : stream) {
+					channel.writeInbound(Unpooled.wrappedBuffer(new byte[]{singleByte}));
+				}
+				assertEquals(List.of(3), monitor.rstFloods, "a threshold of 2 must be reported on the third frame");
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+
+		@Test
+		@DisplayName("skips frame payloads instead of misreading them as frame headers")
+		void shouldSkipFramePayloads() {
+			final RecordingMonitor monitor = new RecordingMonitor(1, 60);
+			final EmbeddedChannel channel = new EmbeddedChannel(monitor.newHandler());
+			try {
+				// a DATA frame whose payload contains bytes that look exactly like a RST_STREAM frame
+				final byte[] trap = rstStreamFrame(7);
+				channel.writeInbound(Unpooled.wrappedBuffer(
+					concat(CONNECTION_PREFACE, frame(0x00, 1, trap), rstStreamFrame(1))
+				));
+				assertEquals(
+					List.of(), monitor.rstFloods,
+					"payload bytes that look like a RST_STREAM frame must not be counted"
+				);
+
+				channel.writeInbound(Unpooled.wrappedBuffer(rstStreamFrame(3)));
+				assertEquals(List.of(2), monitor.rstFloods, "genuine RST_STREAM frames must still be counted");
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+
+		@Test
+		@DisplayName("ignores a connection whose HTTP/2 preface never arrives")
+		void shouldIgnoreNonHttp2Connection() {
+			final RecordingMonitor monitor = new RecordingMonitor(1, 60);
+			final EmbeddedChannel channel = new EmbeddedChannel(monitor.newHandler());
+			try {
+				// plain HTTP/1.1 traffic must never be walked as if it were HTTP/2 frames
+				channel.writeInbound(Unpooled.wrappedBuffer(
+					"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n".getBytes(StandardCharsets.US_ASCII)
+				));
+				channel.writeInbound(Unpooled.wrappedBuffer(rstStreamFrame(1)));
+				channel.writeInbound(Unpooled.wrappedBuffer(rstStreamFrame(3)));
+				assertEquals(List.of(), monitor.rstFloods, "nothing may be counted before the preface is seen");
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+
+		@Test
+		@DisplayName("forwards inbound buffers untouched")
+		void shouldForwardInboundBuffersUntouched() {
+			final RecordingMonitor monitor = new RecordingMonitor(0, 60);
+			final EmbeddedChannel channel = new EmbeddedChannel(monitor.newHandler());
+			try {
+				final byte[] payload = concat(CONNECTION_PREFACE, rstStreamFrame(1));
+				channel.writeInbound(Unpooled.wrappedBuffer(payload));
+				final ByteBuf forwarded = channel.readInbound();
+				assertNotNull(forwarded, "the buffer must reach the next handler");
+				assertEquals(payload.length, forwarded.readableBytes(), "no byte may be consumed on the way");
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("inbound GOAWAY recognition")
+	class InboundGoAway {
+
+		@Test
+		@DisplayName("reports a peer that closes the connection with an error")
+		void shouldReportErroneousGoAwayFromPeer() {
+			final RecordingMonitor monitor = new RecordingMonitor(0, 60);
+			final EmbeddedChannel channel = new EmbeddedChannel(monitor.newHandler());
+			try {
+				channel.writeInbound(Unpooled.wrappedBuffer(concat(CONNECTION_PREFACE, goAwayFrame(7, 9L, 0))));
+				assertEquals(
+					List.of(9L), monitor.receivedGoAways,
+					"a client rejecting what the server sent must be reported - it may be our own defect"
+				);
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+
+		@Test
+		@DisplayName("ignores the graceful NO_ERROR shutdown every client sends")
+		void shouldIgnoreGracefulPeerShutdown() {
+			final RecordingMonitor monitor = new RecordingMonitor(0, 60);
+			final EmbeddedChannel channel = new EmbeddedChannel(monitor.newHandler());
+			try {
+				channel.writeInbound(Unpooled.wrappedBuffer(concat(CONNECTION_PREFACE, goAwayFrame(7, 0L, 0))));
+				assertEquals(List.of(), monitor.receivedGoAways, "an ordinary connection close is not news");
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+
+		@Test
+		@DisplayName("reads an error code that arrived split across reads, and keeps its place in the stream")
+		void shouldReadSplitGoAwayAndResynchronise() {
+			final RecordingMonitor monitor = new RecordingMonitor(1, 60);
+			final EmbeddedChannel channel = new EmbeddedChannel(monitor.newHandler());
+			try {
+				final byte[] debugData = "boom".getBytes(StandardCharsets.US_ASCII);
+				final byte[] stream = concat(
+					CONNECTION_PREFACE, goAwayFrame(7, 1L, debugData.length), debugData,
+					rstStreamFrame(1), rstStreamFrame(3)
+				);
+				for (byte singleByte : stream) {
+					channel.writeInbound(Unpooled.wrappedBuffer(new byte[]{singleByte}));
+				}
+				assertEquals(List.of(1L), monitor.receivedGoAways, "PROTOCOL_ERROR(1) must be read byte by byte");
+				assertEquals(
+					List.of(2), monitor.rstFloods,
+					"the walker must skip the GOAWAY debug data and stay aligned on the following frames"
+				);
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+
+		@Test
+		@DisplayName("reports an unknown extension error code, which framing makes unambiguous")
+		void shouldReportUnknownErrorCode() {
+			final RecordingMonitor monitor = new RecordingMonitor(0, 60);
+			final EmbeddedChannel channel = new EmbeddedChannel(monitor.newHandler());
+			try {
+				channel.writeInbound(Unpooled.wrappedBuffer(concat(CONNECTION_PREFACE, goAwayFrame(7, 0xFEL, 0))));
+				assertEquals(List.of(0xFEL), monitor.receivedGoAways);
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("outbound GOAWAY recognition")
+	class OutboundGoAway {
+
+		@Test
+		@DisplayName("reports an erroneous GOAWAY written by the server")
+		void shouldReportErroneousGoAway() {
+			final RecordingMonitor monitor = new RecordingMonitor(0, 60);
+			final EmbeddedChannel channel = new EmbeddedChannel(monitor.newHandler());
+			try {
+				final byte[] debugData = "Maximum number of RST frames reached".getBytes(StandardCharsets.US_ASCII);
+				channel.writeOutbound(Unpooled.wrappedBuffer(goAwayFrame(Integer.MAX_VALUE, 11L, debugData.length)));
+				channel.writeOutbound(Unpooled.wrappedBuffer(debugData));
+				assertEquals(List.of(11L), monitor.goAways, "ENHANCE_YOUR_CALM(11) must be recognized");
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+
+		@Test
+		@DisplayName("reports connection-level protocol failures too")
+		void shouldReportProtocolErrorGoAway() {
+			final RecordingMonitor monitor = new RecordingMonitor(0, 60);
+			final EmbeddedChannel channel = new EmbeddedChannel(monitor.newHandler());
+			try {
+				channel.writeOutbound(Unpooled.wrappedBuffer(goAwayFrame(5, 1L, 0)));
+				channel.writeOutbound(Unpooled.wrappedBuffer(goAwayFrame(5, 9L, 0)));
+				assertEquals(List.of(1L, 9L), monitor.goAways, "PROTOCOL_ERROR and COMPRESSION_ERROR must be seen");
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+
+		@Test
+		@DisplayName("ignores a graceful NO_ERROR shutdown and ordinary frames")
+		void shouldIgnoreGracefulShutdown() {
+			final RecordingMonitor monitor = new RecordingMonitor(0, 60);
+			final EmbeddedChannel channel = new EmbeddedChannel(monitor.newHandler());
+			try {
+				channel.writeOutbound(Unpooled.wrappedBuffer(goAwayFrame(Integer.MAX_VALUE, 0L, 0)));
+				channel.writeOutbound(Unpooled.wrappedBuffer(frame(0x00, 1, new byte[64])));
+				channel.writeOutbound(Unpooled.wrappedBuffer(rstStreamFrame(1)));
+				assertEquals(List.of(), monitor.goAways, "only erroneous GOAWAY frames may be reported");
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("resilience")
+	class Resilience {
+
+		/**
+		 * Monitor whose every report blows up - stands in for a broken logging appender, a JFR failure, or simply a
+		 * future defect in the reporting path.
+		 */
+		private static Http2ConnectionMonitor explodingMonitor() {
+			return new Http2ConnectionMonitor(1, 60) {
+				@Override
+				protected void reportRstFlood(@Nonnull Channel channel, int resetFrames) {
+					throw new IllegalStateException("boom");
+				}
+
+				@Override
+				protected void reportGoAwaySent(@Nonnull Channel channel, long errorCode) {
+					throw new IllegalStateException("boom");
+				}
+
+				@Override
+				protected void reportGoAwayReceived(@Nonnull Channel channel, long errorCode) {
+					throw new IllegalStateException("boom");
+				}
+			};
+		}
+
+		@Test
+		@DisplayName("a failing inbound report neither drops the buffer nor kills the connection")
+		void shouldSurviveFailingInboundReport() {
+			final EmbeddedChannel channel = new EmbeddedChannel(explodingMonitor().newHandler());
+			try {
+				final byte[] payload = concat(
+					CONNECTION_PREFACE, rstStreamFrame(1), rstStreamFrame(3), rstStreamFrame(5)
+				);
+				channel.writeInbound(Unpooled.wrappedBuffer(payload));
+
+				assertTrue(channel.isActive(), "the connection must survive a broken monitor");
+				assertDoesNotThrow(channel::checkException, "no exception may reach the pipeline");
+				final ByteBuf forwarded = channel.readInbound();
+				assertNotNull(forwarded, "the buffer must still reach the HTTP/2 codec");
+				assertEquals(payload.length, forwarded.readableBytes(), "with every byte intact");
+
+				// monitoring is off for this connection now, but traffic keeps flowing through it
+				final byte[] more = rstStreamFrame(7);
+				channel.writeInbound(Unpooled.wrappedBuffer(more));
+				final ByteBuf second = channel.readInbound();
+				assertNotNull(second, "subsequent reads must keep being forwarded");
+				assertEquals(more.length, second.readableBytes());
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+
+		@Test
+		@DisplayName("a failing outbound report neither loses the frame nor fails the write")
+		void shouldSurviveFailingOutboundReport() {
+			final EmbeddedChannel channel = new EmbeddedChannel(explodingMonitor().newHandler());
+			try {
+				final byte[] goAway = goAwayFrame(5, 1L, 0);
+				channel.writeOutbound(Unpooled.wrappedBuffer(goAway));
+
+				assertTrue(channel.isActive(), "the connection must survive a broken monitor");
+				assertDoesNotThrow(channel::checkException, "no exception may reach the pipeline");
+				final ByteBuf written = channel.readOutbound();
+				assertNotNull(written, "the frame must still reach the socket");
+				assertEquals(goAway.length, written.readableBytes());
+
+				final byte[] more = frame(0x00, 1, new byte[16]);
+				channel.writeOutbound(Unpooled.wrappedBuffer(more));
+				final ByteBuf second = channel.readOutbound();
+				assertNotNull(second, "subsequent writes must keep going out");
+				assertEquals(more.length, second.readableBytes());
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+
+		@Test
+		@DisplayName("a pipeline it does not understand is left alone rather than rejected")
+		void shouldNotRejectUnknownPipeline() {
+			final EmbeddedChannel channel = new EmbeddedChannel();
+			try {
+				// no Http2* handler anywhere - install() must degrade quietly instead of throwing
+				new Http2ConnectionMonitor(0, 60).install(channel.pipeline());
+				assertTrue(channel.isActive(), "an uninstrumentable pipeline must not cost the connection");
+
+				final byte[] payload = concat(CONNECTION_PREFACE, rstStreamFrame(1));
+				channel.writeInbound(Unpooled.wrappedBuffer(payload));
+				final ByteBuf forwarded = channel.readInbound();
+				assertNotNull(forwarded, "traffic must flow through an unmonitored pipeline unchanged");
+				assertEquals(payload.length, forwarded.readableBytes());
+			} finally {
+				channel.finishAndReleaseAll();
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("configuration")
+	class Configuration {
+
+		@AfterEach
+		void tearDown() {
+			System.clearProperty(Http2ConnectionMonitor.PROPERTY_MAX_RST_FRAMES);
+			System.clearProperty(Http2ConnectionMonitor.PROPERTY_RST_FRAME_WINDOW_SECONDS);
+		}
+
+		@Test
+		@DisplayName("leaves the Rapid-Reset defence disabled when nothing is set")
+		void shouldDefaultToReportingOnly() {
+			final Http2ConnectionMonitor monitor = Http2ConnectionMonitor.fromSystemProperties();
+			assertEquals(
+				0, monitor.getMaxRstFramesPerWindow(),
+				"enforcement must be off by default - Armeria's 400 per minute is deliberately not inherited"
+			);
+			assertEquals(
+				Http2ConnectionMonitor.DEFAULT_RST_FRAME_WINDOW_SECONDS, monitor.getRstFrameWindowSeconds()
+			);
+		}
+
+		@Test
+		@DisplayName("enables enforcement when the escape hatch is set")
+		void shouldEnableEnforcementFromSystemProperties() {
+			System.setProperty(Http2ConnectionMonitor.PROPERTY_MAX_RST_FRAMES, "150");
+			System.setProperty(Http2ConnectionMonitor.PROPERTY_RST_FRAME_WINDOW_SECONDS, "30");
+			final Http2ConnectionMonitor monitor = Http2ConnectionMonitor.fromSystemProperties();
+			assertEquals(150, monitor.getMaxRstFramesPerWindow());
+			assertEquals(30, monitor.getRstFrameWindowSeconds());
+		}
+
+		@Test
+		@DisplayName("falls back to the defaults on a malformed or negative value")
+		void shouldFallBackOnMalformedValues() {
+			System.setProperty(Http2ConnectionMonitor.PROPERTY_MAX_RST_FRAMES, "not-a-number");
+			System.setProperty(Http2ConnectionMonitor.PROPERTY_RST_FRAME_WINDOW_SECONDS, "-5");
+			final Http2ConnectionMonitor monitor = Http2ConnectionMonitor.fromSystemProperties();
+			assertEquals(0, monitor.getMaxRstFramesPerWindow(), "a malformed value must not enable enforcement");
+			assertEquals(
+				Http2ConnectionMonitor.DEFAULT_RST_FRAME_WINDOW_SECONDS, monitor.getRstFrameWindowSeconds()
+			);
+		}
+
+		@Test
+		@DisplayName("never hands Netty a zero-length window")
+		void shouldNeverProduceZeroWindow() {
+			System.setProperty(Http2ConnectionMonitor.PROPERTY_RST_FRAME_WINDOW_SECONDS, "0");
+			assertTrue(
+				Http2ConnectionMonitor.fromSystemProperties().getRstFrameWindowSeconds() > 0,
+				"a zero window would silently disable enforcement even when it was asked for"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("pipeline placement")
+	class PipelinePlacement {
+		/**
+		 * Number of cancellations each placement test drives, and therefore the reporting threshold it needs.
+		 */
+		private static final int CANCELLED_REQUESTS = 3;
+
+		private Server server;
+		private RecordingMonitor monitor;
+		private CountDownLatch requestsReceived;
+
+		@AfterEach
+		void tearDown() {
+			if (this.server != null) {
+				this.server.stop().join();
+				this.server = null;
+			}
+		}
+
+		@Test
+		@DisplayName("counts the RST_STREAM frames of a real plaintext HTTP/2 connection")
+		void shouldSeeInboundFramesOfPlaintextConnection() throws Exception {
+			startServer(false, 0);
+			cancelRequests(plainClient(), CANCELLED_REQUESTS);
+
+			awaitLatch(this.monitor.rstFloodReported, "the RST_STREAM flood must be reported");
+			assertEquals(
+				List.of(CANCELLED_REQUESTS), this.monitor.rstFloods,
+				"cancelled requests must be recognized as RST_STREAM frames on the wire"
+			);
+			assertEquals(List.of(), this.monitor.goAways, "nothing may be torn down while enforcement is off");
+		}
+
+		@Test
+		@DisplayName("counts the RST_STREAM frames of a real TLS HTTP/2 connection")
+		void shouldSeeInboundFramesOfTlsConnection() throws Exception {
+			startServer(true, 0);
+			cancelRequests(tlsClient(), CANCELLED_REQUESTS);
+
+			awaitLatch(this.monitor.rstFloodReported, "the RST_STREAM flood must be reported through TLS too");
+			assertEquals(
+				List.of(CANCELLED_REQUESTS), this.monitor.rstFloods,
+				"cancelled requests must be recognized through the TLS handler too"
+			);
+		}
+
+		@Test
+		@DisplayName("reports the flood before the enforced GOAWAY when the escape hatch is on")
+		void shouldReportFloodAndGoAwayWhenEnforcementIsOn() throws Exception {
+			// enforcement at CANCELLED_REQUESTS - 1 makes the last cancellation trip Netty's Rapid-Reset defence
+			startServer(false, CANCELLED_REQUESTS - 1);
+			cancelRequests(plainClient(), CANCELLED_REQUESTS);
+
+			awaitLatch(this.monitor.rstFloodReported, "the flood must be reported");
+			assertEquals(
+				List.of(CANCELLED_REQUESTS), this.monitor.rstFloods,
+				"the flood must be reported on the very frame that trips the limit"
+			);
+
+			awaitLatch(this.monitor.goAwaySentReported, "the enforced GOAWAY must be recognized");
+			assertEquals(
+				List.of(11L), this.monitor.goAways,
+				"GOAWAY(ENHANCE_YOUR_CALM) must be recognized on the outbound path of a real server"
+			);
+		}
+
+		/**
+		 * Boots a server whose pipeline carries the monitor, exactly the way {@link ExternalApiServer} installs it.
+		 */
+		private void startServer(boolean tls, int maxRstFramesPerWindow) {
+			// the reporting threshold is lowered so the test needs a handful of cancellations instead of four hundred
+			this.monitor = new RecordingMonitor(
+				maxRstFramesPerWindow, 60, maxRstFramesPerWindow > 0 ? null : CANCELLED_REQUESTS - 1
+			);
+			this.requestsReceived = new CountDownLatch(CANCELLED_REQUESTS);
+			final ServerBuilder builder = Server.builder()
+				.http2MaxResetFramesPerWindow(maxRstFramesPerWindow, 60)
+				.childChannelPipelineCustomizer(this.monitor::install)
+				.service("/hang", (ctx, req) -> {
+					this.requestsReceived.countDown();
+					// never completes on its own - the client's response timeout cancels it, sending RST_STREAM
+					return HttpResponse.of(new CompletableFuture<HttpResponse>());
+				})
+				.service("/ping", (ctx, req) -> HttpResponse.of("pong"));
+			if (tls) {
+				builder.https(0).tlsSelfSigned();
+			} else {
+				builder.http(0);
+			}
+			this.server = builder.build();
+			this.server.start().join();
+		}
+
+		@Nonnull
+		private WebClient plainClient() {
+			return WebClient.of("h2c://127.0.0.1:" + this.server.activeLocalPort());
+		}
+
+		@Nonnull
+		private WebClient tlsClient() {
+			return WebClient.builder("h2://127.0.0.1:" + this.server.activeLocalPort(SessionProtocol.HTTPS))
+				.factory(ClientFactory.builder().tlsNoVerify().build())
+				.build();
+		}
+
+		/**
+		 * Establishes the connection with one ordinary request, then fires the given number of requests that all time
+		 * out on the client. Each timeout cancels its stream, which is exactly what a legitimate client does under
+		 * load and what reaches the server as a `RST_STREAM` frame - all of them on the one multiplexed connection.
+		 *
+		 * The response timeout is set **per request**, so the warm-up request is not racing a deadline of its own on
+		 * a loaded machine, and it only starts counting once the connection is already established.
+		 */
+		private void cancelRequests(@Nonnull WebClient client, int count) throws Exception {
+			assertEquals("pong", client.get("/ping").aggregate().join().contentUtf8());
+
+			final RequestOptions cancelAfterShortWait = RequestOptions.builder()
+				.responseTimeoutMillis(CANCELLATION_DELAY_MILLIS)
+				.build();
+			final CompletableFuture<?>[] cancelled = new CompletableFuture<?>[count];
+			for (int i = 0; i < count; i++) {
+				cancelled[i] = client.execute(HttpRequest.of(HttpMethod.GET, "/hang"), cancelAfterShortWait)
+					.aggregate()
+					.handle((response, throwable) -> null);
+			}
+			assertTrue(
+				this.requestsReceived.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+				"every request must reach the server, otherwise no stream was ever opened to reset"
+			);
+			CompletableFuture.allOf(cancelled).get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+		}
+	}
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/Http2ConnectionMonitorBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/Http2ConnectionMonitorBenchmark.java
@@ -1,0 +1,298 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spike;
+
+import io.evitadb.externalApi.http.Http2ConnectionMonitor;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures what {@link Http2ConnectionMonitor}'s per-connection handler costs a connection it is watching.
+ *
+ * The handler sits in **every** child channel pipeline, between the TLS handler and the HTTP/2 codec, and every
+ * inbound and outbound byte of every connection passes through it. That is a place where a cheap-looking design
+ * mistake is expensive, so the two claims the implementation rests on are measured here rather than argued:
+ *
+ * 1. **The inbound walk is O(frames), not O(bytes).** It reads the nine-byte frame header one byte at a time - so it
+ *    survives frames split across arbitrary socket reads - and then skips the whole payload in a single index jump.
+ *    If that holds, `dataFrames` costs the same at a 16 KiB payload as at a 256 B one, and the sweep over
+ *    {@link #payloadSize} shows a flat line. If it ever regresses to a per-byte walk, this benchmark is where it
+ *    shows up first.
+ * 2. **Neither direction allocates.** Run with `-prof gc` and compare `gc.alloc.rate.norm` between the
+ *    {@link #monitored} arms. Expect a residual of a thousandth of a byte per operation rather than a flat zero -
+ *    that is fixed background allocation amortized over fewer operations in the slower arm, and it scales with the
+ *    arm's slowdown rather than with anything the handler does. A per-frame allocation would show up as whole bytes.
+ *
+ * **How to read it.** Every operation is an A/B: `monitored = true` puts the monitor in the pipeline,
+ * `monitored = false` runs the identical pipeline without it. Only the **difference** between the two arms is the
+ * handler's cost - the absolute numbers are dominated by `EmbeddedChannel` plumbing that a real connection does not
+ * have.
+ *
+ * **The two directions have different denominators.** The inbound ops ({@link #dataFrames}, {@link #resetFrames})
+ * push {@link #FRAMES_PER_INVOCATION} frames through the walker, which parses every one of their headers - divide by
+ * that for a per-frame figure. {@link #outboundFrames} does **not**: it hands the whole buffer to a single
+ * `writeOutbound`, so the recognition runs **once per write** and rejects on the first frame's type byte, whatever
+ * else the buffer holds behind it. Its figure is therefore per-write and must not be divided.
+ *
+ * Measured results are transcribed in
+ * `documentation/performance/individual/Http2ConnectionMonitorBenchmark/README.md`.
+ *
+ * **What is deliberately not measured.** The reporting path (log line plus JFR event) is throttled to once per minute
+ * per peer and would otherwise dominate a benchmark that provokes it thousands of times a second - so the monitor
+ * used here raises its reporting threshold out of reach. What remains is exactly the code that runs on every
+ * connection all the time, which is the part whose cost anybody has to care about.
+ *
+ * Run through JMH's own runner (the benchmarks jar uses a custom main):
+ * `java -cp evita_test/evita_performance_tests/target/benchmarks.jar org.openjdk.jmh.Main
+ * io\.evitadb\.spike\.Http2ConnectionMonitorBenchmark -prof gc`.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+// the walker needs a long warm-up before it settles - with three warm-up iterations the first measured iteration
+// still came in ~55% above the other four, which is enough to swamp the whole measurement in its own error bar
+@Warmup(iterations = 8, time = 2)
+@Measurement(iterations = 6, time = 2)
+@Fork(2)
+public class Http2ConnectionMonitorBenchmark {
+	/**
+	 * Number of HTTP/2 frames pushed through the pipeline per invocation. Divide any reported figure by this for a
+	 * per-frame number.
+	 */
+	private static final int FRAMES_PER_INVOCATION = 16;
+	/**
+	 * The HTTP/2 connection preface (RFC 9113 §3.4). Written once per iteration so the walker enters framing mode;
+	 * it must NOT be part of the repeated buffer, or the second invocation would try to parse it as a frame header.
+	 */
+	private static final byte[] CONNECTION_PREFACE =
+		"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+	/**
+	 * Size of the synthetic HEADERS frame preceding each DATA frame - roughly what a compressed gRPC request header
+	 * block comes to.
+	 */
+	private static final int HEADERS_FRAME_SIZE = 64;
+
+	/**
+	 * Whether the monitor is in the pipeline. The difference between the two arms IS the measurement.
+	 */
+	@Param({"true", "false"})
+	private boolean monitored;
+
+	/**
+	 * Payload of each DATA frame. Sweeping it is what proves the walk is per-frame rather than per-byte.
+	 */
+	@Param({"256", "16384"})
+	private int payloadSize;
+
+	private EmbeddedChannel channel;
+	private ByteBuf dataFrameStream;
+	private ByteBuf resetFrameStream;
+	private ByteBuf outboundFrameStream;
+
+	/**
+	 * Builds a raw HTTP/2 frame - 3B payload length, 1B type, 1B flags, 4B stream identifier, payload.
+	 */
+	private static byte[] frame(int type, int streamId, int payloadLength) {
+		final byte[] result = new byte[9 + payloadLength];
+		result[0] = (byte) (payloadLength >>> 16);
+		result[1] = (byte) (payloadLength >>> 8);
+		result[2] = (byte) payloadLength;
+		result[3] = (byte) type;
+		result[5] = (byte) (streamId >>> 24);
+		result[6] = (byte) (streamId >>> 16);
+		result[7] = (byte) (streamId >>> 8);
+		result[8] = (byte) streamId;
+		return result;
+	}
+
+	/**
+	 * Concatenates the passed frames into one buffer, the way a socket read delivers several frames at once.
+	 */
+	private static ByteBuf concat(byte[]... frames) {
+		int length = 0;
+		for (byte[] frame : frames) {
+			length += frame.length;
+		}
+		final byte[] result = new byte[length];
+		int offset = 0;
+		for (byte[] frame : frames) {
+			System.arraycopy(frame, 0, result, offset, frame.length);
+			offset += frame.length;
+		}
+		return Unpooled.wrappedBuffer(result);
+	}
+
+	@Setup(Level.Trial)
+	public void setUpBuffers() {
+		// a request-shaped stream: HEADERS followed by DATA, repeated - whole frames only, so the same buffer can be
+		// replayed indefinitely without ever desynchronising the walker
+		final byte[][] dataFrames = new byte[FRAMES_PER_INVOCATION][];
+		for (int i = 0; i < FRAMES_PER_INVOCATION; i += 2) {
+			dataFrames[i] = frame(0x01, 2 * i + 1, HEADERS_FRAME_SIZE);
+			dataFrames[i + 1] = frame(0x00, 2 * i + 1, this.payloadSize);
+		}
+		this.dataFrameStream = concat(dataFrames);
+
+		// the cancellation-storm shape: nothing but RST_STREAM frames, which is the walker's worst case per byte
+		// because every frame is header-only and the payload skip never amortizes anything
+		final byte[][] resetFrames = new byte[FRAMES_PER_INVOCATION][];
+		for (int i = 0; i < FRAMES_PER_INVOCATION; i++) {
+			resetFrames[i] = frame(0x03, 2 * i + 1, 4);
+		}
+		this.resetFrameStream = concat(resetFrames);
+
+		// what the server writes back - the buffers the outbound GOAWAY recognition has to reject one by one
+		final byte[][] outboundFrames = new byte[FRAMES_PER_INVOCATION][];
+		for (int i = 0; i < FRAMES_PER_INVOCATION; i++) {
+			outboundFrames[i] = frame(0x00, 2 * i + 1, this.payloadSize);
+		}
+		this.outboundFrameStream = concat(outboundFrames);
+	}
+
+	@Setup(Level.Iteration)
+	public void setUpChannel() {
+		this.channel = new EmbeddedChannel();
+		final ChannelPipeline pipeline = this.channel.pipeline();
+		// terminal handlers swallow the buffers, so nothing queues up inside EmbeddedChannel across invocations and
+		// the very same buffer can be replayed every invocation without any per-invocation allocation
+		pipeline.addLast(new SwallowingOutboundHandler());
+		// stands in for Armeria's protocol handler purely so the real install() has something to insert in front of -
+		// the placement logic is exercised here rather than bypassed
+		pipeline.addLast(new Http2CodecStub());
+		pipeline.addLast(new SwallowingInboundHandler());
+		if (this.monitored) {
+			new NonReportingMonitor().install(pipeline);
+		}
+		// prime the walker past the connection preface exactly once - it must not be part of the replayed buffer, or
+		// the second invocation would try to read it as a frame header
+		this.channel.writeInbound(Unpooled.wrappedBuffer(CONNECTION_PREFACE));
+	}
+
+	@TearDown(Level.Iteration)
+	public void tearDownChannel() {
+		// the replayed buffers are owned by the trial, not the channel, so only the channel itself is closed here
+		this.channel.close();
+	}
+
+	/**
+	 * The ordinary request shape - HEADERS plus DATA. Compare across {@link #payloadSize} to see whether the walk is
+	 * per-frame or per-byte.
+	 */
+	@Benchmark
+	public void dataFrames() {
+		this.channel.writeInbound(this.dataFrameStream);
+	}
+
+	/**
+	 * A stream of nothing but `RST_STREAM` frames - the highest frame-per-byte density the walker can be handed, and
+	 * the only op in which `recordResetFrame` (and its `System.nanoTime()` call) runs on every frame.
+	 */
+	@Benchmark
+	public void resetFrames() {
+		this.channel.writeInbound(this.resetFrameStream);
+	}
+
+	/**
+	 * The response path - every outbound buffer is offered to the `GOAWAY` recognition, which must reject it on the
+	 * frame-type byte.
+	 */
+	@Benchmark
+	public void outboundFrames() {
+		this.channel.writeOutbound(this.outboundFrameStream);
+	}
+
+	/**
+	 * Monitor whose reporting threshold is out of reach, so the throttled reporting path never runs and the
+	 * measurement is of the always-on walk alone.
+	 */
+	private static class NonReportingMonitor extends Http2ConnectionMonitor {
+
+		NonReportingMonitor() {
+			super(0, 60);
+		}
+
+		@Override
+		protected int reportingThreshold() {
+			return Integer.MAX_VALUE;
+		}
+
+	}
+
+	/**
+	 * Placeholder for Armeria's HTTP/2 protocol handler. Only its class name matters - `install()` inserts the
+	 * monitor in front of the first handler whose simple name starts with `Http2`.
+	 */
+	private static class Http2CodecStub extends ChannelDuplexHandler {
+	}
+
+	/**
+	 * Consumes and releases inbound buffers so {@link EmbeddedChannel}'s inbound queue never grows.
+	 */
+	private static class SwallowingInboundHandler extends ChannelInboundHandlerAdapter {
+
+		@Override
+		public void channelRead(ChannelHandlerContext ctx, Object msg) {
+			// deliberately neither forwarded nor released - the buffers are long-lived unpooled heap buffers owned
+			// by the benchmark and replayed on every invocation
+		}
+	}
+
+	/**
+	 * Consumes and releases outbound buffers so {@link EmbeddedChannel}'s outbound queue never grows.
+	 */
+	private static class SwallowingOutboundHandler extends ChannelOutboundHandlerAdapter {
+
+		@Override
+		public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+			// see SwallowingInboundHandler - the buffer is owned by the benchmark and outlives the write
+			promise.setSuccess();
+		}
+	}
+
+}


### PR DESCRIPTION
Closes #1369

## Problem

When Netty's Rapid-Reset guard (CVE-2023-44487) tripped, the server sent `GOAWAY(ENHANCE_YOUR_CALM)`, closed the connection — taking every unrelated in-flight request with it — and **logged nothing**. The access log kept showing `200`s. Diagnosing it took most of a day and ultimately a JDWP logpoint on `Http2GoAwayHandler` in the *client* JVM.

Root cause of the silence is ours: `logback.xml` pins `com.linecorp.armeria` to `ERROR`, which gags the WARN Armeria does emit. Narrowing that suppression is the zero-upgrade workaround for anyone on 2026.2.1, and is documented on the issue.

## What this does

`Http2ConnectionMonitor` sits in every child channel pipeline, between the TLS handler and the HTTP/2 codec, and reports three otherwise-invisible connection-level events with a throttled WARN plus a metric:

- an `RST_STREAM` flood (peer, count, window, threshold, consequence);
- an erroneous `GOAWAY` **sent** by the server;
- an erroneous `GOAWAY` **received** from a peer — the more alarming direction, since the peer is claiming *evitaDB* violated the protocol.

Metrics: `io_evitadb_external_api_http2_rst_flood_total`, `io_evitadb_external_api_http2_go_away_total` (labelled `direction`, `errorCode`).

## Behaviour change — please review deliberately

**Netty's Rapid-Reset defence is now off by default**, where stock Armeria enables it at 400 resets/minute.

It counts *cancellations*, not requests. A well-behaved client emits one `RST_STREAM` per client-side timeout, so the defence fires hardest exactly when the server is already slow: timeouts → cancellations → connection killed → all in-flight requests die → retry storm. The reporter's outage was *caused* by the defence, not prevented by it. evitaDB sits behind the application layer and talks to a small number of trusted clients.

Turning it off is safe **only because detection is decoupled from enforcement** — the flood is still counted and reported at the same 400/window threshold, minus the severed connection. Enforcement is restored via two deliberately **undocumented** system properties (`evitadb.http2.maxRstFramesPerWindow`, `evitadb.http2.rstFrameWindowSeconds`); they are not `ApiOptions` keys and are absent from user docs by design — see the ADR.

## Defensive design

The monitor cannot take traffic down. Both directions are wrapped in `try/catch (Throwable)`; on failure the monitor disables *itself* for that connection (separately per direction) and the buffer is forwarded **outside** the guarded block so it reaches the codec regardless. `install()` is wrapped too — it runs while a connection is being accepted. This is a deliberate, documented exception to the project's "never silently skip an unexpected state" rule.

## Testing

- `Http2ConnectionMonitorTest` — 22 tests, including against a **real Armeria server on both plaintext and TLS ports**. That test is what caught the original wrong pipeline position (appending the handler makes it see zero bytes), and is the regression gate for any Armeria upgrade.
- 67 tests green across `io.evitadb.externalApi.http` and `io.evitadb.server`.

## Performance

`Http2ConnectionMonitorBenchmark` + writeup in `documentation/performance/individual/`. The handler is on every byte of every connection, so both design claims are measured, not argued:

- **~7 ns per inbound frame**, flat across 48.7× more bytes (+2.2 %, inside the error bar) — the walk is O(frames), not O(bytes). ~14 ns on a unary gRPC request.
- **~24 ns per `RST_STREAM`** (17 ns of it one `System.nanoTime()`, which Netty's own limiter also pays), **~1–3 ns per outbound write**.
- No allocation: `152.000 B/op` identical on the outbound arms; the ≤0.002 B/op inbound residual scales with each arm's slowdown, not with anything the handler does.

## Note on the release line

`dev` is currently the 2026.2 line, so this is positioned as a hotfix for the closed 2026.2 milestone; a later dev→master merge cuts v2026.2.2.