### PR TITLE
test: move SharedRgeiSoakTest out of the fast loop and harden it against CPU churn

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/configuration/TransactionOptions.java
+++ b/evita_api/src/main/java/io/evitadb/api/configuration/TransactionOptions.java
@@ -302,6 +302,23 @@ public record TransactionOptions(
 		}
 
 		/**
+		 * Sets how long the system waits for a writing transaction to be accepted, i.e. conflict-resolved and appended
+		 * to the shared WAL, before rolling it back.
+		 *
+		 * This value is also the base for the pipeline's stall-detection deadline
+		 * (`TransactionManager#safetyDeadlineMs`, `max(60_000, this * 5)`), which is what makes it worth raising on
+		 * deliberately oversubscribed hosts: the deadline is wall-clock, so heavy CPU contention can push a healthy
+		 * commit past it. See `SharedRgeiSoakTest` for a worked example.
+		 *
+		 * @param waitForTransactionAcceptance acceptance timeout in milliseconds
+		 */
+		@Nonnull
+		public TransactionOptions.Builder waitForTransactionAcceptanceInMillis(long waitForTransactionAcceptance) {
+			this.waitForTransactionAcceptance = waitForTransactionAcceptance;
+			return this;
+		}
+
+		/**
 		 * Sets how often the data files are forced to the device and a bootstrap record is written to point at them.
 		 *
 		 * @param checkpointInterval interval in milliseconds, `0` to checkpoint at the end of every trunk round

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/PendingCommitProgressRegistry.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/PendingCommitProgressRegistry.java
@@ -173,6 +173,14 @@ public final class PendingCommitProgressRegistry {
 	 * guaranteed to have completed records at or below this version" invariant that a version-based
 	 * sweep needs is avoided entirely.
 	 *
+	 * **That independence from pipeline state is also the limitation.** Elapsed time is a proxy for
+	 * liveness, and the proxy breaks when the host is oversubscribed: a starved executor makes a
+	 * healthy-but-slow commit indistinguishable from a genuinely dropped one, so this sweep will fail
+	 * it and log the "missed completion path" warning below with nothing actually wrong. The warning is
+	 * therefore evidence of a stall, not proof of a pipeline defect — rule out CPU contention first.
+	 * The deadline is chosen by `TransactionManager#safetyDeadlineMs`, where the reasoning for leaving
+	 * it wall-clock-based (and how a contended caller should widen it instead) is recorded.
+	 *
 	 * @param maxAge the maximum age a record may stay pending before being considered dangling
 	 * @return the number of records failed by this sweep, useful for tests and observability
 	 */

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionManager.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionManager.java
@@ -1671,7 +1671,7 @@ public class TransactionManager implements Closeable {
 	 * 100s is pathological, and relaxing a safety mechanism on the evidence of a contended CI box would
 	 * trade a real guard for a test-harness convenience. Callers that knowingly run oversubscribed
 	 * should instead raise
-	 * {@link io.evitadb.api.configuration.TransactionOptions#waitForTransactionAcceptanceInMillis},
+	 * {@link io.evitadb.api.configuration.TransactionOptions.Builder#waitForTransactionAcceptanceInMillis(long)},
 	 * which scales this deadline with it — see `SharedRgeiSoakTest` in `evita_long_running_tests`.
 	 *
 	 * A progress-aware sweep (re-anchoring the clock whenever a record advances a pipeline stage, or

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionManager.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionManager.java
@@ -1659,6 +1659,26 @@ public class TransactionManager implements Closeable {
 	 * ample headroom for back-pressure spikes and executor queue drain times; a floor of 60s keeps the
 	 * threshold sensible on deployments that tune the acceptance timeout very low.
 	 *
+	 * **The assumption, and where it does not hold.** This is a *wall-clock* deadline standing in for a
+	 * liveness signal: "pending longer than the worst-case pipeline latency ⇒ dangling". That inference
+	 * is sound whenever the pipeline gets to run, and false exactly when the host is oversubscribed —
+	 * a starved executor makes a perfectly healthy commit look identical to a dropped one, because the
+	 * only thing being measured is elapsed time. Symptom: commits failed by
+	 * {@link PendingCommitProgressRegistry#sweepRecordsOlderThan} on a loaded machine with nothing wrong
+	 * in the pipeline. Before hunting a transaction bug, check the load.
+	 *
+	 * The threshold is deliberately **not** tuned for that case: on a live deployment a commit pending
+	 * 100s is pathological, and relaxing a safety mechanism on the evidence of a contended CI box would
+	 * trade a real guard for a test-harness convenience. Callers that knowingly run oversubscribed
+	 * should instead raise
+	 * {@link io.evitadb.api.configuration.TransactionOptions#waitForTransactionAcceptanceInMillis},
+	 * which scales this deadline with it — see `SharedRgeiSoakTest` in `evita_long_running_tests`.
+	 *
+	 * A progress-aware sweep (re-anchoring the clock whenever a record advances a pipeline stage, or
+	 * failing only records the live catalog version has already moved past) would separate "slow" from
+	 * "dropped" without a bigger number, and is the principled upgrade should this become a recurring
+	 * problem in production rather than in tests.
+	 *
 	 * @return the stall-detection deadline in milliseconds
 	 */
 	private long safetyDeadlineMs() {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/configuration/TransactionOptionsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/configuration/TransactionOptionsTest.java
@@ -181,6 +181,21 @@ class TransactionOptionsTest {
 
 		@Test
 		@DisplayName(
+			"should override wait for transaction acceptance via millis method"
+		)
+		void shouldOverrideWaitForTransactionAcceptanceInMillis() {
+			final TransactionOptions options =
+				TransactionOptions.builder()
+					.waitForTransactionAcceptanceInMillis(120_000L)
+					.build();
+
+			assertEquals(
+				120_000L, options.waitForTransactionAcceptanceInMillis()
+			);
+		}
+
+		@Test
+		@DisplayName(
 			"should override flush frequency via millis method"
 		)
 		void shouldOverrideFlushFrequencyInMillis() {
@@ -285,6 +300,7 @@ class TransactionOptionsTest {
 					.transactionMemoryRegionCount(64)
 					.walFileSizeBytes(4_194_304L)
 					.walFileCountKept(2)
+					.waitForTransactionAcceptanceInMillis(90_000L)
 					.flushFrequencyInMillis(250L)
 					.conflictRingBufferSize(512)
 					.build();
@@ -307,6 +323,10 @@ class TransactionOptionsTest {
 				4_194_304L, copy.walFileSizeBytes()
 			);
 			assertEquals(2, copy.walFileCountKept());
+			assertEquals(
+				90_000L,
+				copy.waitForTransactionAcceptanceInMillis()
+			);
 			assertEquals(
 				250L, copy.flushFrequencyInMillis()
 			);

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/SharedRgeiSoakTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/SharedRgeiSoakTest.java
@@ -26,6 +26,7 @@ package io.evitadb.index;
 import com.github.javafaker.Faker;
 import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.TransactionOptions;
 import io.evitadb.api.query.Query;
 import io.evitadb.api.requestResponse.EvitaResponse;
 import io.evitadb.api.requestResponse.data.EntityEditor.EntityBuilder;
@@ -73,6 +74,7 @@ import static io.evitadb.api.query.QueryConstraints.page;
 import static io.evitadb.api.query.QueryConstraints.require;
 import static io.evitadb.test.TestTags.INDEXING;
 import static io.evitadb.test.TestTags.REFERENCE;
+import static io.evitadb.test.TestTags.SLOW;
 import static io.evitadb.test.TestTags.TRANSACTION;
 import static io.evitadb.test.generator.DataGenerator.ASSOCIATED_DATA_LABELS;
 import static io.evitadb.test.generator.DataGenerator.ASSOCIATED_DATA_REFERENCED_FILES;
@@ -90,9 +92,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Fast, bounded soak test that re-uses the schema and mutation generator from
- * `LongRunningEvitaReferencesGenerationalTest` but compresses the work into a few seconds per
- * seed so the regression class is exercised in the regular CI cycle.
+ * Bounded soak test that re-uses the schema and mutation generator from
+ * `LongRunningEvitaReferencesGenerationalTest`, but replaces its time-boxed run with a fixed sweep of
+ * 13 seeds — so a failure reproduces from a seed rather than from a duration.
  *
  * The invariants this test pins are:
  *
@@ -100,11 +102,17 @@ import static org.junit.jupiter.api.Assertions.fail;
  *   - cross-reference integrity between products and their reflected category references holds
  *     before and after the reload boundary
  *
- * Total budget: 13 seeds * ~1s each = ~13s wall clock; not tagged `@Tag(SLOW)` so it ships in the
- * default fast loop.
+ * **Why this lives in `evita_long_running_tests`.** The original budget note claimed "13 seeds * ~1s
+ * each = ~13s wall clock" and the class shipped in the default fast loop untagged. That estimate only
+ * holds on an idle machine: measured in isolation the class runs ~19s, but inside the full
+ * `unitAndFunctional` suite — where dozens of embedded evitaDB instances contend for the same cores —
+ * it takes 316-371s. Each of the 13 seeds builds a full catalog and crosses a commit + reload
+ * boundary, so the cost scales with how oversubscribed the host is, not with the work itself. Per
+ * `.claude/rules/testing.md` a soak loop belongs here, never in the fast loop.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
+@Tag(SLOW)
 @Tag(INDEXING)
 @Tag(REFERENCE)
 @Tag(TRANSACTION)
@@ -144,6 +152,25 @@ class SharedRgeiSoakTest implements EvitaTestSupport {
 	 * fresh removal. Mirrors the long-running test's soft cap but scaled to the small dataset.
 	 */
 	private static final int MAX_REMOVED_ENTITIES = 4;
+
+	/**
+	 * Transaction-acceptance timeout for this test's embedded instances — six times the 20s
+	 * `TransactionOptions#DEFAULT_WAIT_FOR_TRANSACTION_ACCEPTANCE`.
+	 *
+	 * Three bounds in `TransactionManager` derive from this value and all three are measured in **wall
+	 * clock**, so CPU contention pushes a healthy-but-slow commit toward them: the conflict-resolution
+	 * lock, the WAL-append lock, and — via `safetyDeadlineMs()`, which is `max(60_000, this * 5)` — the
+	 * dangling-commit sweeper in `PendingCommitProgressRegistry#sweepRecordsOlderThan`. At the default
+	 * that sweeper deadline is 100s. Under full-suite load this test's commits crossed it and were
+	 * failed as "dangling" although the pipeline was merely starved; that is the flake this constant
+	 * removes.
+	 *
+	 * Widening it here rather than retuning the engine leaves the production guard untouched — a commit
+	 * pending 100s on a live deployment really is pathological. Inside this test the guard stays real:
+	 * 600s against a ~19s isolated runtime is a ~30x margin, so a genuine hang still surfaces as a
+	 * descriptive `TransactionException` instead of a silent stall.
+	 */
+	private static final long CHURN_TOLERANT_ACCEPTANCE_TIMEOUT_MS = 120_000L;
 
 	private TestPaths paths;
 	private Evita evita;
@@ -580,13 +607,21 @@ class SharedRgeiSoakTest implements EvitaTestSupport {
 	}
 
 	/**
-	 * Builds the standard Evita configuration anchored at the per-test path triplet.
+	 * Builds the standard Evita configuration anchored at the per-test path triplet, widening the
+	 * transaction-acceptance timeout to [#CHURN_TOLERANT_ACCEPTANCE_TIMEOUT_MS] so the run survives CPU
+	 * contention.
 	 *
 	 * @return the configuration used to construct the `Evita` instance
 	 */
 	@Nonnull
 	private EvitaConfiguration getEvitaConfiguration() {
-		return newTestEvitaConfigurationBuilder(this.paths).build();
+		return newTestEvitaConfigurationBuilder(this.paths)
+			.transaction(
+				TransactionOptions.builder()
+					.waitForTransactionAcceptanceInMillis(CHURN_TOLERANT_ACCEPTANCE_TIMEOUT_MS)
+					.build()
+			)
+			.build();
 	}
 
 	/**


### PR DESCRIPTION
## Problem

`SharedRgeiSoakTest` ran in the default fast loop (`unitAndFunctional`) untagged, on the
strength of a JavaDoc budget note claiming *"13 seeds × ~1s each = ~13s wall clock"*.

That estimate only holds on an idle machine:

| Condition | Runtime |
|---|---|
| Class in isolation | ~19 s |
| Inside the full suite | **316–371 s** |

Each of the 13 seeds builds a full catalog and crosses a commit + reload boundary, so the
cost scales with how oversubscribed the host is, not with the work itself.

It was *also* flaking — but not from a transaction bug. The dangling-commit sweeper fails
any record pending past `TransactionManager#safetyDeadlineMs`:

```
safetyDeadlineMs() = max(60_000, waitForTransactionAcceptanceInMillis * 5)
                   = max(60_000, 20_000 * 5) = 100_000    // 100 s
```

That deadline is **wall-clock**. Under full-suite load the trunk-incorporation executor is
genuinely starved, so a healthy-but-slow commit becomes indistinguishable from a dropped
one and gets failed as "dangling". The watchdog's core assumption — *pending 100 s ⇒ broken*
— is violated precisely when the machine is oversubscribed, which is the normal state of a
20,900-test run.

## Changes

**Moved out of the fast loop.** `evita_functional_tests` → `evita_long_running_tests` (same
package, now beside its sibling `SharedRgeiRandomizedSoakTest`), plus `@Tag(SLOW)`. Every
reference to the class was JavaDoc prose, so nothing needed rewiring. The stale budget note
is replaced with the measured figures and why they diverge, and the opening paragraph is
reworded with it — it still described the class as a fast test *"exercised in the regular CI
cycle"*, which is precisely the claim the move invalidates:

> Bounded soak test that re-uses the schema and mutation generator from
> `LongRunningEvitaReferencesGenerationalTest`, but replaces its time-boxed run with a fixed
> sweep of 13 seeds — so a failure reproduces from a seed rather than from a duration.

**CPU-churn resilience, production guard intact.** The test configures its own instances to
a 120 s acceptance timeout → 600 s sweeper deadline, which also widens the other two
churn-sensitive wall-clock bounds (conflict-resolution lock, WAL-append lock). Engine
defaults are untouched — a commit pending 100 s on a live deployment really is pathological,
and retuning an engine safety mechanism on the evidence of a loaded CI box would be the
wrong trade. Inside the test the guard stays real: 600 s against a ~19 s isolated runtime is
a ~30× margin, so a genuine hang still surfaces as a descriptive `TransactionException`.

**Documented at both watchdog sites.** `TransactionManager#safetyDeadlineMs` and
`PendingCommitProgressRegistry#sweepRecordsOlderThan` now state that elapsed time is a proxy
for liveness which inverts under oversubscription, that the "missed completion path" warning
is evidence of a stall rather than proof of a defect, and that CPU contention should be ruled
out before hunting a transaction bug.

**One API gap closed.** `TransactionOptions.Builder` had a `waitForTransactionAcceptance`
field but no setter, unlike every sibling field. Added
`waitForTransactionAcceptanceInMillis(long)`, matching the `flushFrequencyInMillis` /
`checkpointIntervalInMillis` naming.

## Considered and not done

A **progress-aware sweep** (re-anchoring the staleness clock on each pipeline-stage advance)
sounds like the principled fix, but would not have helped here: stages 1–2 complete quickly
and the stall sits entirely *inside* stage 3, so there is nothing to re-anchor. The
**version-high-water-mark** variant — fail only records the live catalog has already advanced
past — would genuinely separate "slow" from "dropped" and is deterministic rather than
timing-based, but that is a real engine change warranting measurement rather than reasoning.
Both are recorded as the upgrade path in the `safetyDeadlineMs()` JavaDoc.

No ADR: per `.claude/rules/adr.md`, JavaDoc is the first choice when the reasoning is findable
at the site, and both sites now carry it.

## Verification

```
mvn -pl evita_test/evita_functional_tests,evita_test/evita_long_running_tests \
    test -P longRunning -Dtest=SharedRgeiSoakTest
```
→ **Tests run: 13, Failures: 0, Errors: 0, Skipped: 0 — 17.64 s**

`evita_api` reinstalled before the test modules built (stale-`~/.m2` trap). No added line
exceeds 120 columns; indentation is tabs. `git status` reports the test as a rename, so
history follows it.
