### PR TITLE
fix: keep LocalDateTime as the declared attribute type through the write path (2026.2)

### DIFF
--- a/documentation/adr/2026-08-05-schema-handling-write-path-optimizations.md
+++ b/documentation/adr/2026-08-05-schema-handling-write-path-optimizations.md
@@ -1,7 +1,7 @@
 ---
 title: Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation
 date: 2026-08-05
-updated: 2026-08-05 16:20
+updated: 2026-08-10 08:45
 status: accepted
 kind: optimization
 issues: [1390]
@@ -9,7 +9,7 @@ prs: [1395]
 areas: [evita_api/requestResponse/schema/dto, evita_api/requestResponse/data, evita_engine/index/mutation]
 supersedes: []
 superseded-by: []
-relates: [2026-07-27-write-path-performance-tuning, 2026-08-01-bplustree-cursor-free-insert-path]
+relates: [2026-07-27-write-path-performance-tuning, 2026-08-01-bplustree-cursor-free-insert-path, 2026-08-10-stored-value-normalization-split]
 ---
 
 # Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation
@@ -204,6 +204,9 @@ B remains the larger prize and should be sequenced after its exploration produce
   spent the collation-cache and trunk-merge levers, this one spends the schema-handling lever.
 - `2026-08-01-bplustree-cursor-free-insert-path` — the other allocation-removal record from the same
   round of Senesi profiling, on the index side rather than the schema side.
+- `2026-08-10-stored-value-normalization-split` — same attribute-mutation write path; that record
+  constrains what a mutation may do to the value itself, where this one speeds up how the schema
+  around it is resolved.
 
 ## Timeline
 

--- a/documentation/adr/2026-08-10-stored-value-normalization-split.md
+++ b/documentation/adr/2026-08-10-stored-value-normalization-split.md
@@ -5,7 +5,7 @@ updated: 2026-08-10 10:05
 status: accepted
 kind: fix
 issues: [1403]
-prs: []
+prs: [1404, 1405]
 areas: [evita_common/src/main/java/io/evitadb/dataType, evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute, evita_engine/src/main/java/io/evitadb/index/attribute, evita_engine/src/main/java/io/evitadb/index/bPlusTree]
 supersedes: []
 superseded-by: []

--- a/documentation/adr/2026-08-10-stored-value-normalization-split.md
+++ b/documentation/adr/2026-08-10-stored-value-normalization-split.md
@@ -149,6 +149,9 @@ the one most likely to be re-proposed and is the one to read this record for.
 - `FilterIndexTest.TemporalNormalization` pins the encoding itself: UTC instant, idempotence, order preservation, and
   `LocalDate`/`LocalTime` passing through untouched. `InstantValueColumnTest` pins the column selection on both sides —
   `LocalDateTime` → `InstantValueColumn`, `LocalDate`/`LocalTime` → `LongValueColumn`.
+- `FilterIndexLegacyLocalDateTimeSerializerTest` — round-trips a 2026.1-shaped part through the legacy serializer
+  and rehydrates it exactly as `AttributeIndexLoader` does. The rehydration case fails with `ClassCastException`
+  without the re-anchoring, which is what makes it a real guard rather than a restatement.
 - `EvitaDataTypesTest` — the pre-existing "Conversion to supported type" suite (8 tests, including
   `shouldConvertLocalDateTimeToOffsetDateTime`) still passes unchanged, pinning the query-path contract as deliberately
   retained; new "Conversion to supported stored type" suite adds 6.
@@ -185,14 +188,28 @@ the one most likely to be re-proposed and is the one to read this record for.
   using the evitaDB server system default timezone" — wrong on both counts — and now states only that `LocalDateTime`
   is a first-class attribute type whose wall clock round-trips. The adjacent `<LS to="c">` block still carries the old
   claim for the C# driver and was left alone; nobody verified what that driver actually does.
-- No migration is needed, and the persisted-index question was checked rather than assumed. Bucket keys are stored
-  **already normalized** (`InvertedIndex` applies the normalizer in `addRecord`, and `AttributeIndexLoader` feeds
-  `part.getHistogramPoints()` into the tree verbatim), so changing a normalizer is in principle an on-disk format
-  change for that attribute type. It is not one here: `ValueColumnFactory` and `InstantValueColumn` arrived in
-  `15dc1acee` (2026-06-17), contained only in `v2026.2.x` — the whole primitive-column format postdates 2026.1 — and
-  within 2026.2 no catalog can hold un-normalized `LocalDateTime` bucket keys, because a declared `LocalDateTime`
-  attribute could not be written at all and an auto-evolved one became `OffsetDateTime`. Any future change to
-  `getNormalizer` for a type that *has* been persisted needs a BWC reader; this one does not.
+- **A 2026.1 catalog does need its `LocalDateTime` filter indexes migrated** — an earlier revision of this record
+  claimed the opposite, having checked only that no *2026.2* catalog could hold such keys. Bucket keys are persisted
+  **already normalized** (`InvertedIndex` applies the normalizer in `addRecord`; `AttributeIndexLoader` feeds
+  `part.getHistogramPoints()` into the tree verbatim), so changing a normalizer *is* an on-disk format change for that
+  attribute type. 2026.1 had no `LocalDateTime` branch and persisted raw wall-clock values, while the current tree
+  picks `InstantValueColumn` for that declared type and hard-casts — so loading such a catalog died with
+  `ClassCastException`. `FilterIndexStoragePartSerializer_2026_1` (registered for the 2026.1 `FilterIndexStoragePart`
+  uid in `IndexStoragePartConfigurer`) now re-anchors those values at UTC on read. It is self-healing: the next write
+  persists `Instant` keys through the current serializer, after which the legacy reader is never consulted again.
+- `Migration_2026_2` already re-keys `String` (NFD) and `BigDecimal` (scaled-int) filter parts eagerly at upgrade
+  time, which is the same class of problem. `LocalDateTime` is handled in the BWC *reader* instead, deliberately: the
+  reader covers every read path unconditionally — including any part a migration sweep does not visit — and it is
+  self-healing, whereas the eager route would have to enumerate parts for a type far rarer than `String`. The two
+  compose: a part re-keyed by the migration is read through this same reader first, so it is already anchored.
+- Other index kinds were checked and are **not** affected. Unique indexes select their leaf column through the same
+  `ValueColumnFactory.forKey` and keep raw values, which looks like the same trap, but a `unique` `OffsetDateTime` and
+  a `unique` `LocalDateTime` attribute each write 200 distinct values end-to-end without error — so the reading was
+  wrong and the empirical result governs. `HistogramIndex` is 2026.2-only (no `_2026_1` reader) and `SortIndex` does
+  not use `ValueColumnFactory` at all.
+- **Invariant for the next person:** any future change to `FilterIndex.getNormalizer` for a type that has already been
+  persisted is an on-disk format change, and needs a matching conversion in the BWC reader for the format that wrote
+  it. The normalizer is not merely a runtime detail.
 - 2026.2 was still in testing when this surfaced, so no catalog in the wild carries an attribute auto-evolved to
   `OffsetDateTime` by the defect. Should a test catalog have one, its schema and index remain internally consistent —
   only the declared type is wrong, and re-evolving it is enough.

--- a/documentation/adr/2026-08-10-stored-value-normalization-split.md
+++ b/documentation/adr/2026-08-10-stored-value-normalization-split.md
@@ -169,6 +169,13 @@ the one most likely to be re-proposed and is the one to read this record for.
   of a reference plus three objects (`LocalDateTime` holds a `LocalDate` and a `LocalTime`), and no boxing on lookup
   hot paths. That is a structural estimate from the field layouts, **not a measurement** — nobody has run a heap
   comparison. Only `filterable`/`sortable` attributes are affected, since only those are indexed.
+- The declared type now wins in **both** directions: a bare `LocalDateTime` written to an attribute declared
+  `OffsetDateTime` is rejected with `InvalidMutationException` rather than silently coerced to UTC. That is a
+  restoration, not a new rule — `v2026.1.19` rejected it too (all four `UpsertAttributeMutation` constructors
+  assigned the value verbatim); only the broken 2026.2 accepted it, by rewriting before the check. A client relying
+  on that coercion must convert explicitly, and should prefer `atZone(zone).toOffsetDateTime()` over
+  `atOffset(UTC)` unless it really means a UTC wall clock. Covered by
+  `LocalTemporalAttributeTypeFidelityFunctionalTest#shouldRejectLocalDateTimeValueForOffsetDateTimeAttribute`.
 - `attributeHistogram` still rejects any non-numeric attribute (`AttributeHistogramTranslator` asserts
   `Number.class.isAssignableFrom(...)`), so no temporal type — `OffsetDateTime` included — can produce one. Unchanged
   here, and the reason there is no histogram coverage for `LocalDateTime`.

