### PR TITLE
perf: cut schema-resolution cost and schema-derived key allocation on the write path

### DIFF
--- a/documentation/adr/2026-07-27-write-path-performance-tuning/README.md
+++ b/documentation/adr/2026-07-27-write-path-performance-tuning/README.md
@@ -1,7 +1,7 @@
 ---
 title: Cut commit-merge latency and write-path allocation by pruning the trunk merge, not inverting it
 date: 2026-07-27
-updated: 2026-07-31 21:05
+updated: 2026-08-05 16:00
 status: accepted
 kind: optimization
 issues: [760]
@@ -9,7 +9,7 @@ prs: [1317, 1298]
 areas: [evita_engine/core/transaction, evita_engine/index, evita_engine/core/buffer, evita_engine/index/bPlusTree]
 supersedes: []
 superseded-by: []
-relates: [2026-07-10-more-optimized-data-structures]
+relates: [2026-07-10-more-optimized-data-structures, 2026-08-05-schema-handling-write-path-optimizations]
 ---
 
 # Write-path performance tuning — commit-merge latency and allocation

--- a/documentation/adr/2026-08-01-bplustree-cursor-free-insert-path.md
+++ b/documentation/adr/2026-08-01-bplustree-cursor-free-insert-path.md
@@ -1,7 +1,7 @@
 ---
 title: Answer the B+ tree insert-boundary asserts from the descent instead of a captured cursor path
 date: 2026-08-01
-updated: 2026-08-01 10:45
+updated: 2026-08-05 16:00
 status: accepted
 kind: optimization
 issues: [1333]
@@ -9,7 +9,7 @@ prs: [1356]
 areas: [evita_engine/index/bPlusTree]
 supersedes: []
 superseded-by: []
-relates: [2026-07-10-more-optimized-data-structures, 2026-07-31-bulk-ingest-write-path]
+relates: [2026-07-10-more-optimized-data-structures, 2026-07-31-bulk-ingest-write-path, 2026-08-05-schema-handling-write-path-optimizations]
 ---
 
 # Free the B+ tree insert and read paths from the cursor path

