### PR TITLE
fix: correct OffsetIndex create-vs-update verdict for unflushed re-adds

### DIFF
--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
@@ -2132,7 +2132,9 @@ public class OffsetIndex {
 		/**
 		 * Stores instance of the record to the non-flushed index.
 		 *
-		 * @param create - when true it affects {@link #nonFlushedValuesHistogram} results
+		 * @param create - when true it affects {@link #nonFlushedValuesHistogram} results; when false it still
+		 *               affects them if this version had already removed the same key, because the removal and
+		 *               this write fold into a plain overwrite whose cardinality effect cancels out
 		 */
 		public void put(@Nonnull RecordKey key, @Nonnull VersionedValue value, boolean create) {
 			if (create) {

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
@@ -1663,7 +1663,17 @@ public class OffsetIndex {
 		final byte recordType = this.recordTypeRegistry.idFor(value.getClass());
 		final RecordKey key = new RecordKey(recordType, primaryKey);
 
-		final boolean update = this.roots.latestRoot().containsKey(key);
+		// a not-yet-flushed write to this key from an EARLIER, different version always overrides the published
+		// root, which may not yet reflect it - same precedence as doRemove's lookup below, so a batch that both
+		// removes and re-adds the same key across several not-yet-flushed versions resolves consistently at
+		// promote time. The lookup is deliberately bounded to versions strictly before this one: a remove and a
+		// re-add within the SAME version fold into one entry regardless (see NonFlushedValueSet#put/#remove), so
+		// consulting this version's own not-yet-registered activity here would misjudge a same-transaction
+		// delete-then-recreate of a key that already exists in the published root as a brand new key.
+		final Optional<VersionedValue> nonFlushedValueRef = this.volatileValues.getNonFlushedValueIfVersionMatches(
+			catalogVersion - 1, key);
+		final boolean update = nonFlushedValueRef.isPresent() ?
+			!nonFlushedValueRef.get().removed() : this.roots.latestRoot().containsKey(key);
 		final FileLocation recordLocation = new StorageRecord<>(
 			this.writeKryo,
 			exclusiveWriteAccess,
@@ -2129,6 +2139,11 @@ public class OffsetIndex {
 				this.nonFlushedValuesHistogram.merge(key.recordType(), 1, Integer::sum);
 				this.addedKeys.add(key);
 				this.removedKeys.remove(key);
+			} else if (this.removedKeys.remove(key)) {
+				// this version already dropped a record that existed before it and now writes it back: the two
+				// fold into a plain overwrite, so the removal's cardinality effect has to be undone. Without
+				// this the in-flight count reports one record fewer than the very next flush publishes.
+				this.nonFlushedValuesHistogram.merge(key.recordType(), 1, Integer::sum);
 			}
 			this.nonFlushedValueIndex.put(key, value);
 			this.nonFlushedBlockSizeChangedCallback.accept(value.fileLocation().recordLength());
@@ -2142,8 +2157,12 @@ public class OffsetIndex {
 			this.nonFlushedValuesHistogram.merge(key.recordType(), -1, Integer::sum);
 			this.nonFlushedValueIndex.put(
 				key, new VersionedValue(key.primaryKey(), (byte) (key.recordType() * -1), fileLocation));
-			this.addedKeys.remove(key);
-			this.removedKeys.add(key);
+			// a record created in this very version and dropped again folds into a no-op - undo the creation
+			// rather than record the removal of something that was never published, which would otherwise
+			// make the in-flight count of an untouched index go negative
+			if (!this.addedKeys.remove(key)) {
+				this.removedKeys.add(key);
+			}
 			this.nonFlushedBlockSizeChangedCallback.accept(fileLocation.recordLength());
 		}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
@@ -1075,6 +1075,12 @@ class OffsetIndexTest implements EvitaTestSupport {
 						offsetIndex.contains(1L, 1, EntityBodyStoragePart.class),
 						"contains at v1 should be false after put-then-remove in the same version"
 					);
+					// the two operations fold into a no-op, so the in-flight cardinality must be zero - never
+					// negative, which is what recording the removal of a record that was never published gives
+					assertEquals(
+						0, offsetIndex.count(1L),
+						"count at v1 should be zero after put-then-remove in the same version"
+					);
 				});
 			}
 
@@ -1098,6 +1104,34 @@ class OffsetIndexTest implements EvitaTestSupport {
 					assertTrue(
 						offsetIndex.contains(2L, 1, EntityBodyStoragePart.class),
 						"contains at v2 should be true after remove-then-reput"
+					);
+					// the removal is undone by the re-put, so the record stays counted - the in-flight count
+					// must agree with what the flush is about to publish
+					assertEquals(
+						1, offsetIndex.count(2L),
+						"count at v2 should still be one after remove-then-reput in the same version"
+					);
+				});
+			}
+
+			@DisplayName("remove then re-put of a still-unflushed record keeps the in-flight count at one")
+			@Test
+			void shouldCountRecordRePutAfterRemoveOverUnflushedRecord() {
+				runWithIndex((offsetIndex, decoder) -> {
+					// same shape as above, except the record key 1 stands on is itself still in-flight: it was
+					// created at v1 and never flushed on its own, so the fold at v2 has to be judged against
+					// v1's pending creation rather than against the (still empty) published state
+					offsetIndex.put(1L, bodyPartWithLocale(1, 1, Locale.ENGLISH));
+					offsetIndex.remove(2L, 1, EntityBodyStoragePart.class);
+					offsetIndex.put(2L, bodyPartWithLocale(2, 1, Locale.GERMAN));
+
+					assertEquals(
+						1, offsetIndex.count(1L),
+						"count at v1 should be one - the record created there is untouched by v2's fold"
+					);
+					assertEquals(
+						1, offsetIndex.count(2L),
+						"count at v2 should be one after remove-then-reput over a still-unflushed record"
 					);
 				});
 			}