--- a/documentation/adr/2026-08-10-stored-value-normalization-split.md
+++ b/documentation/adr/2026-08-10-stored-value-normalization-split.md
@@ -1,0 +1,204 @@
+---
+title: LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer
+date: 2026-08-10
+updated: 2026-08-10 10:05
+status: accepted
+kind: fix
+issues: [1403]
+prs: []
+areas: [evita_common/src/main/java/io/evitadb/dataType, evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute, evita_engine/src/main/java/io/evitadb/index/attribute, evita_engine/src/main/java/io/evitadb/index/bPlusTree]
+supersedes: []
+superseded-by: []
+relates: [2026-08-05-schema-handling-write-path-optimizations]
+---
+
+# `LocalDateTime` keeps its declared type end to end; the UTC anchoring that makes it cheap to index moves into `FilterIndex.getNormalizer`
+
+An attribute declared as `LocalDateTime` could not be written at all in 2026.2 — the value was rewritten to an
+`OffsetDateTime` inside the mutation constructor, above the layer that validates it against the schema. The rewrite
+itself was worth keeping, but as an *index encoding*, not as a change of the public type. It now lives in
+`FilterIndex.getNormalizer`, which is where the codebase already performs exactly this remap for `OffsetDateTime`.
+`LocalDateTime` is a first-class schema type again — declared or auto-evolved — while the index still stores it as a
+packed `Instant`.
+
+## Why
+
+A production full reindex failed on every entity carrying a `LocalDateTime` attribute:
+
+```
+InvalidMutationException: Invalid type: `class java.time.OffsetDateTime`! Attribute
+`initialPublishedDate` in schema `Product` was already stored as type class java.time.LocalDateTime.
+```
+
+The attribute comes from a client interface getter returning `LocalDateTime`, so `ClassSchemaAnalyzer` registers that
+type verbatim — and then no value could ever satisfy it. The quieter half of the same defect: when the attribute was
+*not* declared, `AttributeSchemaEvolvingMutation` derives the type from `getAttributeValue().getClass()`, so a
+`LocalDateTime` value silently produced an `OffsetDateTime` attribute definition. No exception, and a schema that no
+longer matches the interface it was generated from.
+
+### Previous state
+
+Until 2026.2 the four `UpsertAttributeMutation` constructors assigned `this.value = value` verbatim. Commit
+`016d93255` (2026-03-27, conditional bucket indexing) changed all four to
+`EvitaDataTypes.toSupportedTypeOrItsArray(value)`. The motivation was sound — `Float`/`Double` must normalize to
+`BigDecimal` or histogram bucket keys disagree with the stored value. `toSupportedType` also rewrites `LocalDateTime`
+to `OffsetDateTime` at UTC (a branch present since the 2023 initial commit, on a method whose own JavaDoc says it is
+"used at query entry points"), and that rewrite rode along into the write path.
+
+## Options considered
+
+### Option A — split the normalizer, and encode in the index (chosen)
+
+Two independent moves. **(1)** `UpsertAttributeMutation` calls a new `toSupportedStoredTypeOrItsArray`, which performs
+every other normalization (`Float`/`Double` → `BigDecimal`, non-`@SupportedEnum` → `String` name, rejection of
+unsupported types) but leaves `LocalDateTime` alone, so the schema records what the client declared. **(2)** the UTC
+anchoring moves to `FilterIndex.getNormalizer` + `ValueColumnFactory.normalizedTypeOf`, so the index stores an
+`Instant` and the tree selects the packed `InstantValueColumn`.
+
+- **Pros:** the two concerns are separated and named — public type vs. index encoding. The encoding lands on the one
+  seam every consumer already reads (all four filter translators, `HistogramIndex`, `AttributeIndexLoader`,
+  `AttributeIndex`, `OwnerFilterIndex`, and `SortIndexView` via `shared.getNormalizer()`), so it is two lines rather
+  than a boundary threaded through storage and reads.
+- **Cons:** two public normalizer entry points that differ in one branch; and `getNormalizer` must stay in lockstep
+  with `normalizedTypeOf` in a different package.
+
+### Option B — delete the `LocalDateTime` branch from `toSupportedType` outright (declined)
+
+One line. `SUPPORTED_QUERY_DATA_TYPES` contains `LocalDateTime`, so a method whose job is "unsupported → supported"
+arguably must not rewrite it. Both gates that could have blocked this are clear: EvitaQL has a literal form for a bare
+`LocalDateTime`, and the gRPC wire path encodes at `DEFAULT_ZONE_OFFSET`, which *is* `ZoneOffset.UTC`.
+
+- **Pros:** removes the contract inconsistency at its root; no second entry point.
+- **Cons:** changes behaviour for every caller, not just the broken one.
+- **Rejected because:** on the query path the rewrite is **inert** — every attribute constraint coerces its value to
+  the declared type via `toTargetType`, and both directions preserve the wall clock (`atOffset(UTC)` out,
+  `toLocalDateTime()` back) — so deleting it fixes nothing there. What it *would* change is the other caller,
+  `ComplexDataObjectConverter`: associated-data map keys would start being written as `LocalDateTime` where existing
+  catalogs hold `OffsetDateTime`, a persistence-format change bought for no behavioural gain. It becomes the better
+  option once `ComplexDataObjectConverter` no longer relies on `toSupportedType` for key normalization.
+
+### Option C — anchor at the server's default time zone instead of UTC (declined)
+
+The original design instinct: resolve the offset dynamically so that changing the server time zone moves stored local
+times with it.
+
+- **Pros:** feels responsive to deployment configuration; superficially "more correct" than a hardcoded UTC.
+- **Rejected because:** a region zone is not a constant offset, which breaks three properties UTC gives for free.
+  **(i)** The mapping stops being a bijection — `02:30` does not exist on a spring-forward day and occurs twice on
+  fall-back, so `atZone` silently picks one. **(ii)** Round-trip stops being idempotent: write, change the zone, read
+  back, get a different wall clock; rows written either side of the change are interpreted under different rules with
+  nothing on disk recording which. **(iii)** Decisively for evitaDB: the normalized value is **persisted in the filter
+  and sort indexes**, so a config change would silently invalidate every index built on those attributes, with no
+  detection and no migration — and across a DST boundary local ordering and instant ordering genuinely differ, so
+  `attributeNatural` could return a different order depending on when the index was built. Oracle is the empirical
+  precedent: it refuses to change the database time zone once `TIMESTAMP WITH LOCAL TIME ZONE` columns hold data
+  (ORA-30079). It would only become viable if the offset were transmitted per session, like PostgreSQL's `timestamptz`
+  — a client-supplied zone, not a server-global one.
+
+### Option D — encode at the mutation or storage boundary (declined)
+
+Keep the conversion near where 2026.2 put it, but derive the schema type from the original value and decode on read.
+
+- **Pros:** the physical `AttributeValue` payload itself would hold the encoded form.
+- **Rejected because:** it reintroduces exactly the coupling that caused this bug — an encoding above the schema check
+  — and it is strictly more work: `AttributesStoragePart.upsertAttribute` and `AttributeIndexMutator` both align the
+  value to `attributeDefinition.getType()` via `toTargetType`, so with the schema saying `LocalDateTime` they would
+  coerce straight back and both would need to learn the encoding, plus a decode on the read path.
+
+## Decision
+
+**Chosen: Option A.** The encoding instinct behind the original code was right — `LocalDateTime` really is the one
+temporal type that indexes badly (see below) — it was simply installed one layer too high, which turned an internal
+representation choice into a change of the public type. Putting it in `getNormalizer` gets the identical physical
+representation while the schema, the mutation and the client boundary all keep speaking `LocalDateTime`. Option C is
+the one most likely to be re-proposed and is the one to read this record for.
+
+## Key technical details
+
+- **Invariant:** a value on its way into storage must never be rewritten away from the data type its attribute schema
+  declares. `AttributeSchemaEvolvingMutation` compares with `attributeSchema.getType().isInstance(attributeValue)` —
+  strict type identity, not convertibility — and derives the schema type from the value's class when auto-evolving, so
+  any normalization applied above it silently becomes schema policy.
+- **Lockstep:** `FilterIndex.getNormalizer` and `ValueColumnFactory.normalizedTypeOf` must agree on which declared
+  types normalize to `Instant`. They live in different packages; `InstantValueColumnTest` pins the pairing.
+- The anchoring is `LocalDateTime.toInstant(ZoneOffset.UTC)`. A **constant** offset makes it a lossless bijection and
+  monotonic with `LocalDateTime`'s natural order, so bucket lookup and ordered iteration are unchanged. The normalizer
+  is idempotent, like its siblings — probes are normalized more than once along a lookup path.
+- The encoding is invisible to clients: the value handed back comes from `AttributesStoragePart`, not from the index.
+- **`LocalDate` and `LocalTime` are deliberately left out of the temporal branch.** Each fits losslessly in a single
+  `long` (`toEpochDay` / `toNanoOfDay`) and already has a `LongKeyCodec`, so they select the 8-byte `LongValueColumn`.
+  Routing them through `Instant` would be a *downgrade* to 12 bytes plus an all-but-unused `int[]`. Do not "fix" this
+  for symmetry.
+- `SortIndex.createNormalizerFor` needs no change: it normalizes only `String`/`Locale`/`Currency`/`BigDecimal` and
+  never handled `OffsetDateTime` either. Sort-side temporal folding happens only in view mode, which adopts the shared
+  inverted index's normalizer.
+
+## Verification
+
+- `LocalTemporalAttributeTypeFidelityFunctionalTest` — written first, against the unfixed build: **5 of the 11 methods
+  then in the class failed, and all five were `LocalDateTime`**. The declared-schema case reproduced the production
+  `InvalidMutationException` verbatim; the auto-evolution case failed with `expected: <java.time.LocalDateTime> but was:
+  <java.time.OffsetDateTime>`. `LocalDate` and `LocalTime` passed before *and* after — confirming-negatives pinning the
+  defect to one branch rather than to local temporal types as a family. A counterfactual run (fix reverted, class
+  otherwise unchanged) re-confirmed the whole class fails without it.
+- Read-back assertions compare against the exact value written, not merely "no exception" — a fix that stopped the
+  throw while leaving a wall-clock-shifting conversion in place would still fail. `attributeNatural`,
+  `attributeEquals`, `attributeBetween`, `attributeGreaterThanEquals` and `attributeLessThan` are asserted per type,
+  covering every translator that reads `getNormalizer`. The localized case is covered separately, since it takes the
+  third `UpsertAttributeMutation` constructor and the `isLocalized` branch of schema verification.
+- `FilterIndexTest.TemporalNormalization` pins the encoding itself: UTC instant, idempotence, order preservation, and
+  `LocalDate`/`LocalTime` passing through untouched. `InstantValueColumnTest` pins the column selection on both sides —
+  `LocalDateTime` → `InstantValueColumn`, `LocalDate`/`LocalTime` → `LongValueColumn`.
+- `EvitaDataTypesTest` — the pre-existing "Conversion to supported type" suite (8 tests, including
+  `shouldConvertLocalDateTimeToOffsetDateTime`) still passes unchanged, pinning the query-path contract as deliberately
+  retained; new "Conversion to supported stored type" suite adds 6.
+- JDWP session against the unfixed build, breaking at `UpsertAttributeMutation:58` and
+  `AttributeSchemaEvolvingMutation:118`:
+
+  ```
+  value.getClass().getName()                           = "java.time.LocalDateTime"   (2026-05-20T12:19:26)
+  this.value.getClass().getName()                      = "java.time.OffsetDateTime"  (2026-05-20T12:19:26Z)
+  attributeSchema.getType().getName()                  = "java.time.LocalDateTime"
+  attributeValue.getClass().getName()                  = "java.time.OffsetDateTime"
+  attributeSchema.getType().isInstance(attributeValue) = false
+  ```
+
+## Consequences & open follow-ups
+
+- Indexed `LocalDateTime` attributes move off `BoxedObjectColumn` onto `InstantValueColumn`: ~12 bytes per key instead
+  of a reference plus three objects (`LocalDateTime` holds a `LocalDate` and a `LocalTime`), and no boxing on lookup
+  hot paths. That is a structural estimate from the field layouts, **not a measurement** — nobody has run a heap
+  comparison. Only `filterable`/`sortable` attributes are affected, since only those are indexed.
+- `attributeHistogram` still rejects any non-numeric attribute (`AttributeHistogramTranslator` asserts
+  `Number.class.isAssignableFrom(...)`), so no temporal type — `OffsetDateTime` included — can produce one. Unchanged
+  here, and the reason there is no histogram coverage for `LocalDateTime`.
+- The UTC anchoring is **not** documented for users: it is an internal encoding with no observable effect, and
+  documenting it would only invite people to reason about a representation they never see.
+  `documentation/user/en/use/data-types.md` previously claimed local date times are "always converted to OffsetDateTime
+  using the evitaDB server system default timezone" — wrong on both counts — and now states only that `LocalDateTime`
+  is a first-class attribute type whose wall clock round-trips. The adjacent `<LS to="c">` block still carries the old
+  claim for the C# driver and was left alone; nobody verified what that driver actually does.
+- No migration is needed, and the persisted-index question was checked rather than assumed. Bucket keys are stored
+  **already normalized** (`InvertedIndex` applies the normalizer in `addRecord`, and `AttributeIndexLoader` feeds
+  `part.getHistogramPoints()` into the tree verbatim), so changing a normalizer is in principle an on-disk format
+  change for that attribute type. It is not one here: `ValueColumnFactory` and `InstantValueColumn` arrived in
+  `15dc1acee` (2026-06-17), contained only in `v2026.2.x` — the whole primitive-column format postdates 2026.1 — and
+  within 2026.2 no catalog can hold un-normalized `LocalDateTime` bucket keys, because a declared `LocalDateTime`
+  attribute could not be written at all and an auto-evolved one became `OffsetDateTime`. Any future change to
+  `getNormalizer` for a type that *has* been persisted needs a BWC reader; this one does not.
+- 2026.2 was still in testing when this surfaced, so no catalog in the wild carries an attribute auto-evolved to
+  `OffsetDateTime` by the defect. Should a test catalog have one, its schema and index remain internally consistent —
+  only the declared type is wrong, and re-evolving it is enough.
+
+## Related work
+
+- [2026-08-05-schema-handling-write-path-optimizations](2026-08-05-schema-handling-write-path-optimizations.md)
+  — same write path through attribute mutations; that record optimizes how schemas are resolved per mutation, this one
+  constrains what a mutation may do to the value on the way through.
+
+## Timeline
+
+- **2026-03-27** — `016d93255` applies the query-path normalizer in all four `UpsertAttributeMutation` constructors,
+  incidental to conditional bucket indexing
+- **2026-08-10** — regression reported from a production full reindex, reproduced, confirmed under JDWP, and fixed;
+  the UTC anchoring re-sited in the index normalizer after review

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403 |
+| 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |
 | 2026-08-04 | [Report HTTP/2 RST_STREAM floods instead of enforcing against them, and turn the Rapid-Reset defence off by default](2026-08-04-http2-connection-teardown-observability.md) | fix | accepted | #1369, PR #1383 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |
 | 2026-08-04 | [Report HTTP/2 RST_STREAM floods instead of enforcing against them, and turn the Rapid-Reset defence off by default](2026-08-04-http2-connection-teardown-observability.md) | fix | accepted | #1369, PR #1383 |

--- a/documentation/user/en/use/data-types.md
+++ b/documentation/user/en/use/data-types.md
@@ -248,13 +248,18 @@ parsing the number will use the correct data type that preserves the precision.
 ### Dates and times
 
 <LS to="j,e,g,r">