--- a/documentation/adr/2026-08-05-schema-handling-write-path-optimizations.md
+++ b/documentation/adr/2026-08-05-schema-handling-write-path-optimizations.md
@@ -1,0 +1,208 @@
+---
+title: Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation
+date: 2026-08-05
+updated: 2026-08-05 16:00
+status: accepted
+kind: optimization
+issues: [1390]
+prs: []
+areas: [evita_api/requestResponse/schema/dto, evita_api/requestResponse/data, evita_engine/index/mutation]
+supersedes: []
+superseded-by: []
+relates: [2026-07-27-write-path-performance-tuning, 2026-08-01-bplustree-cursor-free-insert-path]
+---
+
+# Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation
+
+The Senesi WARM_UP profile of `2026.2.2` attributes 18.7% of write-path CPU to resolving facts from
+immutable schema objects and 18.24% of write-path allocation to `AttributeKey` instances. Both are
+volume, not body cost: the accessors are already plain map lookups, and the keys are re-derived from
+a schema that cannot change while the mutation is being applied. This record covers the resulting
+work — allocation-free "or throw" accessors, canonical `AttributeKey` instances owned by
+`AttributeSchema`, an allocation-free `AttributeKey.compareTo`, and per-run hoisting of reference
+schema resolution in the mutation executors — and, more importantly, the two adjacent options that
+were deliberately **not** taken.
+
+## Why
+
+Bulk ingest applies millions of local mutations against one immutable entity schema. Two families of
+cost fall out of that:
+
+- **Resolution volume.** `EntitySchema.getReference` alone is 15.36% of write-path CPU, with
+  `ReferenceSchema.getIndexedComponents` (1.91%) and `isFacetedInScope` (1.43%) behind it. An audit
+  of the callee bodies found them already near-minimal — `isFacetedInScope` is a `contains` on an
+  `EnumSet`-backed set, `getIndexedComponents` a plain map `get`. The share is therefore how often
+  they are called, and the one genuinely fat accessor was `getReferenceOrThrowException`, which
+  allocated two `Optional`s and a capturing lambda per call to express "get or throw".
+- **Key churn.** Schema-derived `AttributeKey` records are built per attribute per reference per
+  entity purely to be compared or looked up, then discarded. The domain is tiny and
+  schema-bounded — one key per (attribute, locale) pair — while the allocation count scales with the
+  number of entities ingested.
+
+The constraint that makes this non-obvious is that the schema is **not** pinned for the duration of
+an entity's mutation batch. `ContainerizedLocalMutationExecutor` reads it through
+`this.schemaAccessor.get()`, a supplier re-read at every use site, because schema evolution can add
+a reference or an attribute part-way through applying a batch. Any caching strategy has to survive
+that.
+
+### Previous state
+
+`getReferenceOrThrowException` was `getReference(name).map(cast).orElseThrow(() -> new
+ReferenceNotFoundException(name, this))` — three allocations, none hoistable, since the lambda
+captures both `name` and `this`. `AttributeKey.compareTo` delegated to
+`ComparatorUtils.compareLocale(..., () -> ...)`, allocating a capturing `IntSupplier` on every
+comparison inside every sorted structure keyed by an attribute key. The two largest per-reference
+loops (`verifyReferenceCardinalities`, `ReferenceIndexMutator`'s facet-propagation loop) already
+carried a same-name-run memo; several sibling loops did not.
+
+## Options considered
+
+### Option A — accessor-level de-allocation, schema-owned canonical keys, per-run hoisting (chosen)
+
+Remove the allocation from the accessors themselves; let `AttributeSchema` own the canonical
+`AttributeKey` instances so callers stop building them; and hoist reference-schema resolution into a
+local wherever a loop is visible in the same method body and the entity schema is already pinned
+there.
+
+- **Pros:** every change is local and independently revertible; nothing crosses a module boundary;
+  no on-disk format is touched; the caches live on objects that are already immutable and already
+  outlive every use.
+- **Cons:** spread over many small sites, so the win is diffuse and hard to attribute per edit;
+  adds two fields to `AttributeSchema` and one to `ReferenceSchema`.
+
+### Option B — canonicalize reference names at the mutation boundary (declined)
+
+Reference names arrive protobuf-decoded, a fresh `String` per gRPC message, so `HashMap.getNode`'s
+identity fast path always misses and `String.hashCode` is recomputed per message — visible as the
+21.36% top leaf frame. Routing every name through a canonical string table where the mutation is
+built would make every name-keyed lookup in the write path cheap at once, not just this accessor.
+
+- **Pros:** strictly higher leverage than anything in Option A — it fixes `getReference`, the `hppc`
+  maps in the cardinality verifier and the reference indexes together.
+- **Cons:** the obvious placement (canonicalize against `references.keySet()`) does not fit the
+  site — the gRPC converters have no schema or catalog context and live in the module shared with
+  the client; the alternative placement trades that for a later, larger blast radius.
+- **Rejected because:** it needs a design exploration and a measured ceiling before anyone writes
+  code — where the table lives decides whether it is a converter-local detail or a change to the
+  mutation contract, and neither placement has been measured. Explicitly out of scope in #1390.
+  **Revisit** once the exploration in `specifications/write-path-optimizations/` (on `dev`) has a
+  measured ceiling to compare against.
+
+### Option C — memoize the resolved reference schema on the executor across mutations (declined)
+
+A one-element `(name, schema)` memo held as a field on `ContainerizedLocalMutationExecutor` would
+serve nearly every resolution from a field read, since mutations arrive in name-sorted runs.
+
+- **Pros:** removes call volume from all 36 sites at once, including the dispatch methods where no
+  loop is visible and a local cannot help.
+- **Rejected because:** `schemaAccessor` is a supplier that is deliberately re-read per use, so a
+  memo living longer than one method call can serve a schema version that a schema mutation applied
+  in the same batch has already replaced. The correctness cost is a silently stale schema, which is
+  exactly the class of bug that does not show up in tests. **Revisit** only if the executor ever
+  gains an explicit per-batch schema pin with an invalidation hook.
+
+### Option D — delete `ComparableReferenceKey` (declined)
+
+A one-field record wrapping `ReferenceKey` whose whole body is a `compareTo` delegating to
+`ReferenceKey.FULL_COMPARATOR`, allocated per lookup at sites like
+`ReferenceAttributeValueProvider` — 12.34% of write-path allocation spent on a
+`Comparable`-vs-`Comparator` API choice.
+
+- **Rejected because:** it is functionally load-bearing for the non-uniform internal-primary-key
+  mechanism and inseparable from the `ReferenceKey` equality redesign tracked in #1392 — whose
+  `equals` is conditional and therefore non-transitive. Removing the wrapper without settling that
+  first would silently move which side of the non-transitivity a mixed run lands on. **Revisit**
+  after #1392 lands.
+
+## Decision
+
+**Chosen: Option A**, with B, C and D left standing as recorded rejections. A is the part that is
+safe to land as a hotfix on a release branch: it changes no on-disk format, no query semantics and
+no public contract beyond two additive `default` methods, and every edit is defensible on its own.
+B remains the larger prize and should be sequenced after its exploration produces a number.
+
+## Key technical details
+
+- **`AttributeKey` instances handed out by a schema are shared.** `AttributeSchema` now owns a
+  canonical locale-agnostic key plus a lazily-filled `ConcurrentHashMap<Locale, AttributeKey>`
+  (`AttributeSchema.getAttributeKey(...)`). All engine usage is equality-based, so this is
+  behaviour-neutral — **but a future change must not introduce identity-keyed structures over
+  attribute keys, nor treat a key's identity as a per-mutation marker.** Both cache fields are
+  `@EqualsAndHashCode.Exclude`; without that, the lazily-populated map would make two otherwise
+  equal schemas compare unequal depending on which locales had been touched.
+- **Kryo is unaffected.** Schema DTOs are written by hand-written serializers that enumerate fields
+  explicitly and are versioned by `serialVersionUID` through `SerialVersionBasedSerializer`, so
+  derived cache fields are format-neutral and **no `serialVersionUID` bump is warranted**.
+  Reference tracking is off (`KryoFactory:120`, `setReferences(false)`), so sharing one key instance
+  where distinct-but-equal instances used to appear does not change the serialized graph of the
+  WAL-bound mutations built at `ReferenceBlock` and `ContainerizedLocalMutationExecutor`.
+- **The run memo depends on the sortedness invariant, and carries the derived facts too.**
+  `lastResolvedReferenceSchema` in `EntityIndexLocalMutationExecutor.indexAllReferences` /
+  `unindexReferences` and in `propagateOrphanedReferenceAttributeMutations` is only correct because
+  references are stored and iterated in name-sorted runs — the same invariant `ReferencesStoragePart`
+  asserts and re-establishes after every modification. A change that stops sorting references breaks
+  these memos silently. The two index-side loops also carry `indexedForFiltering` /
+  `indexedForEntityComponent` / `indexedForGroupComponent` / `faceted` on the same boundary; that is
+  where the `getIndexedComponents` and `isFacetedInScope` frames actually go. **Each derived boolean
+  keeps the guard that used to gate its evaluation** (`indexedForEntityComponent` is computed only
+  when `indexedForFiltering`, `faceted` only when `indexedForEntityComponent`), because
+  `ReflectedReferenceSchema.isFacetedInScope` asserts on reflected-reference availability and must
+  not start firing where the old control flow never called it.
+- **`updateReferences` now resolves the reference schema eagerly** on every branch instead of up to
+  three times lazily. A reference whose name is unknown to the entity schema cannot be stored in the
+  first place (`verifyReferenceCardinalities` resolves every stored reference), so this only moves an
+  unreachable failure earlier — it is deliberate, not an oversight.
+- **`ReferenceSchema.getIndexedInScopes()` now returns an unmodifiable `EnumSet`**, precomputed in
+  the constructor, where it previously returned a fresh mutable `HashSet` per call. Iteration order
+  is consequently ordinal rather than hash order, and the result is no longer mutable. No caller
+  mutated it; the audit found the accessor is **not** reached from the write path at all (its only
+  non-test callers are `ClassSchemaAnalyzer` and schema-mutation code), so this is a tidy-up rather
+  than a measured win — recorded here so the next reader does not repeat the audit.
+
+## Verification
+
+- `AttributeKeyTest` (new, `evita_api/requestResponse/data`) pins the full ordering contract of
+  `AttributeKey.compareTo` — all four null/non-null locale combinations, locale-string ordering,
+  the tie-break onto the attribute name, and an exhaustive cross-check of every
+  (locale, name) pair against `ComparatorUtils.compareLocale`. It was written and run green
+  **against the old implementation first**, so it pins the historical semantics rather than the
+  rewrite's.
+- Full `evita_functional_tests` suite: see the PR run.
+- **No performance number is claimed here.** The Senesi WARM_UP re-run named in #1390's
+  verification section has not been executed for this change; the percentages quoted above are the
+  measured cost of the *previous* code, from the profile that motivated the issue. The expected wins
+  are argued from reading each site.
+
+## Consequences & open follow-ups
+
+- **Two `AttributeKey` allocation sites were left as-is** —
+  `ReferenceIndexMutator.readReferenceAttributeValue` (`:1797`) and
+  `ContainerizedLocalMutationExecutor.readReferencedEntityAttribute` (`:1280`). Both are keyed by a
+  bare attribute *name* coming from a histogram descriptor that points at a **referenced entity's**
+  attribute, so the owning schema is not in hand and may live in another collection. Threading one
+  in would widen public signatures for a site that is not in the profile's hot frames.
+- **The two `*AttributeAndCompoundSchemaProvider` classes still resolve through the `Optional`
+  accessors.** Their fields are contract-typed (`EntitySchemaContract` /
+  `ReferenceSchemaContract`); narrowing them to the DTOs to reach `getAttributeOrNull` would require
+  widening roughly ten `ReferenceSchemaContract` parameters through `ReferenceIndexMutator`. Worth
+  revisiting only together with a broader decision about DTO-vs-contract typing inside the engine.
+- **`getAttributeOrNull` exists on `EntitySchema` only.** `ReferenceSchema` was deliberately left
+  without one: `ReflectedReferenceSchema` overrides `getAttribute` with an availability assert, so a
+  null-returning sibling would need a matching override to avoid bypassing it — more surface than
+  the single DTO-typed call site justified.
+- **The plan folder must still be retired.** `specifications/write-path-optimizations/` lives on
+  `dev`, not on this release branch, so it cannot be deleted here. Its §1 *Problem A* is implemented
+  by this record and its §1 *Problem B* is Option B above; its §2/§3 (`verifyReferenceCardinalities`
+  rewrite and the `ObjectIntHashMap` size hint) remain untouched and unclaimed.
+
+## Related work
+
+- `2026-07-27-write-path-performance-tuning` — same write path, same profile lineage; that record
+  spent the collation-cache and trunk-merge levers, this one spends the schema-handling lever.
+- `2026-08-01-bplustree-cursor-free-insert-path` — the other allocation-removal record from the same
+  round of Senesi profiling, on the index side rather than the schema side.
+
+## Timeline
+
+- **2026-08-05** — issue #1390 filed from the Senesi WARM_UP profile of `2026.2.2`
+- **2026-08-05** — implemented on `1390-schema-handling-write-path-optimizations`

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390 |
 | 2026-08-04 | [Report HTTP/2 RST_STREAM floods instead of enforcing against them, and turn the Rapid-Reset defence off by default](2026-08-04-http2-connection-teardown-observability.md) | fix | accepted | #1369, PR #1383 |
 | 2026-08-03 | [Readiness discovery-phase probe failures log at DEBUG; only a known-good endpoint failing logs ERROR](2026-08-03-readiness-discovery-log-level.md) | fix | proposed | #1364, PR #1366 |
 | 2026-08-03 | [Enforce the test-tag policy from a JUnit PostDiscoveryFilter, because listener exceptions are swallowed](2026-08-03-test-tag-policy-gate-via-post-discovery-filter.md) | fix | accepted | #1374, PR #1382 |

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/AttributesContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/AttributesContract.java
@@ -33,7 +33,6 @@ import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
 import io.evitadb.dataType.EvitaDataTypes;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.utils.Assert;
-import io.evitadb.utils.ComparatorUtils;
 import io.evitadb.utils.MemoryMeasuringConstants;
 
 import javax.annotation.Nonnull;
@@ -348,8 +347,28 @@ public interface AttributesContract<S extends AttributeSchemaContract> extends S
 		}
 
 		@Override
