### PR TITLE
fix: measure line length in characters, not bytes, in the .editorconfig hook

### DIFF
--- a/.claude/hooks/editorconfig-check-on-edit.sh
+++ b/.claude/hooks/editorconfig-check-on-edit.sh
@@ -216,7 +216,14 @@ collect_added_lines() {
 	fi
 }
 
-if ! VIOLATIONS="$(collect_added_lines | awk \
+# LC_ALL=C is load-bearing, not cargo cult: it pins awk to byte semantics, which is what
+# display_width below assumes when it subtracts UTF-8 continuation bytes. Here `awk` is mawk, which
+# is byte-based unconditionally -- but on a box where /etc/alternatives/awk points at gawk under a
+# UTF-8 locale, length() would already count characters *and* [\200-\277] would become a class of
+# real characters (degree sign, plus-minus, guillemets), so the same code would subtract twice and
+# under-report. Forcing byte semantics makes one implementation of display_width correct in both.
+# The other three checks match ASCII only, so this costs them nothing.
+if ! VIOLATIONS="$(collect_added_lines | LC_ALL=C awk \
 	-v file="${REL_PATH}" \
 	-v indent_style="${INDENT_STYLE}" \
 	-v max_line_length="${MAX_LINE_LENGTH}" \
@@ -226,14 +233,32 @@ if ! VIOLATIONS="$(collect_added_lines | awk \
 	-v check_indent="${IS_INDENT_CHECKED:-0}" '
 	# Columns occupied on screen: a tab advances to the next tab stop rather than counting as one
 	# character, which is how IDEA measures a line against the hard wrap.
-	function display_width(text,   i, len, column) {
+	#
+	# Width is counted in CHARACTERS, not bytes -- that is how EditorConfig defines
+	# max_line_length, and what editorconfig-checker (recommended above for repo-wide audits)
+	# counts. awk runs under LC_ALL=C and therefore sees bytes, which would let a single Czech
+	# letter or an em dash eat two or three columns; a line of Czech prose then measures about a
+	# third over its real width. Every byte in \200-\277 is a UTF-8 continuation byte -- the tail
+	# of a character whose leading byte was already counted -- so subtracting them yields the
+	# codepoint count.
+	#
+	# The subtraction is done per tab-separated segment rather than once at the end, because a tab
+	# stop has to be computed from the character column, not the byte column. The naive "count all
+	# bytes, subtract continuations at the end" form measures "pris<TAB>X" (with all four letters
+	# accented) as 6 columns instead of 9.
+	#
+	# No apostrophe may appear anywhere in this awk program, comments included: it is single-quoted
+	# in the shell, and one apostrophe would end the quote.
+	function display_width(text,   segments, count, i, segment, stripped, continuations, column) {
+		count = split(text, segments, /\t/)
 		column = 0
-		len = length(text)
-		for (i = 1; i <= len; i++) {
-			if (substr(text, i, 1) == "\t") {
+		for (i = 1; i <= count; i++) {
+			segment = segments[i]
+			stripped = segment
+			continuations = gsub(/[\200-\277]/, "", stripped)
+			column += length(segment) - continuations
+			if (i < count) {
 				column += tab_width - (column % tab_width)
-			} else {
-				column++
 			}
 		}
 		return column


### PR DESCRIPTION
Follow-up fix to the `.editorconfig` parity hook shipped in #1358 (issue #1119, already closed).

## The bug

`display_width` in `.claude/hooks/editorconfig-check-on-edit.sh` measured a line by counting what
`awk` calls characters — and `awk` here is mawk, which is byte-based and not UTF-8 aware. Every
multi-byte character therefore ate extra budget against `max_line_length`: Czech diacritics two
columns each, `—` / `„` / `"` three each.

EditorConfig defines `max_line_length` in **characters**, and `editorconfig-checker` — which this
hook's own header recommends for repo-wide audits — counts runes. The hook was measuring something
other than what it declares.

Measured impact:

| line | real width | reported |
|---|---|---|
| `"áb" × 60` | 120 | 180 |
| `"a—" × 60` | 120 | 240 |

Across the repository, outside the trees the hook already excludes: **13,955 lines contain
non-ASCII, and 503 of them would be reported as over the limit while being under it.**

## The fix

Subtract UTF-8 continuation bytes (`[\200-\277]`). Each is the tail of a character whose leading
byte was already counted, so byte count minus continuations is the codepoint count.

Two things that are not obvious and are commented at the site:

- **The subtraction is per tab-separated segment, not once at the end.** A tab stop has to advance
  from the *character* column. The naive "count all bytes, subtract at the end" form measures a
  121-column line as 119 and silently lets it through. The discriminating case needs accents
  *before* a tab — with accents only after it, both forms agree by coincidence.
- **`LC_ALL=C` is load-bearing.** mawk is byte-based unconditionally, but where
  `/etc/alternatives/awk` points at gawk under a UTF-8 locale, `length()` would already count
  characters *and* `[\200-\277]` would become a class of real characters (`°±»`) — the same code
  would subtract twice and under-report. Pinning byte semantics makes one implementation correct on
  both.

## Verification

11 cases driven end to end through the real hook: ASCII baseline at 120/121, diacritics at 120/121,
em dashes and typographic quotes at 120/121, tab stops with accents on either side of the tab, and a
realistic Czech prose line. All pass.

The suite is not vacuous — the pre-fix hook fails 6 of the 11, and a naive
subtract-at-the-end implementation fails exactly the tab-stop case, by accepting a 121-column line.

## Risk

The change only ever **lowers** the measured width, so it cannot newly block an edit that passes
today. The other three checks (indent style, trailing whitespace, line endings) match ASCII only and
are untouched.

No ADR: hook bugfix, no genuine fork, and the reasoning is local to the file — `.claude/rules/adr.md`
excludes this class. The rationale lives in comments at the site and in the commit message.