-Although evitaDB supports *local* variants of the date time like
-[LocalDateTime](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/LocalDateTime.html), it's always
-converted to [OffsetDateTime](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/OffsetDateTime.html)
-using the evitaDB server system default timezone. You can control the default Java timezone in
-[several ways](https://www.baeldung.com/java-jvm-time-zone). If your data is time zone specific, we recommend to work
-directly with the [OffsetDateTime](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/OffsetDateTime.html)
-on the client side and be explicit about the offset from the first day.
+The *local* variants of the date time — such as
+[LocalDateTime](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/LocalDateTime.html) — are
+first-class attribute data types. An attribute declared as `LocalDateTime` stores and returns exactly the wall-clock
+value you wrote, and the entity schema records `LocalDateTime` as its data type — whether you declared the attribute
+up front or let the schema evolve from the first value written.
+
+A local date time carries no offset, so it does not identify a moment in time on its own — two clients in different
+time zones reading the same value read the same wall clock, not the same instant. That is exactly what you want for
+wall-clock data such as opening hours or a recurring schedule. If your data *is* time zone specific, work directly
+with the
+[OffsetDateTime](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/OffsetDateTime.html) on the
+client side and be explicit about the offset from the first day.
 </LS>
 <LS to="c">
 Although evitaDB supports *local* variants of the date time like

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute/UpsertAttributeMutation.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute/UpsertAttributeMutation.java
@@ -55,7 +55,7 @@ public class UpsertAttributeMutation extends AttributeSchemaEvolvingMutation {
 			"Value for attribute `" + attributeKey + "` must not be null. " +
 				"Use `removeAttribute` mutation if you want to remove existing attribute."
 		);
-		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedTypeOrItsArray(value));
+		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedStoredTypeOrItsArray(value));
 	}
 
 	public UpsertAttributeMutation(@Nonnull String attributeName, @Nonnull Serializable value) {
@@ -64,7 +64,7 @@ public class UpsertAttributeMutation extends AttributeSchemaEvolvingMutation {
 			"Value for attribute `" + attributeName + "` must not be null. " +
 				"Use `removeAttribute` mutation if you want to remove existing attribute."
 		);
-		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedTypeOrItsArray(value));
+		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedStoredTypeOrItsArray(value));
 	}
 
 	public UpsertAttributeMutation(@Nonnull String attributeName, @Nonnull Locale locale, @Nonnull Serializable value) {
@@ -73,7 +73,7 @@ public class UpsertAttributeMutation extends AttributeSchemaEvolvingMutation {
 			"Value for attribute `" + attributeName + "` must not be null. " +
 				"Use `removeAttribute` mutation if you want to remove existing attribute."
 		);
-		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedTypeOrItsArray(value));
+		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedStoredTypeOrItsArray(value));
 	}
 
 	private UpsertAttributeMutation(@Nonnull AttributeKey attributeKey, @Nonnull Serializable value, long decisiveTimestamp) {
@@ -82,7 +82,7 @@ public class UpsertAttributeMutation extends AttributeSchemaEvolvingMutation {
 		               "Value for attribute `" + attributeKey + "` must not be null. " +
 			               "Use `removeAttribute` mutation if you want to remove existing attribute."
 		);
-		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedTypeOrItsArray(value));
+		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedStoredTypeOrItsArray(value));
 	}
 
 	@Override