-		public int compareTo(AttributeKey o) {
-			return ComparatorUtils.compareLocale(this.locale, o.locale, () -> this.attributeName.compareTo(o.attributeName));
+		public int compareTo(@Nonnull AttributeKey o) {
+			// this comparison drives every sorted structure keyed by an attribute key, so the semantics of
+			// ComparatorUtils.compareLocale are inlined here - the shared method would allocate a capturing
+			// IntSupplier for the tie-breaking branch on every single comparison
+			final Locale otherLocale = o.locale;
+			if (this.locale == null) {
+				if (otherLocale != null) {
+					// a locale-agnostic key sorts after a localized one
+					return 1;
+				}
+			} else if (otherLocale == null) {
+				return -1;
+			} else if (!this.locale.equals(otherLocale)) {
+				// equal locales necessarily render the same string, so the comparison is only reached for
+				// genuinely different locales
+				final int localeResult = this.locale.toString().compareTo(otherLocale.toString());
+				if (localeResult != 0) {
+					return localeResult;
+				}
+			}
+			// locales tie - break on the attribute name
+			return this.attributeName.compareTo(o.attributeName);
 		}
 
 		/**

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/AttributeSchemaContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/AttributeSchemaContract.java
@@ -31,6 +31,7 @@ import io.evitadb.api.query.filter.Or;
 import io.evitadb.api.query.order.AttributeNatural;
 import io.evitadb.api.query.require.AttributeContent;
 import io.evitadb.api.query.require.AttributeHistogram;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.api.requestResponse.data.EntityContract;
 import io.evitadb.api.requestResponse.data.structure.AssociatedData;
 import io.evitadb.api.requestResponse.data.structure.Attributes;
@@ -43,6 +44,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -343,5 +345,32 @@ public interface AttributeSchemaContract extends NamedSchemaWithDeprecationContr
 	 * of ten using `indexedDecimalPlaces` as exponent.
 	 */
 	int getIndexedDecimalPlaces();
+
+	/**
+	 * Returns the locale-agnostic {@link AttributeKey} of this attribute.
+	 *
+	 * Implementations backed by an immutable schema are expected to return a shared, canonical instance - the write
+	 * path creates these keys per attribute per entity only to compare them or to look values up by them, and the
+	 * schema outlives every such use. Callers must therefore treat the returned key as shared and must not rely on
+	 * its identity; all engine usages are equality-based.
+	 *
+	 * @return attribute key without a locale
+	 */
+	@Nonnull
+	default AttributeKey getAttributeKey() {
+		return new AttributeKey(getName());
+	}
+
+	/**
+	 * Returns the {@link AttributeKey} of this attribute for the passed locale, or the locale-agnostic one when
+	 * `locale` is null. See {@link #getAttributeKey()} for the sharing contract.
+	 *
+	 * @param locale locale of the requested key, null for the locale-agnostic one
+	 * @return attribute key for the passed locale
+	 */
+	@Nonnull
+	default AttributeKey getAttributeKey(@Nullable Locale locale) {
+		return locale == null ? getAttributeKey() : new AttributeKey(getName(), locale);
+	}
 
 }

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/dto/AttributeSchema.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/dto/AttributeSchema.java
@@ -25,6 +25,7 @@ package io.evitadb.api.requestResponse.schema.dto;
 
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictResolutionOverride;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.api.requestResponse.schema.AttributeUniquenessType;
 import io.evitadb.api.requestResponse.schema.mutation.attribute.ScopedAttributeUniquenessType;
 import io.evitadb.dataType.EvitaDataTypes;
@@ -49,11 +50,11 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
-import static java.util.Optional.ofNullable;
 
 
 /**
@@ -151,6 +152,18 @@ public sealed class AttributeSchema implements AttributeSchemaContract
 	 * {@link AttributeSchemaContract#isUniqueWithinLocaleInScope(Scope)}.
 	 */
 	@Getter protected final Map<Scope, AttributeUniquenessType> uniquenessTypeInScopes;
