### PR TITLE
perf: rewrite verifyReferenceCardinalities as an allocation-free run-length scan

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
@@ -24,9 +24,6 @@
 package io.evitadb.index.mutation.storagePart;
 
 import com.carrotsearch.hppc.IntHashSet;
-import com.carrotsearch.hppc.ObjectIntHashMap;
-import com.carrotsearch.hppc.ObjectIntMap;
-import com.carrotsearch.hppc.cursors.ObjectIntCursor;
 import io.evitadb.api.exception.EntityMissingException;
 import io.evitadb.api.exception.InvalidMutationException;
 import io.evitadb.api.exception.MandatoryAssociatedDataNotProvidedException;
@@ -3036,6 +3033,28 @@ public final class ContainerizedLocalMutationExecutor
 	 * Ensures that each reference complies with its respective cardinality requirements. If any violations are found,
 	 * a {@link ReferenceCardinalityViolatedException} is thrown with details of the violations.
 	 *
+	 * The verification is a single run-length scan of the reference array that allocates nothing unless a violation
+	 * is actually found. A plain scan is sufficient because {@link ReferencesStoragePart#getReferences()} is always
+	 * sorted by {@link ReferenceContract#FULL_COMPARATOR} - i.e. by reference name, then referenced primary key and
+	 * finally by internal primary key. The invariant is asserted in
+	 * {@link ReferencesStoragePart#assignMissingIdsAndSort()} and re-established by re-sorting the array after each
+	 * modification of the container. It implies that:
+	 *
+	 * - references sharing the same name form a single contiguous run, so the number of references of a particular
+	 *   name is a mere length of that run and needs no auxiliary map,
+	 * - references sharing the same key are adjacent within such run, so duplicates are recognized by comparing the
+	 *   examined key with the head of the currently examined cluster of equal keys.
+	 *
+	 * **Reference key equality invariant:** {@link ReferenceKey#equals(Object)} takes the internal primary key into
+	 * account only when it is known (positive) on both compared sides, and is therefore not transitive for a mixture
+	 * of keys with known and unknown internal primary keys. This method never observes such a mixture - it is called
+	 * from {@link #verifyConsistency()}, which runs only after {@link #finishLocalMutationExecutionPhase()} assigned
+	 * terminal (positive) internal primary keys to all the references of the container, so all the keys examined here
+	 * are in uniform - known - form and the equality degenerates to a plain comparison of all three key components.
+	 * The examined key is nevertheless compared against the cluster head and not against its immediate predecessor,
+	 * since that is what reproduces the "first key wins as the canonical one" grouping of the hash map this scan
+	 * replaced, should the uniformity invariant ever weaken.
+	 *
 	 * @param referencesStorageContainer An optional container holding the current state of references associated
 	 *                                   with an entity. Can be null if there are no references to validate.
 	 * @throws ReferenceCardinalityViolatedException If any reference violates its defined cardinality
@@ -3049,77 +3068,240 @@ public final class ContainerizedLocalMutationExecutor
 		if (references.isEmpty()) {
 			return;
 		}
-		ObjectIntMap<String> referencesFound = new ObjectIntHashMap<>(references.size());
-		ObjectIntMap<ReferenceKey> duplicatedReferenceFound = null;
-		if (referencesStorageContainer != null) {
-			ReferenceSchemaContract referenceSchema = null;
-			final Reference[] cntReferences = referencesStorageContainer.getReferences();
-			for (int i = 0; i < cntReferences.length; i++) {
-				final Reference reference = cntReferences[i];
-				if (reference.exists()) {
-					if (referenceSchema == null || !referenceSchema.getName().equals(reference.getReferenceName())) {
-						referenceSchema = entitySchema.getReferenceOrThrowException(reference.getReferenceName());
+
+		// both lists are lazy to minimize allocations - a valid entity allocates nothing here
+		List<CardinalityViolation> violations = null;
+		List<CardinalityViolation> duplicateViolations = null;
+		final Reference[] cntReferences = referencesStorageContainer == null ?
+			null : referencesStorageContainer.getReferences();
+
+		if (cntReferences != null) {
+			int index = 0;
+			// name of the previously examined run - the runs must be encountered in ascending order
+			String previousRunName = null;
+			while (index < cntReferences.length) {
+				// dropped references are not taken into account at all
+				if (!cntReferences[index].exists()) {
+					index++;
+					continue;
+				}
+
+				final String referenceName = cntReferences[index].getReferenceKey().referenceName();
+				// verify the premise this scan stands on - the container is expected to be sorted, but the only
+				// other place that asserts it (ReferencesStoragePart#assignMissingIdsAndSort) is reached solely when
+				// a new reference was inserted; the checks are inlined instead of delegated to Assert, because
+				// the message supplier would allocate a capturing lambda on this hot path
+				if (previousRunName != null && previousRunName.compareTo(referenceName) >= 0) {
+					throw new GenericEvitaInternalError(
+						"References of entity `" + this.entityType + "` are not sorted by their name: `" +
+							previousRunName + "` is followed by `" + referenceName + "`!"
+					);
+				}
+				previousRunName = referenceName;
+
+				final ReferenceSchemaContract referenceSchema = entitySchema
+					.getReferenceOrThrowException(referenceName);
+				// skip the entire run of reflected references that are not available
+				if (referenceSchema instanceof final ReflectedReferenceSchemaContract rrsc &&
+					!rrsc.isReflectedReferenceAvailable()) {
+					index = skipReferenceRun(cntReferences, index, referenceName);
+					continue;
+				}
+
+				final Cardinality cardinality = referenceSchema.getCardinality();
+				final boolean duplicatesAllowed = cardinality.allowsDuplicates();
+				// number of existing references within the examined run
+				int referenceCount = 0;
+				// key of the previously examined reference of the run - the keys must not descend within it
+				ReferenceKey previousKey = null;
+				// head of the currently examined cluster of equal keys within the run and the size of that cluster
+				ReferenceKey clusterKey = null;
+				int clusterCount = 0;
+				while (index < cntReferences.length) {
+					final Reference examinedReference = cntReferences[index];
+					final ReferenceKey examinedKey = examinedReference.getReferenceKey();
+					// the run ends with the first reference of a different name
+					if (!referenceName.equals(examinedKey.referenceName())) {
+						break;
 					}
-					// skip reflected references that are not available
-					if (referenceSchema instanceof final ReflectedReferenceSchemaContract rrsc) {
-						if (!rrsc.isReflectedReferenceAvailable()) {
-							while (cntReferences.length > i + 1 && cntReferences[i + 1].getReferenceName().equals(
-								rrsc.getName())) {
-								i++;
+					// the ordering tripwire replays only the numeric tail of ReferenceKey.FULL_COMPARATOR - both keys
+					// belong to the same run, so their names are known to be equal and comparing them again would
+					// double the string comparisons of this loop; equal keys are tolerated, since they are exactly
+					// what the duplicate detection below reports
+					if (previousKey != null) {
+						final int pkComparison = Integer.compare(previousKey.primaryKey(), examinedKey.primaryKey());
+						if (pkComparison > 0 ||
+							(pkComparison == 0 && !previousKey.isUnknownReference() &&
+								!examinedKey.isUnknownReference() &&
+								previousKey.internalPrimaryKey() > examinedKey.internalPrimaryKey())) {
+							throw new GenericEvitaInternalError(
+								"References of entity `" + this.entityType + "` are not sorted by their key: `" +
+									previousKey + "` is followed by `" + examinedKey + "`!"
+							);
+						}
+					}
+					previousKey = examinedKey;
+					if (examinedReference.exists()) {
+						referenceCount++;
+						if (!duplicatesAllowed) {
+							if (clusterKey != null && clusterKey.equals(examinedKey)) {
+								clusterCount++;
+							} else {
+								// a new cluster starts here - report the closed one when it contained duplicates
+								if (clusterCount > 1) {
+									duplicateViolations = addViolation(
+										duplicateViolations,
+										new CardinalityViolation(referenceName, cardinality, clusterCount, true)
+									);
+								}
+								clusterKey = examinedKey;
+								clusterCount = 1;
 							}
-							continue;
 						}
 					}
-					referencesFound.putOrAdd(reference.getReferenceName(), 1, 1);
-					if (!referenceSchema.getCardinality().allowsDuplicates()) {
-						if (duplicatedReferenceFound == null) {
-							duplicatedReferenceFound = new ObjectIntHashMap<>();
-						}
-						duplicatedReferenceFound.putOrAdd(reference.getReferenceKey(), 1, 1);
-					}
+					index++;
 				}
-			}
-		}
-		List<CardinalityViolation> violations = null; // lazy to minimize allocations
-		for (ReferenceSchemaContract examinedSchema : entitySchema.getReferences().values()) {
-			final Cardinality cardinality = examinedSchema.getCardinality();
-			final String referenceName = examinedSchema.getName();
-			if (cardinality.getMin() > 0 && !referencesFound.containsKey(referenceName)) {
-				if (violations == null) {
-					violations = new LinkedList<>();
+				// close the last cluster of the run
+				if (clusterCount > 1) {
+					duplicateViolations = addViolation(
+						duplicateViolations,
+						new CardinalityViolation(referenceName, cardinality, clusterCount, true)
+					);
 				}
-				violations.add(
-					new CardinalityViolation(referenceName, cardinality, 0, false)
-				);
-			} else if (cardinality.getMax() <= 0 && referencesFound.get(referenceName) > 1) {
-				if (violations == null) {
-					violations = new LinkedList<>();
-				}
-				violations.add(
-					new CardinalityViolation(referenceName, cardinality, referencesFound.get(referenceName), false)
-				);
-			}
-		}
-		if (duplicatedReferenceFound != null) {
-			for (ObjectIntCursor<ReferenceKey> cursor : duplicatedReferenceFound) {
-				if (cursor.value > 1) {
-					if (violations == null) {
-						violations = new LinkedList<>();
-					}
-					violations.add(
-						new CardinalityViolation(
-							cursor.key.referenceName(),
-							entitySchema.getReferenceOrThrowException(cursor.key.referenceName()).getCardinality(),
-							cursor.value,
-							true
-						)
+				// the upper limit is verified at the run boundary, where the entire run length is already known;
+				// mind that no Cardinality constant declares maximum lower than one, so this branch never fires at
+				// present - the effective upper limit check is performed by InitialReferencesBuilder and
+				// ExistingReferencesBuilder, which refuse the surplus reference at the moment it is being set
+				if (cardinality.getMax() <= 0 && referenceCount > 1) {
+					violations = addViolation(
+						violations,
+						new CardinalityViolation(referenceName, cardinality, referenceCount, false)
 					);
 				}
 			}
 		}
-		if (violations != null && !violations.isEmpty()) {
+
+		// references that are mandatory, but are not present on the entity at all
+		for (final ReferenceSchemaContract examinedSchema : references.values()) {
+			final Cardinality cardinality = examinedSchema.getCardinality();
+			if (cardinality.getMin() > 0 && !isAnyReferencePresent(cntReferences, examinedSchema)) {
+				violations = addViolation(
+					violations,
+					new CardinalityViolation(examinedSchema.getName(), cardinality, 0, false)
+				);
+			}
+		}
+
+		// duplicates are reported last to keep the original order of the violations in the error message
+		if (duplicateViolations != null) {
+			if (violations == null) {
+				violations = duplicateViolations;
+			} else {
+				violations.addAll(duplicateViolations);
+			}
+		}
+		if (violations != null) {
 			throw new ReferenceCardinalityViolatedException(entitySchema.getName(), violations);
 		}
+	}
+
+	/**
+	 * Returns index of the first reference in the sorted array that follows the contiguous run of references sharing
+	 * the passed reference name. When there is no such reference, the length of the array is returned.
+	 *
+	 * @param sortedReferences references sorted by {@link ReferenceContract#FULL_COMPARATOR}
+	 * @param index            index of a reference that belongs to the skipped run
+	 * @param referenceName    name of the reference the skipped run consists of
+	 * @return index of the first reference behind the run
+	 */
+	private static int skipReferenceRun(
+		@Nonnull Reference[] sortedReferences,
+		int index,
+		@Nonnull String referenceName
+	) {
+		int result = index + 1;
+		while (result < sortedReferences.length &&
+			referenceName.equals(sortedReferences[result].getReferenceKey().referenceName())) {
+			result++;
+		}
+		return result;
+	}
+
+	/**
+	 * Returns true when the passed sorted array of references contains at least a single existing reference of
+	 * the passed schema. The method mirrors the accounting of
+	 * {@link #verifyReferenceCardinalities(ReferencesStoragePart)} - dropped references and references of reflected
+	 * schemas that are not available are not taken into account.
+	 *
+	 * The method is called only for references with mandatory cardinality (which are rare) and relies on the fact
+	 * that the array is sorted by the reference name in the first place.
+	 *
+	 * @param sortedReferences references sorted by {@link ReferenceContract#FULL_COMPARATOR}, may be null when
+	 *                         the entity has no references container at all
+	 * @param referenceSchema  schema of the examined reference
+	 * @return true when at least one existing reference of the examined schema is present
+	 */
+	private static boolean isAnyReferencePresent(
+		@Nullable Reference[] sortedReferences,
+		@Nonnull ReferenceSchemaContract referenceSchema
+	) {
+		if (sortedReferences == null) {
+			return false;
+		}
+		if (referenceSchema instanceof final ReflectedReferenceSchemaContract rrsc &&
+			!rrsc.isReflectedReferenceAvailable()) {
+			return false;
+		}
+		final String referenceName = referenceSchema.getName();
+		// binary search for the very first reference of the examined name
+		int left = 0;
+		int right = sortedReferences.length - 1;
+		int runStart = -1;
+		while (left <= right) {
+			final int middle = (left + right) >>> 1;
+			final int comparisonResult = sortedReferences[middle].getReferenceKey()
+				.referenceName().compareTo(referenceName);
+			if (comparisonResult < 0) {
+				left = middle + 1;
+			} else if (comparisonResult > 0) {
+				right = middle - 1;
+			} else {
+				runStart = middle;
+				right = middle - 1;
+			}
+		}
+		if (runStart < 0) {
+			return false;
+		}
+		// the run may consist of dropped references only - scan it for the first existing one
+		for (int i = runStart; i < sortedReferences.length; i++) {
+			final Reference reference = sortedReferences[i];
+			if (!referenceName.equals(reference.getReferenceKey().referenceName())) {
+				break;
+			}
+			if (reference.exists()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Adds the passed violation to the lazily initialized list of violations. The list is created only when the first
+	 * violation is found, so that the (overwhelmingly more frequent) valid entity allocates nothing.
+	 *
+	 * @param violations list of violations collected so far, may be null when no violation was found yet
+	 * @param violation  violation to be added to the list
+	 * @return the list of violations containing the passed violation
+	 */
+	@Nonnull
+	private static List<CardinalityViolation> addViolation(
+		@Nullable List<CardinalityViolation> violations,
+		@Nonnull CardinalityViolation violation
+	) {
+		final List<CardinalityViolation> result = violations == null ? new LinkedList<>() : violations;
+		result.add(violation);
+		return result;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/entity/ReferencesStoragePart.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/entity/ReferencesStoragePart.java
@@ -90,6 +90,12 @@ public class ReferencesStoragePart implements EntityStoragePart {
 	/**
 	 * See {@link Entity#getReferences()}. References are sorted in ascending order according to
 	 * {@link EntityReference} comparator.
+	 *
+	 * The ordering is not merely an optimization - consumers depend on it for correctness. Namely
+	 * `ContainerizedLocalMutationExecutor#verifyReferenceCardinalities` validates the reference cardinalities by
+	 * a run-length scan that assumes references of the same name form a single contiguous run and that equal keys
+	 * are adjacent within it. Any change to the maintenance of this array must keep it sorted by
+	 * {@link ReferenceContract#FULL_COMPARATOR}.
 	 */
 	private Reference[] references = EMPTY_REFERENCES;
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReferenceIndexingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReferenceIndexingTest.java
@@ -344,6 +344,167 @@ class ReferenceIndexingTest implements EvitaTestSupport, IndexingTestSupport {
 				);
 			}
 		}
+
+		@Test
+		@DisplayName("Should accept entity with references of multiple names and cardinalities")
+		void shouldAcceptEntityWithReferencesOfMultipleNames() {
+			ReferenceIndexingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session
+						.defineEntitySchema(Entities.PRODUCT)
+						.withReferenceTo(Entities.BRAND, Entities.BRAND, Cardinality.EXACTLY_ONE)
+						.withReferenceTo(Entities.CATEGORY, Entities.CATEGORY, Cardinality.ZERO_OR_MORE)
+						.withReferenceTo(Entities.STORE, Entities.STORE, Cardinality.ONE_OR_MORE)
+						.verifySchemaStrictly()
+						.updateVia(session);
+
+					session.createNewEntity(Entities.PRODUCT, 1)
+						.setReference(Entities.BRAND, 1)
+						.setReference(Entities.CATEGORY, 1)
+						.setReference(Entities.CATEGORY, 2)
+						.setReference(Entities.CATEGORY, 3)
+						.setReference(Entities.STORE, 1)
+						.setReference(Entities.STORE, 2)
+						.upsertVia(session);
+				}
+			);
+
+			ReferenceIndexingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					final SealedEntity product = session.getEntity(Entities.PRODUCT, 1, referenceContentAll())
+						.orElseThrow();
+					assertEquals(1, product.getReferences(Entities.BRAND).size());
+					assertEquals(3, product.getReferences(Entities.CATEGORY).size());
+					assertEquals(2, product.getReferences(Entities.STORE).size());
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("Should fail to violate mandatory cardinality when references of other names are present")
+		void shouldFailToViolateMandatoryReferenceCardinalityWhenOtherReferencesArePresent() {
+			try {
+				ReferenceIndexingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session
+							.defineEntitySchema(Entities.PRODUCT)
+							.withReferenceTo(Entities.BRAND, Entities.BRAND, Cardinality.ZERO_OR_MORE)
+							.withReferenceTo(Entities.CATEGORY, Entities.CATEGORY, Cardinality.ZERO_OR_MORE)
+							.withReferenceTo(Entities.STORE, Entities.STORE, Cardinality.EXACTLY_ONE)
+							.verifySchemaStrictly()
+							.updateVia(session);
+
+						session.createNewEntity(Entities.PRODUCT, 1)
+							.setReference(Entities.BRAND, 1)
+							.setReference(Entities.BRAND, 2)
+							.setReference(Entities.CATEGORY, 1)
+							.upsertVia(session);
+					}
+				);
+
+				fail("ReferenceCardinalityViolatedException is expected to be thrown");
+
+			} catch (ReferenceCardinalityViolatedException ex) {
+				assertEquals(
+					"Expected reference cardinalities are violated in entity `PRODUCT`: reference `STORE` is " +
+						"expected to be `EXACTLY_ONE` - but entity contains 0 references.",
+					ex.getMessage()
+				);
+			}
+		}
+
+		@Test
+		@DisplayName("Should report all mandatory references that are missing on the entity")
+		void shouldReportAllMissingMandatoryReferences() {
+			try {
+				ReferenceIndexingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session
+							.defineEntitySchema(Entities.PRODUCT)
+							.withReferenceTo(Entities.BRAND, Entities.BRAND, Cardinality.EXACTLY_ONE)
+							.withReferenceTo(Entities.CATEGORY, Entities.CATEGORY, Cardinality.ZERO_OR_MORE)
+							.withReferenceTo(Entities.STORE, Entities.STORE, Cardinality.ONE_OR_MORE)
+							.verifySchemaStrictly()
+							.updateVia(session);
+
+						session.createNewEntity(Entities.PRODUCT, 1)
+							.setReference(Entities.CATEGORY, 1)
+							.setReference(Entities.CATEGORY, 2)
+							.upsertVia(session);
+					}
+				);
+
+				fail("ReferenceCardinalityViolatedException is expected to be thrown");
+
+			} catch (ReferenceCardinalityViolatedException ex) {
+				// both missing references must be reported in a single exception - the order of the violations
+				// follows the iteration order of the schema reference index and is not asserted on purpose
+				assertTrue(
+					ex.getMessage().startsWith("Expected reference cardinalities are violated in entity `PRODUCT`: "),
+					ex.getMessage()
+				);
+				assertTrue(
+					ex.getMessage().contains(
+						"reference `BRAND` is expected to be `EXACTLY_ONE` - but entity contains 0 references"
+					),
+					ex.getMessage()
+				);
+				assertTrue(
+					ex.getMessage().contains(
+						"reference `STORE` is expected to be `ONE_OR_MORE` - but entity contains 0 references"
+					),
+					ex.getMessage()
+				);
+			}
+		}
+
+		@Test
+		@DisplayName("Should fail to violate mandatory cardinality when the last reference of the name is removed")
+		void shouldFailToViolateMandatoryReferenceCardinalityWhenLastReferenceOfNameIsRemoved() {
+			ReferenceIndexingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session
+						.defineEntitySchema(Entities.PRODUCT)
+						.withReferenceTo(Entities.BRAND, Entities.BRAND, Cardinality.EXACTLY_ONE)
+						.withReferenceTo(Entities.CATEGORY, Entities.CATEGORY, Cardinality.ZERO_OR_MORE)
+						.verifySchemaStrictly()
+						.updateVia(session);
+
+					session.createNewEntity(Entities.PRODUCT, 1)
+						.setReference(Entities.BRAND, 1)
+						.setReference(Entities.CATEGORY, 1)
+						.setReference(Entities.CATEGORY, 2)
+						.upsertVia(session);
+				}
+			);
+
+			try {
+				ReferenceIndexingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.getEntity(Entities.PRODUCT, 1, referenceContentAll())
+							.orElseThrow()
+							.openForWrite()
+							.removeReference(Entities.BRAND, 1)
+							.upsertVia(session);
+					}
+				);
+
+				fail("ReferenceCardinalityViolatedException is expected to be thrown");
+
+			} catch (ReferenceCardinalityViolatedException ex) {
+				assertEquals(
+					"Expected reference cardinalities are violated in entity `PRODUCT`: reference `BRAND` is " +
+						"expected to be `EXACTLY_ONE` - but entity contains 0 references.",
+					ex.getMessage()
+				);
+			}
+		}
 	}
 
 	@Nested


### PR DESCRIPTION
Closes #1391

## What

`ContainerizedLocalMutationExecutor.verifyReferenceCardinalities` was the **#1 allocator (~21%) and #2 CPU consumer (~11%)** of the Senesi WARM_UP profile while building no index and writing no byte. Per entity it allocated two `ObjectIntHashMap`s — one keyed by reference *name*, one by `ReferenceKey` (the latter unsized, so a reference-heavy entity paid ~6 growth/rehash cycles). Every `ObjectIntHashMap` sample in that profile belonged to this one method.

Both maps are unnecessary: `ReferencesStoragePart#getReferences()` is sorted by `ReferenceContract.FULL_COMPARATOR`, so references sharing a name form a contiguous run and equal keys are adjacent within it. The method is now a single run-length pass that **allocates nothing unless a violation is actually found**:

- **per-name cardinality** — the run length; the upper limit is checked at the run boundary;
- **duplicates** — the examined key is compared against the *head of the current cluster* of equal keys. Anchoring on the cluster head rather than on the immediate predecessor is deliberate: it is what reproduces the "first key wins as the canonical one" grouping of the hash map being replaced, and it stays faithful even for a run mixing known and unknown internal PKs, where predecessor-comparison would not;
- **min cardinality** — the only cross-run state; presence is resolved by a lower-bound binary search on the reference name and evaluated only for mandatory references, which are rare.

The three now-unused `hppc` imports are gone from the file.

## Semantics

Preserved exactly, per the issue. That includes the **currently unreachable upper-limit branch** (`getMax() <= 0`): no `Cardinality` constant declares a maximum lower than one, and the effective upper-limit check lives in `InitialReferencesBuilder` / `ExistingReferencesBuilder` (`getMax() <= 1`). It is kept verbatim with a comment naming both facts rather than silently deleted or tightened — tightening it would be a behavioural change out of scope here.

The `ReferenceKey.equals` conditional-equality hazard is documented at the site, not redesigned (that remains #1392): the method runs from `verifyConsistency()`, i.e. after `finishLocalMutationExecutionPhase()` has assigned terminal positive internal PKs, so every key it sees is in uniform *known* form.

## One deliberate behavioural delta

The old map-based count was **order-insensitive** — `putOrAdd` grouped by name regardless of contiguity, so latent disorder in a container would still have produced correct counts. The new scan is order-sensitive, and the only existing sortedness assert (`ReferencesStoragePart#assignMissingIdsAndSort`) sits behind `if (this.unassignedPrimaryKeys)`, reached solely when a *new* reference is inserted — an attribute-only change, a reference removal or a group change never reaches it.

The scan therefore verifies the ordering itself, so **a disordered container now fails loudly with `GenericEvitaInternalError` instead of being validated against a map that could not notice it**. Cost of that tripwire: one `Integer.compare` plus a never-taken branch per reference, and one `String.compareTo` per name run — it deliberately replays only the *numeric tail* of `FULL_COMPARATOR`, since inside a run the names are already known equal and re-comparing them would double the loop's string work. A cross-reference was added at `ReferencesStoragePart.references` so that anyone changing sort maintenance sees the new consumer.

## Verification

- `ReferenceIndexingTest` — **15/15 green**; 10 in the cardinality group: 6 pre-existing **unchanged**, 4 new. The new cases cover the run *boundary*, which nothing exercised before (every existing test used a single reference name): multi-name happy path, mandatory-absent-while-other-names-present, all missing mandatory references reported together, and mandatory reference removed on an existing entity (the dropped-run path).
- Full `unitAndFunctional` — **20838 run, 2 failures, both unrelated**: `ExportS3ServiceTest` (no Docker environment available) and `EvitaTest.shouldKillInactiveSessionsAutomatically`, which passes when re-run in isolation — timing-flaky under suite load.
- **The Senesi WARM_UP re-run named in the issue is not executable**: ADR `2026-07-27-write-path-performance-tuning` records that the catalog snapshot and WAL slice every measurement was taken against were deleted. Re-measuring needs a fresh production export.

## Known coverage limit

The duplicate-cluster logic has no direct test and cannot get one at this level: under the uniform-knownness invariant, identical triples cannot coexist in a strictly sorted array, so the branch is unreachable by construction. It is preserved as the defensive net it already was.