--- a/evita_common/src/main/java/io/evitadb/dataType/EvitaDataTypes.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/EvitaDataTypes.java
@@ -1052,6 +1052,32 @@ public class EvitaDataTypes {
 	}
 
 	/**
+	 * Resolves the component type for an array rebuilt from normalized elements. The type is taken from the first
+	 * **non-null** normalized element, falling back to the source array's component type when every element is `null`.
+	 *
+	 * Deriving it from element zero alone is not enough: a leading `null` says nothing about what the remaining
+	 * elements normalized to, so `{null, 1.5f}` would rebuild as a `Float[]` and then throw on `Array.set` when the
+	 * normalized `BigDecimal` is stored into it. The same applies to a query-path `{null, LocalDateTime}` array, whose
+	 * non-null element normalizes to `OffsetDateTime`.
+	 *
+	 * @param normalizedElements  the already-normalized elements
+	 * @param sourceComponentType component type of the source array, used when every element is `null`
+	 * @return component type the rebuilt array must be created with
+	 */
+	@Nonnull
+	private static Class<?> normalizedComponentType(
+		@Nonnull Serializable[] normalizedElements,
+		@Nonnull Class<?> sourceComponentType
+	) {
+		for (int i = 0; i < normalizedElements.length; i++) {
+			if (normalizedElements[i] != null) {
+				return normalizedElements[i].getClass();
+			}
+		}
+		return sourceComponentType;
+	}
+
+	/**
 	 * Shared implementation of {@link #toSupportedTypeOrItsArray(Serializable)} and
 	 * {@link #toSupportedStoredTypeOrItsArray(Serializable)}.
 	 *
@@ -1088,9 +1114,9 @@ public class EvitaDataTypes {
 			}
 			if (changed) {
 				// create a properly typed array with the normalized component type
-				final Class<?> componentType = result[0] != null
-					? result[0].getClass()
-					: unknownObject.getClass().getComponentType();
+				final Class<?> componentType = normalizedComponentType(
+					result, unknownObject.getClass().getComponentType()
+				);
 				final Object typedArray = Array.newInstance(componentType, length);
 				for (int i = 0; i < length; i++) {
 					Array.set(typedArray, i, result[i]);

--- a/evita_common/src/main/java/io/evitadb/dataType/EvitaDataTypes.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/EvitaDataTypes.java
@@ -927,6 +927,12 @@ public class EvitaDataTypes {
 	 * query processing pipeline. Use {@link #toTargetType(Serializable, Class)} for explicit type
 	 * conversion.
 	 *
+	 * It must **not** be used to normalize a value on its way into storage: the `LocalDateTime`
+	 * rewrite above would strip an attribute of the very type its schema declares. Use
+	 * {@link #toSupportedStoredType(Serializable)} there. The rewrite is harmless on the query path
+	 * because every attribute constraint coerces its value to the attribute's declared type anyway
+	 * (`toTargetType`), and both directions of that coercion preserve the wall clock.
+	 *
 	 * @param unknownObject the value to validate and normalize
 	 * @return normalized value, or `null` if input is `null`
 	 * @throws UnsupportedDataTypeException if the type is not supported by evitaDB (includes Float
@@ -934,6 +940,50 @@ public class EvitaDataTypes {
 	 */
 	@Nullable
 	public static Serializable toSupportedType(@Nullable Serializable unknownObject) throws UnsupportedDataTypeException {
+		return toSupportedType(unknownObject, true);
+	}
+
+	/**
+	 * Validates and normalizes a value that is about to be **stored** in the database — an entity
+	 * attribute value carried by a mutation, as opposed to a value used in a query.
+	 *
+	 * The normalization is identical to {@link #toSupportedType(Serializable)} with one deliberate
+	 * exception: a `LocalDateTime` is passed through untouched instead of being rewritten to an
+	 * `OffsetDateTime` at UTC. `LocalDateTime` is itself one of the supported data types, so an
+	 * attribute *declared* as `LocalDateTime` has to be able to carry one. Rewriting the value in
+	 * the mutation constructor — before the schema is ever consulted — made such an attribute
+	 * impossible to write at all, and silently derived an `OffsetDateTime` attribute when the
+	 * schema was auto-evolved from the value instead of being declared up front.
+	 *
+	 * Query values deliberately keep the rewrite; see {@link #toSupportedType(Serializable)}.
+	 *
+	 * @param unknownObject the value to validate and normalize
+	 * @return normalized value, or `null` if input is `null`
+	 * @throws UnsupportedDataTypeException if the type is not supported by evitaDB
+	 */
+	@Nullable
+	public static Serializable toSupportedStoredType(
+		@Nullable Serializable unknownObject
+	) throws UnsupportedDataTypeException {
+		return toSupportedType(unknownObject, false);
+	}
+
+	/**
+	 * Shared implementation of {@link #toSupportedType(Serializable)} and
+	 * {@link #toSupportedStoredType(Serializable)}.
+	 *
+	 * @param unknownObject           the value to validate and normalize
+	 * @param coerceLocalDateTime     when `true`, `LocalDateTime` is rewritten to `OffsetDateTime`
+	 *                                at UTC; when `false` it is passed through as the supported
+	 *                                type it already is
+	 * @return normalized value, or `null` if input is `null`
+	 * @throws UnsupportedDataTypeException if the type is not supported by evitaDB
+	 */
+	@Nullable
+	private static Serializable toSupportedType(
+		@Nullable Serializable unknownObject,
+		boolean coerceLocalDateTime
+	) throws UnsupportedDataTypeException {
 		if (unknownObject == null) {
 			// nulls are allowed
 			return null;
@@ -949,8 +999,9 @@ public class EvitaDataTypes {
 			}
 			// normalize doubles to big decimal
 			return new BigDecimal(unknownObject.toString());
-		} else if (unknownObject instanceof LocalDateTime) {
-			// always convert local date time to zoned
+		} else if (coerceLocalDateTime && unknownObject instanceof LocalDateTime) {
+			// always convert local date time to zoned - on the query path only, a stored value must
+			// keep the type its attribute schema declares
 			return ((LocalDateTime) unknownObject).atOffset(ZoneOffset.UTC);
 		} else if (unknownObject.getClass().isEnum()) {
 			return unknownObject.getClass().isAnnotationPresent(SupportedEnum.class) ?
@@ -980,6 +1031,41 @@ public class EvitaDataTypes {
 	public static Serializable toSupportedTypeOrItsArray(
 		@Nullable Serializable unknownObject
 	) throws UnsupportedDataTypeException {
+		return toSupportedTypeOrItsArray(unknownObject, true);
+	}
+
+	/**
+	 * Scalar-or-array counterpart of {@link #toSupportedStoredType(Serializable)} — the entry point
+	 * used by attribute mutations, which must preserve the data type the attribute schema declares.
+	 * For scalar values delegates to {@link #toSupportedStoredType(Serializable)}; for arrays
+	 * normalizes each element individually and returns a new array if any element changed.
+	 *
+	 * @param unknownObject the value to validate and normalize (scalar or array, may be `null`)
+	 * @return normalized value, or `null` if input is `null`
+	 * @throws UnsupportedDataTypeException if the type (or array component type) is not supported
+	 */
+	@Nullable
+	public static Serializable toSupportedStoredTypeOrItsArray(
+		@Nullable Serializable unknownObject
+	) throws UnsupportedDataTypeException {
+		return toSupportedTypeOrItsArray(unknownObject, false);
+	}
+
+	/**
+	 * Shared implementation of {@link #toSupportedTypeOrItsArray(Serializable)} and
+	 * {@link #toSupportedStoredTypeOrItsArray(Serializable)}.
+	 *
+	 * @param unknownObject       the value to validate and normalize (scalar or array, may be `null`)
+	 * @param coerceLocalDateTime when `true`, `LocalDateTime` elements are rewritten to
+	 *                            `OffsetDateTime` at UTC; when `false` they are passed through
+	 * @return normalized value, or `null` if input is `null`
+	 * @throws UnsupportedDataTypeException if the type (or array component type) is not supported
+	 */
+	@Nullable
+	private static Serializable toSupportedTypeOrItsArray(
+		@Nullable Serializable unknownObject,
+		boolean coerceLocalDateTime
+	) throws UnsupportedDataTypeException {
 		if (unknownObject == null) {
 			return null;
 		} else if (unknownObject.getClass().isArray()) {
@@ -989,7 +1075,7 @@ public class EvitaDataTypes {
 			for (int i = 0; i < length; i++) {
 				final Object element = Array.get(unknownObject, i);
 				if (element instanceof Serializable s) {
-					final Serializable normalized = toSupportedType(s);
+					final Serializable normalized = toSupportedType(s, coerceLocalDateTime);
 					result[i] = normalized;
 					changed = changed || normalized != s;
 				} else if (element == null) {
@@ -1013,7 +1099,7 @@ public class EvitaDataTypes {
 			}
 			return unknownObject;
 		} else {
-			return toSupportedType(unknownObject);
+			return toSupportedType(unknownObject, coerceLocalDateTime);
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -67,7 +67,9 @@ import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.text.Normalizer;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Comparator;
@@ -221,8 +223,10 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 * Returns the appropriate normalizer function for particular attribute type and key.
 	 *
 	 * `BigDecimal` values are normalized to an order-preserving scaled `int` (respecting the schema's
-	 * `indexedDecimalPlaces`) so the value tree stores them in the compact `IntValueColumn`. The normalizer is
-	 * idempotent: an already-scaled `Integer` (and `null`) passes through unchanged, so a value may be normalized
+	 * `indexedDecimalPlaces`) so the value tree stores them in the compact `IntValueColumn`. Temporal values
+	 * (`OffsetDateTime` and `LocalDateTime`, the latter anchored at UTC) are normalized to an `Instant` so the tree
+	 * stores them in the parallel-array `InstantValueColumn` rather than boxing them. The normalizer is
+	 * idempotent: an already-normalized value (and `null`) passes through unchanged, so a value may be normalized
 	 * more than once on a probe→lookup path without a `ClassCastException`.
 	 *
 	 * @param attributeType        type of the attribute
@@ -238,6 +242,14 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 		if (OffsetDateTime.class.isAssignableFrom(attributeType)) {
 			return comparable -> comparable instanceof OffsetDateTime offsetDateTime
 				? offsetDateTime.toInstant()
+				: (Serializable) comparable;
+		} else if (LocalDateTime.class.isAssignableFrom(attributeType)) {
+			// a local date time has no offset of its own, so it is anchored at UTC - a *constant* offset, which makes
+			// the mapping a lossless bijection AND monotonic with `LocalDateTime`'s natural order, so bucket lookup and
+			// ordered iteration are unaffected. This is purely the index encoding: the schema keeps declaring
+			// `LocalDateTime`, and the value handed back to the client comes from `AttributesStoragePart`, not here
+			return comparable -> comparable instanceof LocalDateTime localDateTime
+				? localDateTime.toInstant(ZoneOffset.UTC)
 				: (Serializable) comparable;
 		} else if (Currency.class.isAssignableFrom(attributeType)) {
 			return comparable -> comparable instanceof Currency currency

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/InstantValueColumn.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/InstantValueColumn.java
@@ -34,8 +34,9 @@ import java.util.Comparator;
 /**
  * Primitive {@link ValueColumn} backed by **two** parallel arrays — a {@code long[]} of epoch-seconds and an
  * {@code int[]} of nanoseconds — for temporal attribute keys. The inverted-index normalizer converts every
- * {@code OffsetDateTime} attribute value to an {@link Instant} before it becomes a bucket key (see
- * {@code FilterIndex.getNormalizer}), so the tree stores {@code Instant} keys ordered by natural order.
+ * {@code OffsetDateTime} attribute value — and every {@code LocalDateTime} one, anchored at UTC — to an
+ * {@link Instant} before it becomes a bucket key (see {@code FilterIndex.getNormalizer}), so the tree stores
+ * {@code Instant} keys ordered by natural order.
  *
  * An {@link Instant} is exactly {@code epochSecond} (a {@code long}) plus {@code nano} (an {@code int} in
  * {@code [0, 999_999_999]}); decomposing it into the pair {@code (seconds, nanos)} is therefore a **lossless
@@ -49,7 +50,8 @@ import java.util.Comparator;
  * occurs and the two arrays can never drift apart (every mutation touches both, with identical indices/lengths).
  *
  * Selected only when the tree comparator is natural order and the normalized key type is {@link Instant} (i.e. the
- * declared attribute type is {@code OffsetDateTime} or {@code Instant}); see {@link ValueColumnFactory}. Otherwise the
+ * declared attribute type is {@code OffsetDateTime}, {@code Instant} or {@code LocalDateTime}); see
+ * {@link ValueColumnFactory}. Otherwise the
  * leaf keeps the universal {@link BoxedObjectColumn}.
  *
  * @param <M> the boxed key type as seen by the tree's generic API (always {@link Instant} at runtime)

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/ValueColumnFactory.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/ValueColumnFactory.java
@@ -118,13 +118,19 @@ public interface ValueColumnFactory<M extends Comparable<M>> {
 	}
 
 	/**
-	 * Maps a plain attribute type to the type actually stored as the tree key, mirroring the only normalization in
-	 * {@code FilterIndex.getNormalizer} that changes the stored class: {@link OffsetDateTime} is stored as its
-	 * {@link Instant}, and so is {@link LocalDateTime} (anchored at UTC — a constant offset, hence a lossless,
-	 * order-preserving mapping). All other types (numbers, {@code LocalDate} / {@code LocalTime}, {@code String},
-	 * {@code Currency}, {@code Locale}, …) keep their own class; `LocalDate` and `LocalTime` each fit losslessly in a
-	 * single {@code long} and are better served by the cheaper {@link LongValueColumn}. The single source of truth for
-	 * this remap lives here — it must stay in lockstep with `FilterIndex.getNormalizer`.
+	 * Maps a plain attribute type to the type actually stored as the tree key, mirroring the **temporal** key-class
+	 * remaps performed by {@code FilterIndex.getNormalizer}: {@link OffsetDateTime} is stored as its {@link Instant},
+	 * and so is {@link LocalDateTime} (anchored at UTC — a constant offset, hence a lossless, order-preserving
+	 * mapping). Those two must stay in lockstep with `FilterIndex.getNormalizer`, and this is their single source of
+	 * truth.
+	 *
+	 * The normalizer changes the stored class for other types too — {@code BigDecimal} to a scaled {@code Integer},
+	 * {@code Currency} / {@code Locale} to their comparable wrappers — but those are **not** remapped here:
+	 * {@code BigDecimal} is matched on its declared type directly in {@link #forKey} (which then selects
+	 * {@link IntValueColumn}), and the wrapper types fall through to the boxed column either way. Everything else
+	 * (numbers, {@code LocalDate} / {@code LocalTime}, {@code String}, …) keeps its own class; `LocalDate` and
+	 * `LocalTime` each fit losslessly in a single {@code long} and are better served by the cheaper
+	 * {@link LongValueColumn}.
 	 *
 	 * @param plainType the plain (non-array) declared attribute type
 	 * @return the normalized key type used by the tree

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/ValueColumnFactory.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/ValueColumnFactory.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Comparator;
 
@@ -65,8 +66,10 @@ public interface ValueColumnFactory<M extends Comparable<M>> {
 	 * byte-compare fast path" section.
 	 *
 	 * A primitive column is chosen only when the comparator is natural order. Temporal keys (normalized type
-	 * {@link Instant}, i.e. declared {@code OffsetDateTime} / {@code Instant}) select the parallel-array
-	 * {@link InstantValueColumn}; integral keys with a supported {@link LongKeyCodec} select {@link LongValueColumn}.
+	 * {@link Instant}, i.e. declared {@code OffsetDateTime} / {@code Instant} / {@code LocalDateTime}) select the
+	 * parallel-array {@link InstantValueColumn}; integral keys with a supported {@link LongKeyCodec} — which includes
+	 * {@code LocalDate} and {@code LocalTime}, each of which fits losslessly in a single {@code long} — select
+	 * {@link LongValueColumn}.
 	 * {@code BigDecimal} keys (normalized upstream to a scaled {@code int}) select the 4-byte {@link IntValueColumn}.
 	 * Otherwise the universal boxed {@link BoxedObjectColumn} (keyed by {@code Comparable.class}, the raw key type the
 	 * tree uses today) is returned, which is behavior-identical to the universal boxed leaf.
@@ -117,15 +120,18 @@ public interface ValueColumnFactory<M extends Comparable<M>> {
 	/**
 	 * Maps a plain attribute type to the type actually stored as the tree key, mirroring the only normalization in
 	 * {@code FilterIndex.getNormalizer} that changes the stored class: {@link OffsetDateTime} is stored as its
-	 * {@link Instant}. All other types (numbers, {@code LocalDate} / {@code LocalTime}, {@code String},
-	 * {@code Currency}, {@code Locale}, …) keep their own class. The single source of truth for this remap lives here.
+	 * {@link Instant}, and so is {@link LocalDateTime} (anchored at UTC — a constant offset, hence a lossless,
+	 * order-preserving mapping). All other types (numbers, {@code LocalDate} / {@code LocalTime}, {@code String},
+	 * {@code Currency}, {@code Locale}, …) keep their own class; `LocalDate` and `LocalTime` each fit losslessly in a
+	 * single {@code long} and are better served by the cheaper {@link LongValueColumn}. The single source of truth for
+	 * this remap lives here — it must stay in lockstep with `FilterIndex.getNormalizer`.
 	 *
 	 * @param plainType the plain (non-array) declared attribute type
 	 * @return the normalized key type used by the tree
 	 */
 	@Nonnull
 	private static Class<?> normalizedTypeOf(@Nonnull Class<?> plainType) {
-		if (OffsetDateTime.class.isAssignableFrom(plainType)) {
+		if (OffsetDateTime.class.isAssignableFrom(plainType) || LocalDateTime.class.isAssignableFrom(plainType)) {
 			return Instant.class;
 		}
 		return plainType;

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/FilterIndexStoragePartSerializer_2026_1.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/FilterIndexStoragePartSerializer_2026_1.java
@@ -35,6 +35,10 @@ import io.evitadb.spi.store.catalog.persistence.storageParts.index.FilterIndexSt
 import io.evitadb.utils.Assert;
 import lombok.RequiredArgsConstructor;
 
+import javax.annotation.Nonnull;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
 /**
  * Backward-compatible {@link Serializer} for the pre-freeze {@link FilterIndexStoragePart} format that did NOT persist
  * the `indexedDecimalPlaces` scale (the scale was re-derived from the schema at load). Reads such legacy blobs into a
@@ -82,7 +86,7 @@ public class FilterIndexStoragePartSerializer_2026_1 extends Serializer<FilterIn
 		final int pointCount = input.readInt();
 		final ValueToRecordBitmap[] points = new ValueToRecordBitmap[pointCount];
 		for (int i = 0; i < pointCount; i++) {
-			points[i] = kryo.readObject(input, ValueToRecordBitmap.class);
+			points[i] = anchorLegacyLocalDateTime(kryo.readObject(input, ValueToRecordBitmap.class));
 		}
 
 		final boolean hasRangeIndex = input.readBoolean();
@@ -92,6 +96,28 @@ public class FilterIndexStoragePartSerializer_2026_1 extends Serializer<FilterIn
 		} else {
 			return new FilterIndexStoragePart(entityIndexPrimaryKey, attributeKey, attributeType, points, null, uniquePartId);
 		}
+	}
+
+	/**
+	 * Re-anchors a legacy `LocalDateTime` bucket value at UTC so it lands in the `Instant` space the current
+	 * `FilterIndex.getNormalizer` keys `LocalDateTime` attributes with.
+	 *
+	 * `2026.1` had no `LocalDateTime` branch in its normalizer, so it persisted the raw wall-clock value; the current
+	 * tree picks {@code InstantValueColumn} for such an attribute and would fail with a `ClassCastException` while
+	 * rehydrating those buckets. Anchoring at UTC is exactly what the normalizer now does on the write path, and
+	 * because the offset is constant the mapping preserves the bucket ordering the reload path relies on.
+	 *
+	 * The conversion is self-healing: once the index is written again it is persisted through the current serializer
+	 * with `Instant` keys, and this legacy reader is no longer consulted for it.
+	 *
+	 * @param bucket bucket just read from a legacy blob
+	 * @return the bucket, with a `LocalDateTime` value replaced by its UTC instant
+	 */
+	@Nonnull
+	private static ValueToRecordBitmap anchorLegacyLocalDateTime(@Nonnull ValueToRecordBitmap bucket) {
+		return bucket.getValue() instanceof LocalDateTime localDateTime
+			? new ValueToRecordBitmap(localDateTime.toInstant(ZoneOffset.UTC), bucket.getRecordIds())
+			: bucket;
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/LocalTemporalAttributeTypeFidelityFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/LocalTemporalAttributeTypeFidelityFunctionalTest.java
@@ -27,6 +27,7 @@ import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.configuration.EvitaConfiguration;
 import io.evitadb.api.configuration.ServerOptions;
 import io.evitadb.api.query.FilterConstraint;
+import io.evitadb.api.exception.InvalidMutationException;
 import io.evitadb.api.requestResponse.EvitaResponse;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.api.requestResponse.data.SealedEntity;
@@ -46,6 +47,8 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -74,6 +77,7 @@ import static io.evitadb.test.TestTags.SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Regression coverage for the *local* temporal attribute types — `LocalDateTime`, `LocalDate` and
@@ -110,6 +114,7 @@ public class LocalTemporalAttributeTypeFidelityFunctionalTest implements EvitaTe
 	private static final String ATTR_LOCAL_DATE_TIME = "initialPublishedDate";
 	private static final String ATTR_LOCAL_DATE = "initialPublishedDay";
 	private static final String ATTR_LOCAL_TIME = "initialPublishedTime";
+	private static final String ATTR_OFFSET_DATE_TIME = "initialPublishedInstant";
 
 	/**
 	 * Wall-clock instants deliberately expressed in a zone whose offset is neither zero nor equal
@@ -486,6 +491,42 @@ public class LocalTemporalAttributeTypeFidelityFunctionalTest implements EvitaTe
 					final Serializable storedValue = product.getAttribute(ATTR_LOCAL_DATE_TIME, Locale.ENGLISH);
 					assertInstanceOf(LocalDateTime.class, storedValue);
 					assertEquals(FIRST_DATE_TIME, storedValue);
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("should reject a LocalDateTime value written to an OffsetDateTime attribute")
+		void shouldRejectLocalDateTimeValueForOffsetDateTimeAttribute() {
+			runWithCatalog(
+				"localTemporalDeclaredOffsetMismatch",
+				session -> {
+					session.defineEntitySchema(ENTITY_PRODUCT)
+						.withAttribute(
+							ATTR_OFFSET_DATE_TIME, OffsetDateTime.class,
+							whichIs -> whichIs.filterable().sortable().nullable()
+						)
+						.updateVia(session);
+
+					// the declared type wins in BOTH directions: a bare `LocalDateTime` is no longer silently
+					// coerced onto an `OffsetDateTime`-typed attribute. This is not new - `2026.1` rejected it
+					// too (all four `UpsertAttributeMutation` constructors assigned the value verbatim); only the
+					// broken `2026.2` accepted it, by rewriting the value before the schema check ran
+					assertThrows(
+						InvalidMutationException.class,
+						() -> session.createNewEntity(ENTITY_PRODUCT, 1)
+							.setAttribute(ATTR_OFFSET_DATE_TIME, FIRST_DATE_TIME)
+							.upsertVia(session)
+					);
+
+					// the attribute itself is perfectly writable with a value of its declared type
+					session.createNewEntity(ENTITY_PRODUCT, 2)
+						.setAttribute(ATTR_OFFSET_DATE_TIME, FIRST_DATE_TIME.atOffset(ZoneOffset.UTC))
+						.upsertVia(session);
+					assertEquals(
+						FIRST_DATE_TIME.atOffset(ZoneOffset.UTC),
+						fetchProduct(session, 2).getAttribute(ATTR_OFFSET_DATE_TIME)
+					);
 				}
 			);
 		}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/LocalTemporalAttributeTypeFidelityFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/LocalTemporalAttributeTypeFidelityFunctionalTest.java
@@ -1,0 +1,593 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.attribute;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.query.FilterConstraint;
+import io.evitadb.api.requestResponse.EvitaResponse;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.data.mutation.attribute.UpsertAttributeMutation;
+import io.evitadb.api.requestResponse.data.structure.EntityReference;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
+import io.evitadb.api.requestResponse.schema.SealedEntitySchema;
+import io.evitadb.core.Evita;
+import io.evitadb.test.EvitaTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.attributeBetween;
+import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
+import static io.evitadb.api.query.QueryConstraints.attributeEquals;
+import static io.evitadb.api.query.QueryConstraints.attributeGreaterThanEquals;
+import static io.evitadb.api.query.QueryConstraints.attributeLessThan;
+import static io.evitadb.api.query.QueryConstraints.attributeNatural;
+import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.dataInLocales;
+import static io.evitadb.api.query.QueryConstraints.entityFetchAllContent;
+import static io.evitadb.api.query.QueryConstraints.filterBy;
+import static io.evitadb.api.query.QueryConstraints.orderBy;
+import static io.evitadb.api.query.QueryConstraints.page;
+import static io.evitadb.api.query.QueryConstraints.require;
+import static io.evitadb.api.query.order.OrderDirection.ASC;
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.DATA_TYPE;
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.SCHEMA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Regression coverage for the *local* temporal attribute types — `LocalDateTime`, `LocalDate` and
+ * `LocalTime` — all three of which are listed by
+ * {@link io.evitadb.dataType.EvitaDataTypes#getSupportedDataTypes()} and are therefore expected to
+ * survive a write untouched, exactly as declared in the entity schema.
+ *
+ * The regression this class guards is specific to `LocalDateTime`: the value handed to
+ * `UpsertAttributeMutation` used to be rewritten to an `OffsetDateTime` before the schema was ever
+ * consulted, which made an attribute *declared* as `LocalDateTime` impossible to write —
+ * `AttributeSchemaEvolvingMutation` rejected the rewritten value against the declared type. The
+ * same rewrite silently derived an `OffsetDateTime` attribute when the schema was auto-evolved
+ * instead of declared, which is the quieter half of the same defect.
+ *
+ * `LocalDate` and `LocalTime` are covered alongside it as confirming negatives — they were never
+ * rewritten and are expected to pass both before and after the fix. Their passing is what pins the
+ * defect to the single `LocalDateTime` branch rather than to local temporal types as a family.
+ *
+ * Every end-to-end assertion reads the value back and compares it to the *exact* instance written.
+ * That is deliberate: an assertion that merely expected "no exception" would also pass a fix that
+ * kept a wall-clock-shifting conversion in the write path, which on a `sortable` attribute would
+ * silently reorder listings rather than fail.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Local temporal attribute types keep their declared type through the write path")
+@Tag(ENGINE)
+@Tag(ATTRIBUTE)
+@Tag(DATA_TYPE)
+@Tag(SCHEMA)
+public class LocalTemporalAttributeTypeFidelityFunctionalTest implements EvitaTestSupport {
+
+	private static final String ENTITY_PRODUCT = "product";
+	private static final String ATTR_LOCAL_DATE_TIME = "initialPublishedDate";
+	private static final String ATTR_LOCAL_DATE = "initialPublishedDay";
+	private static final String ATTR_LOCAL_TIME = "initialPublishedTime";
+
+	/**
+	 * Wall-clock instants deliberately expressed in a zone whose offset is neither zero nor equal
+	 * to the JVM default in CI, so that any implicit offset coercion on the write path shows up as
+	 * a changed value rather than an accidentally-matching one.
+	 */
+	private static final LocalDateTime FIRST_DATE_TIME = LocalDateTime.of(2026, 5, 20, 12, 19, 26);
+	private static final LocalDateTime SECOND_DATE_TIME = LocalDateTime.of(2026, 5, 20, 14, 19, 26);
+	private static final LocalDateTime THIRD_DATE_TIME = LocalDateTime.of(2026, 5, 21, 8, 5, 0);
+	private static final LocalDate FIRST_DATE = LocalDate.of(2026, 5, 20);
+	private static final LocalDate SECOND_DATE = LocalDate.of(2026, 5, 21);
+	private static final LocalDate THIRD_DATE = LocalDate.of(2026, 5, 22);
+	private static final LocalTime FIRST_TIME = LocalTime.of(12, 19, 26);
+	private static final LocalTime SECOND_TIME = LocalTime.of(14, 19, 26);
+	private static final LocalTime THIRD_TIME = LocalTime.of(18, 5, 0);
+
+	/**
+	 * Declares the product schema with one `sortable` + `filterable` attribute per local temporal
+	 * type — the shape produced by a `@Attribute(sortable = true)` getter returning
+	 * {@link LocalDateTime} on a client interface.
+	 */
+	private static void defineSchema(@Nonnull EvitaSessionContract session) {
+		session.defineEntitySchema(ENTITY_PRODUCT)
+			.withAttribute(
+				ATTR_LOCAL_DATE_TIME, LocalDateTime.class,
+				whichIs -> whichIs.filterable().sortable().nullable()
+			)
+			.withAttribute(
+				ATTR_LOCAL_DATE, LocalDate.class,
+				whichIs -> whichIs.filterable().sortable().nullable()
+			)
+			.withAttribute(
+				ATTR_LOCAL_TIME, LocalTime.class,
+				whichIs -> whichIs.filterable().sortable().nullable()
+			)
+			.updateVia(session);
+	}
+
+	/**
+	 * Seeds three products carrying ascending values of a *single* attribute, so a single ordering
+	 * assertion is enough to prove the sortable path end-to-end.
+	 *
+	 * Seeding one attribute at a time is deliberate: it keeps each temporal type's scenario
+	 * independent, so the `LocalDate` and `LocalTime` cases stand as genuine confirming-negatives
+	 * rather than failing collaterally on the shared write of a broken `LocalDateTime` attribute.
+	 */
+	private static void seedAscending(
+		@Nonnull EvitaSessionContract session,
+		@Nonnull String attributeName,
+		@Nonnull Serializable first,
+		@Nonnull Serializable second,
+		@Nonnull Serializable third
+	) {
+		createProduct(session, 1, attributeName, first);
+		createProduct(session, 2, attributeName, second);
+		createProduct(session, 3, attributeName, third);
+	}
+
+	/**
+	 * Creates a single product carrying exactly one local temporal attribute.
+	 */
+	private static void createProduct(
+		@Nonnull EvitaSessionContract session,
+		int pk,
+		@Nonnull String attributeName,
+		@Nonnull Serializable value
+	) {
+		session.createNewEntity(ENTITY_PRODUCT, pk)
+			.setAttribute(attributeName, value)
+			.upsertVia(session);
+	}
+
+	/**
+	 * Returns the primary keys matched by a query ordering ascending on the supplied attribute.
+	 */
+	@Nonnull
+	private static List<Integer> primaryKeysOrderedBy(
+		@Nonnull EvitaSessionContract session,
+		@Nonnull String attributeName
+	) {
+		final EvitaResponse<EntityReference> result = session.query(
+			query(
+				collection(ENTITY_PRODUCT),
+				orderBy(
+					attributeNatural(attributeName, ASC)
+				),
+				require(
+					page(1, Integer.MAX_VALUE)
+				)
+			),
+			EntityReference.class
+		);
+		final List<Integer> primaryKeys = new ArrayList<>(result.getRecordData().size());
+		for (final EntityReference reference : result.getRecordData()) {
+			primaryKeys.add(reference.getPrimaryKey());
+		}
+		return primaryKeys;
+	}
+
+	/**
+	 * Returns the primary keys matched by an equality filter on the supplied attribute.
+	 *
+	 * This is the counterpart to the write-path assertions: query values are still normalized at
+	 * the query entry point (a `LocalDateTime` becomes an `OffsetDateTime` at UTC there), and it is
+	 * the per-constraint coercion back to the attribute's declared type that has to make the two
+	 * meet again. If either half of that round trip shifted the wall clock, this filter would
+	 * silently match nothing.
+	 */
+	@Nonnull
+	private static List<Integer> primaryKeysMatching(
+		@Nonnull EvitaSessionContract session,
+		@Nonnull String attributeName,
+		@Nonnull Serializable value
+	) {
+		final EvitaResponse<EntityReference> result = session.query(
+			query(
+				collection(ENTITY_PRODUCT),
+				filterBy(
+					attributeEquals(attributeName, value)
+				),
+				require(
+					page(1, Integer.MAX_VALUE)
+				)
+			),
+			EntityReference.class
+		);
+		final List<Integer> primaryKeys = new ArrayList<>(result.getRecordData().size());
+		for (final EntityReference reference : result.getRecordData()) {
+			primaryKeys.add(reference.getPrimaryKey());
+		}
+		return primaryKeys;
+	}
+
+	/**
+	 * Returns the primary keys matched by the supplied filter constraint.
+	 *
+	 * Range and comparison constraints reach the index through the same `FilterIndex#getNormalizer` seam as equality
+	 * does, so covering them is what proves the temporal encoding is applied consistently rather than only on the
+	 * equality path.
+	 */
+	@Nonnull
+	private static List<Integer> primaryKeysMatchingConstraint(
+		@Nonnull EvitaSessionContract session,
+		@Nonnull FilterConstraint constraint
+	) {
+		final EvitaResponse<EntityReference> result = session.query(
+			query(
+				collection(ENTITY_PRODUCT),
+				filterBy(constraint),
+				require(
+					page(1, Integer.MAX_VALUE)
+				)
+			),
+			EntityReference.class
+		);
+		final List<Integer> primaryKeys = new ArrayList<>(result.getRecordData().size());
+		for (final EntityReference reference : result.getRecordData()) {
+			primaryKeys.add(reference.getPrimaryKey());
+		}
+		return primaryKeys;
+	}
+
+	/**
+	 * Fetches a seeded product with all attributes loaded.
+	 */
+	@Nonnull
+	private static SealedEntity fetchProduct(@Nonnull EvitaSessionContract session, int pk) {
+		return session.getEntity(ENTITY_PRODUCT, pk, entityFetchAllContent())
+			.orElseThrow(() -> new AssertionError("Product with primary key `" + pk + "` was not found!"));
+	}
+
+	/**
+	 * Builds the standard test configuration with a disabled session inactivity timeout and
+	 * per-test storage / export directories.
+	 */
+	@Nonnull
+	private EvitaConfiguration createConfiguration(@Nonnull TestPaths paths) {
+		return newTestEvitaConfigurationBuilder(paths)
+			.server(ServerOptions.builder().closeSessionsAfterSecondsOfInactivity(-1).build())
+			.build();
+	}
+
+	/**
+	 * Spins up a fresh Evita instance bound to per-test directories, hands an open read-write
+	 * session to the caller and tears the instance down afterwards. The catalog is left in warm-up
+	 * mode so a single session can both write and read.
+	 */
+	private void runWithCatalog(@Nonnull String storageSuffix, @Nonnull Consumer<EvitaSessionContract> scenario) {
+		final TestPaths paths = createTestPaths(storageSuffix);
+		try (
+			Evita evita = new Evita(createConfiguration(paths))
+		) {
+			evita.defineCatalog(TEST_CATALOG);
+			evita.updateCatalog(TEST_CATALOG, scenario);
+		} finally {
+			cleanupTestPaths(paths);
+		}
+	}
+
+	@DisplayName("Mutation contract")
+	@Nested
+	@Tag(CONTRACT)
+	@Tag(ATTRIBUTE)
+	@Tag(DATA_TYPE)
+	class MutationContract {
+
+		/**
+		 * Asserts that the mutation exposes the value it was constructed with, unchanged in type
+		 * and in value.
+		 */
+		private void assertValuePreserved(@Nonnull Serializable value) {
+			final UpsertAttributeMutation mutation = new UpsertAttributeMutation(
+				new AttributeKey(ATTR_LOCAL_DATE_TIME), value
+			);
+			assertEquals(value.getClass(), mutation.getAttributeValue().getClass());
+			assertEquals(value, mutation.getAttributeValue());
+		}
+
+		@Test
+		@DisplayName("should keep a LocalDateTime value as LocalDateTime")
+		void shouldKeepLocalDateTimeValueWhenConstructingMutation() {
+			assertValuePreserved(FIRST_DATE_TIME);
+		}
+
+		@Test
+		@DisplayName("should keep a LocalDate value as LocalDate")
+		void shouldKeepLocalDateValueWhenConstructingMutation() {
+			assertValuePreserved(FIRST_DATE);
+		}
+
+		@Test
+		@DisplayName("should keep a LocalTime value as LocalTime")
+		void shouldKeepLocalTimeValueWhenConstructingMutation() {
+			assertValuePreserved(FIRST_TIME);
+		}
+
+		@Test
+		@DisplayName("should keep a LocalDateTime array as a LocalDateTime array")
+		void shouldKeepLocalDateTimeArrayWhenConstructingMutation() {
+			final LocalDateTime[] value = new LocalDateTime[]{FIRST_DATE_TIME, SECOND_DATE_TIME};
+			final UpsertAttributeMutation mutation = new UpsertAttributeMutation(
+				new AttributeKey(ATTR_LOCAL_DATE_TIME), value
+			);
+			final Serializable storedValue = mutation.getAttributeValue();
+			assertInstanceOf(LocalDateTime[].class, storedValue);
+			assertEquals(FIRST_DATE_TIME, ((LocalDateTime[]) storedValue)[0]);
+			assertEquals(SECOND_DATE_TIME, ((LocalDateTime[]) storedValue)[1]);
+		}
+
+	}
+
+	@DisplayName("Declared schema")
+	@Nested
+	@Tag(ENGINE)
+	@Tag(ATTRIBUTE)
+	@Tag(DATA_TYPE)
+	class DeclaredSchema {
+
+		/**
+		 * Declares the schema, seeds three ascending values of the supplied attribute, then asserts
+		 * that the first value reads back bit-identical, that the declared schema type is
+		 * untouched, and that ascending natural ordering on the attribute yields the seeded order.
+		 */
+		private void assertRoundTripAndOrdering(
+			@Nonnull String storageSuffix,
+			@Nonnull String attributeName,
+			@Nonnull Class<? extends Serializable> expectedType,
+			@Nonnull Serializable first,
+			@Nonnull Serializable second,
+			@Nonnull Serializable third
+		) {
+			runWithCatalog(
+				storageSuffix,
+				session -> {
+					defineSchema(session);
+					seedAscending(session, attributeName, first, second, third);
+
+					final SealedEntity product = fetchProduct(session, 1);
+					final Serializable storedValue = product.getAttribute(attributeName);
+					assertInstanceOf(expectedType, storedValue);
+					// bit-identical read-back — a wall-clock shift introduced by an offset coercion
+					// on the write path would surface here and nowhere else
+					assertEquals(first, storedValue);
+
+					// the declared schema type must survive the write untouched as well
+					final SealedEntitySchema schema = session.getEntitySchema(ENTITY_PRODUCT).orElseThrow();
+					assertEquals(
+						expectedType,
+						schema.getAttribute(attributeName).orElseThrow().getType()
+					);
+
+					// sortable path proven end-to-end
+					assertEquals(List.of(1, 2, 3), primaryKeysOrderedBy(session, attributeName));
+
+					// filterable path proven end-to-end, for each seeded value
+					assertEquals(List.of(1), primaryKeysMatching(session, attributeName, first));
+					assertEquals(List.of(2), primaryKeysMatching(session, attributeName, second));
+					assertEquals(List.of(3), primaryKeysMatching(session, attributeName, third));
+
+					// range and comparison constraints take the same normalizer seam as equality
+					assertEquals(
+						List.of(1, 2),
+						primaryKeysMatchingConstraint(
+							session, attributeBetween(attributeName, first, second)
+						)
+					);
+					assertEquals(
+						List.of(2, 3),
+						primaryKeysMatchingConstraint(
+							session, attributeGreaterThanEquals(attributeName, second)
+						)
+					);
+					assertEquals(
+						List.of(1),
+						primaryKeysMatchingConstraint(
+							session, attributeLessThan(attributeName, second)
+						)
+					);
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("should store and read back a LocalDateTime attribute unchanged")
+		void shouldStoreAndReadBackLocalDateTimeAttribute() {
+			assertRoundTripAndOrdering(
+				"localTemporalDeclaredDateTime", ATTR_LOCAL_DATE_TIME, LocalDateTime.class,
+				FIRST_DATE_TIME, SECOND_DATE_TIME, THIRD_DATE_TIME
+			);
+		}
+
+		@Test
+		@DisplayName("should store and read back a LocalDate attribute unchanged")
+		void shouldStoreAndReadBackLocalDateAttribute() {
+			assertRoundTripAndOrdering(
+				"localTemporalDeclaredDate", ATTR_LOCAL_DATE, LocalDate.class,
+				FIRST_DATE, SECOND_DATE, THIRD_DATE
+			);
+		}
+
+		@Test
+		@DisplayName("should store and read back a LocalTime attribute unchanged")
+		void shouldStoreAndReadBackLocalTimeAttribute() {
+			assertRoundTripAndOrdering(
+				"localTemporalDeclaredTime", ATTR_LOCAL_TIME, LocalTime.class,
+				FIRST_TIME, SECOND_TIME, THIRD_TIME
+			);
+		}
+
+		@Test
+		@DisplayName("should store and read back a localized LocalDateTime attribute unchanged")
+		void shouldStoreAndReadBackLocalizedLocalDateTimeAttribute() {
+			runWithCatalog(
+				"localTemporalDeclaredLocalized",
+				session -> {
+					// a localized attribute reaches the third UpsertAttributeMutation constructor
+					// and the `isLocalized` branch of the schema verification, neither of which the
+					// non-localized scenarios above touch
+					session.defineEntitySchema(ENTITY_PRODUCT)
+						.withLocale(Locale.ENGLISH)
+						.withAttribute(
+							ATTR_LOCAL_DATE_TIME, LocalDateTime.class,
+							whichIs -> whichIs.localized().filterable().sortable().nullable()
+						)
+						.updateVia(session);
+
+					session.createNewEntity(ENTITY_PRODUCT, 1)
+						.setAttribute(ATTR_LOCAL_DATE_TIME, Locale.ENGLISH, FIRST_DATE_TIME)
+						.upsertVia(session);
+
+					final SealedEntity product = session
+						.getEntity(ENTITY_PRODUCT, 1, attributeContentAll(), dataInLocales(Locale.ENGLISH))
+						.orElseThrow();
+					final Serializable storedValue = product.getAttribute(ATTR_LOCAL_DATE_TIME, Locale.ENGLISH);
+					assertInstanceOf(LocalDateTime.class, storedValue);
+					assertEquals(FIRST_DATE_TIME, storedValue);
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("should keep a LocalDateTime attribute unchanged when the entity is updated")
+		void shouldKeepLocalDateTimeAttributeWhenEntityIsUpdated() {
+			runWithCatalog(
+				"localTemporalDeclaredUpdate",
+				session -> {
+					defineSchema(session);
+					seedAscending(
+						session, ATTR_LOCAL_DATE_TIME, FIRST_DATE_TIME, SECOND_DATE_TIME, THIRD_DATE_TIME
+					);
+
+					// second write goes through ExistingEntityBuilder rather than the initial one
+					fetchProduct(session, 1)
+						.openForWrite()
+						.setAttribute(ATTR_LOCAL_DATE_TIME, THIRD_DATE_TIME)
+						.upsertVia(session);
+
+					final Serializable storedValue = fetchProduct(session, 1).getAttribute(ATTR_LOCAL_DATE_TIME);
+					assertInstanceOf(LocalDateTime.class, storedValue);
+					assertEquals(THIRD_DATE_TIME, storedValue);
+				}
+			);
+		}
+
+	}
+
+	@DisplayName("Auto-evolved schema")
+	@Nested
+	@Tag(ENGINE)
+	@Tag(SCHEMA)
+	@Tag(DATA_TYPE)
+	class AutoEvolvedSchema {
+
+		/**
+		 * Upserts a single product carrying only the supplied attribute against a schema that does
+		 * not declare it, then returns the attribute schema the engine derived from the value.
+		 */
+		@Nonnull
+		private AttributeSchemaContract evolveAttributeSchemaFor(
+			@Nonnull EvitaSessionContract session,
+			@Nonnull String attributeName,
+			@Nonnull Serializable value
+		) {
+			session.defineEntitySchema(ENTITY_PRODUCT).updateVia(session);
+			session.createNewEntity(ENTITY_PRODUCT, 1)
+				.setAttribute(attributeName, value)
+				.upsertVia(session);
+
+			final SealedEntitySchema schema = session.getEntitySchema(ENTITY_PRODUCT).orElseThrow();
+			final AttributeSchemaContract attributeSchema = schema.getAttribute(attributeName).orElse(null);
+			assertNotNull(attributeSchema, "Attribute `" + attributeName + "` was not evolved into the schema!");
+			return attributeSchema;
+		}
+
+		@Test
+		@DisplayName("should derive a LocalDateTime attribute from a LocalDateTime value")
+		void shouldDeriveLocalDateTimeAttributeFromLocalDateTimeValue() {
+			runWithCatalog(
+				"localTemporalEvolvedDateTime",
+				session -> {
+					assertEquals(
+						LocalDateTime.class,
+						evolveAttributeSchemaFor(session, ATTR_LOCAL_DATE_TIME, FIRST_DATE_TIME).getType()
+					);
+					assertEquals(
+						FIRST_DATE_TIME,
+						session.getEntity(ENTITY_PRODUCT, 1, attributeContentAll())
+							.orElseThrow()
+							.getAttribute(ATTR_LOCAL_DATE_TIME)
+					);
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("should derive a LocalDate attribute from a LocalDate value")
+		void shouldDeriveLocalDateAttributeFromLocalDateValue() {
+			runWithCatalog(
+				"localTemporalEvolvedDate",
+				session -> assertEquals(
+					LocalDate.class,
+					evolveAttributeSchemaFor(session, ATTR_LOCAL_DATE, FIRST_DATE).getType()
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("should derive a LocalTime attribute from a LocalTime value")
+		void shouldDeriveLocalTimeAttributeFromLocalTimeValue() {
+			runWithCatalog(
+				"localTemporalEvolvedTime",
+				session -> assertEquals(
+					LocalTime.class,
+					evolveAttributeSchemaFor(session, ATTR_LOCAL_TIME, FIRST_TIME).getType()
+				)
+			);
+		}
+
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/LocalTemporalAttributeTypeFidelityFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/LocalTemporalAttributeTypeFidelityFunctionalTest.java
@@ -96,7 +96,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * rewritten and are expected to pass both before and after the fix. Their passing is what pins the
  * defect to the single `LocalDateTime` branch rather than to local temporal types as a family.
  *
- * Every end-to-end assertion reads the value back and compares it to the *exact* instance written.
+ * Every end-to-end assertion reads the value back and compares it to the *exact value* written — equality, not
+ * reference identity: the engine materializes a fresh instance on read.
  * That is deliberate: an assertion that merely expected "no exception" would also pass a fix that
  * kept a wall-clock-shifting conversion in the write path, which on a `sortable` attribute would
  * silently reorder listings rather than fail.

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/EvitaDataTypesTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/EvitaDataTypesTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -2504,6 +2505,65 @@ class EvitaDataTypesTest {
 					.toSupportedStoredType(
 						new HashMap<String, String>()
 					)
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should type a rebuilt array from the"
+			+ " first non-null element"
+		)
+		void shouldTypeRebuiltArrayFromFirstNonNullElement() {
+			// a leading `null` says nothing about what the
+			// remaining elements normalize to - deriving the
+			// component type from element zero alone rebuilt
+			// a Float[] and then threw on Array.set
+			final Float[] input = {null, 1.5f};
+
+			final Serializable result =
+				EvitaDataTypes
+					.toSupportedStoredTypeOrItsArray(
+						input
+					);
+
+			assertInstanceOf(
+				BigDecimal[].class, result
+			);
+			final BigDecimal[] normalized =
+				(BigDecimal[]) result;
+			assertNull(normalized[0]);
+			assertEquals(
+				new BigDecimal("1.5"), normalized[1]
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should type a rebuilt query-path array from"
+			+ " the first non-null element"
+		)
+		void shouldTypeRebuiltQueryArrayFromFirstNonNull() {
+			// same hazard on the query path, where a
+			// LocalDateTime element still normalizes away
+			final LocalDateTime[] input = {
+				null,
+				LocalDateTime.of(2026, 5, 20, 12, 19, 26)
+			};
+
+			final Serializable result =
+				EvitaDataTypes.toSupportedTypeOrItsArray(
+					input
+				);
+
+			assertInstanceOf(
+				OffsetDateTime[].class, result
+			);
+			final OffsetDateTime[] normalized =
+				(OffsetDateTime[]) result;
+			assertNull(normalized[0]);
+			assertEquals(
+				input[1].atOffset(ZoneOffset.UTC),
+				normalized[1]
 			);
 		}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/EvitaDataTypesTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/EvitaDataTypesTest.java
@@ -2415,6 +2415,126 @@ class EvitaDataTypesTest {
 	}
 
 	@Nested
+	@DisplayName("Conversion to supported stored type")
+	class ConversionToSupportedStoredType {
+
+		@Test
+		@DisplayName(
+			"should keep LocalDateTime as"
+			+ " LocalDateTime"
+		)
+		void shouldKeepLocalDateTime() {
+			// the query-path variant rewrites this
+			// value to an OffsetDateTime at UTC; a
+			// value on its way into storage must
+			// keep the type its schema declares
+			final LocalDateTime input =
+				LocalDateTime.of(
+					2021, 6, 15, 10, 30
+				);
+
+			assertSame(
+				input,
+				EvitaDataTypes.toSupportedStoredType(
+					input
+				)
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should keep a LocalDateTime array"
+			+ " untouched"
+		)
+		void shouldKeepLocalDateTimeArray() {
+			final LocalDateTime[] input = {
+				LocalDateTime.of(
+					2021, 6, 15, 10, 30
+				),
+				LocalDateTime.of(
+					2021, 6, 16, 11, 45
+				)
+			};
+
+			assertSame(
+				input,
+				EvitaDataTypes
+					.toSupportedStoredTypeOrItsArray(
+						input
+					)
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should still normalize Float to"
+			+ " BigDecimal"
+		)
+		void shouldStillNormalizeFloat() {
+			assertEquals(
+				new BigDecimal("3.14"),
+				EvitaDataTypes.toSupportedStoredType(
+					3.14f
+				)
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should still convert non-@SupportedEnum"
+			+ " to String"
+		)
+		void shouldStillConvertNonSupportedEnum() {
+			assertEquals(
+				"CATALOG",
+				EvitaDataTypes.toSupportedStoredType(
+					ClassifierType.CATALOG
+				)
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should still reject an unsupported type"
+		)
+		void shouldStillRejectUnsupportedType() {
+			assertThrows(
+				UnsupportedDataTypeException.class,
+				() -> EvitaDataTypes
+					.toSupportedStoredType(
+						new HashMap<String, String>()
+					)
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should keep LocalDate and LocalTime"
+			+ " untouched"
+		)
+		void shouldKeepLocalDateAndLocalTime() {
+			final LocalDate date =
+				LocalDate.of(2021, 6, 15);
+			final LocalTime time =
+				LocalTime.of(10, 30);
+
+			assertSame(
+				date,
+				EvitaDataTypes.toSupportedStoredType(
+					date
+				)
+			);
+			assertSame(
+				time,
+				EvitaDataTypes.toSupportedStoredType(
+					time
+				)
+			);
+		}
+
+	}
+
+	@Nested
 	@DisplayName("Size estimation")
 	class EstimateSizeTest {
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexTest.java
@@ -51,6 +51,9 @@ import org.junit.jupiter.api.Test;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.text.Normalizer;
@@ -69,6 +72,7 @@ import static io.evitadb.test.TestTags.HISTOGRAM;
 import static io.evitadb.test.TestTags.INDEXING;
 import static io.evitadb.test.TestTags.ATTRIBUTE;
 import static io.evitadb.test.TestTags.FILTER;
+import static io.evitadb.test.TestTags.DATA_TYPE;
 
 /**
  * This test verifies {@link FilterIndex} contract.
@@ -1581,6 +1585,68 @@ class FilterIndexTest {
 			assertSame(BigDecimal.class, EvitaDataTypes.resolveRangeInnerNumericType(BigDecimalNumberRange.class));
 			assertNull(EvitaDataTypes.resolveRangeInnerNumericType(Integer.class));
 			assertNull(EvitaDataTypes.resolveRangeInnerNumericType(DateTimeRange.class));
+		}
+
+	}
+
+	/**
+	 * Pins the index-side encoding of the temporal attribute types. `LocalDateTime` carries no offset of its own, so
+	 * it is anchored at UTC before it becomes a bucket key — the same `Instant` space `OffsetDateTime` already uses,
+	 * which is what lets the tree store it in the packed `InstantValueColumn` instead of boxing it. Because the
+	 * anchor is a *constant* offset the mapping is a lossless bijection and monotonic with `LocalDateTime`'s natural
+	 * order, so equality lookup and ordered iteration are unaffected. `LocalDate` and `LocalTime` are deliberately
+	 * left alone — each fits losslessly in a single `long`, so they take the cheaper `LongValueColumn`.
+	 */
+	@Nested
+	@DisplayName("Temporal attribute index encoding")
+	@Tag(ENGINE)
+	@Tag(INDEXING)
+	@Tag(ATTRIBUTE)
+	@Tag(DATA_TYPE)
+	class TemporalNormalization {
+
+		@Test
+		@DisplayName("LocalDateTime is normalized to its UTC instant")
+		void shouldNormalizeLocalDateTimeToUtcInstant() {
+			final LocalDateTime value = LocalDateTime.of(2026, 5, 20, 12, 19, 26);
+
+			assertEquals(
+				value.toInstant(ZoneOffset.UTC),
+				FilterIndex.getNormalizer(LocalDateTime.class, 0).apply(value)
+			);
+		}
+
+		@Test
+		@DisplayName("normalizing an already-normalized LocalDateTime value is a no-op")
+		void shouldBeIdempotentForLocalDateTime() {
+			// probe values are normalized more than once along a lookup path - a second pass must not throw
+			final Function<Object, Serializable> normalizer = FilterIndex.getNormalizer(LocalDateTime.class, 0);
+			final Serializable once = normalizer.apply(LocalDateTime.of(2026, 5, 20, 12, 19, 26));
+
+			assertEquals(once, normalizer.apply(once));
+		}
+
+		@Test
+		@DisplayName("LocalDateTime normalization preserves natural order")
+		void shouldPreserveOrderForLocalDateTime() {
+			// a constant offset cannot reorder values - this is precisely what a region time zone would not guarantee
+			final Function<Object, Serializable> normalizer = FilterIndex.getNormalizer(LocalDateTime.class, 0);
+			final LocalDateTime earlier = LocalDateTime.of(2026, 5, 20, 12, 19, 26);
+			final LocalDateTime later = LocalDateTime.of(2026, 5, 20, 14, 19, 26);
+
+			assertTrue(
+				((Instant) normalizer.apply(earlier)).isBefore((Instant) normalizer.apply(later))
+			);
+		}
+
+		@Test
+		@DisplayName("LocalDate and LocalTime pass through unnormalized")
+		void shouldLeaveLocalDateAndLocalTimeAlone() {
+			final LocalDate date = LocalDate.of(2026, 5, 20);
+			final LocalTime time = LocalTime.of(12, 19, 26);
+
+			assertSame(date, FilterIndex.getNormalizer(LocalDate.class, 0).apply(date));
+			assertSame(time, FilterIndex.getNormalizer(LocalTime.class, 0).apply(time));
 		}
 
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/InstantValueColumnTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/InstantValueColumnTest.java
@@ -31,6 +31,9 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -55,7 +58,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Verifies the temporal parallel-array value column: the lossless
  * {@code Instant ↔ (seconds, nanos)} decomposition, the {@link InstantValueColumn} array operations (proven equivalent
  * to the boxed {@link BoxedObjectColumn}, including the nano tiebreak), the {@link ValueColumnFactory} selection of the
- * column for {@code OffsetDateTime} / {@code Instant} natural-order keys, an end-to-end randomized workload on an
+ * column for {@code OffsetDateTime} / {@code Instant} / {@code LocalDateTime} natural-order keys (and its
+ * deliberate non-selection for {@code LocalDate} / {@code LocalTime}, which stay on the cheaper single-long
+ * column), an end-to-end randomized workload on an
  * {@link Instant}-keyed {@link TransactionalBucketBPlusTree} matched against a {@link TreeMap} oracle, and the MVCC
  * commit / rollback of such a tree (so the two-array lockstep deep copy runs across a real transaction layer).
  *
@@ -240,6 +245,37 @@ class InstantValueColumnTest {
 			assertInstanceOf(
 				InstantValueColumn.class,
 				ValueColumnFactory.forKey(Instant.class, null).create(BLOCK_SIZE)
+			);
+		}
+
+		@Test
+		@DisplayName("LocalDateTime natural-order keys select the Instant column too")
+		void shouldSelectInstantColumnForLocalDateTime() {
+			// `LocalDateTime` is normalized to an `Instant` at UTC by `FilterIndex#getNormalizer`, so the column
+			// selection in `ValueColumnFactory#normalizedTypeOf` has to agree - the two must stay in lockstep or the
+			// tree would be handed `Instant` keys while sizing itself for a boxed column
+			assertInstanceOf(
+				InstantValueColumn.class,
+				ValueColumnFactory.forKey(LocalDateTime.class, Comparator.naturalOrder()).create(BLOCK_SIZE)
+			);
+			assertInstanceOf(
+				InstantValueColumn.class,
+				ValueColumnFactory.forKey(LocalDateTime.class, null).create(BLOCK_SIZE)
+			);
+		}
+
+		@Test
+		@DisplayName("LocalDate / LocalTime keep the cheaper single-long column")
+		void shouldKeepLongColumnForLocalDateAndLocalTime() {
+			// both fit losslessly in one `long` (epoch-day / nano-of-day), so routing them through `Instant` would
+			// cost an extra all-but-unused `int[]` per leaf - they must NOT be swept into the temporal branch
+			assertInstanceOf(
+				LongValueColumn.class,
+				ValueColumnFactory.forKey(LocalDate.class, Comparator.naturalOrder()).create(BLOCK_SIZE)
+			);
+			assertInstanceOf(
+				LongValueColumn.class,
+				ValueColumnFactory.forKey(LocalTime.class, null).create(BLOCK_SIZE)
 			);
 		}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/index/serializer/FilterIndexLegacyLocalDateTimeSerializerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/index/serializer/FilterIndexLegacyLocalDateTimeSerializerTest.java
@@ -1,0 +1,168 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.index.serializer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import io.evitadb.index.attribute.FilterIndex;
+import io.evitadb.index.invertedIndex.InvertedIndex;
+import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
+import io.evitadb.spi.store.catalog.persistence.storageParts.compressor.ReadWriteKeyCompressor;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.FilterIndexStoragePart;
+import io.evitadb.store.index.IndexStoragePartConfigurer;
+import io.evitadb.store.shared.kryo.KryoFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.ByteArrayOutputStream;
+import java.io.Serializable;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.function.Function;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.SERIALIZATION;
+import static io.evitadb.test.TestTags.STORAGE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Migration coverage for `2026.1` filter indexes built over a `LocalDateTime` attribute.
+ *
+ * `2026.1` had no `LocalDateTime` branch in `FilterIndex.getNormalizer`, so it persisted the raw wall-clock value as
+ * the bucket key. `2026.2` normalizes such an attribute to a UTC `Instant` so the B+ tree can store it in the packed
+ * `InstantValueColumn` — which means a legacy blob read verbatim would be fed `LocalDateTime` keys into a column that
+ * hard-casts to `Instant`, and the catalog would fail to load with a `ClassCastException`.
+ * {@link FilterIndexStoragePartSerializer_2026_1} therefore re-anchors those values on read.
+ *
+ * The rehydration assertion is the one that matters: it is the exact call `AttributeIndexLoader` makes, and it is what
+ * fails without the conversion.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("2026.1 LocalDateTime filter index migrates to the UTC instant key space")
+@Tag(STORAGE)
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
+@Tag(SERIALIZATION)
+class FilterIndexLegacyLocalDateTimeSerializerTest {
+	private static final AttributeIndexKey ATTRIBUTE_KEY = new AttributeIndexKey(null, "initialPublishedDate", null);
+	private static final LocalDateTime FIRST = LocalDateTime.of(2026, 5, 20, 12, 19, 26);
+	private static final LocalDateTime SECOND = LocalDateTime.of(2026, 5, 20, 14, 19, 26);
+	private static final LocalDateTime THIRD = LocalDateTime.of(2026, 5, 21, 8, 5, 0);
+
+	private Kryo kryo;
+	private FilterIndexStoragePartSerializer_2026_1 legacySerializer;
+
+	@BeforeEach
+	void setUp() {
+		final ReadWriteKeyCompressor keyCompressor = new ReadWriteKeyCompressor(Collections.emptyMap());
+		this.kryo = KryoFactory.createKryo(new IndexStoragePartConfigurer(keyCompressor));
+		this.legacySerializer = new FilterIndexStoragePartSerializer_2026_1(keyCompressor);
+	}
+
+	/**
+	 * Round-trips a part through the legacy serializer, mimicking a blob written by `2026.1`.
+	 */
+	@Nonnull
+	private FilterIndexStoragePart roundTrip(@Nonnull Class<?> attributeType, @Nonnull Serializable... values) {
+		final ValueToRecordBitmap[] points = new ValueToRecordBitmap[values.length];
+		for (int i = 0; i < values.length; i++) {
+			points[i] = new ValueToRecordBitmap(values[i], i + 1);
+		}
+		final FilterIndexStoragePart legacyPart = new FilterIndexStoragePart(
+			1, ATTRIBUTE_KEY, attributeType, points, null, 1L
+		);
+
+		final ByteArrayOutputStream buffer = new ByteArrayOutputStream(512);
+		try (final Output output = new Output(buffer)) {
+			this.legacySerializer.write(this.kryo, output, legacyPart);
+		}
+		try (final Input input = new Input(buffer.toByteArray())) {
+			return this.legacySerializer.read(this.kryo, input, FilterIndexStoragePart.class);
+		}
+	}
+
+	@Test
+	@DisplayName("should re-anchor legacy LocalDateTime bucket keys at UTC on read")
+	void shouldReAnchorLegacyLocalDateTimeKeys() {
+		final FilterIndexStoragePart migrated = roundTrip(LocalDateTime.class, FIRST, SECOND, THIRD);
+
+		final ValueToRecordBitmap[] points = migrated.getHistogramPoints();
+		assertEquals(3, points.length);
+		for (final ValueToRecordBitmap point : points) {
+			assertInstanceOf(Instant.class, point.getValue());
+		}
+		assertEquals(FIRST.toInstant(ZoneOffset.UTC), points[0].getValue());
+		assertEquals(SECOND.toInstant(ZoneOffset.UTC), points[1].getValue());
+		assertEquals(THIRD.toInstant(ZoneOffset.UTC), points[2].getValue());
+	}
+
+	@Test
+	@DisplayName("should rehydrate a migrated legacy part into an InvertedIndex and stay queryable")
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	void shouldRehydrateMigratedLegacyPart() {
+		final FilterIndexStoragePart migrated = roundTrip(LocalDateTime.class, FIRST, SECOND, THIRD);
+
+		// exactly what AttributeIndexLoader#loadInvertedIndex does - this throws ClassCastException when the
+		// legacy LocalDateTime keys are not re-anchored, because the tree picks InstantValueColumn for the type
+		final InvertedIndex reloaded = new InvertedIndex(
+			LocalDateTime.class,
+			migrated.getHistogramPoints(),
+			FilterIndex.getNormalizer(LocalDateTime.class, 0),
+			(Comparator) Comparator.naturalOrder(),
+			0
+		);
+
+		// `InvertedIndex#getRecordsEqualTo` takes an ALREADY-normalized probe (see its parameter name) - `FilterIndex`
+		// applies the normalizer before delegating, so mirror that here. Passing a raw `LocalDateTime` would reach the
+		// `Instant` column unconverted, which is a caller error rather than a migration defect
+		final Function<Object, Serializable> normalizer = FilterIndex.getNormalizer(LocalDateTime.class, 0);
+		assertArrayEquals(new int[]{1}, reloaded.getRecordsEqualTo(normalizer.apply(FIRST)).getArray());
+		assertArrayEquals(new int[]{2}, reloaded.getRecordsEqualTo(normalizer.apply(SECOND)).getArray());
+		assertArrayEquals(new int[]{3}, reloaded.getRecordsEqualTo(normalizer.apply(THIRD)).getArray());
+	}
+
+	@Test
+	@DisplayName("should leave non-temporal legacy bucket keys untouched")
+	void shouldLeaveOtherLegacyKeysUntouched() {
+		final FilterIndexStoragePart migrated = roundTrip(String.class, "alpha", "beta");
+
+		final ValueToRecordBitmap[] points = migrated.getHistogramPoints();
+		assertEquals(2, points.length);
+		assertEquals("alpha", points[0].getValue());
+		assertEquals("beta", points[1].getValue());
+	}
+
+}


### PR DESCRIPTION
Release-branch counterpart of #1404, cherry-picked onto `release_2026-2` so this single fix can ship to 2026.2 on its own. The branch is based on `release_2026-2`, and the patch is byte-identical to #1404 apart from one context line in the generated ADR index (`dev` carries an ADR the release branch does not).

Review discussion belongs on #1404.


## Problem

An attribute **declared as `LocalDateTime` could not be written at all** in `2026.2`. All four
`UpsertAttributeMutation` constructors normalized the value with `EvitaDataTypes.toSupportedType`, which rewrites
`LocalDateTime` to `OffsetDateTime` at UTC. That happens *before* `AttributeSchemaEvolvingMutation` validates the
value against the schema, and the check is strict type identity — so the upsert always failed:

```
InvalidMutationException: Invalid type: `class java.time.OffsetDateTime`! Attribute `initialPublishedDate`
in schema `Product` was already stored as type class java.time.LocalDateTime.
```

Second, silent symptom: with an auto-evolved schema the type is derived from `getAttributeValue().getClass()`, so a
`LocalDateTime` value quietly produced an **`OffsetDateTime`** attribute definition.

Introduced by `016d93255` (2026-03-27, conditional bucket indexing), whose motivation — normalizing `Float`/`Double`
to `BigDecimal` so histogram bucket keys agree with the stored value — was sound; the `LocalDateTime` rewrite rode
along because it sits in the same `if`/`else` chain.

## Approach

The rewrite is worth keeping, but as an **index encoding**, not as a change of the public type. Split in two:

**1. Write path keeps the declared type.** `UpsertAttributeMutation` now calls a new
`EvitaDataTypes.toSupportedStoredTypeOrItsArray`, which performs every other normalization (`Float`/`Double` →
`BigDecimal`, non-`@SupportedEnum` → `String` name, rejection of unsupported types) but leaves `LocalDateTime` alone.
The schema records what the client declared, whether declared explicitly or auto-evolved.

**2. UTC anchoring moves into the index.** `FilterIndex.getNormalizer` anchors `LocalDateTime` at UTC and
`ValueColumnFactory.normalizedTypeOf` maps it to `Instant`, so the B+ tree stores it in the packed
`InstantValueColumn` instead of `BoxedObjectColumn` (~12 bytes per key rather than a reference plus three objects,
and no boxing on lookup hot paths). A **constant** offset makes the mapping a lossless bijection and monotonic with
natural order, so equality lookup and ordered iteration are unaffected. Every consumer reads that one seam — the four
filter translators, `HistogramIndex`, `AttributeIndexLoader`, `AttributeIndex`, `OwnerFilterIndex`, and
`SortIndexView` via `shared.getNormalizer()`.

`LocalDate` and `LocalTime` are deliberately left out of the temporal branch: each fits losslessly in a single `long`
(`toEpochDay` / `toNanoOfDay`) and already selects the cheaper 8-byte `LongValueColumn`, so routing them through
`Instant` would be a downgrade.

The **query entry point is unchanged on purpose**: the rewrite is inert there, because every attribute constraint
coerces its value to the declared type via `toTargetType` and both directions preserve the wall clock.

## Verification

- `LocalTemporalAttributeTypeFidelityFunctionalTest` — written first against the unfixed build: **5 of 11 methods
  failed, all five `LocalDateTime`**; `LocalDate` / `LocalTime` passed before and after, pinning the defect to one
  branch. A counterfactual run with the fix reverted re-confirmed the class fails without it. Read-back assertions
  compare against the exact value written (not merely "no exception"), and `attributeNatural`, `attributeEquals`,
  `attributeBetween`, `attributeGreaterThanEquals` and `attributeLessThan` are asserted per type. The localized case
  is covered separately.
- `FilterIndexTest.TemporalNormalization` pins the encoding — UTC instant, idempotence, order preservation, and
  `LocalDate` / `LocalTime` passing through. `InstantValueColumnTest` pins column selection on both sides.
- `EvitaDataTypesTest` — the pre-existing "Conversion to supported type" suite still passes unchanged, pinning the
  query-path contract as deliberately retained.
- Root cause confirmed under JDWP; the evidence chain is quoted in the ADR.
- **Full `unitAndFunctional` suite: 20 894 tests.** Five did not pass, none attributable to this change: two are known
  flakes (`CdcCallbackDispatcherTest` asserts on a JVM-wide thread counter; `ExportS3ServiceTest` needs Docker), and
  the other three (`SharedRgeiSoakTest`, `EvitaClientReadWriteTest`, `EvitaSessionServiceFunctionalTest`) failed on a
  >100 s commit-pipeline stall under full-suite load and **all pass in isolation** (132 tests, 0 failures).

## Notes

- No migration needed. Bucket keys are stored already-normalized, so changing a normalizer is in principle an on-disk
  format change — but `ValueColumnFactory` / `InstantValueColumn` arrived in `15dc1acee`, contained only in
  `v2026.2.x`, and within 2026.2 no catalog can hold un-normalized `LocalDateTime` keys (a declared attribute could
  not be written, an auto-evolved one became `OffsetDateTime`).
- The UTC anchoring is intentionally **not** documented for users — it has no observable effect.
  `documentation/user/en/use/data-types.md` previously claimed local date times are "always converted to
  OffsetDateTime using the evitaDB server system default timezone", wrong on both counts; it now states only that
  `LocalDateTime` is a first-class attribute type whose wall clock round-trips. The adjacent `<LS to="c">` block still
  carries the old claim for the C# driver and was left alone — nobody verified what that driver does.
- Rationale, including the rejected server-default-timezone option and why UTC wins, is recorded in
  `documentation/adr/2026-08-10-stored-value-normalization-split.md`.