+	/**
+	 * Canonical locale-agnostic {@link AttributeKey} of this attribute. The write path derives such a key from the
+	 * schema per attribute per entity only to compare it or to look a value up by it, and then discards it - since
+	 * the schema is immutable and outlives all of those uses, the key is created once here instead.
+	 */
+	@EqualsAndHashCode.Exclude @Nonnull private final AttributeKey attributeKey;
+	/**
+	 * Canonical localized {@link AttributeKey} instances of this attribute, keyed by locale and filled in on demand.
+	 * The locale domain is bounded by the locales of the entities using this schema, so the map stays small. It is
+	 * `null` for non-localized attributes, which never look a localized key up repeatedly.
+	 */
+	@EqualsAndHashCode.Exclude @Nullable private final Map<Locale, AttributeKey> localizedAttributeKeys;
 
 	/**
 	 * Converts an array of ScopedAttributeUniquenessType objects into an EnumMap linking Scope to AttributeUniquenessType.
@@ -436,6 +449,36 @@ public sealed class AttributeSchema implements AttributeSchemaContract
 		this.defaultValue = EvitaDataTypes.toTargetType(defaultValue, this.plainType);
 		this.indexedDecimalPlaces = indexedDecimalPlaces;
 		this.conflictResolutionOverride = conflictResolutionOverride;
+		this.attributeKey = new AttributeKey(this.name);
+		this.localizedAttributeKeys = localized ? new ConcurrentHashMap<>(8) : null;
+	}
+
+	@Nonnull
+	@Override
+	public AttributeKey getAttributeKey() {
+		return this.attributeKey;
+	}
+
+	@Nonnull
+	@Override
+	public AttributeKey getAttributeKey(@Nullable Locale locale) {
+		if (locale == null) {
+			return this.attributeKey;
+		}
+		final Map<Locale, AttributeKey> theLocalizedKeys = this.localizedAttributeKeys;
+		if (theLocalizedKeys == null) {
+			// non-localized attribute - a localized key of it is never requested repeatedly, caching would not pay off
+			return new AttributeKey(this.name, locale);
+		}
+		final AttributeKey cachedKey = theLocalizedKeys.get(locale);
+		if (cachedKey != null) {
+			return cachedKey;
+		}
+		// deliberately not computeIfAbsent - it would allocate a capturing lambda on every call, which is exactly
+		// the allocation this cache exists to remove
+		final AttributeKey newKey = new AttributeKey(this.name, locale);
+		final AttributeKey concurrentlyStoredKey = theLocalizedKeys.putIfAbsent(locale, newKey);
+		return concurrentlyStoredKey == null ? newKey : concurrentlyStoredKey;
 	}
 
 	@Override
@@ -471,7 +514,9 @@ public sealed class AttributeSchema implements AttributeSchemaContract
 	@Nonnull
 	@Override
 	public AttributeUniquenessType getUniquenessType(@Nonnull Scope scope) {
-		return ofNullable(this.uniquenessTypeInScopes.get(scope)).orElse(AttributeUniquenessType.NOT_UNIQUE);
+		// plain null-check instead of Optional wrapping - this accessor is called per attribute on the write path
+		final AttributeUniquenessType uniquenessType = this.uniquenessTypeInScopes.get(scope);
+		return uniquenessType == null ? AttributeUniquenessType.NOT_UNIQUE : uniquenessType;
 	}
 
 	@Override

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/dto/EntitySchema.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/dto/EntitySchema.java
@@ -822,6 +822,20 @@ public final class EntitySchema implements EntitySchemaContract {
 		return ofNullable(this.attributes.get(attributeName));
 	}
 
+	/**
+	 * Variant of {@link #getAttribute(String)} that returns the schema directly instead of wrapping it into
+	 * an {@link Optional}. It exists for the write path, which resolves an attribute schema for every attribute
+	 * mutation it applies and would otherwise allocate an `Optional` per resolution. The `Optional` returning variant
+	 * remains the contract for everyone else, per the project rule that `Optional` belongs at the read boundary.
+	 *
+	 * @param attributeName name of the attribute to look up
+	 * @return the attribute schema, or `null` when the entity schema does not know an attribute of such name
+	 */
+	@Nullable
+	public EntityAttributeSchemaContract getAttributeOrNull(@Nonnull String attributeName) {
+		return this.attributes.get(attributeName);
+	}
+
 	@Nonnull
 	@Override
 	public Optional<EntityAttributeSchemaContract> getAttributeByName(@Nonnull String attributeName, @Nonnull NamingConvention namingConvention) {
@@ -882,8 +896,14 @@ public final class EntitySchema implements EntitySchemaContract {
 	@Nonnull
 	@Override
 	public AssociatedDataSchemaContract getAssociatedDataOrThrowException(@Nonnull String dataName) {
-		return ofNullable(this.associatedData.get(dataName))
-			.orElseThrow(() -> new EvitaInvalidUsageException("Associated data `" + dataName + "` is not known in entity `" + getName() + "` schema!"));
+		// this method is on the hot write path - avoid the Optional wrapper and the capturing lambda of orElseThrow
+		final AssociatedDataSchema associatedDataSchema = this.associatedData.get(dataName);
+		if (associatedDataSchema == null) {
+			throw new EvitaInvalidUsageException(
+				"Associated data `" + dataName + "` is not known in entity `" + getName() + "` schema!"
+			);
+		}
+		return associatedDataSchema;
 	}
 
 	@Nonnull
@@ -931,9 +951,12 @@ public final class EntitySchema implements EntitySchemaContract {
 	@Nonnull
 	@Override
 	public ReferenceSchema getReferenceOrThrowException(@Nonnull String referenceName) {
-		return getReference(referenceName)
-			.map(ReferenceSchema.class::cast)
-			.orElseThrow(() -> new ReferenceNotFoundException(referenceName, this));
+		// this method is one of the hottest on the write path - avoid both Optional wrappers and the capturing lambda
+		final ReferenceSchema referenceSchema = this.references.get(referenceName);
+		if (referenceSchema == null) {
+			throw new ReferenceNotFoundException(referenceName, this);
+		}
+		return referenceSchema;
 	}
 
 	@Override

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/dto/ReferenceSchema.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/dto/ReferenceSchema.java
@@ -104,6 +104,12 @@ public sealed class ReferenceSchema implements ReferenceSchemaContract permits R
 	 */
 	protected final Map<Scope, ReferenceIndexType> indexedInScopes;
 	/**
+	 * Scopes in which this reference is actually indexed - i.e. the keys of {@link #indexedInScopes} whose value is
+	 * something else than {@link ReferenceIndexType#NONE}. Derived from an immutable input, so it is computed once in
+	 * the constructor instead of being re-collected into a new set on every {@link #getIndexedInScopes()} call.
+	 */
+	private final Set<Scope> indexedScopes;
+	/**
 	 * Indexed components configured per scope for this reference, specifying which parts
 	 * of the reference relationship (entity, group entity, or both) are indexed.
 	 */
@@ -218,6 +224,24 @@ public sealed class ReferenceSchema implements ReferenceSchemaContract permits R
 			}
 		}
 		return theIndexType;
+	}
+
+	/**
+	 * Extracts the scopes the reference is actually indexed in - i.e. those mapped to an index type other than
+	 * {@link ReferenceIndexType#NONE}. The result backs {@link #getIndexedInScopes()} and is therefore immutable.
+	 *
+	 * @param indexedInScopes the per-scope index types of the reference
+	 * @return an unmodifiable set of the scopes the reference is indexed in
+	 */
+	@Nonnull
+	private static Set<Scope> toIndexedScopeSet(@Nonnull Map<Scope, ReferenceIndexType> indexedInScopes) {
+		final EnumSet<Scope> result = EnumSet.noneOf(Scope.class);
+		for (final Entry<Scope, ReferenceIndexType> entry : indexedInScopes.entrySet()) {
+			if (entry.getValue() != ReferenceIndexType.NONE) {
+				result.add(entry.getKey());
+			}
+		}
+		return result.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(result);
 	}
 
 	/**
@@ -866,6 +890,7 @@ public sealed class ReferenceSchema implements ReferenceSchemaContract permits R
 		this.groupTypeNameVariants = Collections.unmodifiableMap(groupTypeNameVariants);
 		this.referencedGroupTypeManaged = referencedGroupTypeManaged;
 		this.indexedInScopes = CollectionUtils.toUnmodifiableMap(indexedInScopes);
+		this.indexedScopes = toIndexedScopeSet(this.indexedInScopes);
 		this.indexedComponentsInScopes = CollectionUtils.toUnmodifiableMap(indexedComponentsInScopes);
 		this.facetedInScopes = CollectionUtils.toUnmodifiableSet(facetedInScopes);
 		this.facetedPartiallyInScopes = CollectionUtils.toUnmodifiableMap(facetedPartiallyInScopes);
@@ -966,17 +991,15 @@ public sealed class ReferenceSchema implements ReferenceSchemaContract permits R
 
 	@Override
 	public boolean isIndexedInScope(@Nonnull Scope scope) {
-		return this.indexedInScopes.containsKey(scope) && this.indexedInScopes.get(scope) != ReferenceIndexType.NONE;
+		// single map lookup - a missing entry and an explicit NONE mean the same thing here
+		final ReferenceIndexType indexType = this.indexedInScopes.get(scope);
+		return indexType != null && indexType != ReferenceIndexType.NONE;
 	}
 
 	@Nonnull
 	@Override
 	public Set<Scope> getIndexedInScopes() {
-		return this.indexedInScopes.entrySet()
-			.stream()
-			.filter(entry -> entry.getValue() != ReferenceIndexType.NONE)
-			.map(Map.Entry::getKey)
-			.collect(Collectors.toSet());
+		return this.indexedScopes;
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/AttributeIndexMutator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/AttributeIndexMutator.java
@@ -891,10 +891,11 @@ public interface AttributeIndexMutator {
 	) {
 		return it -> {
 			final AttributeSchema attributeSchema = attributeSchemaProvider.getAttributeSchema(it.attributeName());
+			// canonical keys shared by the schema - they are only used to look the existing value up
 			return existingAttributeValueProvider.apply(
 				attributeSchema.isLocalized() ?
-					new AttributeKey(it.attributeName(), locale) :
-					new AttributeKey(it.attributeName())
+					attributeSchema.getAttributeKey(locale) :
+					attributeSchema.getAttributeKey()
 			);
 		};
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/EntityIndexLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/EntityIndexLocalMutationExecutor.java
@@ -23,7 +23,6 @@
 
 package io.evitadb.index.mutation.local;
 
-import io.evitadb.api.exception.ReferenceNotFoundException;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
 import io.evitadb.api.requestResponse.data.Droppable;
@@ -1908,9 +1907,8 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 			final ReferenceKey effectiveReferenceKey = referenceKey != null
 				? referenceKey : representativeKey.referenceKey();
 			final String referenceName = effectiveReferenceKey.referenceName();
-			referenceSchema = entitySchema.getReference(referenceName)
-				.orElseThrow(() -> new ReferenceNotFoundException(
-					referenceName, entitySchema));
+			// same contract as the previous getReference(..).orElseThrow(..) chain, without the Optional and the lambda
+			referenceSchema = entitySchema.getReferenceOrThrowException(referenceName);
 			if (ReferenceIndexMutator.isIndexedReferenceForFilteringAndPartitioning(referenceSchema, getScope())) {
 				ReferenceIndexMutator.removeEntireSuiteOfSortableAttributeCompounds(
 					this,
@@ -2119,15 +2117,35 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 		@Nonnull EntityExistingDataFactory existingDataSupplierFactory
 	) {
 		final int epk = entity.getPrimaryKeyOrThrowException();
+		// references come in name-sorted runs, so the schema resolved for the previous reference is almost always
+		// the one needed again - resolve it, and the facts derived from it, once per run instead of once per
+		// reference. The scope is fixed for the whole loop and the schema is immutable, so all three facts can
+		// only change where the run boundary moves. The `indexedForFiltering` guards below keep the evaluation
+		// order identical to the per-reference form they replace
+		ReferenceSchemaContract lastResolvedReferenceSchema = null;
+		boolean indexedForFiltering = false;
+		boolean indexedForEntityComponent = false;
+		boolean indexedForGroupComponent = false;
 		for (ReferenceContract reference : entity.getReferences()) {
 			if (reference.exists()) {
 				final ReferenceKey referenceKey = reference.getReferenceKey();
-				final ReferenceSchemaContract referenceSchema =
-					entitySchema.getReferenceOrThrowException(referenceKey.referenceName());
+				if (lastResolvedReferenceSchema == null ||
+					!lastResolvedReferenceSchema.getName().equals(referenceKey.referenceName())) {
+					lastResolvedReferenceSchema =
+						entitySchema.getReferenceOrThrowException(referenceKey.referenceName());
+					indexedForFiltering = ReferenceIndexMutator.isIndexedReferenceForFiltering(
+						lastResolvedReferenceSchema, scope
+					);
+					indexedForEntityComponent = indexedForFiltering &&
+						ReferenceIndexMutator.isIndexedForEntityComponent(lastResolvedReferenceSchema, scope);
+					indexedForGroupComponent = indexedForFiltering &&
+						ReferenceIndexMutator.isIndexedForGroupComponent(lastResolvedReferenceSchema, scope);
+				}
+				final ReferenceSchemaContract referenceSchema = lastResolvedReferenceSchema;
 				final RepresentativeReferenceKey rrk = getRepresentativeReferenceKey(
 					epk, globalIndex, referenceKey, referenceSchema, true
 				);
-				if (ReferenceIndexMutator.isIndexedReferenceForFiltering(referenceSchema, scope)) {
+				if (indexedForFiltering) {
 					final Integer groupId = extractActiveGroupPrimaryKey(reference);
 					// histogram: remove histogram entries before facet/component cleanup
 					ReferenceIndexMutator.removeHistogramFromIndex(
@@ -2139,7 +2157,7 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 						this
 					);
 					// entity component: entity type index + entity reduced index (only when configured)
-					if (ReferenceIndexMutator.isIndexedForEntityComponent(referenceSchema, scope)) {
+					if (indexedForEntityComponent) {
 						final ReferencedTypeEntityIndex referenceTypeIndex =
 							ReferenceIndexMutator.getOrCreateReferencedTypeEntityIndex(
 								this, referenceKey.referenceName(), scope
@@ -2154,7 +2172,7 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 						);
 					}
 					// group component: independent — group type index + group reduced index
-					if (ReferenceIndexMutator.isIndexedForGroupComponent(referenceSchema, scope)) {
+					if (indexedForGroupComponent) {
 						removeFromGroupIndexes(
 							epk, entitySchema, referenceSchema, rrk, referenceKey,
 							reference, scope, existingDataSupplierFactory
@@ -2410,15 +2428,39 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 		@Nonnull EntityExistingDataFactory existingDataSupplierFactory
 	) {
 		final int epk = entity.getPrimaryKeyOrThrowException();
+		// references come in name-sorted runs, so the schema resolved for the previous reference is almost always
+		// the one needed again - resolve it, and the facts derived from it, once per run instead of once per
+		// reference. The scope is fixed for the whole loop and the schema is immutable, so all four facts can
+		// only change where the run boundary moves. The guards below keep the evaluation order identical to the
+		// per-reference form they replace - `faceted` in particular is only ever evaluated under the same
+		// condition that guarded it before
+		ReferenceSchemaContract lastResolvedReferenceSchema = null;
+		boolean indexedForFiltering = false;
+		boolean indexedForEntityComponent = false;
+		boolean indexedForGroupComponent = false;
+		boolean faceted = false;
 		for (ReferenceContract reference : entity.getReferences()) {
 			if (reference.exists()) {
 				final ReferenceKey referenceKey = reference.getReferenceKey();
-				final ReferenceSchemaContract referenceSchema =
-					entitySchema.getReferenceOrThrowException(referenceKey.referenceName());
+				if (lastResolvedReferenceSchema == null ||
+					!lastResolvedReferenceSchema.getName().equals(referenceKey.referenceName())) {
+					lastResolvedReferenceSchema =
+						entitySchema.getReferenceOrThrowException(referenceKey.referenceName());
+					indexedForFiltering = ReferenceIndexMutator.isIndexedReferenceForFiltering(
+						lastResolvedReferenceSchema, scope
+					);
+					indexedForEntityComponent = indexedForFiltering &&
+						ReferenceIndexMutator.isIndexedForEntityComponent(lastResolvedReferenceSchema, scope);
+					indexedForGroupComponent = indexedForFiltering &&
+						ReferenceIndexMutator.isIndexedForGroupComponent(lastResolvedReferenceSchema, scope);
+					faceted = indexedForEntityComponent &&
+						lastResolvedReferenceSchema.isFacetedInScope(scope);
+				}
+				final ReferenceSchemaContract referenceSchema = lastResolvedReferenceSchema;
 				final RepresentativeReferenceKey rrk = getRepresentativeReferenceKey(
 					epk, globalIndex, referenceKey, referenceSchema, true
 				);
-				if (ReferenceIndexMutator.isIndexedReferenceForFiltering(referenceSchema, scope)) {
+				if (indexedForFiltering) {
 					final Integer groupId = extractActiveGroupPrimaryKey(reference);
 					// prevent referenceInsertGlobal from deferring a histogram add —
 					// indexAllReferences handles histogram directly with the correct groupId
@@ -2432,7 +2474,7 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 						this
 					);
 					// entity component: entity type index + entity reduced index (only when configured)
-					if (ReferenceIndexMutator.isIndexedForEntityComponent(referenceSchema, scope)) {
+					if (indexedForEntityComponent) {
 						final ReferencedTypeEntityIndex referenceTypeIndex =
 							ReferenceIndexMutator.getOrCreateReferencedTypeEntityIndex(
 								this, rrk.referenceName(), scope
@@ -2448,7 +2490,7 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 							existingDataSupplierFactory
 						);
 						// cross-reference facet indexing: only when entity component is enabled
-						if (referenceSchema.isFacetedInScope(scope)) {
+						if (faceted) {
 							for (ReferenceContract otherRef : entity.getReferences()) {
 								if (ReferenceKey.FULL_COMPARATOR.compare(
 									rrk.referenceKey(), otherRef.getReferenceKey()
@@ -2466,10 +2508,7 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 						}
 					}
 					// group component: independent — group type index + group reduced index
-					if (
-						groupId != null &&
-							ReferenceIndexMutator.isIndexedForGroupComponent(referenceSchema, scope)
-					) {
+					if (groupId != null && indexedForGroupComponent) {
 						insertIntoGroupIndexes(
 							epk, entitySchema, referenceSchema, rrk, referenceKey,
 							groupId, scope, existingDataSupplierFactory

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
@@ -256,13 +256,14 @@ public final class ContainerizedLocalMutationExecutor
 			final boolean nullable = attributeSchema.isNullable();
 			if (attributeSchema.isLocalized()) {
 				for (final Locale locale : entityLocales) {
-					final AttributeKey attributeKey = new AttributeKey(attributeSchema.getName(), locale);
+					// canonical key shared by the schema - it is only compared and looked up here
+					final AttributeKey attributeKey = attributeSchema.getAttributeKey(locale);
 					if (!reference.isAttributeValuePresentAndExists(attributeKey)) {
 						missingAttributeHandler.accept(defaultValue, nullable, attributeKey);
 					}
 				}
 			} else {
-				final AttributeKey attributeKey = new AttributeKey(attributeSchema.getName());
+				final AttributeKey attributeKey = attributeSchema.getAttributeKey();
 				if (!reference.isAttributeValuePresentAndExists(attributeKey)) {
 					missingAttributeHandler.accept(defaultValue, nullable, attributeKey);
 				}
@@ -2126,14 +2127,15 @@ public final class ContainerizedLocalMutationExecutor
 			final boolean nullable = attribute.isNullable();
 			if (checkLocalized && attribute.isLocalized()) {
 				for (final Locale locale : entityLocales) {
-					final AttributeKey attributeKey = new AttributeKey(attribute.getName(), locale);
+					// canonical key shared by the schema - it is only compared and looked up here
+					final AttributeKey attributeKey = attribute.getAttributeKey(locale);
 					final Set<AttributeKey> localeAttributes = availableLocalizedAttributes.get(locale);
 					if (localeAttributes == null || !localeAttributes.contains(attributeKey)) {
 						missingAttributeHandler.accept(defaultValue, nullable, attributeKey);
 					}
 				}
 			} else if (checkGlobal && !attribute.isLocalized()) {
-				final AttributeKey attributeKey = new AttributeKey(attribute.getName());
+				final AttributeKey attributeKey = attribute.getAttributeKey();
 				if (!availableGlobalAttributes.contains(attributeKey)) {
 					missingAttributeHandler.accept(defaultValue, nullable, attributeKey);
 				}
@@ -2750,13 +2752,20 @@ public final class ContainerizedLocalMutationExecutor
 		// go through all input mutations
 		final Map<EntityReference, List<ReferenceAttributeMutation>>
 			referenceAttributeMutationsByEntityReference = new LazyHashMap<>(inputMutations.size());
+		// attribute mutations of one reference arrive in a run, so the schema resolved for the previous mutation is
+		// almost always the one needed again - a name comparison is cheaper than a repeated map lookup
+		ReferenceSchema lastResolvedReferenceSchema = null;
 		for (LocalMutation<?, ?> inputMutation : inputMutations) {
 			// and check if there are any reference attribute mutation
 			if (inputMutation instanceof ReferenceAttributeMutation ram) {
 				final ReferenceKey referenceKey = getReferenceKeyManager().getAssignedReferenceKey(ram.getReferenceKey());
 				// find the reference schema
 				final String referenceName = referenceKey.referenceName();
-				final ReferenceSchema referenceSchema = entitySchema.getReferenceOrThrowException(referenceName);
+				if (lastResolvedReferenceSchema == null ||
+					!lastResolvedReferenceSchema.getName().equals(referenceName)) {
+					lastResolvedReferenceSchema = entitySchema.getReferenceOrThrowException(referenceName);
+				}
+				final ReferenceSchema referenceSchema = lastResolvedReferenceSchema;
 				// if the mutation relate to reference which hasn't been created in the same entity update
 				if (!getReferenceKeyManager().isReferenceKeyCreated(referenceKey)) {
 					// access the data store reader of referenced collection
@@ -3175,13 +3184,18 @@ public final class ContainerizedLocalMutationExecutor
 	 * {@link AttributesStoragePart#getAttributes()}. The appropriate storage part is located by information about
 	 * locale in passed `localMutation` argument.
 	 */
