### PR TITLE
fix: resolve WAL append position from the newest file, not the log reference

### DIFF
--- a/documentation/user/en/deep-dive/storage-model.md
+++ b/documentation/user/en/deep-dive/storage-model.md
@@ -163,13 +163,60 @@ Data records contain the actual data payload for each record type and are used t
 
 The write-ahead log is a separate data structure to which all transactional changes are written in the form of serialized "mutations" when a transaction commit is accepted. Individual mutations are written using the <a href="#record-structure-in-the-storage">standard structure</a>, one after the other, in the order they were performed in the transaction. Transactions are separated by a header that contains the overall transaction length in bytes (`int32`). Also, at the start of each transaction, a <SourceClass>evita_api/src/main/java/io/evitadb/api/requestResponse/transaction/TransactionMutation.java</SourceClass> record is written, containing basic information about the transaction itself for easier orientation. After this, the list of individual mutations follows. The transaction length header allows fast navigation between transactions in the WAL file without deserializing each mutation.
 
-Each transaction in the WAL is followed by a cumulative CRC32C checksum (8 bytes as `int64`). This checksum is calculated over all bytes written to the WAL file from the beginning up to (but not including) the checksum itself. This includes the transaction length headers, TransactionMutation records, and all mutation payloads. The cumulative nature of this checksum means that any corruption in any part of the WAL file will be detected when reading subsequent transactions. If a checksum mismatch is detected during WAL reading, the database will truncate the WAL at the point of corruption and recover using only the valid preceding transactions.
+Each transaction in the WAL is followed by a cumulative CRC32C checksum (8 bytes as `int64`). This checksum is calculated over all bytes written to the WAL file from the beginning up to (but not including) the checksum itself. This includes the transaction length headers, TransactionMutation records, and all mutation payloads. If a checksum mismatch is detected during WAL reading, the database will truncate the WAL at the point of corruption and recover using only the valid preceding transactions.
+
+<Note type="info">
+
+<NoteTitle toggles="true">
+
+##### What the cumulative checksum does and does not detect
+
+</NoteTitle>
+
+The name *cumulative* makes it sound as though each checksum vouches for the whole file up to that point. In practice each one vouches for its own transaction. The distinction matters if you are reasoning about what the WAL protects you from, so it is worth a paragraph.
+
+The checksum after a transaction is calculated from every byte before it, and those bytes include the checksums of the earlier transactions. That last part is the catch. CRC checksums have a well-known property: if you feed some data into the calculation and then feed in that data's own checksum, you always land on the same fixed number, whatever the data was. It is the trick network protocols use to check a packet in a single pass. Here it means the calculation effectively starts fresh at every checksum, so each one ends up describing only the transaction it follows.
+
+That still leaves your data covered, just by two mechanisms rather than one:
+
+- **A half-written or damaged transaction is caught by the checksum.** This is the failure that actually happens — the server loses power in the middle of a commit, or a disk hands back bad bytes. The damaged transaction fails its check and everything written before it stays valid. It is also why turning `computeCRC32C` off makes writes slower: without the checksum to spot the damage, evitaDB has to prevent it instead, by flushing every write to the device in order (see the <a href="/documentation/operate/configure?lang=evitaql#storage-configuration" target="_blank">storage configuration</a>).
+- **Transactions that are shuffled, repeated or missing are caught by the catalog version.** Every transaction is stamped with the catalog version it produces, and those numbers increase by exactly one. When evitaDB replays the log it insists on seeing them in that order with none skipped, so a log whose transactions have been reordered, duplicated, or copied in from elsewhere is rejected before any of it is applied.
+
+Neither mechanism is intended to protect against someone deliberately editing the WAL, and a cleverer checksum would not change that — anyone who can alter the data can recalculate the checksums to match. Checksums catch accidents, not sabotage.
+
+</Note>
+
+<Note type="info">
+
+<NoteTitle toggles="true">
+
+##### What happens when a bit flips on disk
+
+</NoteTitle>
+
+Storage hardware occasionally returns something other than what was written to it — a bit flipped by a failing cell, a controller firmware bug, a cable glitch. No database can stop that from happening. What evitaDB guarantees is that it will not *silently replay* the result: corrupted transactions are recognised as corrupted rather than applied as if they were genuine changes to your data.
+
+A flipped bit anywhere inside a transaction changes the bytes the checksum was calculated from, so the value on disk no longer matches what gets recalculated on the way in. That holds wherever the flip lands — in a mutation payload, in the record headers, in the transaction length prefix, or even inside the stored checksum itself. Any of them produce a mismatch.
+
+CRC32C is chosen for this because its detection guarantees are precise rather than probabilistic in the cases that matter most:
+
+- a single flipped bit is **always** detected;
+- a run of consecutive damaged bits up to 32 bits long — the typical shape of a hardware read error — is **always** detected;
+- for wider or more scattered damage, the chance of corruption slipping through is about one in four billion.
+
+A transaction also passes a second, independent check. Every record inside it carries its own CRC32C as part of the <a href="#record-structure-in-the-storage">standard record structure</a>, verified when the record is deserialized during replay. Damage therefore has to defeat two separate checksums to reach your data.
+
+When a mismatch is found, evitaDB trims the WAL back to the last transaction that verified and keeps the original file as `_damaged_wal.bck`, so the untrimmed bytes remain available for inspection. Note that this drops the damaged transaction *and everything recorded after it* — the log is a sequence, and there is no way to safely apply later changes across a gap. Everything before the damaged transaction is kept and replayed as normal.
+
+One consequence worth planning around: **all of this depends on `computeCRC32C` being enabled** (it is by default). Switch it off and both layers of checking become no-ops that always answer "matches", so damaged data would be replayed as though it were real. The write-ordering mode that replaces it protects against a crash leaving a half-written transaction; it does nothing about a disk that hands back the wrong bytes. Leave checksums on unless you specifically want that write throughput and accept losing silent-corruption detection to get it.
+
+</Note>
 
 The write-ahead log has a maximum file size set by the <a href="https://evitadb.io/documentation/operate/configure#transaction-configuration" target="_blank">walFileSizeBytes</a> setting. Once this limit is reached, the file is closed and a new one is created with the next index number in its name. The maximum number of WAL files is determined by <a href="https://evitadb.io/documentation/operate/configure#transaction-configuration" target="_blank">walFileCountKept</a>. When this maximum is reached, the oldest file is removed. This mechanism ensures WAL files never grow excessively large and do not accumulate indefinitely on the disk.
 
-Each WAL file starts and ends with cumulative CRC32C checksum. Initial cumulative checksum refers to the end cumulative checksum of the previous WAL file (or zero if it’s the first file). This allows for continuous verification of the entire WAL sequence across multiple files.
+Each WAL file starts and ends with a cumulative CRC32C checksum. The one at the start is a copy of the closing checksum of the previous WAL file (or zero for the very first file), so each file records which one it followed. As the note above explains, it is the catalog versions rather than this value that actually verify that order when the database starts.
 
-At the end of each WAL file except the current one that is still being written to, there is a pair of `int64` values representing the first and last catalog versions recorded in that WAL file, followed by a third `int64` value containing the final cumulative CRC32C checksum of the entire WAL file content. This allows quick navigation among WAL files if you need to locate a particular transaction that made changes to the catalog matching a specific version and also verification that the file content is intact.
+At the end of each WAL file except the current one that is still being written to, there is a pair of `int64` values representing the first and last catalog versions recorded in that WAL file, followed by a third `int64` value containing the final cumulative CRC32C checksum, calculated over everything before it including those two versions. The version pair is what lets evitaDB go straight to the right file when it needs the transaction that moved the catalog to a particular version, instead of opening them all.
 
 #### WAL Transaction Format
 
@@ -195,7 +242,7 @@ Each transaction in the WAL file has the following structure:
 | Mutation payloads     | record[]  | variable        |
 | Cumulative CRC32C     | int64     | 8B              |
 
