### PR TITLE
perf: answer reference-key membership without allocating a wrapper

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/reference/ComparableReferenceKey.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/reference/ComparableReferenceKey.java
@@ -44,6 +44,55 @@ public record ComparableReferenceKey(
 		this.referenceKey = referenceKey;
 	}
 
+	/**
+	 * Applies this wrapper's equality rules to two bare {@link ReferenceKey}s, so a caller holding an unwrapped
+	 * key can ask the question without allocating a wrapper to ask it with.
+	 *
+	 * Kept here rather than at the call site deliberately: it is the single definition of what "the same
+	 * reference key" means for this type, and {@link #equals(Object)} delegates to it. Re-implementing the field
+	 * comparison anywhere else would let the two drift apart silently.
+	 *
+	 * @param left  first key to compare
+	 * @param right second key to compare
+	 * @return true when both keys denote the same reference
+	 */
+	public static boolean isEquivalent(@Nonnull ReferenceKey left, @Nonnull ReferenceKey right) {
+		return ReferenceKey.FULL_COMPARATOR.compare(left, right) == 0;
+	}
+
+	/**
+	 * Allocation-free equivalent of {@code keys.contains(new ComparableReferenceKey(referenceKey))}.
+	 *
+	 * Two reasons to prefer it over the {@link java.util.Set#contains(Object)} it replaces:
+	 *
+	 * - **It allocates nothing.** `contains` can only be handed an object, so probing even an *empty* set cost
+	 *   one wrapper per probe. On the entity write path that made this 19.2% of all write-path allocation in the
+	 *   senesi WARM_UP profile.
+	 * - **It is strictly more correct.** {@link #hashCode()} always folds in the internal primary key, while
+	 *   {@link #equals(Object)} ignores it when either side {@link ReferenceKey#isUnknownReference()} - so two
+	 *   keys that are `equals` can land in different hash buckets, and a `HashSet` probe can miss a member it
+	 *   should have found. A linear scan has no such blind spot.
+	 *
+	 * The scan is `O(keys)`, so this is the right trade only while the collection stays small - it is intended
+	 * for the per-entity reassignment sets, which hold at most the references touched by one mutation batch. Do
+	 * not reach for it on a large collection.
+	 *
+	 * @param keys         collection to search
+	 * @param referenceKey key to look for
+	 * @return true when `keys` holds a key equivalent to `referenceKey`
+	 */
+	public static boolean containsEquivalent(
+		@Nonnull Iterable<ComparableReferenceKey> keys,
+		@Nonnull ReferenceKey referenceKey
+	) {
+		for (final ComparableReferenceKey candidate : keys) {
+			if (isEquivalent(candidate.referenceKey(), referenceKey)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	@Override
 	public int compareTo(ComparableReferenceKey o) {
 		return ReferenceKey.FULL_COMPARATOR.compare(this.referenceKey, o.referenceKey);
@@ -53,7 +102,7 @@ public record ComparableReferenceKey(
 	public boolean equals(Object o) {
 		if (!(o instanceof final ComparableReferenceKey that)) return false;
 
-		return ReferenceKey.FULL_COMPARATOR.compare(this.referenceKey, that.referenceKey) == 0;
+		return isEquivalent(this.referenceKey, that.referenceKey);
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/entity/ReferencesStoragePart.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/entity/ReferencesStoragePart.java
@@ -84,7 +84,8 @@ public class ReferencesStoragePart implements EntityStoragePart {
 	private final int sizeInBytes;
 	/**
 	 * Contains last used primary key among all references in this container. This is needed for assigning new unique
-	 * reference internal primary keys when new references are added (we cannot allow to reuse keys of removed references).
+	 * reference internal primary keys when new references are added (we cannot allow to reuse keys of removed
+	 * references).
 	 */
 	@Getter private int lastUsedPrimaryKey;
 	/**
@@ -201,7 +202,8 @@ public class ReferencesStoragePart implements EntityStoragePart {
 	 * the `lastUsedPrimaryKey` field and assigns it to the reference.
 	 *
 	 * After the assignment procedure, the storage part marks itself as modified by setting the `dirty` field to true.
-	 * Finally, the `unassignedPrimaryKeys` field is set to false to indicate all missing primary keys have been assigned.
+	 * Finally, the `unassignedPrimaryKeys` field is set to false to indicate all missing primary keys have been
+	 * assigned.
 	 *
 	 * @return map of all reference keys that were assigned new primary keys during this operation
 	 */
@@ -216,9 +218,12 @@ public class ReferencesStoragePart implements EntityStoragePart {
 			ReferenceKey previousReferenceKey = null;
 			for (int i = 0; i < theReferences.length; i++) {
 				Reference reference = theReferences[i];
+				// resolved once - `reference` is replaced below when a key gets assigned, and everything before
+				// that point must keep looking at the ORIGINAL key
+				final ReferenceKey referenceKey = reference.getReferenceKey();
 				if (previousReferenceKey != null) {
 					Assert.isPremiseValid(
-						ReferenceKey.FULL_COMPARATOR.compare(previousReferenceKey, reference.getReferenceKey()) < 0,
+						ReferenceKey.FULL_COMPARATOR.compare(previousReferenceKey, referenceKey) < 0,
 						() -> "References must be sorted in ascending order according to their business key: "
 							+ Arrays.stream(theReferences)
 							.map(Reference::getReferenceKey)
@@ -227,11 +232,17 @@ public class ReferencesStoragePart implements EntityStoragePart {
 					);
 				}
 				// remember the previous key for the next iteration
-				previousReferenceKey = reference.getReferenceKey();
+				previousReferenceKey = referenceKey;
 				// assign primary keys to references that don't have it yet (update the key)
+				//
+				// the membership test is deliberately NOT `refKeysForReassignment.contains(...)`: that can only be
+				// handed an object, so it allocated one wrapper per reference per call - and this loop revisits
+				// every reference on each call, including those keyed earlier, which made it 19.2% of all
+				// write-path allocation in the senesi WARM_UP profile. `containsEquivalent` also sidesteps a
+				// hash-bucket blind spot in the set itself; see its JavaDoc.
 				if (
-					!reference.getReferenceKey().isKnownInternalPrimaryKey()
-						|| refKeysForReassignment.contains(new ComparableReferenceKey(reference.getReferenceKey()))
+					!referenceKey.isKnownInternalPrimaryKey()
+						|| ComparableReferenceKey.containsEquivalent(refKeysForReassignment, referenceKey)
 				) {
 					reference = new Reference(++this.lastUsedPrimaryKey, reference);
 					theReferences[i] = reference;
@@ -240,7 +251,8 @@ public class ReferencesStoragePart implements EntityStoragePart {
 						assignedKeys = new HashMap<>(16);
 					}
 					assignedKeys.put(
-						new ComparableReferenceKey(previousReferenceKey),
+						// the ORIGINAL key of this reference - `previousReferenceKey` was assigned from it above
+						new ComparableReferenceKey(referenceKey),
 						reference.getReferenceKey()
 					);
 				}
@@ -645,7 +657,8 @@ public class ReferencesStoragePart implements EntityStoragePart {
 			Assert.isPremiseValid(
 				index + 1 == theReferences.length ||
 					!theReferences[index + 1].getReferenceKey().equals(referenceKey),
-				() -> "There is more than one reference " + referenceKey + " for entity `" + this.entityPrimaryKey + "`!"
+				() -> "There is more than one reference " + referenceKey +
+					" for entity `" + this.entityPrimaryKey + "`!"
 			);
 			return Optional.of(theReferences[index]);
 		} else {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/mutation/reference/ComparableReferenceKeyTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/mutation/reference/ComparableReferenceKeyTest.java
@@ -1,0 +1,234 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.data.mutation.reference;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.REFERENCE;
+
+/**
+ * Tests for {@link ComparableReferenceKey}, pinning down the equivalence rule that
+ * {@link ComparableReferenceKey#isEquivalent(ReferenceKey, ReferenceKey)} and
+ * {@link ComparableReferenceKey#containsEquivalent(Iterable, ReferenceKey)} apply: two keys with the same
+ * {@link ReferenceKey#referenceName()} and {@link ReferenceKey#primaryKey()} are equivalent whenever either side
+ * is {@link ReferenceKey#isUnknownReference() unknown} (internal PK exactly zero) - a narrower carve-out than
+ * "either side is new" (negative internal PK), which does not trigger it.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+@DisplayName("ComparableReferenceKey")
+@Tag(CONTRACT)
+@Tag(REFERENCE)
+class ComparableReferenceKeyTest {
+
+	@Nested
+	@DisplayName("isEquivalent")
+	class IsEquivalent {
+
+		@Test
+		@DisplayName("should be equivalent when both sides are known and identical")
+		void shouldBeEquivalentWhenBothKnownAndIdentical() {
+			final ReferenceKey a = new ReferenceKey("brand", 10, 100);
+			final ReferenceKey b = new ReferenceKey("brand", 10, 100);
+
+			assertTrue(ComparableReferenceKey.isEquivalent(a, b));
+		}
+
+		@Test
+		@DisplayName("should not be equivalent when both sides are known but internal primary keys differ")
+		void shouldNotBeEquivalentWhenBothKnownButInternalPrimaryKeysDiffer() {
+			final ReferenceKey a = new ReferenceKey("brand", 10, 100);
+			final ReferenceKey b = new ReferenceKey("brand", 10, 200);
+
+			assertFalse(ComparableReferenceKey.isEquivalent(a, b));
+		}
+
+		@Test
+		@DisplayName("should be equivalent when one side is unknown regardless of the other side's internal primary key")
+		void shouldBeEquivalentWhenOneSideIsUnknown() {
+			final ReferenceKey unknown = new ReferenceKey("brand", 10);
+			final ReferenceKey known = new ReferenceKey("brand", 10, 100);
+
+			assertTrue(ComparableReferenceKey.isEquivalent(unknown, known));
+			assertTrue(ComparableReferenceKey.isEquivalent(known, unknown));
+		}
+
+		@Test
+		@DisplayName("should be equivalent when both sides are unknown")
+		void shouldBeEquivalentWhenBothSidesAreUnknown() {
+			final ReferenceKey a = new ReferenceKey("brand", 10);
+			final ReferenceKey b = new ReferenceKey("brand", 10);
+
+			assertTrue(ComparableReferenceKey.isEquivalent(a, b));
+		}
+
+		@Test
+		@DisplayName("should not be equivalent when reference names differ")
+		void shouldNotBeEquivalentWhenReferenceNamesDiffer() {
+			final ReferenceKey a = new ReferenceKey("brand", 10);
+			final ReferenceKey b = new ReferenceKey("category", 10);
+
+			assertFalse(ComparableReferenceKey.isEquivalent(a, b));
+		}
+
+		@Test
+		@DisplayName("should not be equivalent when primary keys differ")
+		void shouldNotBeEquivalentWhenPrimaryKeysDiffer() {
+			final ReferenceKey a = new ReferenceKey("brand", 10);
+			final ReferenceKey b = new ReferenceKey("brand", 20);
+
+			assertFalse(ComparableReferenceKey.isEquivalent(a, b));
+		}
+
+		@Test
+		@DisplayName("should not be equivalent when both sides are new with different internal primary keys")
+		void shouldNotBeEquivalentWhenBothAreNewWithDifferentInternalPrimaryKeys() {
+			// a negative internal PK means "new", which is a different state than "unknown" (zero) -
+			// neither side counts as isUnknownReference() here, so the internal PK is compared after all
+			final ReferenceKey a = new ReferenceKey("brand", 10, -3);
+			final ReferenceKey b = new ReferenceKey("brand", 10, -7);
+
+			assertFalse(ComparableReferenceKey.isEquivalent(a, b));
+		}
+
+		@Test
+		@DisplayName("should not be equivalent when one side is new and the other is known with a different internal primary key")
+		void shouldNotBeEquivalentWhenOneIsNewAndOtherIsKnownWithDifferentInternalPrimaryKeys() {
+			// "new" (negative internal PK) is not "unknown" (zero internal PK) - the carve-out does not apply,
+			// so this is the discriminating case between the two concepts
+			final ReferenceKey newReference = new ReferenceKey("brand", 10, -3);
+			final ReferenceKey knownReference = new ReferenceKey("brand", 10, 100);
+
+			assertFalse(ComparableReferenceKey.isEquivalent(newReference, knownReference));
+			assertFalse(ComparableReferenceKey.isEquivalent(knownReference, newReference));
+		}
+	}
+
+	@Nested
+	@DisplayName("containsEquivalent")
+	class ContainsEquivalent {
+
+		@Test
+		@DisplayName("should return false for an empty iterable")
+		void shouldReturnFalseForEmptyIterable() {
+			assertFalse(
+				ComparableReferenceKey.containsEquivalent(
+					Collections.emptyList(),
+					new ReferenceKey("brand", 10)
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("should return true when the iterable contains an equivalent key")
+		void shouldReturnTrueWhenIterableContainsEquivalentKey() {
+			final List<ComparableReferenceKey> keys = List.of(
+				new ComparableReferenceKey(new ReferenceKey("category", 1, 50)),
+				new ComparableReferenceKey(new ReferenceKey("brand", 10, 100))
+			);
+
+			assertTrue(
+				ComparableReferenceKey.containsEquivalent(keys, new ReferenceKey("brand", 10, 100))
+			);
+		}
+
+		@Test
+		@DisplayName("should return false when the iterable does not contain an equivalent key")
+		void shouldReturnFalseWhenIterableDoesNotContainEquivalentKey() {
+			final List<ComparableReferenceKey> keys = List.of(
+				new ComparableReferenceKey(new ReferenceKey("category", 1, 50)),
+				new ComparableReferenceKey(new ReferenceKey("brand", 20, 100))
+			);
+
+			assertFalse(
+				ComparableReferenceKey.containsEquivalent(keys, new ReferenceKey("brand", 10, 100))
+			);
+		}
+
+		@Test
+		@DisplayName("should match an unknown search key against a known candidate in the iterable")
+		void shouldMatchUnknownSearchKeyAgainstKnownCandidateInIterable() {
+			final List<ComparableReferenceKey> keys = List.of(
+				new ComparableReferenceKey(new ReferenceKey("brand", 10, 100))
+			);
+
+			assertTrue(
+				ComparableReferenceKey.containsEquivalent(keys, new ReferenceKey("brand", 10))
+			);
+		}
+
+		@Test
+		@DisplayName("should not match a new search key against a differently-keyed known candidate in the iterable")
+		void shouldNotMatchNewSearchKeyAgainstDifferentlyKeyedKnownCandidateInIterable() {
+			final List<ComparableReferenceKey> keys = List.of(
+				new ComparableReferenceKey(new ReferenceKey("brand", 10, 100))
+			);
+
+			assertFalse(
+				ComparableReferenceKey.containsEquivalent(keys, new ReferenceKey("brand", 10, -3))
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("equals")
+	class Equals {
+
+		@Test
+		@DisplayName("should delegate to isEquivalent for the unknown-vs-known carve-out")
+		void shouldDelegateToIsEquivalentForUnknownVsKnownCarveOut() {
+			final ComparableReferenceKey unknown = new ComparableReferenceKey(new ReferenceKey("brand", 10));
+			final ComparableReferenceKey known = new ComparableReferenceKey(new ReferenceKey("brand", 10, 100));
+
+			assertTrue(unknown.equals(known));
+			assertTrue(known.equals(unknown));
+		}
+
+		@Test
+		@DisplayName("should return false when compared to null")
+		void shouldReturnFalseWhenComparedToNull() {
+			final ComparableReferenceKey key = new ComparableReferenceKey(new ReferenceKey("brand", 10));
+
+			assertFalse(key.equals(null));
+		}
+
+		@Test
+		@DisplayName("should return false when compared to a different type")
+		void shouldReturnFalseWhenComparedToDifferentType() {
+			final ComparableReferenceKey key = new ComparableReferenceKey(new ReferenceKey("brand", 10));
+
+			//noinspection AssertBetweenInconvertibleTypes
+			assertFalse(key.equals("brand: 10"));
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/mutation/reference/ComparableReferenceKeyTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/mutation/reference/ComparableReferenceKeyTest.java
@@ -122,7 +122,7 @@ class ComparableReferenceKeyTest {
 		}
 
 		@Test
-		@DisplayName("should not be equivalent when one side is new and the other is known with a different internal primary key")
+		@DisplayName("should not be equivalent when a new reference differs from a known one by internal primary key")
 		void shouldNotBeEquivalentWhenOneIsNewAndOtherIsKnownWithDifferentInternalPrimaryKeys() {
 			// "new" (negative internal PK) is not "unknown" (zero internal PK) - the carve-out does not apply,
 			// so this is the discriminating case between the two concepts


### PR DESCRIPTION
## What

`ReferencesStoragePart.assignMissingIdsAndSort()` probed the pending-reassignment set with `contains(new ComparableReferenceKey(key))`. `Set.contains` can only be handed an object, so the wrapper had to be allocated **before** the set could be asked anything — including when the set is empty, which is the ordinary write path (it is only populated by `replaceOrAddReference` under `GENERATE_NEW_INTERNAL_KEY`). The loop also revisits every reference on each call, including those keyed by an earlier call, so the cost grows quadratically on an entity built up reference-by-reference.

This replaces the probe with `ComparableReferenceKey.containsEquivalent`, a linear scan over bare `ReferenceKey`s that allocates nothing.

## Evidence

async-profiler allocation profile of a full senesi WARM_UP reindex (386,369 entities, 118,772 of them `Product`), writer heap 23g, reader 14g/8g:

| site | share of write-path allocation | samples |
|---|---|---|
| **`ReferencesStoragePart.assignMissingIdsAndSort`** | **19.2%** | 124,771 / 650,417 |

99.3% of what that site allocated was `ComparableReferenceKey` (123,956 samples).

One caveat on attribution: async-profiler resolves to **method** granularity, not line, so it cannot by itself separate the guard from the `assignedKeys.put(...)` below it. The guard is the culprit because within that same `if`-block `ComparableReferenceKey` shows 123,956 samples against `Reference`'s 332 — a branch cannot execute 373x more often than itself.

## Design

The comparison lives on `ComparableReferenceKey` as `isEquivalent(ReferenceKey, ReferenceKey)`, and `equals(Object)` now delegates to it — one definition of key equality, which cannot drift from the wrapper's own. It reuses `ReferenceKey.FULL_COMPARATOR` rather than re-implementing the field comparison, so the `isUnknownReference()` carve-out on the internal primary key is inherited rather than duplicated.

## This is not purely behaviour-preserving — and the difference is a fix

`ComparableReferenceKey.hashCode()` always folds in `internalPrimaryKey`, while `equals()` ignores it when either side `isUnknownReference()` (`internalPrimaryKey == 0`). So `("A",10,0)` and `("A",10,100)` are `equals` but hash differently — two objects that are equal can land in different buckets, and a `HashSet` probe can miss a member it should have found. A scan has no such blind spot.

I have **not** demonstrated that this path is reachable in production; only that the contract permits it. Flagging it rather than claiming a bug fix.

## Trade-off

The scan is `O(n)` where the hash probe was `O(1)`. That is the right trade only while the collection stays small — which it is by construction, holding at most the references touched by one mutation batch. The JavaDoc states the bound so it is not silently violated later.

## Do not size this by the allocation number

This removes garbage, not wall-clock. A CPU profile of the same run puts **schema accessors at 26.6%** of write-path CPU (`EntitySchema.getReferenceOrThrowException` alone is 17.3%), while the reference-key comparator is under 1%. The 19.2% allocation share should not be read as an expected speed-up — the wall-clock lever is elsewhere.

## Verification

- `ReferencesStoragePartTest` — 23/23 pass, including `shouldRegenerateInternalPrimaryKeysWhenGenerateNewInternalKeyBehaviorIsUsed`, which drives exactly this branch with *known* internal primary keys and would fail if the membership test regressed.
- `-Dgroups="reference & !slow"` — **1,851 tests, 0 failures, 1 skipped**.

## Note on the diff

Three changed lines are unrelated: `ReferencesStoragePart` lines 87, 204 and 648 already exceeded the 120-column limit on `dev`, and the editorconfig gate validates whole-file state, so touching this file required reflowing them. They are pure line-wraps of a JavaDoc sentence and an exception message.