-	private void updateAttributes(@Nonnull EntitySchemaContract entitySchema, @Nonnull AttributeMutation localMutation) {
+	private void updateAttributes(@Nonnull EntitySchema entitySchema, @Nonnull AttributeMutation localMutation) {
 		final AttributeKey attributeKey = localMutation.getAttributeKey();
-		final AttributeSchemaContract attributeDefinition = entitySchema.getAttribute(attributeKey.attributeName())
-			.orElseThrow(() -> new EvitaInvalidUsageException(
+		// resolved once per attribute mutation - the Optional-returning variant would allocate per resolution
+		final AttributeSchemaContract attributeDefinition = entitySchema.getAttributeOrNull(
+			attributeKey.attributeName()
+		);
+		if (attributeDefinition == null) {
+			throw new EvitaInvalidUsageException(
 				"Attribute `" + attributeKey.attributeName() +
 					"` is not known for entity `" + entitySchema.getName() + "`."
-			));
+			);
+		}
 		// get or create the locale-specific attributes container, or the locale-agnostic (global) one
 		final Locale attributeLocale = attributeKey.locale();
 		final AttributesStoragePart attributesStorageContainer = attributeLocale != null
@@ -3251,21 +3265,22 @@ public final class ContainerizedLocalMutationExecutor
 		final ReferencesStoragePart referencesStorageCnt = getReferencesStoragePart(this.entityType, this.entityPrimaryKey);
 		// replace or add the mutated reference in the container
 		final ReferenceKey referenceKey = localMutation.getReferenceKey();
+		// resolve the reference schema once - the very same name was previously looked up up to three times per
+		// mutation (twice from a supplier, once for the cardinality check, once more when removing the reference).
+		// The resolution is now eager on every branch; a reference whose name is unknown to the schema cannot be
+		// stored in the first place, so this only moves an unreachable failure earlier
+		final ReferenceSchema referenceSchema = entitySchema.getReferenceOrThrowException(referenceKey.referenceName());
+		final MissingReferenceBehavior missingReferenceBehavior =
+			referenceSchema instanceof ReflectedReferenceSchemaContract ?
+				MissingReferenceBehavior.ACCEPT_INTERNAL_KEY : MissingReferenceBehavior.GENERATE_NEW_INTERNAL_KEY;
 		final ReferenceContract updatedReference;
 		if (referenceKey.isKnownInternalPrimaryKey() || referenceKey.isNewReference()) {
 			updatedReference = referencesStorageCnt.replaceOrAddReference(
 				referenceKey,
 				referenceContract -> localMutation.mutateLocal(entitySchema, referenceContract),
-				() -> entitySchema.getReferenceOrThrowException(
-					referenceKey.referenceName()
-				) instanceof ReflectedReferenceSchemaContract ?
-					MissingReferenceBehavior.ACCEPT_INTERNAL_KEY : MissingReferenceBehavior.GENERATE_NEW_INTERNAL_KEY
+				() -> missingReferenceBehavior
 			);
-		} else if (
-			entitySchema.getReferenceOrThrowException(referenceKey.referenceName())
-			            .getCardinality()
-			            .allowsDuplicates()
-		) {
+		} else if (referenceSchema.getCardinality().allowsDuplicates()) {
 			throw new InvalidMutationException(
 				"Reference `" + referenceKey.referenceName() + "` in entity `" + entitySchema.getName() + "` allows duplicates. " +
 					"It's not possible to modify it without providing identification using reference key with internal id!"
@@ -3274,10 +3289,7 @@ public final class ContainerizedLocalMutationExecutor
 			updatedReference = referencesStorageCnt.replaceOrAddReference(
 				referenceKey,
 				referenceContract -> localMutation.mutateLocal(entitySchema, referenceContract),
-				() -> entitySchema.getReferenceOrThrowException(
-					referenceKey.referenceName()
-				) instanceof ReflectedReferenceSchemaContract ?
-					MissingReferenceBehavior.ACCEPT_INTERNAL_KEY : MissingReferenceBehavior.GENERATE_NEW_INTERNAL_KEY
+				() -> missingReferenceBehavior
 			);
 		}
 		// change in entity parts also change the entity itself (we need to update the version)
@@ -3288,10 +3300,7 @@ public final class ContainerizedLocalMutationExecutor
 		if (localMutation instanceof ReferenceAttributeMutation referenceAttributesUpdateMutation) {
 			recomputeLanguageOnAttributeUpdate(referenceAttributesUpdateMutation.getAttributeMutation());
 		} else if (localMutation instanceof RemoveReferenceMutation) {
-			removeEntireReference(
-				updatedReference,
-				entitySchema.getReferenceOrThrowException(referenceKey.referenceName())
-			);
+			removeEntireReference(updatedReference, referenceSchema);
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ReferenceBlock.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ReferenceBlock.java
@@ -234,7 +234,7 @@ class ReferenceBlock<T> {
 					// set-up a stream of reference attribute mutations for each locale
 					return locales.stream()
 						.map(locale -> {
-							final AttributeKey attributeKey = new AttributeKey(attributeSchema.getName(), locale);
+							final AttributeKey attributeKey = attributeSchema.getAttributeKey(locale);
 							return new ReferenceAttributeMutation(
 								attributeValueProvider.getReferenceKey(referencedEntitySchema, reference),
 								new UpsertAttributeMutation(
@@ -245,7 +245,7 @@ class ReferenceBlock<T> {
 						});
 				} else {
 					// set-up a stream with single reference attribute mutation
-					final AttributeKey attributeKey = new AttributeKey(attributeSchema.getName());
+					final AttributeKey attributeKey = attributeSchema.getAttributeKey();
 					return Stream.of(
 						new ReferenceAttributeMutation(
 							attributeValueProvider.getReferenceKey(referencedEntitySchema, reference),
@@ -270,7 +270,7 @@ class ReferenceBlock<T> {
 					return locales
 						.stream()
 						.map(locale -> {
-							final AttributeKey attributeKey = new AttributeKey(attributeSchema.getName(), locale);
+							final AttributeKey attributeKey = attributeSchema.getAttributeKey(locale);
 							final Serializable value = valueLookup.apply(attributeKey);
 							if (value == null && !attributeSchema.isNullable()) {
 								// if the value is missing and the attribute is not nullable, add it to the missing set
@@ -289,7 +289,7 @@ class ReferenceBlock<T> {
 						.filter(Objects::nonNull);
 				} else {
 					// set-up a stream with single reference attribute mutation
-					final AttributeKey attributeKey = new AttributeKey(attributeSchema.getName());
+					final AttributeKey attributeKey = attributeSchema.getAttributeKey();
 					final Serializable value = valueLookup.apply(attributeKey);
 					if (value == null && !attributeSchema.isNullable()) {
 						// if the value is missing and the attribute is not nullable, add it to the missing set

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/AttributeKeyTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/AttributeKeyTest.java
@@ -1,0 +1,174 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.data;
+
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.utils.ComparatorUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.COMPARATOR;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the total ordering of {@link AttributeKey#compareTo(AttributeKey)}. The ordering is load-bearing for every
+ * sorted structure keyed by an attribute key (sorted attribute containers and their binary searches), so this test
+ * exists to keep the contract fixed while the method body is optimized for allocation.
+ *
+ * The contract, inherited from {@link ComparatorUtils#compareLocale(Locale, Locale, java.util.function.IntSupplier)}:
+ * a **non-null locale sorts before a null one**, two non-null locales compare by {@link Locale#toString()}, and only
+ * a tie on the locale level falls through to the attribute name.
+ *
+ * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("AttributeKey ordering")
+@Tag(CONTRACT)
+@Tag(ATTRIBUTE)
+@Tag(COMPARATOR)
+class AttributeKeyTest {
+
+	private static final Locale CZECH = new Locale("cs");
+	private static final Locale ENGLISH = Locale.ENGLISH;
+	private static final Locale US = Locale.US;
+
+	/**
+	 * Asserts that `left` sorts strictly before `right` and that the comparison is antisymmetric.
+	 */
+	private static void assertOrderedBefore(AttributeKey left, AttributeKey right) {
+		assertTrue(left.compareTo(right) < 0, () -> left + " should sort before " + right);
+		assertTrue(right.compareTo(left) > 0, () -> right + " should sort after " + left);
+	}
+
+	@Nested
+	@DisplayName("locale is the primary ordering level")
+	class LocaleOrdering {
+
+		@Test
+		@DisplayName("localized key sorts before non-localized one regardless of the attribute name")
+		void shouldOrderLocalizedKeyBeforeNonLocalizedOne() {
+			// the localized key loses on the name level, yet still sorts first - locale dominates
+			assertOrderedBefore(new AttributeKey("zzz", ENGLISH), new AttributeKey("aaa"));
+			assertOrderedBefore(new AttributeKey("aaa", ENGLISH), new AttributeKey("aaa"));
+		}
+
+		@Test
+		@DisplayName("two localized keys are ordered by the locale string")
+		void shouldOrderLocalizedKeysByLocaleString() {
+			// "cs" < "en" < "en_US" as plain strings
+			assertOrderedBefore(new AttributeKey("zzz", CZECH), new AttributeKey("aaa", ENGLISH));
+			assertOrderedBefore(new AttributeKey("zzz", ENGLISH), new AttributeKey("aaa", US));
+		}
+
+		@Test
+		@DisplayName("equal locales fall through to the attribute name")
+		void shouldFallThroughToAttributeNameOnEqualLocales() {
+			assertOrderedBefore(new AttributeKey("aaa", ENGLISH), new AttributeKey("zzz", ENGLISH));
+			// distinct instances rendering the same locale string are still a tie
+			assertOrderedBefore(new AttributeKey("aaa", new Locale("en")), new AttributeKey("zzz", ENGLISH));
+		}
+
+		@Test
+		@DisplayName("both locales null falls through to the attribute name")
+		void shouldFallThroughToAttributeNameOnBothLocalesNull() {
+			assertOrderedBefore(new AttributeKey("aaa"), new AttributeKey("zzz"));
+		}
+	}
+
+	@Nested
+	@DisplayName("comparison is reflexive and consistent with equality")
+	class Consistency {
+
+		@Test
+		@DisplayName("equal keys compare as zero")
+		void shouldCompareEqualKeysAsZero() {
+			assertEquals(0, new AttributeKey("code").compareTo(new AttributeKey("code")));
+			assertEquals(0, new AttributeKey("code", ENGLISH).compareTo(new AttributeKey("code", ENGLISH)));
+			// distinct but equal locale instances
+			assertEquals(0, new AttributeKey("code", new Locale("en")).compareTo(new AttributeKey("code", ENGLISH)));
+			// self-comparison
+			final AttributeKey key = new AttributeKey("code", US);
+			assertEquals(0, key.compareTo(key));
+		}
+
+		@Test
+		@DisplayName("sorting a mixed set yields locales first, then the locale-agnostic keys")
+		void shouldSortMixedKeysDeterministically() {
+			final List<AttributeKey> keys = new ArrayList<>(6);
+			keys.add(new AttributeKey("name"));
+			keys.add(new AttributeKey("code", US));
+			keys.add(new AttributeKey("code"));
+			keys.add(new AttributeKey("name", CZECH));
+			keys.add(new AttributeKey("code", ENGLISH));
+			keys.add(new AttributeKey("code", CZECH));
+			keys.sort(null);
+
+			assertEquals(
+				List.of(
+					new AttributeKey("code", CZECH),
+					new AttributeKey("name", CZECH),
+					new AttributeKey("code", ENGLISH),
+					new AttributeKey("code", US),
+					new AttributeKey("code"),
+					new AttributeKey("name")
+				),
+				keys
+			);
+		}
+
+		@Test
+		@DisplayName("ordering matches the shared ComparatorUtils.compareLocale semantics")
+		void shouldMatchComparatorUtilsSemantics() {
+			// the historical implementation delegated here - the ordering must remain identical
+			final Locale[] locales = {null, CZECH, ENGLISH, US};
+			final String[] names = {"aaa", "zzz"};
+			for (final Locale leftLocale : locales) {
+				for (final String leftName : names) {
+					for (final Locale rightLocale : locales) {
+						for (final String rightName : names) {
+							final AttributeKey left = new AttributeKey(leftName, leftLocale);
+							final AttributeKey right = new AttributeKey(rightName, rightLocale);
+							final int expected = ComparatorUtils.compareLocale(
+								leftLocale, rightLocale, () -> leftName.compareTo(rightName)
+							);
+							assertEquals(
+								Integer.signum(expected),
+								Integer.signum(left.compareTo(right)),
+								() -> "mismatch for " + left + " vs " + right
+							);
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #1390

Delivers all six parts of the issue. The Senesi WARM_UP profile of `2026.2.2` attributes 18.7% of
write-path CPU to resolving facts from immutable schema objects and 18.24% of write-path allocation
to short-lived `AttributeKey` records. Both are **call volume**, not body cost — the accessors are
already plain map lookups, and the keys are re-derived from a schema that cannot change while the
mutation is being applied.

Decision record: `documentation/adr/2026-08-05-schema-handling-write-path-optimizations.md`.

## What changed

| Part | Change |
|---|---|
| 1 | `EntitySchema.getReferenceOrThrowException` / `getAssociatedDataOrThrowException` → map get + null-check + throw, dropping two `Optional`s and a capturing lambda per call |
| 2 | `indexAllReferences` / `unindexReferences` / `propagateOrphanedReferenceAttributeMutations` resolve the reference schema **and its derived facts** once per name-sorted run; `updateReferences` resolves once instead of up to three times per mutation |
| 3 | `ReferenceSchema.getIndexedInScopes()` precomputed in the constructor as an unmodifiable `EnumSet` |
| 4 | `AttributeSchema` owns canonical `AttributeKey` instances (one locale-agnostic + a lazy `Locale`-keyed map); 8 hot sites rewired |
| 5 | `AttributeKey.compareTo` inlines the `ComparatorUtils.compareLocale` semantics instead of allocating a capturing `IntSupplier` per comparison |
| 6 | `isIndexedInScope` single lookup; `getUniquenessType` null-check; `EntitySchema.getAttributeOrNull` for `updateAttributes` |

## Safety

- **No on-disk format change, no `serialVersionUID` bump.** Schema DTOs are written by hand-written
  serializers that enumerate fields explicitly and are versioned through `SerialVersionBasedSerializer`,
  so the derived cache fields are invisible to persistence.
- **Sharing `AttributeKey` instances is behaviour-neutral.** Verified: no `IdentityHashMap` and no `==`
  anywhere keys on `AttributeKey`, and Kryo runs with `setReferences(false)` (`KryoFactory:120`), so the
  serialized graph of the WAL-bound mutations is unchanged.
- **The hoisted derived facts keep their original guards.** `indexedForEntityComponent` is computed only
  under `indexedForFiltering`, `faceted` only under `indexedForEntityComponent` — because
  `ReflectedReferenceSchema.isFacetedInScope` asserts on reflected-reference availability and must not
  start firing where the old control flow never called it.
- Both cache fields on `AttributeSchema` are `@EqualsAndHashCode.Exclude`; without that the lazily
  populated map would make two otherwise-equal schemas compare unequal depending on which locales had
  been touched.

## Verification

- `AttributeKeyTest` (new, 7 tests) pins the full `AttributeKey` ordering contract — all four
  null/non-null locale combinations, locale-string ordering, the tie-break onto the attribute name, and
  an exhaustive cross-check of every (locale, name) pair against `ComparatorUtils.compareLocale`. It was
  written and **run green against the previous implementation first**, so it pins the historical
  semantics rather than the rewrite's.
- `evita_engine` and all upstream modules compile clean.
- Full `evita_functional_tests` suite: **still running locally at the time this PR was opened.** CI is
  the authority here; I will confirm once it reports.

## Not done, deliberately

- **No performance number is claimed.** The Senesi WARM_UP re-run named in the issue's verification
  section has not been executed — it is a multi-hour two-process job in a separate worktree. The
  percentages above are the measured cost of the *previous* code, from the profile that motivated the
  issue; the expected wins are argued from reading each site.
- **Part 3's target is not actually on the write path.** `ReferenceSchema.getIndexedInScopes()` has no
  caller in `io.evitadb.index.mutation` — its only non-test callers are `ClassSchemaAnalyzer` and
  schema-mutation code. It is memoized as the issue asked, but it is a tidy-up, not a win. Recorded in
  the ADR so the next reader does not repeat the audit.
- **Two `AttributeKey` sites left alone** — `ReferenceIndexMutator.readReferenceAttributeValue` and
  `ContainerizedLocalMutationExecutor.readReferencedEntityAttribute`. Both are keyed by a bare attribute
  *name* from a histogram descriptor pointing at a **referenced entity's** attribute, so the owning
  schema is not in hand and may live in another collection.
- **The two `*AttributeAndCompoundSchemaProvider` classes** still resolve through the `Optional`
  accessors; narrowing their contract-typed fields to the DTOs would mean widening ~10
  `ReferenceSchemaContract` parameters through `ReferenceIndexMutator`.
- **Out of scope per the issue, recorded with reasons in the ADR:** reference-name canonicalization
  (needs a design exploration and a measured ceiling) and `ComparableReferenceKey` removal (load-bearing
  for the non-uniform internal-PK mechanism, inseparable from #1392).
- `specifications/write-path-optimizations/` lives on `dev`, not on this release branch, so the plan
  folder cannot be retired here.