@@ -1525,6 +1559,62 @@ class OffsetIndexTest implements EvitaTestSupport {
 					assertEquals(1, offsetIndex.count(1L), "count at v1 sees only key 1");
 					assertEquals(2, offsetIndex.count(2L), "count at v2 sees keys 1 and 2");
 					assertEquals(3, offsetIndex.count(3L), "count at v3 sees keys 1, 2 and 3");
+				});
+			}
+
+			@DisplayName("a flushed record removed at one version and re-added at the next survives the batch")
+			@Test
+			void shouldPromoteRemovalAndReAddOfFlushedRecordInOneBatch() {
+				runWithIndex((offsetIndex, decoder) -> {
+					final EntityBodyStoragePart original = bodyPartWithLocale(1, 1, Locale.ENGLISH);
+					final EntityBodyStoragePart reAdded = bodyPartWithLocale(3, 1, Locale.FRENCH);
+
+					// key 1 is published by its own flush, then dropped at v2 and re-created at v3 - both
+					// promoted by one flush. The re-add is a creation, not an overwrite: by the time v3 is
+					// applied, v2 has already taken the key out of the root the batch is folding into.
+					offsetIndex.put(1L, original);
+					offsetIndex.flush(1L);
+					offsetIndex.remove(2L, 1, EntityBodyStoragePart.class);
+					offsetIndex.put(3L, reAdded);
+					offsetIndex.flush(3L);
+
+					assertEquals(reAdded, offsetIndex.get(3L, 1, EntityBodyStoragePart.class),
+						"get key 1 at v3 resolves the re-added payload");
+					assertTrue(offsetIndex.contains(3L, 1, EntityBodyStoragePart.class),
+						"contains key 1 at v3 agrees with get");
+					assertFalse(offsetIndex.contains(2L, 1, EntityBodyStoragePart.class),
+						"key 1 stays absent at v2, where it was removed");
+					assertEquals(original, offsetIndex.get(1L, 1, EntityBodyStoragePart.class),
+						"get key 1 at v1 still resolves the payload flushed there");
+					assertEquals(1, offsetIndex.count(1L), "count at v1 sees key 1");
+					assertEquals(0, offsetIndex.count(2L), "count at v2 sees no key");
+					assertEquals(1, offsetIndex.count(3L), "count at v3 sees the re-added key 1");
+				});
+			}
+
+			@DisplayName("an in-flight record removed and re-added inside one later version survives the batch")
+			@Test
+			void shouldPromoteRemovalAndReAddOfInFlightRecordWithinOneVersion() {
+				runWithIndex((offsetIndex, decoder) -> {
+					final EntityBodyStoragePart original = bodyPartWithLocale(1, 1, Locale.ENGLISH);
+					final EntityBodyStoragePart reAdded = bodyPartWithLocale(2, 1, Locale.GERMAN);
+
+					// key 1 is created at v1 but never flushed on its own; v2 drops and immediately re-creates
+					// it, folding both into a single entry. That entry is an overwrite, not a creation: v1 puts
+					// the key into the root first when the whole batch is promoted by one flush.
+					offsetIndex.put(1L, original);
+					offsetIndex.remove(2L, 1, EntityBodyStoragePart.class);
+					offsetIndex.put(2L, reAdded);
+					offsetIndex.flush(2L);
+
+					assertEquals(reAdded, offsetIndex.get(2L, 1, EntityBodyStoragePart.class),
+						"get key 1 at v2 resolves the re-added payload");
+					assertTrue(offsetIndex.contains(2L, 1, EntityBodyStoragePart.class),
+						"contains key 1 at v2 agrees with get");
+					assertEquals(original, offsetIndex.get(1L, 1, EntityBodyStoragePart.class),
+						"get key 1 at v1 still resolves the payload written there");
+					assertEquals(1, offsetIndex.count(1L), "count at v1 sees key 1");
+					assertEquals(1, offsetIndex.count(2L), "count at v2 sees the re-added key 1");
 				});
 			}
 		}


### PR DESCRIPTION
Closes #1406

Two independent defects in `OffsetIndex`'s flush path, both reachable from generational seed `-802520018`.

**1. `doPut` decided create-vs-update from the published root alone**, ignoring a not-yet-flushed write to the same key from an earlier version. `doRemove` already consulted the in-flight state, so the two paths disagreed and promotion fired `Record was already present!` or `Record was not present!`.

The new lookup is deliberately bounded to versions *strictly before* this one. A remove and a re-add within the same version fold into a single entry regardless, so consulting this version's own not-yet-registered activity would misjudge a same-transaction delete-then-recreate of a key that already exists in the published root as a brand new key.

**2. `NonFlushedValueSet` mis-counted cardinality** — found while writing tests for the first defect, and independent of it. A key created and then removed within one version recorded the removal of something never published, driving the in-flight record count **negative** (`count()` returned `-1`). A key removed and then re-added within one version lost the removal's cardinality effect and reported one record fewer than the very next flush published.

## Verification

Both reported assertions reproduce deterministically from two short black-box tests when only the `doPut` hunk is reverted — the fix was proven by revert-verify rather than by the suite going green.

The cardinality defects are covered by three new tests, plus count assertions added to two existing ones that previously asserted nothing about counts. `OffsetIndexTest` 80/80. Full `unitAndFunctional` (20879 tests) clean of both messages.

## Note for reviewers

Fixing this removes a crash that was pre-empting two further failures on the same seed, on removal paths during WAL replay. Those are pre-existing and **not** caused by this change; they are being filed separately rather than folded in here.