-The cumulative CRC32C is computed incrementally as bytes are written to the WAL file. When reading transactions, this checksum is verified to ensure data integrity. If verification fails, a `WriteAheadLogCorruptedException` (for catalog WAL) or `EngineMutationLogCorruptedException` (for engine WAL) is thrown, and the WAL is truncated to the last valid transaction.
+The cumulative CRC32C is computed as the bytes are written to the WAL file, and checked again when transactions are read back. A transaction that fails the check on startup does not stop the database. evitaDB trims the WAL back to the last transaction that verified, keeps the untrimmed file next to it as `_damaged_wal.bck` so nothing disappears silently, and logs a warning. Recovering as far as the data is sound is deliberate — the alternative would be a database that refuses to start because its last commit was interrupted. A `WriteAheadLogCorruptedException` (for catalog WAL) or `EngineMutationLogCorruptedException` (for engine WAL) is raised only for damage that cannot be handled this way, such as a WAL file that is missing altogether or too short to make sense of.
 
 If the end of a WAL file contains a partially written record or transaction (i.e., its size does not match the size specified in the transaction header or in a transaction mutation), the WAL file is truncated to the last valid WAL entry upon database startup.
 

--- a/evita_common/src/main/java/io/evitadb/utils/Crc32CWrapper.java
+++ b/evita_common/src/main/java/io/evitadb/utils/Crc32CWrapper.java
@@ -182,6 +182,13 @@ public class Crc32CWrapper {
 	 * `new Crc32CWrapper(cumulative).withLong(value).getValue()` but without ever calling
 	 * {@link #forceValue(long)}.
 	 *
+	 * **Folding a checksum into the state that produced it yields a constant.** `combineLong(x, x)` returns the
+	 * same value for every `x` — it computes `CRC(M ‖ CRC(M))`, the CRC *residue*, which is what lets protocols
+	 * verify a frame by checking for one magic value. This is a property of CRCs, not of this implementation, and
+	 * it means such a fold **erases** the running value rather than extending it. Deliberate at the WAL's
+	 * per-transaction boundary; a defect anywhere it is mistaken for chaining. See the `checksum` field of
+	 * `io.evitadb.store.wal.AbstractMutationLog`.
+	 *
 	 * @param cumulative the running cumulative CRC32C value to fold {@code value} into
 	 * @param value      the long value to fold in, in the same little-endian layout as {@link #withLong(long)}
 	 * @return the updated cumulative CRC32C value

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -3059,9 +3059,27 @@ public class DefaultCatalogPersistenceService
 			this.closed = true;
 			// stop the ticker and settle the debt before anything is torn down: no service may go away still owing
 			// a device flush, or the bytes it wrote would depend on the operating system getting round to them.
-			// The bootstrap record is deliberately NOT written here - it is a checkpoint pointer, and leaving it at
-			// the last checkpoint simply means restart resumes from there and replays the rest from the WAL.
+			//
+			// A checkpoint owed by the last round is published first. That round already built the bootstrap record
+			// and left the index at its own version, so this publishes a state that is by construction complete -
+			// it does not wait for anything, and it does not drain: `TransactionManager#close` fails pending
+			// transactions rather than finishing them, so newer versions may still be missing and the write-ahead
+			// log remains the authority on them. What it buys is that a clean restart resumes from here instead of
+			// replaying from whichever checkpoint the ticker last happened to reach. Nothing is written when no
+			// checkpoint is owed, which is the case whenever the round that just finished checkpointed itself.
 			if (this.checkpointCoordinator != null) {
+				try {
+					// ordered before the WAL is closed: publishing also tells the log how far it has been processed
+					this.checkpointCoordinator.checkpointIfOwed();
+				} catch (RuntimeException ex) {
+					// shutdown must not be aborted by this - the state stays crash-consistent either way, the next
+					// start simply replays more of the write-ahead log than it would have needed to
+					log.error(
+						"Final checkpoint of catalog `{}` failed - the next start will resume from the previous " +
+							"checkpoint and replay the remainder from the write-ahead log!",
+						this.catalogName, ex
+					);
+				}
 				try {
 					this.checkpointCoordinator.forcePendingSyncs();
 				} catch (RuntimeException ex) {

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
@@ -154,6 +154,9 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	/**
 	 * The size of the cumulative CRC32C checksum written after each transaction in the WAL file.
 	 * The checksum is stored as a little-endian long (8 bytes).
+	 *
+	 * See the {@link #checksum} field for what this value does and does not detect — it is narrower than
+	 * "cumulative" suggests, and the difference has been rediscovered more than once.
 	 */
 	public static final int CUMULATIVE_CRC32_SIZE = 8;
 	/**
@@ -161,7 +164,10 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	 *
 	 * - first catalog version mutation of the WAL file
 	 * - last catalog version mutation of the WAL file
-	 * - final cumulative CRC32C checksum of the entire WAL file content
+	 * - final cumulative CRC32C checksum, computed over the whole file including these two versions
+	 *
+	 * The third long is the CRC32C of every byte before it, but it does not attest to the file as a whole —
+	 * see the {@link #checksum} field.
 	 */
 	public static final int WAL_TAIL_LENGTH = 8 + 8 + CUMULATIVE_CRC32_SIZE;
 	/**
@@ -169,7 +175,33 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	 */
 	protected static final long CUT_WAL_CACHE_AFTER_INACTIVITY_MS = 300_000L; // 5 minutes
 	/**
-	 * The calculator for computing checksums.
+	 * The running CRC32C written after every transaction. **This is the authoritative description of what that
+	 * value guarantees** — the constants above and the format documentation point here rather than restating it.
+	 *
+	 * Each stored value is the CRC32C of every byte preceding it in the file, exactly as the format documents.
+	 * Because that coverage includes the *previous stored checksums*, and `CRC(M ‖ CRC(M))` is the CRC **residue**
+	 * — a constant, whatever `M` was — the running value returns to that same constant at every stored checksum.
+	 * Both statements are therefore true at once: a checksum covers everything before it, **and** it carries no
+	 * information about anything before the preceding checksum.
+	 *
+	 * What that means in practice:
+	 *
+	 * - **Detected:** damage inside a transaction — a torn write, a hole left by out-of-order writeback, bit rot.
+	 *   This is the case recovery exists for, and it is why `computeCRC32C` and write ordering are coupled (see
+	 *   {@link #openWalChannel(Path)}).
+	 * - **Not detected:** whole transactions exchanged, duplicated, dropped, or spliced in from another WAL file;
+	 *   nor a wrong per-file seed. Each transaction's checksum verifies from the same constant wherever it sits.
+	 *   `CatalogWriteAheadLogTest#shouldNotDetectReorderedTransactions` pins this.
+	 * - **Covered elsewhere:** all of the above is rejected by the catalog-version continuity check during replay
+	 *   — {@link io.evitadb.core.transaction.TransactionManager} asserts every transaction carries exactly the
+	 *   next expected catalog version. Ordering is that check's job, never this one's.
+	 *
+	 * No arrangement of this scheme can do better: a chain that survives a transaction boundary has to *exclude*
+	 * the checksum bytes from its coverage. Nor would chaining defend against a forged transaction — anyone able
+	 * to rewrite the bytes can recompute the checksums over them. CRC detects accidents, not tampering.
+	 *
+	 * Not to be confused with the record-level cumulative checksum in
+	 * {@link io.evitadb.store.offsetIndex.model.StorageRecord}, which covers one record and is unrelated to this.
 	 */
 	protected final Checksum checksum;
 	/**
@@ -700,7 +732,7 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	 *   the device in any order, so a crash can leave a *hole* — bytes missing in the middle of a
 	 *   transaction while later bytes landed. The file length is unchanged, so the framing still parses
 	 *   and nothing about the record looks wrong; the only thing that can tell a hole from valid data is
-	 *   the cumulative CRC32C chain, which recovery verifies per transaction and reacts to by truncating.
+	 *   the cumulative CRC32C, which recovery verifies per transaction and reacts to by truncating.
 	 * - **Write ordering (slow, the fallback).** With `computeCRC32C` switched off that chain degrades to
 	 *   {@link io.evitadb.store.checksum.Checksum#NO_OP}, whose comparison always answers "matches" — so a
 	 *   hole is waved straight through recovery and replayed as if it were real history. There is then no
@@ -818,9 +850,6 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 		this.kryoPool = kryoPool;
 		this.processedVersion = new AtomicLong(version);
 		this.storageSettings = storageSettings;
-		this.checksum = storageSettings.createCumulativeChecksum(logRecordReference.cumulativeChecksum());
-		// we must calculate the checksum into the cumulative checksum instance
-		this.checksum.update(logRecordReference.cumulativeChecksum());
 		this.cutWalCacheTask = this.createDelayedAsyncTask(
 			"WAL cache cutter",
 			scheduler,
@@ -836,17 +865,28 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 		this.maxWalFileSizeBytes = storageSettings.walFileSizeBytes();
 		this.walFileCountKept = storageSettings.walFileCountKept();
 		this.storageFolder = storageFolder;
-		final AtomicInteger currentWalFileIndex = new AtomicInteger(logRecordReference.fileIndex());
+		final int[] firstAndLastWalFileIndex = getFirstAndLastWalFileIndex(storageFolder);
+		// Two different questions, and only one file index used to answer both of them. The reference says where
+		// REPLAY starts; the newest file on disk says where APPENDS resume. They coincide only when nothing rotated
+		// since the last published bootstrap record, which a restart cannot rely on - a catalog deliberately
+		// resumes from the last checkpoint and replays the remainder (see DefaultCatalogPersistenceService#close),
+		// and a crash publishes no bootstrap record at all. All that may be demanded of the reference is that the
+		// file it points into still exists, which rotation guarantees: a WAL file is dropped only once every
+		// version inside it has been processed (see #removeWalFiles).
+		final int activeWalFileIndex = firstAndLastWalFileIndex[1];
+		final int referencedWalFileIndex = logRecordReference.fileIndex();
 		try {
-			final int[] firstAndLastWalFileIndex = getFirstAndLastWalFileIndex(storageFolder);
-
-			final Path walFilePath = storageFolder.resolve(this.walFileNameProvider.apply(currentWalFileIndex.get()));
+			final Path walFilePath = storageFolder.resolve(this.walFileNameProvider.apply(activeWalFileIndex));
 			Assert.isPremiseValid(
-				firstAndLastWalFileIndex[1] == logRecordReference.fileIndex(),
+				referencedWalFileIndex >= firstAndLastWalFileIndex[0] &&
+					referencedWalFileIndex <= activeWalFileIndex,
 				() -> new WriteAheadLogCorruptedException(this.walKind,
-					"The last WAL file index in the storage (" + firstAndLastWalFileIndex[1] + ") " +
-						"does not match the expected index from the log record reference (" + walFilePath + ")!",
-					"WAL file index mismatch!"
+					"The WAL file the log record reference points at (" +
+						this.walFileNameProvider.apply(referencedWalFileIndex) + ") is not among the files present " +
+						"in the storage (" + this.walFileNameProvider.apply(firstAndLastWalFileIndex[0]) + " to " +
+						this.walFileNameProvider.apply(firstAndLastWalFileIndex[1]) + ") - replay cannot start " +
+						"from a file that is gone!",
+					"WAL file referenced by the log record reference is missing!"
 				)
 			);
 
@@ -855,25 +895,33 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 			);
 
 			final FirstAndLastVersionsInWalFile versions = checkAndTruncate(
-				walFilePath, kryoPool, logRecordReference
+				walFilePath, kryoPool, activeWalFileIndex, logRecordReference
 			);
 
-			// the WAL file has been truncated - we need to adjust the log record reference accordingly
-			if (versions.logFileRecordReference() != null) {
+			// the WAL file has been truncated - we need to adjust the log record reference accordingly. Only when
+			// the truncation touched the very file the reference points into, though: `versions` describes the
+			// ACTIVE file, and adopting it while the reference lives in an older one would move replay's starting
+			// point forward past transactions that were never processed.
+			if (versions.logFileRecordReference() != null && activeWalFileIndex == referencedWalFileIndex) {
 				logRecordReference = versions.logFileRecordReference();
 			}
 
-			lastVersion.ifPresent(
-				firstAndLastVersionsInWalFile -> Assert.isPremiseValid(
-					firstAndLastVersionsInWalFile.lastVersion() + 1 == versions.firstVersion(),
-					() -> new WriteAheadLogCorruptedException(this.walKind,
-						currentWalFileIndex.get(),
-						firstAndLastVersionsInWalFile.lastVersion(),
-						versions.firstVersion(),
-						this.walFileNameProvider
+			// nothing to join when the active file holds no transaction yet - a crash between rotation creating
+			// the next file and the first append landing in it leaves exactly that, and the finalized run before
+			// it is already verified continuous by `verifyWalFileVersionsAndReturnLastFinalized`
+			if (versions.firstVersion() > -1) {
+				lastVersion.ifPresent(
+					firstAndLastVersionsInWalFile -> Assert.isPremiseValid(
+						firstAndLastVersionsInWalFile.lastVersion() + 1 == versions.firstVersion(),
+						() -> new WriteAheadLogCorruptedException(this.walKind,
+							activeWalFileIndex,
+							firstAndLastVersionsInWalFile.lastVersion(),
+							versions.firstVersion(),
+							this.walFileNameProvider
+						)
 					)
-				)
-			);
+				);
+			}
 
 			// create the WAL file if it does not exist
 			final boolean created = createWalFile(walFilePath, true, this.walKind);
@@ -889,9 +937,18 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 				this.storageSettings.createCompressor().orElse(null)
 			);
 
+			// Where REPLAY starts and where APPENDS resume hold the same checksum only while the reference still
+			// sits in the newest file; once rotation has left it behind they diverge. Resolved from the active
+			// file so the value stored alongside it describes that file rather than the reference's position.
+			// Note this is bookkeeping, not a correctness guard: the value seeds nothing that is later verified
+			// (see the `checksum` field for why), so getting it wrong is invisible rather than corrupting.
+			final long activeFileCumulativeChecksum = resolveActiveFileCumulativeChecksum(
+				versions, logRecordReference, walFilePath, created
+			);
+
 			// if the file was just created, write the initial cumulative checksum
 			if (created) {
-				theOutput.writeLong(logRecordReference.cumulativeChecksum());
+				theOutput.writeLong(activeFileCumulativeChecksum);
 				this.contentLengthBuffer.clear();
 				this.contentLengthBuffer.put(theOutput.getBuffer(), 0, theOutput.position());
 				this.contentLengthBuffer.flip();
@@ -899,30 +956,95 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 					walFileChannel.write(this.contentLengthBuffer) == CUMULATIVE_CRC32_SIZE,
 					"Failed to write initial cumulative checksum to WAL file!"
 				);
-				// every transaction appended later chains its checksum onto this seed, so it has to be on
-				// the device before any of them - the first append's force would cover it, but this file
-				// is created once and the sync is not worth economising on
+				// part of the file's declared format and read back by every scan, so it has to be on the
+				// device before any transaction lands after it - the first append's force would cover it,
+				// but this file is created once and the sync is not worth economising on
 				forceDurable(walFileChannel);
 			}
 
+			this.checksum = storageSettings.createCumulativeChecksum(activeFileCumulativeChecksum);
+			// we must calculate the checksum into the cumulative checksum instance
+			this.checksum.update(activeFileCumulativeChecksum);
+
 			this.currentWalFile.set(
 				new CurrentMutationLogFile(
-					currentWalFileIndex.get(),
+					activeWalFileIndex,
 					versions.firstVersion(),
 					versions.lastVersion(),
 					walFilePath,
 					walFileChannel,
 					theOutput,
 					walFileChannel.size(),
-					logRecordReference.cumulativeChecksum()
+					activeFileCumulativeChecksum
 				)
 			);
 		} catch (IOException e) {
 			throw new WriteAheadLogCorruptedException(this.walKind,
-				"Failed to open WAL file `" + this.walFileNameProvider.apply(currentWalFileIndex.get()) + "`!",
+				"Failed to open WAL file `" + this.walFileNameProvider.apply(activeWalFileIndex) + "`!",
 				"Failed to open the WAL file!",
 				e
 			);
+		}
+	}
+
+	/**
+	 * Resolves the cumulative checksum the active WAL file currently stands at.
+	 *
+	 * This is deliberately **not** the reference's checksum. The reference describes the last *processed*
+	 * transaction and is where replay starts; this value belongs to the newest file on disk, and the two diverge
+	 * the moment rotation happens after the last published bootstrap record.
+	 *
+	 * Be aware of what this value does and does not do — it is recorded and carried forward, but nothing verified
+	 * later depends on it. See the {@link #checksum} field for why a WAL checksum cannot carry state across a
+	 * transaction boundary; the practical consequence is that an error here is inert rather than corrupting.
+	 *
+	 * @param activeFileVersions  what scanning the active file found in it
+	 * @param logRecordReference  the reference the log was opened against
+	 * @param walFilePath         path of the active WAL file
+	 * @param created             whether the active file had to be created by this constructor
+	 * @return the cumulative checksum the active file stands at
+	 * @throws IOException if the active file's seed cannot be read
+	 */
+	private long resolveActiveFileCumulativeChecksum(
+		@Nonnull FirstAndLastVersionsInWalFile activeFileVersions,
+		@Nonnull LogFileRecordReference logRecordReference,
+		@Nonnull Path walFilePath,
+		boolean created
+	) throws IOException {
+		final LogFileRecordReference scannedReference = activeFileVersions.logFileRecordReference();
+		if (scannedReference != null) {
+			// the scan found a chain that differs from the reference's, and it describes the active file
+			return scannedReference.cumulativeChecksum();
+		}
+		if (activeFileVersions.firstVersion() > -1 || created) {
+			// either the scan confirmed the active file's chain already equals the reference's (that is what a
+			// null reference means there), or the file is brand new and is seeded from the reference
+			return logRecordReference.cumulativeChecksum();
+		}
+		// The active file holds no transaction at all - it carries only the 8-byte cumulative checksum header that
+		// rotation seeds a new file with. That header is the chain the previous file ended on, and is the only
+		// correct seed here. The reference must not be used instead: it stops at the last PROCESSED transaction,
+		// which can be several transactions short of the end of the previous file.
+		Assert.isPremiseValid(
+			walFilePath.toFile().length() >= CUMULATIVE_CRC32_SIZE,
+			() -> new WriteAheadLogCorruptedException(this.walKind,
+				"The newest WAL file `" + walFilePath + "` holds neither a transaction nor the cumulative " +
+					"checksum header rotation seeds it with - the chain it continues cannot be established!",
+				"WAL file is missing its cumulative checksum header!"
+			)
+		);
+		// the append channel is write-only, so the seed is read through a channel of its own
+		try (final FileChannel readChannel = FileChannel.open(walFilePath, StandardOpenOption.READ)) {
+			final ByteBuffer seedBuffer = ByteBuffer.allocate(CUMULATIVE_CRC32_SIZE).order(ByteOrder.LITTLE_ENDIAN);
+			Assert.isPremiseValid(
+				readChannel.read(seedBuffer, 0) == CUMULATIVE_CRC32_SIZE,
+				() -> new WriteAheadLogCorruptedException(this.walKind,
+					"Failed to read the cumulative checksum header of WAL file `" + walFilePath + "`!",
+					"Failed to read the WAL file cumulative checksum header!"
+				)
+			);
+			seedBuffer.flip();
+			return seedBuffer.getLong();
 		}
 	}
 
@@ -1582,6 +1704,31 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 		@Nonnull Pool<Kryo> catalogKryoPool,
 		@Nonnull LogFileRecordReference logRecordReference
 	) {
+		return checkAndTruncate(walFilePath, catalogKryoPool, logRecordReference.fileIndex(), logRecordReference);
+	}
+
+	/**
+	 * Same as {@link #checkAndTruncate(Path, Pool, LogFileRecordReference)}, but told explicitly which WAL file
+	 * index is being scanned instead of taking it from the reference.
+	 *
+	 * The two differ whenever a restart resumes from a reference that rotation has left behind: the file to scan
+	 * and truncate is the newest one on disk, while the reference still points into an older, finalized file. Any
+	 * reference this method derives describes **the file it scanned**, so passing the index separately is what
+	 * keeps it from minting a reference carrying one file's index and another file's position and checksum.
+	 *
+	 * @param walFilePath        the path to the WAL file to check and truncate
+	 * @param catalogKryoPool    the Kryo object pool to use for deserialization
+	 * @param walFileIndex       index of the WAL file being scanned - stamped on any derived reference
+	 * @param logRecordReference the reference whose cumulative checksum decides whether a derived one is needed
+	 * @return the first and last catalog versions found in the scanned file
+	 */
+	@Nonnull
+	protected FirstAndLastVersionsInWalFile checkAndTruncate(
+		@Nonnull Path walFilePath,
+		@Nonnull Pool<Kryo> catalogKryoPool,
+		int walFileIndex,
+		@Nonnull LogFileRecordReference logRecordReference
+	) {
 		if (AbstractMutationLog.isWalEmptyOrNonExisting(walFilePath)) {
 			return FirstAndLastVersionsInWalFile.EMPTY;
 		}
@@ -1631,7 +1778,7 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 							// otherwise we need to return a new reference with corrected checksum and position
 							new LogFileRecordReference(
 								this.walFileNameProvider,
-								logRecordReference.fileIndex(),
+								walFileIndex,
 								new FileLocation(scanResult.lastTxStartPosition(), scanResult.lastTxLength()),
 								scanResult.cumulativeChecksum()
 							)
@@ -2190,7 +2337,8 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	/**
 	 * Writes the WAL (Write Ahead Log) tail information to the specified WAL file.
 	 * The method writes the first and last change versions specified to the tail of the WAL file,
-	 * followed by the final cumulative CRC32C checksum of the entire WAL file content.
+	 * followed by the final cumulative CRC32C checksum, computed over everything preceding it including those
+	 * two versions. That value does not attest to the file as a whole — see the {@link #checksum} field.
 	 *
 	 * @param firstCvInFile  the first change version present in the WAL file
 	 * @param lastCvInFile   the last change version present in the WAL file

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
@@ -1526,31 +1526,48 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	}
 
 	/**
-	 * Returns UUID of the first transaction that is present in the WAL file and which transitions the catalog to
-	 * the version that is greater by one than the current catalog version.
+	 * Returns the first transaction that follows the given reference - the point replay resumes from.
 	 *
-	 * @param walReference the current catalog version
-	 * @return UUID of the first transaction that is present in the WAL file and which transitions the catalog to
+	 * The search is **not** confined to the file the reference points into. A reference may name the last
+	 * transaction of a file rotation has since finalized, in which case the transactions still to be replayed
+	 * begin in a later file; the search walks forward until it finds one or runs out of files.
+	 *
+	 * @param walReference the position already processed, or `null` to start from the beginning of the newest file
+	 * @return the first transaction after `walReference`, or empty when nothing remains to be replayed
 	 */
 	@Nonnull
 	public Optional<TransactionMutationWithWalFileReference> getFirstNonProcessedTransaction(
 		@Nullable LogFileRecordReference walReference
 	) {
-		final Path walFilePath;
-		final int walFileIndex;
-		final long startPosition;
+		final int newestWalFileIndex = getWalFileIndex();
+		int walFileIndex;
+		long startPosition;
 		if (walReference == null) {
-			walFileIndex = getWalFileIndex();
-			walFilePath = this.storageFolder.resolve(this.walFileNameProvider.apply(walFileIndex));
+			walFileIndex = newestWalFileIndex;
 			startPosition = CUMULATIVE_CRC32_SIZE;
 		} else {
-			walFilePath = walReference.toFilePath(this.storageFolder);
 			walFileIndex = walReference.fileIndex();
 			final FileLocation fileLocation = Objects.requireNonNull(walReference.fileLocation());
 			startPosition = fileLocation.endPosition();
 		}
-		final File walFile = walFilePath.toFile();
-		if (walFile.exists() && walFile.length() > startPosition + TRANSACTION_PREFIX_SIZE + CUMULATIVE_CRC32_SIZE) {
+
+		// The reference may end the file it points into: a checkpoint that lands exactly on a rotation boundary
+		// leaves the remainder in the NEXT file. Everything past the last transaction of a rotated file is its
+		// `WAL_TAIL_LENGTH` trailer, which carries no transaction - reading it as one interprets the version bytes
+		// as a record length and fails the whole recovery, even though the transactions are intact one file over.
+		// So walk forward: a finalized file that holds nothing but its tail hands the search to its successor.
+		while (walFileIndex <= newestWalFileIndex) {
+			final Path walFilePath = this.storageFolder.resolve(this.walFileNameProvider.apply(walFileIndex));
+			final File walFile = walFilePath.toFile();
+			// a finalized file always ends with the trailer, so anything at or below it means "no transaction
+			// left here"; the active file carries no trailer and only needs room for a record and its checksum
+			final long minimumRemainder = walFileIndex < newestWalFileIndex ?
+				WAL_TAIL_LENGTH : TRANSACTION_PREFIX_SIZE + CUMULATIVE_CRC32_SIZE;
+			if (!walFile.exists() || walFile.length() <= startPosition + minimumRemainder) {
+				walFileIndex++;
+				startPosition = CUMULATIVE_CRC32_SIZE;
+				continue;
+			}
 			final Kryo kryo = this.kryoPool.obtain();
 			try (
 				final RandomAccessFile randomAccessOldWalFile = new RandomAccessFile(walFile, "r");

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DeferredCheckpointPersistenceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DeferredCheckpointPersistenceTest.java
@@ -54,6 +54,7 @@ import java.util.EnumSet;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.evitadb.spi.store.catalog.persistence.CatalogPersistenceService.getCatalogBootstrapFileName;
 import static io.evitadb.test.TestTags.STORAGE;
 import static io.evitadb.test.TestTags.TRANSACTION;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -153,7 +154,7 @@ class DeferredCheckpointPersistenceTest implements EvitaTestSupport {
 	}
 
 	@Test
-	@DisplayName("should checkpoint on close so no service goes away owing a device flush")
+	@DisplayName("should publish an owed checkpoint on close so a clean restart need not replay it")
 	void shouldCheckpointPendingSyncsOnClose() {
 		try (DefaultCatalogPersistenceService cps = createService(NEVER_ELAPSES_MILLIS)) {
 			cps.getStoragePartPersistenceService(0L)
@@ -166,14 +167,50 @@ class DeferredCheckpointPersistenceTest implements EvitaTestSupport {
 		}
 		// must not throw - close settles the outstanding device flushes rather than abandoning them
 
-		// reopening lands on the last CHECKPOINTED version, which is the state a restart legitimately sees:
-		// everything past it is replayed from the write-ahead log
+		// The round that deferred had already built its bootstrap record and left the index at its own version, so
+		// close publishes that state as it stands. It waits for nothing and drains nothing - `TransactionManager`
+		// fails pending transactions on close rather than finishing them, so anything newer than the last completed
+		// round remains the write-ahead log's business. What this buys is that a clean restart resumes here instead
+		// of replaying from whichever checkpoint the ticker last happened to reach.
 		try (final DefaultCatalogPersistenceService reopened = createLoadingService(NEVER_ELAPSES_MILLIS)) {
-			assertTrue(
-				reopened.getLastCatalogVersion() < 2L,
-				"A version whose bootstrap record was never written must not come back as persisted."
+			assertEquals(
+				2L, reopened.getLastCatalogVersion(),
+				"The checkpoint owed when the service closed must have been published, so the restart resumes from it."
 			);
 		}
+	}
+
+	@Test
+	@DisplayName("should write no bootstrap record on close when no checkpoint is owed")
+	void shouldNotCheckpointOnCloseWhenNothingIsOwed() {
+		final Path bootstrapFile = getTestDirectory()
+			.resolve(DIR_DEFERRED_CHECKPOINT_TEST)
+			.resolve(CATALOG_NAME)
+			.resolve(getCatalogBootstrapFileName(CATALOG_NAME));
+
+		final long lengthBeforeClose;
+		// a real interval, so a coordinator genuinely exists - interval 0 creates none at all, and closing without
+		// one would prove nothing about whether close checkpoints only when it is owed
+		try (final DefaultCatalogPersistenceService cps = createService(NEVER_ELAPSES_MILLIS)) {
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+			storeHeaderAt(cps, 2L);
+			// settle the debt before closing, exactly as the ticker or a backup would
+			cps.checkpoint();
+			assertEquals(
+				2L, cps.getLastCatalogVersion(),
+				"Precondition: the checkpoint must be settled, leaving nothing owed at close."
+			);
+			lengthBeforeClose = bootstrapFile.toFile().length();
+		}
+
+		// the calibration for the test above: close publishes what is OWED, and a settled checkpoint owes nothing.
+		// Records here are fixed-size, so an unchanged length is an unchanged record count - without this assertion
+		// the test above would pass just as happily if close wrote a bootstrap record unconditionally.
+		assertEquals(
+			lengthBeforeClose, bootstrapFile.toFile().length(),
+			"Close must not append a bootstrap record when the last round already checkpointed."
+		);
 	}
 
 	@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DeferredCheckpointPersistenceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DeferredCheckpointPersistenceTest.java
@@ -195,6 +195,7 @@ class DeferredCheckpointPersistenceTest implements EvitaTestSupport {
 			cps.getStoragePartPersistenceService(0L)
 				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
 			storeHeaderAt(cps, 2L);
+			final long lengthBeforeCheckpoint = bootstrapFile.toFile().length();
 			// settle the debt before closing, exactly as the ticker or a backup would
 			cps.checkpoint();
 			assertEquals(
@@ -202,6 +203,15 @@ class DeferredCheckpointPersistenceTest implements EvitaTestSupport {
 				"Precondition: the checkpoint must be settled, leaving nothing owed at close."
 			);
 			lengthBeforeClose = bootstrapFile.toFile().length();
+			// `getLastCatalogVersion` answers from the in-memory `bootstrapUsed`, so on its own it cannot tell
+			// "the record was written" from "the service merely thinks so". Proving the checkpoint above grew the
+			// file is what makes the comparison after close meaningful: it establishes that this measurement
+			// detects an appended record, so an unchanged length afterwards is evidence of no append rather than
+			// evidence of a file nothing ever writes to.
+			assertTrue(
+				lengthBeforeClose > lengthBeforeCheckpoint,
+				"Precondition: settling a checkpoint must append a bootstrap record."
+			);
 		}
 
 		// the calibration for the test above: close publishes what is OWED, and a settled checkpoint owes nothing.

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
@@ -47,7 +47,6 @@ import io.evitadb.utils.FileUtils;
 import io.evitadb.utils.UUIDUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -56,7 +55,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -203,7 +201,7 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 			),
 			Mockito.mock(Scheduler.class),
 			offsetDateTime -> {},
-			null
+			AbstractMutationLog.WalPurgeCallback.NO_OP
 		);
 	}
 
@@ -220,7 +218,7 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 			new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)),
 			walFileSizeBytes,
 			10,
-			null
+			AbstractMutationLog.WalPurgeCallback.NO_OP
 		);
 	}
 
@@ -233,8 +231,9 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 	 * @param logFileRecordReference the reference the log is opened against
 	 * @param walFileSizeBytes       the maximum size of each WAL file in bytes
 	 * @param walFileCountKept       how many WAL files rotation leaves unqueued for removal
-	 * @param onWalPurgeCallback     invoked when a purge actually removes files; a test that lets the purge fire
-	 *                               must pass one, because `removeWalFiles` dereferences it unconditionally
+	 * @param onWalPurgeCallback     invoked when a purge actually removes files; `removeWalFiles` dereferences it
+	 *                               unconditionally, so a test that never purges still passes
+	 *                               {@link AbstractMutationLog.WalPurgeCallback#NO_OP} rather than `null`
 	 * @return a configured CatalogWriteAheadLog instance
 	 */
 	@Nonnull
@@ -243,7 +242,7 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 		@Nonnull LogFileRecordReference logFileRecordReference,
 		long walFileSizeBytes,
 		int walFileCountKept,
-		@Nullable AbstractMutationLog.WalPurgeCallback onWalPurgeCallback
+		@Nonnull AbstractMutationLog.WalPurgeCallback onWalPurgeCallback
 	) {
 		return new CatalogWriteAheadLog(
 			catalogVersion,

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
@@ -1103,12 +1103,60 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 	 *
 	 * Note what is deliberately **not** claimed here: that appends continue a checksum chain. Each transaction's
 	 * trailing checksum covers only its own bytes - the running value returns to a fixed constant after every
-	 * record, so no test in this class can distinguish one append-chain seed from another. See the punch list's
-	 * entry on the cumulative checksum for why.
+	 * record, so no test in this class can distinguish one append-chain seed from another. The authoritative
+	 * account of what that checksum does and does not cover is on `AbstractMutationLog#checksum`.
 	 */
 	@Nested
 	@DisplayName("Restart from a position the log has moved past")
 	class RestartAfterRotation {
+
+		@Test
+		@DisplayName("should resume replay when the reference is the last transaction of a rotated file")
+		void shouldResumeReplayWhenReferenceIsLastTransactionOfRotatedFile() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+
+			// small enough that a handful of 200-byte transactions rotate the file more than once
+			final long walFileSizeLimit = 1_000L;
+
+			LogFileRecordReference lastInFirstFile = null;
+			long lastVersionInFirstFile = -1L;
+			try (CatalogWriteAheadLog wal = createTestWal(
+				0L, new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)), walFileSizeLimit, 10,
+				AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				for (int version = 1; version <= 8; version++) {
+					final TransactionWithData txData = createTestTransaction(version - 1, 200);
+					final LogFileRecordReference reference = wal.append(txData.mutation(), txData.data());
+					if (reference.fileIndex() == 0) {
+						lastInFirstFile = reference;
+						lastVersionInFirstFile = version;
+					}
+				}
+			}
+			final LogFileRecordReference processedReference = Objects.requireNonNull(lastInFirstFile);
+			assertTrue(
+				CatalogWriteAheadLogTest.this.walDirectory.resolve(getWalFileName(TEST_CATALOG, 1)).toFile().exists(),
+				"Precondition: rotation must have produced a second WAL file."
+			);
+
+			// the checkpoint landed exactly on the rotation boundary: everything in file 0 is processed and the
+			// remainder lives in file 1. Replay must cross that boundary rather than read into the finalized tail
+			try (CatalogWriteAheadLog reopened = createTestWal(
+				lastVersionInFirstFile, processedReference, walFileSizeLimit, 10,
+				AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				assertEquals(
+					lastVersionInFirstFile + 1,
+					reopened.getFirstNonProcessedTransaction(processedReference)
+						.orElseThrow(() -> new AssertionError("Replay found nothing after the reference!"))
+						.transactionMutation()
+						.getVersion(),
+					"replay must continue into the next WAL file when the reference ends the previous one"
+				);
+			}
+		}
 
 		@Test
 		@DisplayName("should resume replay and keep appending when the reference lags inside the active file")

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
@@ -47,6 +47,7 @@ import io.evitadb.utils.FileUtils;
 import io.evitadb.utils.UUIDUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -64,6 +66,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Tag;
 
@@ -212,10 +215,40 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 	 */
 	@Nonnull
 	private CatalogWriteAheadLog createTestWalWithCustomSize(long walFileSizeBytes) {
-		return new CatalogWriteAheadLog(
+		return createTestWal(
 			0L,
-			TEST_CATALOG,
 			new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)),
+			walFileSizeBytes,
+			10,
+			null
+		);
+	}
+
+	/**
+	 * Creates a test instance of CatalogWriteAheadLog opened against an explicit log record reference. This is the
+	 * shape a restart takes: the reference is whatever the catalog header found through the last published bootstrap
+	 * record, and the WAL directory holds whatever rotation left behind since.
+	 *
+	 * @param catalogVersion         the catalog version the log resumes from
+	 * @param logFileRecordReference the reference the log is opened against
+	 * @param walFileSizeBytes       the maximum size of each WAL file in bytes
+	 * @param walFileCountKept       how many WAL files rotation leaves unqueued for removal
+	 * @param onWalPurgeCallback     invoked when a purge actually removes files; a test that lets the purge fire
+	 *                               must pass one, because `removeWalFiles` dereferences it unconditionally
+	 * @return a configured CatalogWriteAheadLog instance
+	 */
+	@Nonnull
+	private CatalogWriteAheadLog createTestWal(
+		long catalogVersion,
+		@Nonnull LogFileRecordReference logFileRecordReference,
+		long walFileSizeBytes,
+		int walFileCountKept,
+		@Nullable AbstractMutationLog.WalPurgeCallback onWalPurgeCallback
+	) {
+		return new CatalogWriteAheadLog(
+			catalogVersion,
+			TEST_CATALOG,
+			logFileRecordReference,
 			this.walDirectory,
 			this.catalogKryoPool,
 			new StorageSettings(
@@ -224,13 +257,62 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 					.build(),
 				TransactionOptions.builder()
 					.walFileSizeBytes(walFileSizeBytes)
-					.walFileCountKept(10)
+					.walFileCountKept(walFileCountKept)
 					.build()
 			),
 			Mockito.mock(Scheduler.class),
 			offsetDateTime -> {},
-			null
+			onWalPurgeCallback
 		);
+	}
+
+	/**
+	 * Appends 200-byte transactions, one catalog version each starting at 1, until the given WAL file appears -
+	 * i.e. until rotation has happened as many times as that file's index. Deterministic: the file size limit and
+	 * the transaction size decide the count, nothing timing-dependent.
+	 *
+	 * @param wal            the log to append to
+	 * @param awaitedWalFile the WAL file whose appearance ends the loop
+	 * @param referenceAt    catalog version whose append reference is captured and returned
+	 * @return the reference returned by the append of `referenceAt`, plus the last version written
+	 */
+	@Nonnull
+	private RotatedWal appendUntilWalFileAppears(
+		@Nonnull CatalogWriteAheadLog wal,
+		@Nonnull Path awaitedWalFile,
+		long referenceAt
+	) {
+		LogFileRecordReference capturedReference = null;
+		long transactionVersion = 1;
+		while (!Files.exists(awaitedWalFile)) {
+			final TransactionWithData txData = createTestTransaction((int) (transactionVersion - 1), 200);
+			final LogFileRecordReference reference = wal.append(txData.mutation(), txData.data());
+			if (transactionVersion == referenceAt) {
+				capturedReference = reference;
+			}
+			transactionVersion++;
+			if (transactionVersion > 500) {
+				throw new AssertionError(
+					"WAL did not rotate up to `" + awaitedWalFile + "` within the expected number of transactions!"
+				);
+			}
+		}
+		return new RotatedWal(
+			Objects.requireNonNull(capturedReference, "No reference was captured for version " + referenceAt + "!"),
+			transactionVersion - 1
+		);
+	}
+
+	/**
+	 * Outcome of {@link #appendUntilWalFileAppears(CatalogWriteAheadLog, Path, long)}.
+	 *
+	 * @param capturedReference reference of the append that was singled out as "the last checkpointed one"
+	 * @param lastVersion       the last catalog version actually written
+	 */
+	private record RotatedWal(
+		@Nonnull LogFileRecordReference capturedReference,
+		long lastVersion
+	) {
 	}
 
 	/**
@@ -693,6 +775,10 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 	/**
 	 * Nested tests for cumulative CRC32 checksum functionality.
 	 * These tests verify the checksum computation and storage in the WAL file.
+	 *
+	 * Before reading anything here as an integrity guarantee, see the `checksum` field of
+	 * {@link AbstractMutationLog} - it is the authoritative account of what these values detect, which is
+	 * narrower than "cumulative" suggests. In short: damage inside a transaction, and nothing about ordering.
 	 */
 	@Nested
 	@DisplayName("Cumulative CRC32 Tests")
@@ -773,6 +859,14 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 			CatalogWriteAheadLogTest.this.tested = createTestWal();
 		}
 
+		/**
+		 * Proves the stored checksum equals an independently computed CRC32C over every byte preceding it, which
+		 * is exactly what the format specifies.
+		 *
+		 * It does **not** prove that the file is tamper-evident or that its transactions are pinned in place, and
+		 * it must not be cited for either - `shouldNotDetectReorderedTransactions` below shows why. The two tests
+		 * are deliberately adjacent: this one is the reason the misreading is tempting, that one is the correction.
+		 */
 		@Test
 		@DisplayName("should write correct cumulative CRC32C checksum to WAL file")
 		void shouldWriteCorrectCumulativeCrc32ChecksumToWalFile() throws IOException {
@@ -820,6 +914,82 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 				);
 			}
 
+			CatalogWriteAheadLogTest.this.tested = createTestWal();
+		}
+
+		/**
+		 * Pins what the cumulative checksum actually detects, which is less than the chain suggests.
+		 *
+		 * Each stored checksum genuinely is the CRC32C of every byte preceding it - `shouldWriteCorrectCumulativeCrc32
+		 * ChecksumToWalFile` verifies exactly that against an independently computed CRC. The catch is that this
+		 * coverage includes the previous stored checksums, and `CRC(M ‖ CRC(M))` is the CRC residue: a constant,
+		 * whatever `M` was. The running register therefore returns to that same constant at every stored checksum, so
+		 * each value ends up determined by the constant plus its own transaction's bytes and nothing earlier.
+		 *
+		 * What that catches: damage **inside** a transaction whose stored checksum was not also rewritten. What it
+		 * cannot catch is below - whole transactions exchanged, duplicated, or spliced in from another file, since
+		 * each carries a checksum that verifies from the same constant wherever it is placed.
+		 *
+		 * **That gap is closed elsewhere, not here.** Every transaction carries the catalog version it produces, and
+		 * trunk incorporation asserts each one is exactly the next expected version
+		 * ({@link io.evitadb.core.transaction.TransactionManager}, "Unexpected catalog version!"). Exchanged,
+		 * duplicated, dropped and cross-file-spliced transactions all break that sequence and are rejected loudly.
+		 * So this test pins where the *checksum's* reach ends, not a hole in the engine - and the reason it asserts
+		 * acceptance rather than rejection is that the WAL layer is not the layer that says no.
+		 */
+		@Test
+		@DisplayName("should not detect two whole transactions exchanged - the chain resets at every checksum")
+		void shouldNotDetectReorderedTransactions() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+
+			final Path walPath = CatalogWriteAheadLogTest.this.walDirectory.resolve(getWalFileName(TEST_CATALOG, 0));
+
+			// three transactions with identical payload sizes, so each occupies exactly the same number of bytes and
+			// two of them can be exchanged without disturbing a single length prefix
+			try (CatalogWriteAheadLog wal = createTestWal()) {
+				for (int i = 0; i < 3; i++) {
+					final TransactionWithData txData = createTestTransaction(i, 200);
+					wal.append(txData.mutation(), txData.data());
+				}
+			}
+
+			final byte[] original = Files.readAllBytes(walPath);
+			final int header = AbstractMutationLog.CUMULATIVE_CRC32_SIZE;
+			final int blockLength = (original.length - header) / 3;
+			assertEquals(
+				header + blockLength * 3, original.length,
+				"Precondition: the three transactions must be equally long for the exchange to be byte-neutral."
+			);
+
+			// exchange the first two transactions, each carried over whole - its length prefix, its records and its
+			// own trailing cumulative checksum
+			final byte[] tampered = original.clone();
+			System.arraycopy(original, header + blockLength, tampered, header, blockLength);
+			System.arraycopy(original, header, tampered, header + blockLength, blockLength);
+			Files.write(walPath, tampered);
+
+			// reopening runs `checkAndTruncate`, which verifies every transaction's cumulative checksum in turn
+			try (CatalogWriteAheadLog ignored = createTestWal(
+				0L, new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)), 1_048_576L, 10,
+				AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				// nothing to do - construction is what scans the file
+			}
+
+			assertFalse(
+				Files.exists(CatalogWriteAheadLogTest.this.walDirectory.resolve("_damaged_wal.bck")),
+				"The swap is currently accepted, so no damaged-file backup may be produced - a backup here means " +
+					"the chain started detecting reordering and this test is now the one that is out of date."
+			);
+			assertEquals(
+				original.length, walPath.toFile().length(),
+				"The swap is currently accepted, so nothing may be truncated off the file."
+			);
+
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
 			CatalogWriteAheadLogTest.this.tested = createTestWal();
 		}
 
@@ -913,6 +1083,257 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 			}
 
 			// Clean directory and recreate WAL for tearDown
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+			CatalogWriteAheadLogTest.this.tested = createTestWal();
+		}
+	}
+
+	/**
+	 * Restart behaviour when the log has moved past the position a restart resumes from - either by rotating into
+	 * later files, or by appending transactions the trunk never incorporated.
+	 *
+	 * A catalog resumes from the last **published bootstrap record**, not from the newest state it had in memory:
+	 * `DefaultCatalogPersistenceService#close` deliberately leaves that pointer at the last checkpoint, "which
+	 * simply means restart resumes from there and replays the rest from the WAL". Everything appended since is the
+	 * tail replay consumes, and it may span several files.
+	 *
+	 * These tests pin the parts of that contract independently: rotation must never drop the file the reference
+	 * needs (which would leave an unbridgeable gap), reopening against such a reference must work, and a
+	 * transaction appended after the restart must survive the next restart intact.
+	 *
+	 * Note what is deliberately **not** claimed here: that appends continue a checksum chain. Each transaction's
+	 * trailing checksum covers only its own bytes - the running value returns to a fixed constant after every
+	 * record, so no test in this class can distinguish one append-chain seed from another. See the punch list's
+	 * entry on the cumulative checksum for why.
+	 */
+	@Nested
+	@DisplayName("Restart from a position the log has moved past")
+	class RestartAfterRotation {
+
+		@Test
+		@DisplayName("should resume replay and keep appending when the reference lags inside the active file")
+		void shouldResumeReplayAndAppendWhenReferenceLagsInsideActiveFile() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+
+			final Path walFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 0));
+			final long walFileSizeLimit = 1_048_576L;
+
+			// four transactions land in one file, but only the second was ever incorporated - which is what a
+			// crash leaves behind whenever appends outran the trunk rounds processing them
+			LogFileRecordReference afterSecond = null;
+			LogFileRecordReference afterFourth = null;
+			try (CatalogWriteAheadLog wal = createTestWal(
+				0L, new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)), walFileSizeLimit, 10,
+				AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				for (int version = 1; version <= 4; version++) {
+					final TransactionWithData txData = createTestTransaction(version - 1, 200);
+					final LogFileRecordReference reference = wal.append(txData.mutation(), txData.data());
+					if (version == 2) {
+						afterSecond = reference;
+					} else if (version == 4) {
+						afterFourth = reference;
+					}
+				}
+			}
+			final LogFileRecordReference processedReference = Objects.requireNonNull(afterSecond);
+			final LogFileRecordReference lastAppendedReference = Objects.requireNonNull(afterFourth);
+
+			// the restart resumes from transaction 2; transactions 3 and 4 are the tail replay consumes
+			final LogFileRecordReference postRestartReference;
+			try (CatalogWriteAheadLog reopened = createTestWal(
+				2L, processedReference, walFileSizeLimit, 10, AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				assertEquals(
+					3L,
+					reopened.getFirstNonProcessedTransaction(processedReference)
+						.orElseThrow(() -> new AssertionError("Replay found nothing after the reference!"))
+						.transactionMutation()
+						.getVersion(),
+					"replay must resume at the first transaction the trunk never incorporated"
+				);
+
+				final TransactionWithData txData = createTestTransaction(4, 200);
+				postRestartReference = reopened.append(txData.mutation(), txData.data());
+			}
+			final long walFileLengthAfterRestart = walFile.toFile().length();
+
+			// A third open is what would discover a transaction 5 the reopen wrote wrongly - a scan rejects the
+			// file outright, or quietly truncates the offending transaction back off it. Both assertions below
+			// are therefore needed: either outcome alone would let the other pass unnoticed. This covers the
+			// reopen path where `checkAndTruncate` mints a corrected reference and the constructor adopts it,
+			// which no other test in this class exercises.
+			try (CatalogWriteAheadLog reopenedAgain = createTestWal(
+				5L, postRestartReference, walFileSizeLimit, 10, AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				assertEquals(
+					5L,
+					reopenedAgain.getFirstNonProcessedTransaction(lastAppendedReference)
+						.orElseThrow(() -> new AssertionError("The transaction appended after the restart is gone!"))
+						.transactionMutation()
+						.getVersion(),
+					"the transaction appended after the restart must still be readable"
+				);
+			}
+			assertEquals(
+				walFileLengthAfterRestart, walFile.toFile().length(),
+				"reopening must not truncate the transaction appended after the restart - a shorter file means " +
+					"the scan rejected it and silently repaired the file"
+			);
+
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+			CatalogWriteAheadLogTest.this.tested = createTestWal();
+		}
+
+		@Test
+		@DisplayName("should keep the WAL file holding the first non-processed transaction")
+		void shouldKeepWalFileHoldingFirstNonProcessedTransaction() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+
+			final Path firstWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 0));
+			final Path fourthWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 3));
+
+			// only two files are kept, so rotation queues files 0 and 1 for removal - but the queue is
+			// version-gated, and version 4 (still unprocessed) lives in file 0
+			final CatalogWriteAheadLog wal = createTestWal(
+				0L, new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)), 4_096L, 2,
+				AbstractMutationLog.WalPurgeCallback.NO_OP
+			);
+			try {
+				appendUntilWalFileAppears(wal, fourthWalFile, 3L);
+				assertTrue(
+					wal.getFirstVersionOf(1) > 4L,
+					"test setup: version 4 must still live in file 0 for this assertion to mean anything"
+				);
+
+				wal.walProcessedUntil(3L);
+			} finally {
+				// close() runs the purge (AbstractMutationLog#close), so the assertions come after it
+				wal.close();
+			}
+
+			assertTrue(
+				Files.exists(firstWalFile),
+				"file 0 holds version 4, the first non-processed transaction - purging it would leave a gap " +
+					"that replay after a restart could never bridge"
+			);
+
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+			CatalogWriteAheadLogTest.this.tested = createTestWal();
+		}
+
+		@Test
+		@DisplayName("should purge rotated WAL files once every transaction in them is processed")
+		void shouldPurgeWalFilesOnceEveryTransactionInThemIsProcessed() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+
+			final Path firstWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 0));
+			final Path secondWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 1));
+			final Path fourthWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 3));
+
+			// the calibration of the test above: with the same rotation and the same kept-count, the two queued
+			// files DO disappear once nothing unprocessed is left in them. Without this, that test would pass
+			// just as happily if the purge never ran at all.
+			final CatalogWriteAheadLog wal = createTestWal(
+				0L, new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)), 4_096L, 2,
+				AbstractMutationLog.WalPurgeCallback.NO_OP
+			);
+			try {
+				appendUntilWalFileAppears(wal, fourthWalFile, 3L);
+				// every version below the first one in file 2 is contained in files 0 and 1
+				wal.walProcessedUntil(wal.getFirstVersionOf(2));
+			} finally {
+				wal.close();
+			}
+
+			assertFalse(Files.exists(firstWalFile), "file 0 is fully processed and must be purged");
+			assertFalse(Files.exists(secondWalFile), "file 1 is fully processed and must be purged");
+
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+			CatalogWriteAheadLogTest.this.tested = createTestWal();
+		}
+
+		@Test
+		@DisplayName("should reopen against a reference that sits several rotations back")
+		void shouldReopenAgainstReferenceSeveralRotationsBack() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+
+			final Path firstWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 0));
+			final Path fourthWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 3));
+
+			final LogFileRecordReference checkpointedReference;
+			final long lastWrittenVersion;
+			final long firstWalFileLengthBeforeRestart;
+
+			// nothing is purged here - the point is the reference's distance from the newest file, not its absence
+			try (CatalogWriteAheadLog wal = createTestWalWithCustomSize(4_096L)) {
+				final RotatedWal rotated = appendUntilWalFileAppears(wal, fourthWalFile, 3L);
+				checkpointedReference = rotated.capturedReference();
+				lastWrittenVersion = rotated.lastVersion();
+			}
+			firstWalFileLengthBeforeRestart = firstWalFile.toFile().length();
+
+			// this is what a restart does: open against the reference the last checkpoint left behind
+			final LogFileRecordReference postRestartReference;
+			try (CatalogWriteAheadLog reopened = createTestWal(
+				3L, checkpointedReference, 4_096L, 10, AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				assertEquals(
+					4L,
+					reopened.getFirstNonProcessedTransaction(checkpointedReference)
+						.orElseThrow(() -> new AssertionError("Replay found nothing after the reference!"))
+						.transactionMutation()
+						.getVersion(),
+					"replay must resume at the transaction right after the checkpointed one"
+				);
+
+				final TransactionWithData txData = createTestTransaction((int) lastWrittenVersion, 200);
+				postRestartReference = reopened.append(txData.mutation(), txData.data());
+			}
+
+			assertEquals(
+				firstWalFileLengthBeforeRestart, firstWalFile.toFile().length(),
+				"a restart must not truncate or append to an already rotated-away WAL file - appends belong in " +
+					"the newest file, and file 0's tail record is not a partially written transaction"
+			);
+			assertEquals(
+				3, postRestartReference.fileIndex(),
+				"the post-restart append belongs in the newest WAL file, not in the one the reference points at"
+			);
+
+			// Opening a third time is what proves the APPEND chain was seeded correctly: the scan recomputes each
+			// transaction's cumulative checksum from the file's stored seed and rejects the file when one does not
+			// match. A restart that continued the reference's chain instead of the active file's would write a
+			// transaction whose checksum is wrong, and this is the open that finds it.
+			try (CatalogWriteAheadLog reopenedAgain = createTestWal(
+				lastWrittenVersion + 1, postRestartReference, 4_096L, 10, AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				assertTrue(
+					reopenedAgain.getFirstNonProcessedTransaction(postRestartReference).isEmpty(),
+					"nothing follows the transaction appended after the restart"
+				);
+			}
+
 			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
 			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
 			CatalogWriteAheadLogTest.this.tested = createTestWal();

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/EngineMutationLogTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/EngineMutationLogTest.java
@@ -660,6 +660,11 @@ class EngineMutationLogTest implements EvitaTestSupport {
 
 	/**
 	 * Nested tests for cumulative CRC32 checksum functionality.
+	 *
+	 * The engine log shares `AbstractMutationLog` with the catalog log, so the guarantee is identical - see the
+	 * `checksum` field there for what these values actually detect (damage inside a transaction, and nothing
+	 * about ordering). The behaviour is characterised once, by
+	 * `CatalogWriteAheadLogTest#shouldNotDetectReorderedTransactions`, rather than duplicated here.
 	 */
 	@Nested
 	@DisplayName("Cumulative CRC32 Tests")


### PR DESCRIPTION
Closes #1407

Reopening a catalog WAL threw `WriteAheadLogCorruptedException` whenever the log record reference no longer pointed at the newest WAL file — over a state that was perfectly recoverable. It surfaced intermittently as `shouldCorrectlyRotateAllFiles` failing after ~60 seconds.

## The fix

**1. Separate the two roles.** The constructor used a single file index to answer two different questions: where *replay* starts (the reference, pointing at the last **processed** transaction) and where *appends* resume (the newest file on disk). Those coincide only while nothing has rotated since the last published bootstrap record — and bootstrap records are published only at checkpoints, with a crash publishing none at all.

The referenced file now need only still **exist** (`first <= ref <= last`). `checkAndTruncate` runs against the newest file and receives that file's index explicitly, so a derived `LogFileRecordReference` can never be stamped with the reference's index. The truncation result is adopted only when the scanned file is the referenced one. The finalized-neighbour continuity check is skipped when the active file holds no transaction yet — exactly what a crash between rotation creating a file and the first append landing in it leaves behind.

**2. Publish an owed checkpoint on close.** A clean restart now resumes from the last version already propagated to the view rather than replaying from whichever checkpoint the ticker last reached. It does not drain and does not slow shutdown — `TransactionManager#close` fails pending transactions rather than finishing them — and writes nothing when no checkpoint is owed.

**Persistence format is unchanged.** No serializer, record shape or version constant is touched, and the new read path is strictly more permissive.

## Also in here: the cumulative checksum documentation

Investigating this turned up a claim in the format documentation that does not hold, so it is corrected in the same change rather than left to mislead the next reader.

Each stored checksum **is** the CRC32C of every byte preceding it, exactly as specified. But because that coverage includes the previous stored checksums, and `CRC(M ‖ CRC(M))` is the CRC residue — a constant — the running value resets at every stored checksum. So each one detects damage within its own transaction and carries nothing about anything earlier. Reordering, duplication and gaps are caught by the **catalog-version continuity check** during replay instead, which rejects them loudly.

No code change follows from this: the guarantee is intact, only the description was wrong. `AbstractMutationLog#checksum` now carries the authoritative account and everything else points at it; three comments written during (1) that asserted a chaining which does not happen are corrected; and the user documentation gains two plain-language notes, including one on how bit flips are detected and the warning that `computeCRC32C=false` turns both checksum layers into no-ops.

## Verification

`shouldCorrectlyRotateAllFiles` passes 3/3, previously intermittent. The ~60 s race is replaced by deterministic sub-second tests: reopening against a reference several rotations back, the gap-prevention invariant, and a purge calibration proving that test would fail if the purge never ran — writing which revealed that **no test had ever let a WAL purge fire**. `shouldNotDetectReorderedTransactions` pins where the checksum's reach ends. Option 2 is revert-verified: removing the call fails its test and nothing else.

Full `unitAndFunctional`: 20879 tests, no related failures.
