### PR TITLE
fix: unify the 2026.2.4 hotfix into a single release-triggering merge

### DIFF
--- a/documentation/adr/2026-08-05-schema-handling-write-path-optimizations.md
+++ b/documentation/adr/2026-08-05-schema-handling-write-path-optimizations.md
@@ -1,7 +1,7 @@
 ---
 title: Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation
 date: 2026-08-05
-updated: 2026-08-05 16:20
+updated: 2026-08-10 08:45
 status: accepted
 kind: optimization
 issues: [1390]
@@ -9,7 +9,7 @@ prs: [1395]
 areas: [evita_api/requestResponse/schema/dto, evita_api/requestResponse/data, evita_engine/index/mutation]
 supersedes: []
 superseded-by: []
-relates: [2026-07-27-write-path-performance-tuning, 2026-08-01-bplustree-cursor-free-insert-path]
+relates: [2026-07-27-write-path-performance-tuning, 2026-08-01-bplustree-cursor-free-insert-path, 2026-08-10-stored-value-normalization-split]
 ---
 
 # Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation
@@ -204,6 +204,9 @@ B remains the larger prize and should be sequenced after its exploration produce
   spent the collation-cache and trunk-merge levers, this one spends the schema-handling lever.
 - `2026-08-01-bplustree-cursor-free-insert-path` — the other allocation-removal record from the same
   round of Senesi profiling, on the index side rather than the schema side.
+- `2026-08-10-stored-value-normalization-split` — same attribute-mutation write path; that record
+  constrains what a mutation may do to the value itself, where this one speeds up how the schema
+  around it is resolved.
 
 ## Timeline
 

--- a/documentation/adr/2026-08-10-stored-value-normalization-split.md
+++ b/documentation/adr/2026-08-10-stored-value-normalization-split.md
@@ -5,7 +5,7 @@ updated: 2026-08-10 10:05
 status: accepted
 kind: fix
 issues: [1403]
-prs: []
+prs: [1404, 1405]
 areas: [evita_common/src/main/java/io/evitadb/dataType, evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute, evita_engine/src/main/java/io/evitadb/index/attribute, evita_engine/src/main/java/io/evitadb/index/bPlusTree]
 supersedes: []
 superseded-by: []

--- a/documentation/adr/2026-08-10-stored-value-normalization-split.md
+++ b/documentation/adr/2026-08-10-stored-value-normalization-split.md
@@ -149,6 +149,9 @@ the one most likely to be re-proposed and is the one to read this record for.
 - `FilterIndexTest.TemporalNormalization` pins the encoding itself: UTC instant, idempotence, order preservation, and
   `LocalDate`/`LocalTime` passing through untouched. `InstantValueColumnTest` pins the column selection on both sides —
   `LocalDateTime` → `InstantValueColumn`, `LocalDate`/`LocalTime` → `LongValueColumn`.
+- `FilterIndexLegacyLocalDateTimeSerializerTest` — round-trips a 2026.1-shaped part through the legacy serializer
+  and rehydrates it exactly as `AttributeIndexLoader` does. The rehydration case fails with `ClassCastException`
+  without the re-anchoring, which is what makes it a real guard rather than a restatement.
 - `EvitaDataTypesTest` — the pre-existing "Conversion to supported type" suite (8 tests, including
   `shouldConvertLocalDateTimeToOffsetDateTime`) still passes unchanged, pinning the query-path contract as deliberately
   retained; new "Conversion to supported stored type" suite adds 6.
@@ -185,14 +188,28 @@ the one most likely to be re-proposed and is the one to read this record for.
   using the evitaDB server system default timezone" — wrong on both counts — and now states only that `LocalDateTime`
   is a first-class attribute type whose wall clock round-trips. The adjacent `<LS to="c">` block still carries the old
   claim for the C# driver and was left alone; nobody verified what that driver actually does.
-- No migration is needed, and the persisted-index question was checked rather than assumed. Bucket keys are stored
-  **already normalized** (`InvertedIndex` applies the normalizer in `addRecord`, and `AttributeIndexLoader` feeds
-  `part.getHistogramPoints()` into the tree verbatim), so changing a normalizer is in principle an on-disk format
-  change for that attribute type. It is not one here: `ValueColumnFactory` and `InstantValueColumn` arrived in
-  `15dc1acee` (2026-06-17), contained only in `v2026.2.x` — the whole primitive-column format postdates 2026.1 — and
-  within 2026.2 no catalog can hold un-normalized `LocalDateTime` bucket keys, because a declared `LocalDateTime`
-  attribute could not be written at all and an auto-evolved one became `OffsetDateTime`. Any future change to
-  `getNormalizer` for a type that *has* been persisted needs a BWC reader; this one does not.
+- **A 2026.1 catalog does need its `LocalDateTime` filter indexes migrated** — an earlier revision of this record
+  claimed the opposite, having checked only that no *2026.2* catalog could hold such keys. Bucket keys are persisted
+  **already normalized** (`InvertedIndex` applies the normalizer in `addRecord`; `AttributeIndexLoader` feeds
+  `part.getHistogramPoints()` into the tree verbatim), so changing a normalizer *is* an on-disk format change for that
+  attribute type. 2026.1 had no `LocalDateTime` branch and persisted raw wall-clock values, while the current tree
+  picks `InstantValueColumn` for that declared type and hard-casts — so loading such a catalog died with
+  `ClassCastException`. `FilterIndexStoragePartSerializer_2026_1` (registered for the 2026.1 `FilterIndexStoragePart`
+  uid in `IndexStoragePartConfigurer`) now re-anchors those values at UTC on read. It is self-healing: the next write
+  persists `Instant` keys through the current serializer, after which the legacy reader is never consulted again.
+- `Migration_2026_2` already re-keys `String` (NFD) and `BigDecimal` (scaled-int) filter parts eagerly at upgrade
+  time, which is the same class of problem. `LocalDateTime` is handled in the BWC *reader* instead, deliberately: the
+  reader covers every read path unconditionally — including any part a migration sweep does not visit — and it is
+  self-healing, whereas the eager route would have to enumerate parts for a type far rarer than `String`. The two
+  compose: a part re-keyed by the migration is read through this same reader first, so it is already anchored.
+- Other index kinds were checked and are **not** affected. Unique indexes select their leaf column through the same
+  `ValueColumnFactory.forKey` and keep raw values, which looks like the same trap, but a `unique` `OffsetDateTime` and
+  a `unique` `LocalDateTime` attribute each write 200 distinct values end-to-end without error — so the reading was
+  wrong and the empirical result governs. `HistogramIndex` is 2026.2-only (no `_2026_1` reader) and `SortIndex` does
+  not use `ValueColumnFactory` at all.
+- **Invariant for the next person:** any future change to `FilterIndex.getNormalizer` for a type that has already been
+  persisted is an on-disk format change, and needs a matching conversion in the BWC reader for the format that wrote
+  it. The normalizer is not merely a runtime detail.
 - 2026.2 was still in testing when this surfaced, so no catalog in the wild carries an attribute auto-evolved to
   `OffsetDateTime` by the defect. Should a test catalog have one, its schema and index remain internally consistent —
   only the declared type is wrong, and re-evolving it is enough.

--- a/documentation/adr/2026-08-10-stored-value-normalization-split.md
+++ b/documentation/adr/2026-08-10-stored-value-normalization-split.md
@@ -169,6 +169,13 @@ the one most likely to be re-proposed and is the one to read this record for.
   of a reference plus three objects (`LocalDateTime` holds a `LocalDate` and a `LocalTime`), and no boxing on lookup
   hot paths. That is a structural estimate from the field layouts, **not a measurement** — nobody has run a heap
   comparison. Only `filterable`/`sortable` attributes are affected, since only those are indexed.
+- The declared type now wins in **both** directions: a bare `LocalDateTime` written to an attribute declared
+  `OffsetDateTime` is rejected with `InvalidMutationException` rather than silently coerced to UTC. That is a
+  restoration, not a new rule — `v2026.1.19` rejected it too (all four `UpsertAttributeMutation` constructors
+  assigned the value verbatim); only the broken 2026.2 accepted it, by rewriting before the check. A client relying
+  on that coercion must convert explicitly, and should prefer `atZone(zone).toOffsetDateTime()` over
+  `atOffset(UTC)` unless it really means a UTC wall clock. Covered by
+  `LocalTemporalAttributeTypeFidelityFunctionalTest#shouldRejectLocalDateTimeValueForOffsetDateTimeAttribute`.
 - `attributeHistogram` still rejects any non-numeric attribute (`AttributeHistogramTranslator` asserts
   `Number.class.isAssignableFrom(...)`), so no temporal type — `OffsetDateTime` included — can produce one. Unchanged
   here, and the reason there is no histogram coverage for `LocalDateTime`.

--- a/documentation/adr/2026-08-10-stored-value-normalization-split.md
+++ b/documentation/adr/2026-08-10-stored-value-normalization-split.md
@@ -1,0 +1,204 @@
+---
+title: LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer
+date: 2026-08-10
+updated: 2026-08-10 10:05
+status: accepted
+kind: fix
+issues: [1403]
+prs: []
+areas: [evita_common/src/main/java/io/evitadb/dataType, evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute, evita_engine/src/main/java/io/evitadb/index/attribute, evita_engine/src/main/java/io/evitadb/index/bPlusTree]
+supersedes: []
+superseded-by: []
+relates: [2026-08-05-schema-handling-write-path-optimizations]
+---
+
+# `LocalDateTime` keeps its declared type end to end; the UTC anchoring that makes it cheap to index moves into `FilterIndex.getNormalizer`
+
+An attribute declared as `LocalDateTime` could not be written at all in 2026.2 — the value was rewritten to an
+`OffsetDateTime` inside the mutation constructor, above the layer that validates it against the schema. The rewrite
+itself was worth keeping, but as an *index encoding*, not as a change of the public type. It now lives in
+`FilterIndex.getNormalizer`, which is where the codebase already performs exactly this remap for `OffsetDateTime`.
+`LocalDateTime` is a first-class schema type again — declared or auto-evolved — while the index still stores it as a
+packed `Instant`.
+
+## Why
+
+A production full reindex failed on every entity carrying a `LocalDateTime` attribute:
+
+```
+InvalidMutationException: Invalid type: `class java.time.OffsetDateTime`! Attribute
+`initialPublishedDate` in schema `Product` was already stored as type class java.time.LocalDateTime.
+```
+
+The attribute comes from a client interface getter returning `LocalDateTime`, so `ClassSchemaAnalyzer` registers that
+type verbatim — and then no value could ever satisfy it. The quieter half of the same defect: when the attribute was
+*not* declared, `AttributeSchemaEvolvingMutation` derives the type from `getAttributeValue().getClass()`, so a
+`LocalDateTime` value silently produced an `OffsetDateTime` attribute definition. No exception, and a schema that no
+longer matches the interface it was generated from.
+
+### Previous state
+
+Until 2026.2 the four `UpsertAttributeMutation` constructors assigned `this.value = value` verbatim. Commit
+`016d93255` (2026-03-27, conditional bucket indexing) changed all four to
+`EvitaDataTypes.toSupportedTypeOrItsArray(value)`. The motivation was sound — `Float`/`Double` must normalize to
+`BigDecimal` or histogram bucket keys disagree with the stored value. `toSupportedType` also rewrites `LocalDateTime`
+to `OffsetDateTime` at UTC (a branch present since the 2023 initial commit, on a method whose own JavaDoc says it is
+"used at query entry points"), and that rewrite rode along into the write path.
+
+## Options considered
+
+### Option A — split the normalizer, and encode in the index (chosen)
+
+Two independent moves. **(1)** `UpsertAttributeMutation` calls a new `toSupportedStoredTypeOrItsArray`, which performs
+every other normalization (`Float`/`Double` → `BigDecimal`, non-`@SupportedEnum` → `String` name, rejection of
+unsupported types) but leaves `LocalDateTime` alone, so the schema records what the client declared. **(2)** the UTC
+anchoring moves to `FilterIndex.getNormalizer` + `ValueColumnFactory.normalizedTypeOf`, so the index stores an
+`Instant` and the tree selects the packed `InstantValueColumn`.
+
+- **Pros:** the two concerns are separated and named — public type vs. index encoding. The encoding lands on the one
+  seam every consumer already reads (all four filter translators, `HistogramIndex`, `AttributeIndexLoader`,
+  `AttributeIndex`, `OwnerFilterIndex`, and `SortIndexView` via `shared.getNormalizer()`), so it is two lines rather
+  than a boundary threaded through storage and reads.
+- **Cons:** two public normalizer entry points that differ in one branch; and `getNormalizer` must stay in lockstep
+  with `normalizedTypeOf` in a different package.
+
+### Option B — delete the `LocalDateTime` branch from `toSupportedType` outright (declined)
+
+One line. `SUPPORTED_QUERY_DATA_TYPES` contains `LocalDateTime`, so a method whose job is "unsupported → supported"
+arguably must not rewrite it. Both gates that could have blocked this are clear: EvitaQL has a literal form for a bare
+`LocalDateTime`, and the gRPC wire path encodes at `DEFAULT_ZONE_OFFSET`, which *is* `ZoneOffset.UTC`.
+
+- **Pros:** removes the contract inconsistency at its root; no second entry point.
+- **Cons:** changes behaviour for every caller, not just the broken one.
+- **Rejected because:** on the query path the rewrite is **inert** — every attribute constraint coerces its value to
+  the declared type via `toTargetType`, and both directions preserve the wall clock (`atOffset(UTC)` out,
+  `toLocalDateTime()` back) — so deleting it fixes nothing there. What it *would* change is the other caller,
+  `ComplexDataObjectConverter`: associated-data map keys would start being written as `LocalDateTime` where existing
+  catalogs hold `OffsetDateTime`, a persistence-format change bought for no behavioural gain. It becomes the better
+  option once `ComplexDataObjectConverter` no longer relies on `toSupportedType` for key normalization.
+
+### Option C — anchor at the server's default time zone instead of UTC (declined)
+
+The original design instinct: resolve the offset dynamically so that changing the server time zone moves stored local
+times with it.
+
+- **Pros:** feels responsive to deployment configuration; superficially "more correct" than a hardcoded UTC.
+- **Rejected because:** a region zone is not a constant offset, which breaks three properties UTC gives for free.
+  **(i)** The mapping stops being a bijection — `02:30` does not exist on a spring-forward day and occurs twice on
+  fall-back, so `atZone` silently picks one. **(ii)** Round-trip stops being idempotent: write, change the zone, read
+  back, get a different wall clock; rows written either side of the change are interpreted under different rules with
+  nothing on disk recording which. **(iii)** Decisively for evitaDB: the normalized value is **persisted in the filter
+  and sort indexes**, so a config change would silently invalidate every index built on those attributes, with no
+  detection and no migration — and across a DST boundary local ordering and instant ordering genuinely differ, so
+  `attributeNatural` could return a different order depending on when the index was built. Oracle is the empirical
+  precedent: it refuses to change the database time zone once `TIMESTAMP WITH LOCAL TIME ZONE` columns hold data
+  (ORA-30079). It would only become viable if the offset were transmitted per session, like PostgreSQL's `timestamptz`
+  — a client-supplied zone, not a server-global one.
+
+### Option D — encode at the mutation or storage boundary (declined)
+
+Keep the conversion near where 2026.2 put it, but derive the schema type from the original value and decode on read.
+
+- **Pros:** the physical `AttributeValue` payload itself would hold the encoded form.
+- **Rejected because:** it reintroduces exactly the coupling that caused this bug — an encoding above the schema check
+  — and it is strictly more work: `AttributesStoragePart.upsertAttribute` and `AttributeIndexMutator` both align the
+  value to `attributeDefinition.getType()` via `toTargetType`, so with the schema saying `LocalDateTime` they would
+  coerce straight back and both would need to learn the encoding, plus a decode on the read path.
+
+## Decision
+
+**Chosen: Option A.** The encoding instinct behind the original code was right — `LocalDateTime` really is the one
+temporal type that indexes badly (see below) — it was simply installed one layer too high, which turned an internal
+representation choice into a change of the public type. Putting it in `getNormalizer` gets the identical physical
+representation while the schema, the mutation and the client boundary all keep speaking `LocalDateTime`. Option C is
+the one most likely to be re-proposed and is the one to read this record for.
+
+## Key technical details
+
+- **Invariant:** a value on its way into storage must never be rewritten away from the data type its attribute schema
+  declares. `AttributeSchemaEvolvingMutation` compares with `attributeSchema.getType().isInstance(attributeValue)` —
+  strict type identity, not convertibility — and derives the schema type from the value's class when auto-evolving, so
+  any normalization applied above it silently becomes schema policy.
+- **Lockstep:** `FilterIndex.getNormalizer` and `ValueColumnFactory.normalizedTypeOf` must agree on which declared
+  types normalize to `Instant`. They live in different packages; `InstantValueColumnTest` pins the pairing.
+- The anchoring is `LocalDateTime.toInstant(ZoneOffset.UTC)`. A **constant** offset makes it a lossless bijection and
+  monotonic with `LocalDateTime`'s natural order, so bucket lookup and ordered iteration are unchanged. The normalizer
+  is idempotent, like its siblings — probes are normalized more than once along a lookup path.
+- The encoding is invisible to clients: the value handed back comes from `AttributesStoragePart`, not from the index.
+- **`LocalDate` and `LocalTime` are deliberately left out of the temporal branch.** Each fits losslessly in a single
+  `long` (`toEpochDay` / `toNanoOfDay`) and already has a `LongKeyCodec`, so they select the 8-byte `LongValueColumn`.
+  Routing them through `Instant` would be a *downgrade* to 12 bytes plus an all-but-unused `int[]`. Do not "fix" this
+  for symmetry.
+- `SortIndex.createNormalizerFor` needs no change: it normalizes only `String`/`Locale`/`Currency`/`BigDecimal` and
+  never handled `OffsetDateTime` either. Sort-side temporal folding happens only in view mode, which adopts the shared
+  inverted index's normalizer.
+
+## Verification
+
+- `LocalTemporalAttributeTypeFidelityFunctionalTest` — written first, against the unfixed build: **5 of the 11 methods
+  then in the class failed, and all five were `LocalDateTime`**. The declared-schema case reproduced the production
+  `InvalidMutationException` verbatim; the auto-evolution case failed with `expected: <java.time.LocalDateTime> but was:
+  <java.time.OffsetDateTime>`. `LocalDate` and `LocalTime` passed before *and* after — confirming-negatives pinning the
+  defect to one branch rather than to local temporal types as a family. A counterfactual run (fix reverted, class
+  otherwise unchanged) re-confirmed the whole class fails without it.
+- Read-back assertions compare against the exact value written, not merely "no exception" — a fix that stopped the
+  throw while leaving a wall-clock-shifting conversion in place would still fail. `attributeNatural`,
+  `attributeEquals`, `attributeBetween`, `attributeGreaterThanEquals` and `attributeLessThan` are asserted per type,
+  covering every translator that reads `getNormalizer`. The localized case is covered separately, since it takes the
+  third `UpsertAttributeMutation` constructor and the `isLocalized` branch of schema verification.
+- `FilterIndexTest.TemporalNormalization` pins the encoding itself: UTC instant, idempotence, order preservation, and
+  `LocalDate`/`LocalTime` passing through untouched. `InstantValueColumnTest` pins the column selection on both sides —
+  `LocalDateTime` → `InstantValueColumn`, `LocalDate`/`LocalTime` → `LongValueColumn`.
+- `EvitaDataTypesTest` — the pre-existing "Conversion to supported type" suite (8 tests, including
+  `shouldConvertLocalDateTimeToOffsetDateTime`) still passes unchanged, pinning the query-path contract as deliberately
+  retained; new "Conversion to supported stored type" suite adds 6.
+- JDWP session against the unfixed build, breaking at `UpsertAttributeMutation:58` and
+  `AttributeSchemaEvolvingMutation:118`:
+
+  ```
+  value.getClass().getName()                           = "java.time.LocalDateTime"   (2026-05-20T12:19:26)
+  this.value.getClass().getName()                      = "java.time.OffsetDateTime"  (2026-05-20T12:19:26Z)
+  attributeSchema.getType().getName()                  = "java.time.LocalDateTime"
+  attributeValue.getClass().getName()                  = "java.time.OffsetDateTime"
+  attributeSchema.getType().isInstance(attributeValue) = false
+  ```
+
+## Consequences & open follow-ups
+
+- Indexed `LocalDateTime` attributes move off `BoxedObjectColumn` onto `InstantValueColumn`: ~12 bytes per key instead
+  of a reference plus three objects (`LocalDateTime` holds a `LocalDate` and a `LocalTime`), and no boxing on lookup
+  hot paths. That is a structural estimate from the field layouts, **not a measurement** — nobody has run a heap
+  comparison. Only `filterable`/`sortable` attributes are affected, since only those are indexed.
+- `attributeHistogram` still rejects any non-numeric attribute (`AttributeHistogramTranslator` asserts
+  `Number.class.isAssignableFrom(...)`), so no temporal type — `OffsetDateTime` included — can produce one. Unchanged
+  here, and the reason there is no histogram coverage for `LocalDateTime`.
+- The UTC anchoring is **not** documented for users: it is an internal encoding with no observable effect, and
+  documenting it would only invite people to reason about a representation they never see.
+  `documentation/user/en/use/data-types.md` previously claimed local date times are "always converted to OffsetDateTime
+  using the evitaDB server system default timezone" — wrong on both counts — and now states only that `LocalDateTime`
+  is a first-class attribute type whose wall clock round-trips. The adjacent `<LS to="c">` block still carries the old
+  claim for the C# driver and was left alone; nobody verified what that driver actually does.
+- No migration is needed, and the persisted-index question was checked rather than assumed. Bucket keys are stored
+  **already normalized** (`InvertedIndex` applies the normalizer in `addRecord`, and `AttributeIndexLoader` feeds
+  `part.getHistogramPoints()` into the tree verbatim), so changing a normalizer is in principle an on-disk format
+  change for that attribute type. It is not one here: `ValueColumnFactory` and `InstantValueColumn` arrived in
+  `15dc1acee` (2026-06-17), contained only in `v2026.2.x` — the whole primitive-column format postdates 2026.1 — and
+  within 2026.2 no catalog can hold un-normalized `LocalDateTime` bucket keys, because a declared `LocalDateTime`
+  attribute could not be written at all and an auto-evolved one became `OffsetDateTime`. Any future change to
+  `getNormalizer` for a type that *has* been persisted needs a BWC reader; this one does not.
+- 2026.2 was still in testing when this surfaced, so no catalog in the wild carries an attribute auto-evolved to
+  `OffsetDateTime` by the defect. Should a test catalog have one, its schema and index remain internally consistent —
+  only the declared type is wrong, and re-evolving it is enough.
+
+## Related work
+
+- [2026-08-05-schema-handling-write-path-optimizations](2026-08-05-schema-handling-write-path-optimizations.md)
+  — same write path through attribute mutations; that record optimizes how schemas are resolved per mutation, this one
+  constrains what a mutation may do to the value on the way through.
+
+## Timeline
+
+- **2026-03-27** — `016d93255` applies the query-path normalizer in all four `UpsertAttributeMutation` constructors,
+  incidental to conditional bucket indexing
+- **2026-08-10** — regression reported from a production full reindex, reproduced, confirmed under JDWP, and fixed;
+  the UTC anchoring re-sited in the index normalizer after review

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403 |
+| 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |
 | 2026-08-04 | [Report HTTP/2 RST_STREAM floods instead of enforcing against them, and turn the Rapid-Reset defence off by default](2026-08-04-http2-connection-teardown-observability.md) | fix | accepted | #1369, PR #1383 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |
 | 2026-08-04 | [Report HTTP/2 RST_STREAM floods instead of enforcing against them, and turn the Rapid-Reset defence off by default](2026-08-04-http2-connection-teardown-observability.md) | fix | accepted | #1369, PR #1383 |

--- a/documentation/user/en/deep-dive/storage-model.md
+++ b/documentation/user/en/deep-dive/storage-model.md
@@ -163,13 +163,60 @@ Data records contain the actual data payload for each record type and are used t
 
 The write-ahead log is a separate data structure to which all transactional changes are written in the form of serialized "mutations" when a transaction commit is accepted. Individual mutations are written using the <a href="#record-structure-in-the-storage">standard structure</a>, one after the other, in the order they were performed in the transaction. Transactions are separated by a header that contains the overall transaction length in bytes (`int32`). Also, at the start of each transaction, a <SourceClass>evita_api/src/main/java/io/evitadb/api/requestResponse/transaction/TransactionMutation.java</SourceClass> record is written, containing basic information about the transaction itself for easier orientation. After this, the list of individual mutations follows. The transaction length header allows fast navigation between transactions in the WAL file without deserializing each mutation.
 
-Each transaction in the WAL is followed by a cumulative CRC32C checksum (8 bytes as `int64`). This checksum is calculated over all bytes written to the WAL file from the beginning up to (but not including) the checksum itself. This includes the transaction length headers, TransactionMutation records, and all mutation payloads. The cumulative nature of this checksum means that any corruption in any part of the WAL file will be detected when reading subsequent transactions. If a checksum mismatch is detected during WAL reading, the database will truncate the WAL at the point of corruption and recover using only the valid preceding transactions.
+Each transaction in the WAL is followed by a cumulative CRC32C checksum (8 bytes as `int64`). This checksum is calculated over all bytes written to the WAL file from the beginning up to (but not including) the checksum itself. This includes the transaction length headers, TransactionMutation records, and all mutation payloads. If a checksum mismatch is detected during WAL reading, the database will truncate the WAL at the point of corruption and recover using only the valid preceding transactions.
+
+<Note type="info">
+
+<NoteTitle toggles="true">
+
+##### What the cumulative checksum does and does not detect
+
+</NoteTitle>
+
+The name *cumulative* makes it sound as though each checksum vouches for the whole file up to that point. In practice each one vouches for its own transaction. The distinction matters if you are reasoning about what the WAL protects you from, so it is worth a paragraph.
+
+The checksum after a transaction is calculated from every byte before it, and those bytes include the checksums of the earlier transactions. That last part is the catch. CRC checksums have a well-known property: if you feed some data into the calculation and then feed in that data's own checksum, you always land on the same fixed number, whatever the data was. It is the trick network protocols use to check a packet in a single pass. Here it means the calculation effectively starts fresh at every checksum, so each one ends up describing only the transaction it follows.
+
+That still leaves your data covered, just by two mechanisms rather than one:
+
+- **A half-written or damaged transaction is caught by the checksum.** This is the failure that actually happens — the server loses power in the middle of a commit, or a disk hands back bad bytes. The damaged transaction fails its check and everything written before it stays valid. It is also why turning `computeCRC32C` off makes writes slower: without the checksum to spot the damage, evitaDB has to prevent it instead, by flushing every write to the device in order (see the <a href="/documentation/operate/configure?lang=evitaql#storage-configuration" target="_blank">storage configuration</a>).
+- **Transactions that are shuffled, repeated or missing are caught by the catalog version.** Every transaction is stamped with the catalog version it produces, and those numbers increase by exactly one. When evitaDB replays the log it insists on seeing them in that order with none skipped, so a log whose transactions have been reordered, duplicated, or copied in from elsewhere is rejected before any of it is applied.
+
+Neither mechanism is intended to protect against someone deliberately editing the WAL, and a cleverer checksum would not change that — anyone who can alter the data can recalculate the checksums to match. Checksums catch accidents, not sabotage.
+
+</Note>
+
+<Note type="info">
+
+<NoteTitle toggles="true">
+
+##### What happens when a bit flips on disk
+
+</NoteTitle>
+
+Storage hardware occasionally returns something other than what was written to it — a bit flipped by a failing cell, a controller firmware bug, a cable glitch. No database can stop that from happening. What evitaDB guarantees is that it will not *silently replay* the result: corrupted transactions are recognised as corrupted rather than applied as if they were genuine changes to your data.
+
+A flipped bit anywhere inside a transaction changes the bytes the checksum was calculated from, so the value on disk no longer matches what gets recalculated on the way in. That holds wherever the flip lands — in a mutation payload, in the record headers, in the transaction length prefix, or even inside the stored checksum itself. Any of them produce a mismatch.
+
+CRC32C is chosen for this because its detection guarantees are precise rather than probabilistic in the cases that matter most:
+
+- a single flipped bit is **always** detected;
+- a run of consecutive damaged bits up to 32 bits long — the typical shape of a hardware read error — is **always** detected;
+- for wider or more scattered damage, the chance of corruption slipping through is about one in four billion.
+
+A transaction also passes a second, independent check. Every record inside it carries its own CRC32C as part of the <a href="#record-structure-in-the-storage">standard record structure</a>, verified when the record is deserialized during replay. Damage therefore has to defeat two separate checksums to reach your data.
+
+When a mismatch is found, evitaDB trims the WAL back to the last transaction that verified and keeps the original file as `_damaged_wal.bck`, so the untrimmed bytes remain available for inspection. Note that this drops the damaged transaction *and everything recorded after it* — the log is a sequence, and there is no way to safely apply later changes across a gap. Everything before the damaged transaction is kept and replayed as normal.
+
+One consequence worth planning around: **all of this depends on `computeCRC32C` being enabled** (it is by default). Switch it off and both layers of checking become no-ops that always answer "matches", so damaged data would be replayed as though it were real. The write-ordering mode that replaces it protects against a crash leaving a half-written transaction; it does nothing about a disk that hands back the wrong bytes. Leave checksums on unless you specifically want that write throughput and accept losing silent-corruption detection to get it.
+
+</Note>
 
 The write-ahead log has a maximum file size set by the <a href="https://evitadb.io/documentation/operate/configure#transaction-configuration" target="_blank">walFileSizeBytes</a> setting. Once this limit is reached, the file is closed and a new one is created with the next index number in its name. The maximum number of WAL files is determined by <a href="https://evitadb.io/documentation/operate/configure#transaction-configuration" target="_blank">walFileCountKept</a>. When this maximum is reached, the oldest file is removed. This mechanism ensures WAL files never grow excessively large and do not accumulate indefinitely on the disk.
 
-Each WAL file starts and ends with cumulative CRC32C checksum. Initial cumulative checksum refers to the end cumulative checksum of the previous WAL file (or zero if it’s the first file). This allows for continuous verification of the entire WAL sequence across multiple files.
+Each WAL file starts and ends with a cumulative CRC32C checksum. The one at the start is a copy of the closing checksum of the previous WAL file (or zero for the very first file), so each file records which one it followed. As the note above explains, it is the catalog versions rather than this value that actually verify that order when the database starts.
 
-At the end of each WAL file except the current one that is still being written to, there is a pair of `int64` values representing the first and last catalog versions recorded in that WAL file, followed by a third `int64` value containing the final cumulative CRC32C checksum of the entire WAL file content. This allows quick navigation among WAL files if you need to locate a particular transaction that made changes to the catalog matching a specific version and also verification that the file content is intact.
+At the end of each WAL file except the current one that is still being written to, there is a pair of `int64` values representing the first and last catalog versions recorded in that WAL file, followed by a third `int64` value containing the final cumulative CRC32C checksum, calculated over everything before it including those two versions. The version pair is what lets evitaDB go straight to the right file when it needs the transaction that moved the catalog to a particular version, instead of opening them all.
 
 #### WAL Transaction Format
 
@@ -195,7 +242,7 @@ Each transaction in the WAL file has the following structure:
 | Mutation payloads     | record[]  | variable        |
 | Cumulative CRC32C     | int64     | 8B              |
 
-The cumulative CRC32C is computed incrementally as bytes are written to the WAL file. When reading transactions, this checksum is verified to ensure data integrity. If verification fails, a `WriteAheadLogCorruptedException` (for catalog WAL) or `EngineMutationLogCorruptedException` (for engine WAL) is thrown, and the WAL is truncated to the last valid transaction.
+The cumulative CRC32C is computed as the bytes are written to the WAL file, and checked again when transactions are read back. A transaction that fails the check on startup does not stop the database. evitaDB trims the WAL back to the last transaction that verified, keeps the untrimmed file next to it as `_damaged_wal.bck` so nothing disappears silently, and logs a warning. Recovering as far as the data is sound is deliberate — the alternative would be a database that refuses to start because its last commit was interrupted. A `WriteAheadLogCorruptedException` (for catalog WAL) or `EngineMutationLogCorruptedException` (for engine WAL) is raised only for damage that cannot be handled this way, such as a WAL file that is missing altogether or too short to make sense of.
 
 If the end of a WAL file contains a partially written record or transaction (i.e., its size does not match the size specified in the transaction header or in a transaction mutation), the WAL file is truncated to the last valid WAL entry upon database startup.
 

--- a/documentation/user/en/use/data-types.md
+++ b/documentation/user/en/use/data-types.md
@@ -248,13 +248,18 @@ parsing the number will use the correct data type that preserves the precision.
 ### Dates and times
 
 <LS to="j,e,g,r">
-Although evitaDB supports *local* variants of the date time like
-[LocalDateTime](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/LocalDateTime.html), it's always
-converted to [OffsetDateTime](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/OffsetDateTime.html)
-using the evitaDB server system default timezone. You can control the default Java timezone in
-[several ways](https://www.baeldung.com/java-jvm-time-zone). If your data is time zone specific, we recommend to work
-directly with the [OffsetDateTime](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/OffsetDateTime.html)
-on the client side and be explicit about the offset from the first day.
+The *local* variants of the date time — such as
+[LocalDateTime](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/LocalDateTime.html) — are
+first-class attribute data types. An attribute declared as `LocalDateTime` stores and returns exactly the wall-clock
+value you wrote, and the entity schema records `LocalDateTime` as its data type — whether you declared the attribute
+up front or let the schema evolve from the first value written.
+
+A local date time carries no offset, so it does not identify a moment in time on its own — two clients in different
+time zones reading the same value read the same wall clock, not the same instant. That is exactly what you want for
+wall-clock data such as opening hours or a recurring schedule. If your data *is* time zone specific, work directly
+with the
+[OffsetDateTime](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/OffsetDateTime.html) on the
+client side and be explicit about the offset from the first day.
 </LS>
 <LS to="c">
 Although evitaDB supports *local* variants of the date time like

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute/UpsertAttributeMutation.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute/UpsertAttributeMutation.java
@@ -55,7 +55,7 @@ public class UpsertAttributeMutation extends AttributeSchemaEvolvingMutation {
 			"Value for attribute `" + attributeKey + "` must not be null. " +
 				"Use `removeAttribute` mutation if you want to remove existing attribute."
 		);
-		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedTypeOrItsArray(value));
+		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedStoredTypeOrItsArray(value));
 	}
 
 	public UpsertAttributeMutation(@Nonnull String attributeName, @Nonnull Serializable value) {
@@ -64,7 +64,7 @@ public class UpsertAttributeMutation extends AttributeSchemaEvolvingMutation {
 			"Value for attribute `" + attributeName + "` must not be null. " +
 				"Use `removeAttribute` mutation if you want to remove existing attribute."
 		);
-		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedTypeOrItsArray(value));
+		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedStoredTypeOrItsArray(value));
 	}
 
 	public UpsertAttributeMutation(@Nonnull String attributeName, @Nonnull Locale locale, @Nonnull Serializable value) {
@@ -73,7 +73,7 @@ public class UpsertAttributeMutation extends AttributeSchemaEvolvingMutation {
 			"Value for attribute `" + attributeName + "` must not be null. " +
 				"Use `removeAttribute` mutation if you want to remove existing attribute."
 		);
-		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedTypeOrItsArray(value));
+		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedStoredTypeOrItsArray(value));
 	}
 
 	private UpsertAttributeMutation(@Nonnull AttributeKey attributeKey, @Nonnull Serializable value, long decisiveTimestamp) {
@@ -82,7 +82,7 @@ public class UpsertAttributeMutation extends AttributeSchemaEvolvingMutation {
 		               "Value for attribute `" + attributeKey + "` must not be null. " +
 			               "Use `removeAttribute` mutation if you want to remove existing attribute."
 		);
-		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedTypeOrItsArray(value));
+		this.value = Objects.requireNonNull(EvitaDataTypes.toSupportedStoredTypeOrItsArray(value));
 	}
 
 	@Override

--- a/evita_common/src/main/java/io/evitadb/dataType/EvitaDataTypes.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/EvitaDataTypes.java
@@ -1052,6 +1052,32 @@ public class EvitaDataTypes {
 	}
 
 	/**
+	 * Resolves the component type for an array rebuilt from normalized elements. The type is taken from the first
+	 * **non-null** normalized element, falling back to the source array's component type when every element is `null`.
+	 *
+	 * Deriving it from element zero alone is not enough: a leading `null` says nothing about what the remaining
+	 * elements normalized to, so `{null, 1.5f}` would rebuild as a `Float[]` and then throw on `Array.set` when the
+	 * normalized `BigDecimal` is stored into it. The same applies to a query-path `{null, LocalDateTime}` array, whose
+	 * non-null element normalizes to `OffsetDateTime`.
+	 *
+	 * @param normalizedElements  the already-normalized elements
+	 * @param sourceComponentType component type of the source array, used when every element is `null`
+	 * @return component type the rebuilt array must be created with
+	 */
+	@Nonnull
+	private static Class<?> normalizedComponentType(
+		@Nonnull Serializable[] normalizedElements,
+		@Nonnull Class<?> sourceComponentType
+	) {
+		for (int i = 0; i < normalizedElements.length; i++) {
+			if (normalizedElements[i] != null) {
+				return normalizedElements[i].getClass();
+			}
+		}
+		return sourceComponentType;
+	}
+
+	/**
 	 * Shared implementation of {@link #toSupportedTypeOrItsArray(Serializable)} and
 	 * {@link #toSupportedStoredTypeOrItsArray(Serializable)}.
 	 *
@@ -1088,9 +1114,9 @@ public class EvitaDataTypes {
 			}
 			if (changed) {
 				// create a properly typed array with the normalized component type
-				final Class<?> componentType = result[0] != null
-					? result[0].getClass()
-					: unknownObject.getClass().getComponentType();
+				final Class<?> componentType = normalizedComponentType(
+					result, unknownObject.getClass().getComponentType()
+				);
 				final Object typedArray = Array.newInstance(componentType, length);
 				for (int i = 0; i < length; i++) {
 					Array.set(typedArray, i, result[i]);

--- a/evita_common/src/main/java/io/evitadb/dataType/EvitaDataTypes.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/EvitaDataTypes.java
@@ -927,6 +927,12 @@ public class EvitaDataTypes {
 	 * query processing pipeline. Use {@link #toTargetType(Serializable, Class)} for explicit type
 	 * conversion.
 	 *
+	 * It must **not** be used to normalize a value on its way into storage: the `LocalDateTime`
+	 * rewrite above would strip an attribute of the very type its schema declares. Use
+	 * {@link #toSupportedStoredType(Serializable)} there. The rewrite is harmless on the query path
+	 * because every attribute constraint coerces its value to the attribute's declared type anyway
+	 * (`toTargetType`), and both directions of that coercion preserve the wall clock.
+	 *
 	 * @param unknownObject the value to validate and normalize
 	 * @return normalized value, or `null` if input is `null`
 	 * @throws UnsupportedDataTypeException if the type is not supported by evitaDB (includes Float
@@ -934,6 +940,50 @@ public class EvitaDataTypes {
 	 */
 	@Nullable
 	public static Serializable toSupportedType(@Nullable Serializable unknownObject) throws UnsupportedDataTypeException {
+		return toSupportedType(unknownObject, true);
+	}
+
+	/**
+	 * Validates and normalizes a value that is about to be **stored** in the database — an entity
+	 * attribute value carried by a mutation, as opposed to a value used in a query.
+	 *
+	 * The normalization is identical to {@link #toSupportedType(Serializable)} with one deliberate
+	 * exception: a `LocalDateTime` is passed through untouched instead of being rewritten to an
+	 * `OffsetDateTime` at UTC. `LocalDateTime` is itself one of the supported data types, so an
+	 * attribute *declared* as `LocalDateTime` has to be able to carry one. Rewriting the value in
+	 * the mutation constructor — before the schema is ever consulted — made such an attribute
+	 * impossible to write at all, and silently derived an `OffsetDateTime` attribute when the
+	 * schema was auto-evolved from the value instead of being declared up front.
+	 *
+	 * Query values deliberately keep the rewrite; see {@link #toSupportedType(Serializable)}.
+	 *
+	 * @param unknownObject the value to validate and normalize
+	 * @return normalized value, or `null` if input is `null`
+	 * @throws UnsupportedDataTypeException if the type is not supported by evitaDB
+	 */
+	@Nullable
+	public static Serializable toSupportedStoredType(
+		@Nullable Serializable unknownObject
+	) throws UnsupportedDataTypeException {
+		return toSupportedType(unknownObject, false);
+	}
+
+	/**
+	 * Shared implementation of {@link #toSupportedType(Serializable)} and
+	 * {@link #toSupportedStoredType(Serializable)}.
+	 *
+	 * @param unknownObject           the value to validate and normalize
+	 * @param coerceLocalDateTime     when `true`, `LocalDateTime` is rewritten to `OffsetDateTime`
+	 *                                at UTC; when `false` it is passed through as the supported
+	 *                                type it already is
+	 * @return normalized value, or `null` if input is `null`
+	 * @throws UnsupportedDataTypeException if the type is not supported by evitaDB
+	 */
+	@Nullable
+	private static Serializable toSupportedType(
+		@Nullable Serializable unknownObject,
+		boolean coerceLocalDateTime
+	) throws UnsupportedDataTypeException {
 		if (unknownObject == null) {
 			// nulls are allowed
 			return null;
@@ -949,8 +999,9 @@ public class EvitaDataTypes {
 			}
 			// normalize doubles to big decimal
 			return new BigDecimal(unknownObject.toString());
-		} else if (unknownObject instanceof LocalDateTime) {
-			// always convert local date time to zoned
+		} else if (coerceLocalDateTime && unknownObject instanceof LocalDateTime) {
+			// always convert local date time to zoned - on the query path only, a stored value must
+			// keep the type its attribute schema declares
 			return ((LocalDateTime) unknownObject).atOffset(ZoneOffset.UTC);
 		} else if (unknownObject.getClass().isEnum()) {
 			return unknownObject.getClass().isAnnotationPresent(SupportedEnum.class) ?
@@ -980,6 +1031,41 @@ public class EvitaDataTypes {
 	public static Serializable toSupportedTypeOrItsArray(
 		@Nullable Serializable unknownObject
 	) throws UnsupportedDataTypeException {
+		return toSupportedTypeOrItsArray(unknownObject, true);
+	}
+
+	/**
+	 * Scalar-or-array counterpart of {@link #toSupportedStoredType(Serializable)} — the entry point
+	 * used by attribute mutations, which must preserve the data type the attribute schema declares.
+	 * For scalar values delegates to {@link #toSupportedStoredType(Serializable)}; for arrays
+	 * normalizes each element individually and returns a new array if any element changed.
+	 *
+	 * @param unknownObject the value to validate and normalize (scalar or array, may be `null`)
+	 * @return normalized value, or `null` if input is `null`
+	 * @throws UnsupportedDataTypeException if the type (or array component type) is not supported
+	 */
+	@Nullable
+	public static Serializable toSupportedStoredTypeOrItsArray(
+		@Nullable Serializable unknownObject
+	) throws UnsupportedDataTypeException {
+		return toSupportedTypeOrItsArray(unknownObject, false);
+	}
+
+	/**
+	 * Shared implementation of {@link #toSupportedTypeOrItsArray(Serializable)} and
+	 * {@link #toSupportedStoredTypeOrItsArray(Serializable)}.
+	 *
+	 * @param unknownObject       the value to validate and normalize (scalar or array, may be `null`)
+	 * @param coerceLocalDateTime when `true`, `LocalDateTime` elements are rewritten to
+	 *                            `OffsetDateTime` at UTC; when `false` they are passed through
+	 * @return normalized value, or `null` if input is `null`
+	 * @throws UnsupportedDataTypeException if the type (or array component type) is not supported
+	 */
+	@Nullable
+	private static Serializable toSupportedTypeOrItsArray(
+		@Nullable Serializable unknownObject,
+		boolean coerceLocalDateTime
+	) throws UnsupportedDataTypeException {
 		if (unknownObject == null) {
 			return null;
 		} else if (unknownObject.getClass().isArray()) {
@@ -989,7 +1075,7 @@ public class EvitaDataTypes {
 			for (int i = 0; i < length; i++) {
 				final Object element = Array.get(unknownObject, i);
 				if (element instanceof Serializable s) {
-					final Serializable normalized = toSupportedType(s);
+					final Serializable normalized = toSupportedType(s, coerceLocalDateTime);
 					result[i] = normalized;
 					changed = changed || normalized != s;
 				} else if (element == null) {
@@ -1013,7 +1099,7 @@ public class EvitaDataTypes {
 			}
 			return unknownObject;
 		} else {
-			return toSupportedType(unknownObject);
+			return toSupportedType(unknownObject, coerceLocalDateTime);
 		}
 	}
 

--- a/evita_common/src/main/java/io/evitadb/utils/Crc32CWrapper.java
+++ b/evita_common/src/main/java/io/evitadb/utils/Crc32CWrapper.java
@@ -182,6 +182,13 @@ public class Crc32CWrapper {
 	 * `new Crc32CWrapper(cumulative).withLong(value).getValue()` but without ever calling
 	 * {@link #forceValue(long)}.
 	 *
+	 * **Folding a checksum into the state that produced it yields a constant.** `combineLong(x, x)` returns the
+	 * same value for every `x` — it computes `CRC(M ‖ CRC(M))`, the CRC *residue*, which is what lets protocols
+	 * verify a frame by checking for one magic value. This is a property of CRCs, not of this implementation, and
+	 * it means such a fold **erases** the running value rather than extending it. Deliberate at the WAL's
+	 * per-transaction boundary; a defect anywhere it is mistaken for chaining. See the `checksum` field of
+	 * `io.evitadb.store.wal.AbstractMutationLog`.
+	 *
 	 * @param cumulative the running cumulative CRC32C value to fold {@code value} into
 	 * @param value      the long value to fold in, in the same little-endian layout as {@link #withLong(long)}
 	 * @return the updated cumulative CRC32C value

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -67,7 +67,9 @@ import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.text.Normalizer;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Comparator;
@@ -221,8 +223,10 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 * Returns the appropriate normalizer function for particular attribute type and key.
 	 *
 	 * `BigDecimal` values are normalized to an order-preserving scaled `int` (respecting the schema's
-	 * `indexedDecimalPlaces`) so the value tree stores them in the compact `IntValueColumn`. The normalizer is
-	 * idempotent: an already-scaled `Integer` (and `null`) passes through unchanged, so a value may be normalized
+	 * `indexedDecimalPlaces`) so the value tree stores them in the compact `IntValueColumn`. Temporal values
+	 * (`OffsetDateTime` and `LocalDateTime`, the latter anchored at UTC) are normalized to an `Instant` so the tree
+	 * stores them in the parallel-array `InstantValueColumn` rather than boxing them. The normalizer is
+	 * idempotent: an already-normalized value (and `null`) passes through unchanged, so a value may be normalized
 	 * more than once on a probe→lookup path without a `ClassCastException`.
 	 *
 	 * @param attributeType        type of the attribute
@@ -238,6 +242,14 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 		if (OffsetDateTime.class.isAssignableFrom(attributeType)) {
 			return comparable -> comparable instanceof OffsetDateTime offsetDateTime
 				? offsetDateTime.toInstant()
+				: (Serializable) comparable;
+		} else if (LocalDateTime.class.isAssignableFrom(attributeType)) {
+			// a local date time has no offset of its own, so it is anchored at UTC - a *constant* offset, which makes
+			// the mapping a lossless bijection AND monotonic with `LocalDateTime`'s natural order, so bucket lookup and
+			// ordered iteration are unaffected. This is purely the index encoding: the schema keeps declaring
+			// `LocalDateTime`, and the value handed back to the client comes from `AttributesStoragePart`, not here
+			return comparable -> comparable instanceof LocalDateTime localDateTime
+				? localDateTime.toInstant(ZoneOffset.UTC)
 				: (Serializable) comparable;
 		} else if (Currency.class.isAssignableFrom(attributeType)) {
 			return comparable -> comparable instanceof Currency currency

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/InstantValueColumn.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/InstantValueColumn.java
@@ -34,8 +34,9 @@ import java.util.Comparator;
 /**
  * Primitive {@link ValueColumn} backed by **two** parallel arrays — a {@code long[]} of epoch-seconds and an
  * {@code int[]} of nanoseconds — for temporal attribute keys. The inverted-index normalizer converts every
- * {@code OffsetDateTime} attribute value to an {@link Instant} before it becomes a bucket key (see
- * {@code FilterIndex.getNormalizer}), so the tree stores {@code Instant} keys ordered by natural order.
+ * {@code OffsetDateTime} attribute value — and every {@code LocalDateTime} one, anchored at UTC — to an
+ * {@link Instant} before it becomes a bucket key (see {@code FilterIndex.getNormalizer}), so the tree stores
+ * {@code Instant} keys ordered by natural order.
  *
  * An {@link Instant} is exactly {@code epochSecond} (a {@code long}) plus {@code nano} (an {@code int} in
  * {@code [0, 999_999_999]}); decomposing it into the pair {@code (seconds, nanos)} is therefore a **lossless
@@ -49,7 +50,8 @@ import java.util.Comparator;
  * occurs and the two arrays can never drift apart (every mutation touches both, with identical indices/lengths).
  *
  * Selected only when the tree comparator is natural order and the normalized key type is {@link Instant} (i.e. the
- * declared attribute type is {@code OffsetDateTime} or {@code Instant}); see {@link ValueColumnFactory}. Otherwise the
+ * declared attribute type is {@code OffsetDateTime}, {@code Instant} or {@code LocalDateTime}); see
+ * {@link ValueColumnFactory}. Otherwise the
  * leaf keeps the universal {@link BoxedObjectColumn}.
  *
  * @param <M> the boxed key type as seen by the tree's generic API (always {@link Instant} at runtime)

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/ValueColumnFactory.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/ValueColumnFactory.java
@@ -118,13 +118,19 @@ public interface ValueColumnFactory<M extends Comparable<M>> {
 	}
 
 	/**
-	 * Maps a plain attribute type to the type actually stored as the tree key, mirroring the only normalization in
-	 * {@code FilterIndex.getNormalizer} that changes the stored class: {@link OffsetDateTime} is stored as its
-	 * {@link Instant}, and so is {@link LocalDateTime} (anchored at UTC — a constant offset, hence a lossless,
-	 * order-preserving mapping). All other types (numbers, {@code LocalDate} / {@code LocalTime}, {@code String},
-	 * {@code Currency}, {@code Locale}, …) keep their own class; `LocalDate` and `LocalTime` each fit losslessly in a
-	 * single {@code long} and are better served by the cheaper {@link LongValueColumn}. The single source of truth for
-	 * this remap lives here — it must stay in lockstep with `FilterIndex.getNormalizer`.
+	 * Maps a plain attribute type to the type actually stored as the tree key, mirroring the **temporal** key-class
+	 * remaps performed by {@code FilterIndex.getNormalizer}: {@link OffsetDateTime} is stored as its {@link Instant},
+	 * and so is {@link LocalDateTime} (anchored at UTC — a constant offset, hence a lossless, order-preserving
+	 * mapping). Those two must stay in lockstep with `FilterIndex.getNormalizer`, and this is their single source of
+	 * truth.
+	 *
+	 * The normalizer changes the stored class for other types too — {@code BigDecimal} to a scaled {@code Integer},
+	 * {@code Currency} / {@code Locale} to their comparable wrappers — but those are **not** remapped here:
+	 * {@code BigDecimal} is matched on its declared type directly in {@link #forKey} (which then selects
+	 * {@link IntValueColumn}), and the wrapper types fall through to the boxed column either way. Everything else
+	 * (numbers, {@code LocalDate} / {@code LocalTime}, {@code String}, …) keeps its own class; `LocalDate` and
+	 * `LocalTime` each fit losslessly in a single {@code long} and are better served by the cheaper
+	 * {@link LongValueColumn}.
 	 *
 	 * @param plainType the plain (non-array) declared attribute type
 	 * @return the normalized key type used by the tree

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/ValueColumnFactory.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/ValueColumnFactory.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Comparator;
 
@@ -65,8 +66,10 @@ public interface ValueColumnFactory<M extends Comparable<M>> {
 	 * byte-compare fast path" section.
 	 *
 	 * A primitive column is chosen only when the comparator is natural order. Temporal keys (normalized type
-	 * {@link Instant}, i.e. declared {@code OffsetDateTime} / {@code Instant}) select the parallel-array
-	 * {@link InstantValueColumn}; integral keys with a supported {@link LongKeyCodec} select {@link LongValueColumn}.
+	 * {@link Instant}, i.e. declared {@code OffsetDateTime} / {@code Instant} / {@code LocalDateTime}) select the
+	 * parallel-array {@link InstantValueColumn}; integral keys with a supported {@link LongKeyCodec} — which includes
+	 * {@code LocalDate} and {@code LocalTime}, each of which fits losslessly in a single {@code long} — select
+	 * {@link LongValueColumn}.
 	 * {@code BigDecimal} keys (normalized upstream to a scaled {@code int}) select the 4-byte {@link IntValueColumn}.
 	 * Otherwise the universal boxed {@link BoxedObjectColumn} (keyed by {@code Comparable.class}, the raw key type the
 	 * tree uses today) is returned, which is behavior-identical to the universal boxed leaf.
@@ -117,15 +120,18 @@ public interface ValueColumnFactory<M extends Comparable<M>> {
 	/**
 	 * Maps a plain attribute type to the type actually stored as the tree key, mirroring the only normalization in
 	 * {@code FilterIndex.getNormalizer} that changes the stored class: {@link OffsetDateTime} is stored as its
-	 * {@link Instant}. All other types (numbers, {@code LocalDate} / {@code LocalTime}, {@code String},
-	 * {@code Currency}, {@code Locale}, …) keep their own class. The single source of truth for this remap lives here.
+	 * {@link Instant}, and so is {@link LocalDateTime} (anchored at UTC — a constant offset, hence a lossless,
+	 * order-preserving mapping). All other types (numbers, {@code LocalDate} / {@code LocalTime}, {@code String},
+	 * {@code Currency}, {@code Locale}, …) keep their own class; `LocalDate` and `LocalTime` each fit losslessly in a
+	 * single {@code long} and are better served by the cheaper {@link LongValueColumn}. The single source of truth for
+	 * this remap lives here — it must stay in lockstep with `FilterIndex.getNormalizer`.
 	 *
 	 * @param plainType the plain (non-array) declared attribute type
 	 * @return the normalized key type used by the tree
 	 */
 	@Nonnull
 	private static Class<?> normalizedTypeOf(@Nonnull Class<?> plainType) {
-		if (OffsetDateTime.class.isAssignableFrom(plainType)) {
+		if (OffsetDateTime.class.isAssignableFrom(plainType) || LocalDateTime.class.isAssignableFrom(plainType)) {
 			return Instant.class;
 		}
 		return plainType;

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
@@ -2132,7 +2132,9 @@ public class OffsetIndex {
 		/**
 		 * Stores instance of the record to the non-flushed index.
 		 *
-		 * @param create - when true it affects {@link #nonFlushedValuesHistogram} results
+		 * @param create - when true it affects {@link #nonFlushedValuesHistogram} results; when false it still
+		 *               affects them if this version had already removed the same key, because the removal and
+		 *               this write fold into a plain overwrite whose cardinality effect cancels out
 		 */
 		public void put(@Nonnull RecordKey key, @Nonnull VersionedValue value, boolean create) {
 			if (create) {

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
@@ -1663,7 +1663,17 @@ public class OffsetIndex {
 		final byte recordType = this.recordTypeRegistry.idFor(value.getClass());
 		final RecordKey key = new RecordKey(recordType, primaryKey);
 
-		final boolean update = this.roots.latestRoot().containsKey(key);
+		// a not-yet-flushed write to this key from an EARLIER, different version always overrides the published
+		// root, which may not yet reflect it - same precedence as doRemove's lookup below, so a batch that both
+		// removes and re-adds the same key across several not-yet-flushed versions resolves consistently at
+		// promote time. The lookup is deliberately bounded to versions strictly before this one: a remove and a
+		// re-add within the SAME version fold into one entry regardless (see NonFlushedValueSet#put/#remove), so
+		// consulting this version's own not-yet-registered activity here would misjudge a same-transaction
+		// delete-then-recreate of a key that already exists in the published root as a brand new key.
+		final Optional<VersionedValue> nonFlushedValueRef = this.volatileValues.getNonFlushedValueIfVersionMatches(
+			catalogVersion - 1, key);
+		final boolean update = nonFlushedValueRef.isPresent() ?
+			!nonFlushedValueRef.get().removed() : this.roots.latestRoot().containsKey(key);
 		final FileLocation recordLocation = new StorageRecord<>(
 			this.writeKryo,
 			exclusiveWriteAccess,
@@ -2129,6 +2139,11 @@ public class OffsetIndex {
 				this.nonFlushedValuesHistogram.merge(key.recordType(), 1, Integer::sum);
 				this.addedKeys.add(key);
 				this.removedKeys.remove(key);
+			} else if (this.removedKeys.remove(key)) {
+				// this version already dropped a record that existed before it and now writes it back: the two
+				// fold into a plain overwrite, so the removal's cardinality effect has to be undone. Without
+				// this the in-flight count reports one record fewer than the very next flush publishes.
+				this.nonFlushedValuesHistogram.merge(key.recordType(), 1, Integer::sum);
 			}
 			this.nonFlushedValueIndex.put(key, value);
 			this.nonFlushedBlockSizeChangedCallback.accept(value.fileLocation().recordLength());
@@ -2142,8 +2157,12 @@ public class OffsetIndex {
 			this.nonFlushedValuesHistogram.merge(key.recordType(), -1, Integer::sum);
 			this.nonFlushedValueIndex.put(
 				key, new VersionedValue(key.primaryKey(), (byte) (key.recordType() * -1), fileLocation));
-			this.addedKeys.remove(key);
-			this.removedKeys.add(key);
+			// a record created in this very version and dropped again folds into a no-op - undo the creation
+			// rather than record the removal of something that was never published, which would otherwise
+			// make the in-flight count of an untouched index go negative
+			if (!this.addedKeys.remove(key)) {
+				this.removedKeys.add(key);
+			}
 			this.nonFlushedBlockSizeChangedCallback.accept(fileLocation.recordLength());
 		}
 

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -3059,9 +3059,27 @@ public class DefaultCatalogPersistenceService
 			this.closed = true;
 			// stop the ticker and settle the debt before anything is torn down: no service may go away still owing
 			// a device flush, or the bytes it wrote would depend on the operating system getting round to them.
-			// The bootstrap record is deliberately NOT written here - it is a checkpoint pointer, and leaving it at
-			// the last checkpoint simply means restart resumes from there and replays the rest from the WAL.
+			//
+			// A checkpoint owed by the last round is published first. That round already built the bootstrap record
+			// and left the index at its own version, so this publishes a state that is by construction complete -
+			// it does not wait for anything, and it does not drain: `TransactionManager#close` fails pending
+			// transactions rather than finishing them, so newer versions may still be missing and the write-ahead
+			// log remains the authority on them. What it buys is that a clean restart resumes from here instead of
+			// replaying from whichever checkpoint the ticker last happened to reach. Nothing is written when no
+			// checkpoint is owed, which is the case whenever the round that just finished checkpointed itself.
 			if (this.checkpointCoordinator != null) {
+				try {
+					// ordered before the WAL is closed: publishing also tells the log how far it has been processed
+					this.checkpointCoordinator.checkpointIfOwed();
+				} catch (RuntimeException ex) {
+					// shutdown must not be aborted by this - the state stays crash-consistent either way, the next
+					// start simply replays more of the write-ahead log than it would have needed to
+					log.error(
+						"Final checkpoint of catalog `{}` failed - the next start will resume from the previous " +
+							"checkpoint and replay the remainder from the write-ahead log!",
+						this.catalogName, ex
+					);
+				}
 				try {
 					this.checkpointCoordinator.forcePendingSyncs();
 				} catch (RuntimeException ex) {

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/FilterIndexStoragePartSerializer_2026_1.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/FilterIndexStoragePartSerializer_2026_1.java
@@ -35,6 +35,10 @@ import io.evitadb.spi.store.catalog.persistence.storageParts.index.FilterIndexSt
 import io.evitadb.utils.Assert;
 import lombok.RequiredArgsConstructor;
 
+import javax.annotation.Nonnull;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
 /**
  * Backward-compatible {@link Serializer} for the pre-freeze {@link FilterIndexStoragePart} format that did NOT persist
  * the `indexedDecimalPlaces` scale (the scale was re-derived from the schema at load). Reads such legacy blobs into a
@@ -82,7 +86,7 @@ public class FilterIndexStoragePartSerializer_2026_1 extends Serializer<FilterIn
 		final int pointCount = input.readInt();
 		final ValueToRecordBitmap[] points = new ValueToRecordBitmap[pointCount];
 		for (int i = 0; i < pointCount; i++) {
-			points[i] = kryo.readObject(input, ValueToRecordBitmap.class);
+			points[i] = anchorLegacyLocalDateTime(kryo.readObject(input, ValueToRecordBitmap.class));
 		}
 
 		final boolean hasRangeIndex = input.readBoolean();
@@ -92,6 +96,28 @@ public class FilterIndexStoragePartSerializer_2026_1 extends Serializer<FilterIn
 		} else {
 			return new FilterIndexStoragePart(entityIndexPrimaryKey, attributeKey, attributeType, points, null, uniquePartId);
 		}
+	}
+
+	/**
+	 * Re-anchors a legacy `LocalDateTime` bucket value at UTC so it lands in the `Instant` space the current
+	 * `FilterIndex.getNormalizer` keys `LocalDateTime` attributes with.
+	 *
+	 * `2026.1` had no `LocalDateTime` branch in its normalizer, so it persisted the raw wall-clock value; the current
+	 * tree picks {@code InstantValueColumn} for such an attribute and would fail with a `ClassCastException` while
+	 * rehydrating those buckets. Anchoring at UTC is exactly what the normalizer now does on the write path, and
+	 * because the offset is constant the mapping preserves the bucket ordering the reload path relies on.
+	 *
+	 * The conversion is self-healing: once the index is written again it is persisted through the current serializer
+	 * with `Instant` keys, and this legacy reader is no longer consulted for it.
+	 *
+	 * @param bucket bucket just read from a legacy blob
+	 * @return the bucket, with a `LocalDateTime` value replaced by its UTC instant
+	 */
+	@Nonnull
+	private static ValueToRecordBitmap anchorLegacyLocalDateTime(@Nonnull ValueToRecordBitmap bucket) {
+		return bucket.getValue() instanceof LocalDateTime localDateTime
+			? new ValueToRecordBitmap(localDateTime.toInstant(ZoneOffset.UTC), bucket.getRecordIds())
+			: bucket;
 	}
 
 }

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
@@ -154,6 +154,9 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	/**
 	 * The size of the cumulative CRC32C checksum written after each transaction in the WAL file.
 	 * The checksum is stored as a little-endian long (8 bytes).
+	 *
+	 * See the {@link #checksum} field for what this value does and does not detect — it is narrower than
+	 * "cumulative" suggests, and the difference has been rediscovered more than once.
 	 */
 	public static final int CUMULATIVE_CRC32_SIZE = 8;
 	/**
@@ -161,7 +164,10 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	 *
 	 * - first catalog version mutation of the WAL file
 	 * - last catalog version mutation of the WAL file
-	 * - final cumulative CRC32C checksum of the entire WAL file content
+	 * - final cumulative CRC32C checksum, computed over the whole file including these two versions
+	 *
+	 * The third long is the CRC32C of every byte before it, but it does not attest to the file as a whole —
+	 * see the {@link #checksum} field.
 	 */
 	public static final int WAL_TAIL_LENGTH = 8 + 8 + CUMULATIVE_CRC32_SIZE;
 	/**
@@ -169,7 +175,33 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	 */
 	protected static final long CUT_WAL_CACHE_AFTER_INACTIVITY_MS = 300_000L; // 5 minutes
 	/**
-	 * The calculator for computing checksums.
+	 * The running CRC32C written after every transaction. **This is the authoritative description of what that
+	 * value guarantees** — the constants above and the format documentation point here rather than restating it.
+	 *
+	 * Each stored value is the CRC32C of every byte preceding it in the file, exactly as the format documents.
+	 * Because that coverage includes the *previous stored checksums*, and `CRC(M ‖ CRC(M))` is the CRC **residue**
+	 * — a constant, whatever `M` was — the running value returns to that same constant at every stored checksum.
+	 * Both statements are therefore true at once: a checksum covers everything before it, **and** it carries no
+	 * information about anything before the preceding checksum.
+	 *
+	 * What that means in practice:
+	 *
+	 * - **Detected:** damage inside a transaction — a torn write, a hole left by out-of-order writeback, bit rot.
+	 *   This is the case recovery exists for, and it is why `computeCRC32C` and write ordering are coupled (see
+	 *   {@link #openWalChannel(Path)}).
+	 * - **Not detected:** whole transactions exchanged, duplicated, dropped, or spliced in from another WAL file;
+	 *   nor a wrong per-file seed. Each transaction's checksum verifies from the same constant wherever it sits.
+	 *   `CatalogWriteAheadLogTest#shouldNotDetectReorderedTransactions` pins this.
+	 * - **Covered elsewhere:** all of the above is rejected by the catalog-version continuity check during replay
+	 *   — {@link io.evitadb.core.transaction.TransactionManager} asserts every transaction carries exactly the
+	 *   next expected catalog version. Ordering is that check's job, never this one's.
+	 *
+	 * No arrangement of this scheme can do better: a chain that survives a transaction boundary has to *exclude*
+	 * the checksum bytes from its coverage. Nor would chaining defend against a forged transaction — anyone able
+	 * to rewrite the bytes can recompute the checksums over them. CRC detects accidents, not tampering.
+	 *
+	 * Not to be confused with the record-level cumulative checksum in
+	 * {@link io.evitadb.store.offsetIndex.model.StorageRecord}, which covers one record and is unrelated to this.
 	 */
 	protected final Checksum checksum;
 	/**
@@ -700,7 +732,7 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	 *   the device in any order, so a crash can leave a *hole* — bytes missing in the middle of a
 	 *   transaction while later bytes landed. The file length is unchanged, so the framing still parses
 	 *   and nothing about the record looks wrong; the only thing that can tell a hole from valid data is
-	 *   the cumulative CRC32C chain, which recovery verifies per transaction and reacts to by truncating.
+	 *   the cumulative CRC32C, which recovery verifies per transaction and reacts to by truncating.
 	 * - **Write ordering (slow, the fallback).** With `computeCRC32C` switched off that chain degrades to
 	 *   {@link io.evitadb.store.checksum.Checksum#NO_OP}, whose comparison always answers "matches" — so a
 	 *   hole is waved straight through recovery and replayed as if it were real history. There is then no
@@ -818,9 +850,6 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 		this.kryoPool = kryoPool;
 		this.processedVersion = new AtomicLong(version);
 		this.storageSettings = storageSettings;
-		this.checksum = storageSettings.createCumulativeChecksum(logRecordReference.cumulativeChecksum());
-		// we must calculate the checksum into the cumulative checksum instance
-		this.checksum.update(logRecordReference.cumulativeChecksum());
 		this.cutWalCacheTask = this.createDelayedAsyncTask(
 			"WAL cache cutter",
 			scheduler,
@@ -836,17 +865,28 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 		this.maxWalFileSizeBytes = storageSettings.walFileSizeBytes();
 		this.walFileCountKept = storageSettings.walFileCountKept();
 		this.storageFolder = storageFolder;
-		final AtomicInteger currentWalFileIndex = new AtomicInteger(logRecordReference.fileIndex());
+		final int[] firstAndLastWalFileIndex = getFirstAndLastWalFileIndex(storageFolder);
+		// Two different questions, and only one file index used to answer both of them. The reference says where
+		// REPLAY starts; the newest file on disk says where APPENDS resume. They coincide only when nothing rotated
+		// since the last published bootstrap record, which a restart cannot rely on - a catalog deliberately
+		// resumes from the last checkpoint and replays the remainder (see DefaultCatalogPersistenceService#close),
+		// and a crash publishes no bootstrap record at all. All that may be demanded of the reference is that the
+		// file it points into still exists, which rotation guarantees: a WAL file is dropped only once every
+		// version inside it has been processed (see #removeWalFiles).
+		final int activeWalFileIndex = firstAndLastWalFileIndex[1];
+		final int referencedWalFileIndex = logRecordReference.fileIndex();
 		try {
-			final int[] firstAndLastWalFileIndex = getFirstAndLastWalFileIndex(storageFolder);
-
-			final Path walFilePath = storageFolder.resolve(this.walFileNameProvider.apply(currentWalFileIndex.get()));
+			final Path walFilePath = storageFolder.resolve(this.walFileNameProvider.apply(activeWalFileIndex));
 			Assert.isPremiseValid(
-				firstAndLastWalFileIndex[1] == logRecordReference.fileIndex(),
+				referencedWalFileIndex >= firstAndLastWalFileIndex[0] &&
+					referencedWalFileIndex <= activeWalFileIndex,
 				() -> new WriteAheadLogCorruptedException(this.walKind,
-					"The last WAL file index in the storage (" + firstAndLastWalFileIndex[1] + ") " +
-						"does not match the expected index from the log record reference (" + walFilePath + ")!",
-					"WAL file index mismatch!"
+					"The WAL file the log record reference points at (" +
+						this.walFileNameProvider.apply(referencedWalFileIndex) + ") is not among the files present " +
+						"in the storage (" + this.walFileNameProvider.apply(firstAndLastWalFileIndex[0]) + " to " +
+						this.walFileNameProvider.apply(firstAndLastWalFileIndex[1]) + ") - replay cannot start " +
+						"from a file that is gone!",
+					"WAL file referenced by the log record reference is missing!"
 				)
 			);
 
@@ -855,25 +895,33 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 			);
 
 			final FirstAndLastVersionsInWalFile versions = checkAndTruncate(
-				walFilePath, kryoPool, logRecordReference
+				walFilePath, kryoPool, activeWalFileIndex, logRecordReference
 			);
 
-			// the WAL file has been truncated - we need to adjust the log record reference accordingly
-			if (versions.logFileRecordReference() != null) {
+			// the WAL file has been truncated - we need to adjust the log record reference accordingly. Only when
+			// the truncation touched the very file the reference points into, though: `versions` describes the
+			// ACTIVE file, and adopting it while the reference lives in an older one would move replay's starting
+			// point forward past transactions that were never processed.
+			if (versions.logFileRecordReference() != null && activeWalFileIndex == referencedWalFileIndex) {
 				logRecordReference = versions.logFileRecordReference();
 			}
 
-			lastVersion.ifPresent(
-				firstAndLastVersionsInWalFile -> Assert.isPremiseValid(
-					firstAndLastVersionsInWalFile.lastVersion() + 1 == versions.firstVersion(),
-					() -> new WriteAheadLogCorruptedException(this.walKind,
-						currentWalFileIndex.get(),
-						firstAndLastVersionsInWalFile.lastVersion(),
-						versions.firstVersion(),
-						this.walFileNameProvider
+			// nothing to join when the active file holds no transaction yet - a crash between rotation creating
+			// the next file and the first append landing in it leaves exactly that, and the finalized run before
+			// it is already verified continuous by `verifyWalFileVersionsAndReturnLastFinalized`
+			if (versions.firstVersion() > -1) {
+				lastVersion.ifPresent(
+					firstAndLastVersionsInWalFile -> Assert.isPremiseValid(
+						firstAndLastVersionsInWalFile.lastVersion() + 1 == versions.firstVersion(),
+						() -> new WriteAheadLogCorruptedException(this.walKind,
+							activeWalFileIndex,
+							firstAndLastVersionsInWalFile.lastVersion(),
+							versions.firstVersion(),
+							this.walFileNameProvider
+						)
 					)
-				)
-			);
+				);
+			}
 
 			// create the WAL file if it does not exist
 			final boolean created = createWalFile(walFilePath, true, this.walKind);
@@ -889,9 +937,18 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 				this.storageSettings.createCompressor().orElse(null)
 			);
 
+			// Where REPLAY starts and where APPENDS resume hold the same checksum only while the reference still
+			// sits in the newest file; once rotation has left it behind they diverge. Resolved from the active
+			// file so the value stored alongside it describes that file rather than the reference's position.
+			// Note this is bookkeeping, not a correctness guard: the value seeds nothing that is later verified
+			// (see the `checksum` field for why), so getting it wrong is invisible rather than corrupting.
+			final long activeFileCumulativeChecksum = resolveActiveFileCumulativeChecksum(
+				versions, logRecordReference, walFilePath, created
+			);
+
 			// if the file was just created, write the initial cumulative checksum
 			if (created) {
-				theOutput.writeLong(logRecordReference.cumulativeChecksum());
+				theOutput.writeLong(activeFileCumulativeChecksum);
 				this.contentLengthBuffer.clear();
 				this.contentLengthBuffer.put(theOutput.getBuffer(), 0, theOutput.position());
 				this.contentLengthBuffer.flip();
@@ -899,30 +956,95 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 					walFileChannel.write(this.contentLengthBuffer) == CUMULATIVE_CRC32_SIZE,
 					"Failed to write initial cumulative checksum to WAL file!"
 				);
-				// every transaction appended later chains its checksum onto this seed, so it has to be on
-				// the device before any of them - the first append's force would cover it, but this file
-				// is created once and the sync is not worth economising on
+				// part of the file's declared format and read back by every scan, so it has to be on the
+				// device before any transaction lands after it - the first append's force would cover it,
+				// but this file is created once and the sync is not worth economising on
 				forceDurable(walFileChannel);
 			}
 
+			this.checksum = storageSettings.createCumulativeChecksum(activeFileCumulativeChecksum);
+			// we must calculate the checksum into the cumulative checksum instance
+			this.checksum.update(activeFileCumulativeChecksum);
+
 			this.currentWalFile.set(
 				new CurrentMutationLogFile(
-					currentWalFileIndex.get(),
+					activeWalFileIndex,
 					versions.firstVersion(),
 					versions.lastVersion(),
 					walFilePath,
 					walFileChannel,
 					theOutput,
 					walFileChannel.size(),
-					logRecordReference.cumulativeChecksum()
+					activeFileCumulativeChecksum
 				)
 			);
 		} catch (IOException e) {
 			throw new WriteAheadLogCorruptedException(this.walKind,
-				"Failed to open WAL file `" + this.walFileNameProvider.apply(currentWalFileIndex.get()) + "`!",
+				"Failed to open WAL file `" + this.walFileNameProvider.apply(activeWalFileIndex) + "`!",
 				"Failed to open the WAL file!",
 				e
 			);
+		}
+	}
+
+	/**
+	 * Resolves the cumulative checksum the active WAL file currently stands at.
+	 *
+	 * This is deliberately **not** the reference's checksum. The reference describes the last *processed*
+	 * transaction and is where replay starts; this value belongs to the newest file on disk, and the two diverge
+	 * the moment rotation happens after the last published bootstrap record.
+	 *
+	 * Be aware of what this value does and does not do — it is recorded and carried forward, but nothing verified
+	 * later depends on it. See the {@link #checksum} field for why a WAL checksum cannot carry state across a
+	 * transaction boundary; the practical consequence is that an error here is inert rather than corrupting.
+	 *
+	 * @param activeFileVersions  what scanning the active file found in it
+	 * @param logRecordReference  the reference the log was opened against
+	 * @param walFilePath         path of the active WAL file
+	 * @param created             whether the active file had to be created by this constructor
+	 * @return the cumulative checksum the active file stands at
+	 * @throws IOException if the active file's seed cannot be read
+	 */
+	private long resolveActiveFileCumulativeChecksum(
+		@Nonnull FirstAndLastVersionsInWalFile activeFileVersions,
+		@Nonnull LogFileRecordReference logRecordReference,
+		@Nonnull Path walFilePath,
+		boolean created
+	) throws IOException {
+		final LogFileRecordReference scannedReference = activeFileVersions.logFileRecordReference();
+		if (scannedReference != null) {
+			// the scan found a chain that differs from the reference's, and it describes the active file
+			return scannedReference.cumulativeChecksum();
+		}
+		if (activeFileVersions.firstVersion() > -1 || created) {
+			// either the scan confirmed the active file's chain already equals the reference's (that is what a
+			// null reference means there), or the file is brand new and is seeded from the reference
+			return logRecordReference.cumulativeChecksum();
+		}
+		// The active file holds no transaction at all - it carries only the 8-byte cumulative checksum header that
+		// rotation seeds a new file with. That header is the chain the previous file ended on, and is the only
+		// correct seed here. The reference must not be used instead: it stops at the last PROCESSED transaction,
+		// which can be several transactions short of the end of the previous file.
+		Assert.isPremiseValid(
+			walFilePath.toFile().length() >= CUMULATIVE_CRC32_SIZE,
+			() -> new WriteAheadLogCorruptedException(this.walKind,
+				"The newest WAL file `" + walFilePath + "` holds neither a transaction nor the cumulative " +
+					"checksum header rotation seeds it with - the chain it continues cannot be established!",
+				"WAL file is missing its cumulative checksum header!"
+			)
+		);
+		// the append channel is write-only, so the seed is read through a channel of its own
+		try (final FileChannel readChannel = FileChannel.open(walFilePath, StandardOpenOption.READ)) {
+			final ByteBuffer seedBuffer = ByteBuffer.allocate(CUMULATIVE_CRC32_SIZE).order(ByteOrder.LITTLE_ENDIAN);
+			Assert.isPremiseValid(
+				readChannel.read(seedBuffer, 0) == CUMULATIVE_CRC32_SIZE,
+				() -> new WriteAheadLogCorruptedException(this.walKind,
+					"Failed to read the cumulative checksum header of WAL file `" + walFilePath + "`!",
+					"Failed to read the WAL file cumulative checksum header!"
+				)
+			);
+			seedBuffer.flip();
+			return seedBuffer.getLong();
 		}
 	}
 
@@ -1582,6 +1704,31 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 		@Nonnull Pool<Kryo> catalogKryoPool,
 		@Nonnull LogFileRecordReference logRecordReference
 	) {
+		return checkAndTruncate(walFilePath, catalogKryoPool, logRecordReference.fileIndex(), logRecordReference);
+	}
+
+	/**
+	 * Same as {@link #checkAndTruncate(Path, Pool, LogFileRecordReference)}, but told explicitly which WAL file
+	 * index is being scanned instead of taking it from the reference.
+	 *
+	 * The two differ whenever a restart resumes from a reference that rotation has left behind: the file to scan
+	 * and truncate is the newest one on disk, while the reference still points into an older, finalized file. Any
+	 * reference this method derives describes **the file it scanned**, so passing the index separately is what
+	 * keeps it from minting a reference carrying one file's index and another file's position and checksum.
+	 *
+	 * @param walFilePath        the path to the WAL file to check and truncate
+	 * @param catalogKryoPool    the Kryo object pool to use for deserialization
+	 * @param walFileIndex       index of the WAL file being scanned - stamped on any derived reference
+	 * @param logRecordReference the reference whose cumulative checksum decides whether a derived one is needed
+	 * @return the first and last catalog versions found in the scanned file
+	 */
+	@Nonnull
+	protected FirstAndLastVersionsInWalFile checkAndTruncate(
+		@Nonnull Path walFilePath,
+		@Nonnull Pool<Kryo> catalogKryoPool,
+		int walFileIndex,
+		@Nonnull LogFileRecordReference logRecordReference
+	) {
 		if (AbstractMutationLog.isWalEmptyOrNonExisting(walFilePath)) {
 			return FirstAndLastVersionsInWalFile.EMPTY;
 		}
@@ -1631,7 +1778,7 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 							// otherwise we need to return a new reference with corrected checksum and position
 							new LogFileRecordReference(
 								this.walFileNameProvider,
-								logRecordReference.fileIndex(),
+								walFileIndex,
 								new FileLocation(scanResult.lastTxStartPosition(), scanResult.lastTxLength()),
 								scanResult.cumulativeChecksum()
 							)
@@ -2190,7 +2337,8 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	/**
 	 * Writes the WAL (Write Ahead Log) tail information to the specified WAL file.
 	 * The method writes the first and last change versions specified to the tail of the WAL file,
-	 * followed by the final cumulative CRC32C checksum of the entire WAL file content.
+	 * followed by the final cumulative CRC32C checksum, computed over everything preceding it including those
+	 * two versions. That value does not attest to the file as a whole — see the {@link #checksum} field.
 	 *
 	 * @param firstCvInFile  the first change version present in the WAL file
 	 * @param lastCvInFile   the last change version present in the WAL file

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
@@ -1526,31 +1526,48 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	}
 
 	/**
-	 * Returns UUID of the first transaction that is present in the WAL file and which transitions the catalog to
-	 * the version that is greater by one than the current catalog version.
+	 * Returns the first transaction that follows the given reference - the point replay resumes from.
 	 *
-	 * @param walReference the current catalog version
-	 * @return UUID of the first transaction that is present in the WAL file and which transitions the catalog to
+	 * The search is **not** confined to the file the reference points into. A reference may name the last
+	 * transaction of a file rotation has since finalized, in which case the transactions still to be replayed
+	 * begin in a later file; the search walks forward until it finds one or runs out of files.
+	 *
+	 * @param walReference the position already processed, or `null` to start from the beginning of the newest file
+	 * @return the first transaction after `walReference`, or empty when nothing remains to be replayed
 	 */
 	@Nonnull
 	public Optional<TransactionMutationWithWalFileReference> getFirstNonProcessedTransaction(
 		@Nullable LogFileRecordReference walReference
 	) {
-		final Path walFilePath;
-		final int walFileIndex;
-		final long startPosition;
+		final int newestWalFileIndex = getWalFileIndex();
+		int walFileIndex;
+		long startPosition;
 		if (walReference == null) {
-			walFileIndex = getWalFileIndex();
-			walFilePath = this.storageFolder.resolve(this.walFileNameProvider.apply(walFileIndex));
+			walFileIndex = newestWalFileIndex;
 			startPosition = CUMULATIVE_CRC32_SIZE;
 		} else {
-			walFilePath = walReference.toFilePath(this.storageFolder);
 			walFileIndex = walReference.fileIndex();
 			final FileLocation fileLocation = Objects.requireNonNull(walReference.fileLocation());
 			startPosition = fileLocation.endPosition();
 		}
-		final File walFile = walFilePath.toFile();
-		if (walFile.exists() && walFile.length() > startPosition + TRANSACTION_PREFIX_SIZE + CUMULATIVE_CRC32_SIZE) {
+
+		// The reference may end the file it points into: a checkpoint that lands exactly on a rotation boundary
+		// leaves the remainder in the NEXT file. Everything past the last transaction of a rotated file is its
+		// `WAL_TAIL_LENGTH` trailer, which carries no transaction - reading it as one interprets the version bytes
+		// as a record length and fails the whole recovery, even though the transactions are intact one file over.
+		// So walk forward: a finalized file that holds nothing but its tail hands the search to its successor.
+		while (walFileIndex <= newestWalFileIndex) {
+			final Path walFilePath = this.storageFolder.resolve(this.walFileNameProvider.apply(walFileIndex));
+			final File walFile = walFilePath.toFile();
+			// a finalized file always ends with the trailer, so anything at or below it means "no transaction
+			// left here"; the active file carries no trailer and only needs room for a record and its checksum
+			final long minimumRemainder = walFileIndex < newestWalFileIndex ?
+				WAL_TAIL_LENGTH : TRANSACTION_PREFIX_SIZE + CUMULATIVE_CRC32_SIZE;
+			if (!walFile.exists() || walFile.length() <= startPosition + minimumRemainder) {
+				walFileIndex++;
+				startPosition = CUMULATIVE_CRC32_SIZE;
+				continue;
+			}
 			final Kryo kryo = this.kryoPool.obtain();
 			try (
 				final RandomAccessFile randomAccessOldWalFile = new RandomAccessFile(walFile, "r");

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/LocalTemporalAttributeTypeFidelityFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/LocalTemporalAttributeTypeFidelityFunctionalTest.java
@@ -27,6 +27,7 @@ import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.configuration.EvitaConfiguration;
 import io.evitadb.api.configuration.ServerOptions;
 import io.evitadb.api.query.FilterConstraint;
+import io.evitadb.api.exception.InvalidMutationException;
 import io.evitadb.api.requestResponse.EvitaResponse;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.api.requestResponse.data.SealedEntity;
@@ -46,6 +47,8 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -74,6 +77,7 @@ import static io.evitadb.test.TestTags.SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Regression coverage for the *local* temporal attribute types — `LocalDateTime`, `LocalDate` and
@@ -110,6 +114,7 @@ public class LocalTemporalAttributeTypeFidelityFunctionalTest implements EvitaTe
 	private static final String ATTR_LOCAL_DATE_TIME = "initialPublishedDate";
 	private static final String ATTR_LOCAL_DATE = "initialPublishedDay";
 	private static final String ATTR_LOCAL_TIME = "initialPublishedTime";
+	private static final String ATTR_OFFSET_DATE_TIME = "initialPublishedInstant";
 
 	/**
 	 * Wall-clock instants deliberately expressed in a zone whose offset is neither zero nor equal
@@ -486,6 +491,42 @@ public class LocalTemporalAttributeTypeFidelityFunctionalTest implements EvitaTe
 					final Serializable storedValue = product.getAttribute(ATTR_LOCAL_DATE_TIME, Locale.ENGLISH);
 					assertInstanceOf(LocalDateTime.class, storedValue);
 					assertEquals(FIRST_DATE_TIME, storedValue);
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("should reject a LocalDateTime value written to an OffsetDateTime attribute")
+		void shouldRejectLocalDateTimeValueForOffsetDateTimeAttribute() {
+			runWithCatalog(
+				"localTemporalDeclaredOffsetMismatch",
+				session -> {
+					session.defineEntitySchema(ENTITY_PRODUCT)
+						.withAttribute(
+							ATTR_OFFSET_DATE_TIME, OffsetDateTime.class,
+							whichIs -> whichIs.filterable().sortable().nullable()
+						)
+						.updateVia(session);
+
+					// the declared type wins in BOTH directions: a bare `LocalDateTime` is no longer silently
+					// coerced onto an `OffsetDateTime`-typed attribute. This is not new - `2026.1` rejected it
+					// too (all four `UpsertAttributeMutation` constructors assigned the value verbatim); only the
+					// broken `2026.2` accepted it, by rewriting the value before the schema check ran
+					assertThrows(
+						InvalidMutationException.class,
+						() -> session.createNewEntity(ENTITY_PRODUCT, 1)
+							.setAttribute(ATTR_OFFSET_DATE_TIME, FIRST_DATE_TIME)
+							.upsertVia(session)
+					);
+
+					// the attribute itself is perfectly writable with a value of its declared type
+					session.createNewEntity(ENTITY_PRODUCT, 2)
+						.setAttribute(ATTR_OFFSET_DATE_TIME, FIRST_DATE_TIME.atOffset(ZoneOffset.UTC))
+						.upsertVia(session);
+					assertEquals(
+						FIRST_DATE_TIME.atOffset(ZoneOffset.UTC),
+						fetchProduct(session, 2).getAttribute(ATTR_OFFSET_DATE_TIME)
+					);
 				}
 			);
 		}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/LocalTemporalAttributeTypeFidelityFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/LocalTemporalAttributeTypeFidelityFunctionalTest.java
@@ -1,0 +1,593 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.attribute;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.query.FilterConstraint;
+import io.evitadb.api.requestResponse.EvitaResponse;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.data.mutation.attribute.UpsertAttributeMutation;
+import io.evitadb.api.requestResponse.data.structure.EntityReference;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
+import io.evitadb.api.requestResponse.schema.SealedEntitySchema;
+import io.evitadb.core.Evita;
+import io.evitadb.test.EvitaTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.attributeBetween;
+import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
+import static io.evitadb.api.query.QueryConstraints.attributeEquals;
+import static io.evitadb.api.query.QueryConstraints.attributeGreaterThanEquals;
+import static io.evitadb.api.query.QueryConstraints.attributeLessThan;
+import static io.evitadb.api.query.QueryConstraints.attributeNatural;
+import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.dataInLocales;
+import static io.evitadb.api.query.QueryConstraints.entityFetchAllContent;
+import static io.evitadb.api.query.QueryConstraints.filterBy;
+import static io.evitadb.api.query.QueryConstraints.orderBy;
+import static io.evitadb.api.query.QueryConstraints.page;
+import static io.evitadb.api.query.QueryConstraints.require;
+import static io.evitadb.api.query.order.OrderDirection.ASC;
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.DATA_TYPE;
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.SCHEMA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Regression coverage for the *local* temporal attribute types — `LocalDateTime`, `LocalDate` and
+ * `LocalTime` — all three of which are listed by
+ * {@link io.evitadb.dataType.EvitaDataTypes#getSupportedDataTypes()} and are therefore expected to
+ * survive a write untouched, exactly as declared in the entity schema.
+ *
+ * The regression this class guards is specific to `LocalDateTime`: the value handed to
+ * `UpsertAttributeMutation` used to be rewritten to an `OffsetDateTime` before the schema was ever
+ * consulted, which made an attribute *declared* as `LocalDateTime` impossible to write —
+ * `AttributeSchemaEvolvingMutation` rejected the rewritten value against the declared type. The
+ * same rewrite silently derived an `OffsetDateTime` attribute when the schema was auto-evolved
+ * instead of declared, which is the quieter half of the same defect.
+ *
+ * `LocalDate` and `LocalTime` are covered alongside it as confirming negatives — they were never
+ * rewritten and are expected to pass both before and after the fix. Their passing is what pins the
+ * defect to the single `LocalDateTime` branch rather than to local temporal types as a family.
+ *
+ * Every end-to-end assertion reads the value back and compares it to the *exact* instance written.
+ * That is deliberate: an assertion that merely expected "no exception" would also pass a fix that
+ * kept a wall-clock-shifting conversion in the write path, which on a `sortable` attribute would
+ * silently reorder listings rather than fail.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Local temporal attribute types keep their declared type through the write path")
+@Tag(ENGINE)
+@Tag(ATTRIBUTE)
+@Tag(DATA_TYPE)
+@Tag(SCHEMA)
+public class LocalTemporalAttributeTypeFidelityFunctionalTest implements EvitaTestSupport {
+
+	private static final String ENTITY_PRODUCT = "product";
+	private static final String ATTR_LOCAL_DATE_TIME = "initialPublishedDate";
+	private static final String ATTR_LOCAL_DATE = "initialPublishedDay";
+	private static final String ATTR_LOCAL_TIME = "initialPublishedTime";
+
+	/**
+	 * Wall-clock instants deliberately expressed in a zone whose offset is neither zero nor equal
+	 * to the JVM default in CI, so that any implicit offset coercion on the write path shows up as
+	 * a changed value rather than an accidentally-matching one.
+	 */
+	private static final LocalDateTime FIRST_DATE_TIME = LocalDateTime.of(2026, 5, 20, 12, 19, 26);
+	private static final LocalDateTime SECOND_DATE_TIME = LocalDateTime.of(2026, 5, 20, 14, 19, 26);
+	private static final LocalDateTime THIRD_DATE_TIME = LocalDateTime.of(2026, 5, 21, 8, 5, 0);
+	private static final LocalDate FIRST_DATE = LocalDate.of(2026, 5, 20);
+	private static final LocalDate SECOND_DATE = LocalDate.of(2026, 5, 21);
+	private static final LocalDate THIRD_DATE = LocalDate.of(2026, 5, 22);
+	private static final LocalTime FIRST_TIME = LocalTime.of(12, 19, 26);
+	private static final LocalTime SECOND_TIME = LocalTime.of(14, 19, 26);
+	private static final LocalTime THIRD_TIME = LocalTime.of(18, 5, 0);
+
+	/**
+	 * Declares the product schema with one `sortable` + `filterable` attribute per local temporal
+	 * type — the shape produced by a `@Attribute(sortable = true)` getter returning
+	 * {@link LocalDateTime} on a client interface.
+	 */
+	private static void defineSchema(@Nonnull EvitaSessionContract session) {
+		session.defineEntitySchema(ENTITY_PRODUCT)
+			.withAttribute(
+				ATTR_LOCAL_DATE_TIME, LocalDateTime.class,
+				whichIs -> whichIs.filterable().sortable().nullable()
+			)
+			.withAttribute(
+				ATTR_LOCAL_DATE, LocalDate.class,
+				whichIs -> whichIs.filterable().sortable().nullable()
+			)
+			.withAttribute(
+				ATTR_LOCAL_TIME, LocalTime.class,
+				whichIs -> whichIs.filterable().sortable().nullable()
+			)
+			.updateVia(session);
+	}
+
+	/**
+	 * Seeds three products carrying ascending values of a *single* attribute, so a single ordering
+	 * assertion is enough to prove the sortable path end-to-end.
+	 *
+	 * Seeding one attribute at a time is deliberate: it keeps each temporal type's scenario
+	 * independent, so the `LocalDate` and `LocalTime` cases stand as genuine confirming-negatives
+	 * rather than failing collaterally on the shared write of a broken `LocalDateTime` attribute.
+	 */
+	private static void seedAscending(
+		@Nonnull EvitaSessionContract session,
+		@Nonnull String attributeName,
+		@Nonnull Serializable first,
+		@Nonnull Serializable second,
+		@Nonnull Serializable third
+	) {
+		createProduct(session, 1, attributeName, first);
+		createProduct(session, 2, attributeName, second);
+		createProduct(session, 3, attributeName, third);
+	}
+
+	/**
+	 * Creates a single product carrying exactly one local temporal attribute.
+	 */
+	private static void createProduct(
+		@Nonnull EvitaSessionContract session,
+		int pk,
+		@Nonnull String attributeName,
+		@Nonnull Serializable value
+	) {
+		session.createNewEntity(ENTITY_PRODUCT, pk)
+			.setAttribute(attributeName, value)
+			.upsertVia(session);
+	}
+
+	/**
+	 * Returns the primary keys matched by a query ordering ascending on the supplied attribute.
+	 */
+	@Nonnull
+	private static List<Integer> primaryKeysOrderedBy(
+		@Nonnull EvitaSessionContract session,
+		@Nonnull String attributeName
+	) {
+		final EvitaResponse<EntityReference> result = session.query(
+			query(
+				collection(ENTITY_PRODUCT),
+				orderBy(
+					attributeNatural(attributeName, ASC)
+				),
+				require(
+					page(1, Integer.MAX_VALUE)
+				)
+			),
+			EntityReference.class
+		);
+		final List<Integer> primaryKeys = new ArrayList<>(result.getRecordData().size());
+		for (final EntityReference reference : result.getRecordData()) {
+			primaryKeys.add(reference.getPrimaryKey());
+		}
+		return primaryKeys;
+	}
+
+	/**
+	 * Returns the primary keys matched by an equality filter on the supplied attribute.
+	 *
+	 * This is the counterpart to the write-path assertions: query values are still normalized at
+	 * the query entry point (a `LocalDateTime` becomes an `OffsetDateTime` at UTC there), and it is
+	 * the per-constraint coercion back to the attribute's declared type that has to make the two
+	 * meet again. If either half of that round trip shifted the wall clock, this filter would
+	 * silently match nothing.
+	 */
+	@Nonnull
+	private static List<Integer> primaryKeysMatching(
+		@Nonnull EvitaSessionContract session,
+		@Nonnull String attributeName,
+		@Nonnull Serializable value
+	) {
+		final EvitaResponse<EntityReference> result = session.query(
+			query(
+				collection(ENTITY_PRODUCT),
+				filterBy(
+					attributeEquals(attributeName, value)
+				),
+				require(
+					page(1, Integer.MAX_VALUE)
+				)
+			),
+			EntityReference.class
+		);
+		final List<Integer> primaryKeys = new ArrayList<>(result.getRecordData().size());
+		for (final EntityReference reference : result.getRecordData()) {
+			primaryKeys.add(reference.getPrimaryKey());
+		}
+		return primaryKeys;
+	}
+
+	/**
+	 * Returns the primary keys matched by the supplied filter constraint.
+	 *
+	 * Range and comparison constraints reach the index through the same `FilterIndex#getNormalizer` seam as equality
+	 * does, so covering them is what proves the temporal encoding is applied consistently rather than only on the
+	 * equality path.
+	 */
+	@Nonnull
+	private static List<Integer> primaryKeysMatchingConstraint(
+		@Nonnull EvitaSessionContract session,
+		@Nonnull FilterConstraint constraint
+	) {
+		final EvitaResponse<EntityReference> result = session.query(
+			query(
+				collection(ENTITY_PRODUCT),
+				filterBy(constraint),
+				require(
+					page(1, Integer.MAX_VALUE)
+				)
+			),
+			EntityReference.class
+		);
+		final List<Integer> primaryKeys = new ArrayList<>(result.getRecordData().size());
+		for (final EntityReference reference : result.getRecordData()) {
+			primaryKeys.add(reference.getPrimaryKey());
+		}
+		return primaryKeys;
+	}
+
+	/**
+	 * Fetches a seeded product with all attributes loaded.
+	 */
+	@Nonnull
+	private static SealedEntity fetchProduct(@Nonnull EvitaSessionContract session, int pk) {
+		return session.getEntity(ENTITY_PRODUCT, pk, entityFetchAllContent())
+			.orElseThrow(() -> new AssertionError("Product with primary key `" + pk + "` was not found!"));
+	}
+
+	/**
+	 * Builds the standard test configuration with a disabled session inactivity timeout and
+	 * per-test storage / export directories.
+	 */
+	@Nonnull
+	private EvitaConfiguration createConfiguration(@Nonnull TestPaths paths) {
+		return newTestEvitaConfigurationBuilder(paths)
+			.server(ServerOptions.builder().closeSessionsAfterSecondsOfInactivity(-1).build())
+			.build();
+	}
+
+	/**
+	 * Spins up a fresh Evita instance bound to per-test directories, hands an open read-write
+	 * session to the caller and tears the instance down afterwards. The catalog is left in warm-up
+	 * mode so a single session can both write and read.
+	 */
+	private void runWithCatalog(@Nonnull String storageSuffix, @Nonnull Consumer<EvitaSessionContract> scenario) {
+		final TestPaths paths = createTestPaths(storageSuffix);
+		try (
+			Evita evita = new Evita(createConfiguration(paths))
+		) {
+			evita.defineCatalog(TEST_CATALOG);
+			evita.updateCatalog(TEST_CATALOG, scenario);
+		} finally {
+			cleanupTestPaths(paths);
+		}
+	}
+
+	@DisplayName("Mutation contract")
+	@Nested
+	@Tag(CONTRACT)
+	@Tag(ATTRIBUTE)
+	@Tag(DATA_TYPE)
+	class MutationContract {
+
+		/**
+		 * Asserts that the mutation exposes the value it was constructed with, unchanged in type
+		 * and in value.
+		 */
+		private void assertValuePreserved(@Nonnull Serializable value) {
+			final UpsertAttributeMutation mutation = new UpsertAttributeMutation(
+				new AttributeKey(ATTR_LOCAL_DATE_TIME), value
+			);
+			assertEquals(value.getClass(), mutation.getAttributeValue().getClass());
+			assertEquals(value, mutation.getAttributeValue());
+		}
+
+		@Test
+		@DisplayName("should keep a LocalDateTime value as LocalDateTime")
+		void shouldKeepLocalDateTimeValueWhenConstructingMutation() {
+			assertValuePreserved(FIRST_DATE_TIME);
+		}
+
+		@Test
+		@DisplayName("should keep a LocalDate value as LocalDate")
+		void shouldKeepLocalDateValueWhenConstructingMutation() {
+			assertValuePreserved(FIRST_DATE);
+		}
+
+		@Test
+		@DisplayName("should keep a LocalTime value as LocalTime")
+		void shouldKeepLocalTimeValueWhenConstructingMutation() {
+			assertValuePreserved(FIRST_TIME);
+		}
+
+		@Test
+		@DisplayName("should keep a LocalDateTime array as a LocalDateTime array")
+		void shouldKeepLocalDateTimeArrayWhenConstructingMutation() {
+			final LocalDateTime[] value = new LocalDateTime[]{FIRST_DATE_TIME, SECOND_DATE_TIME};
+			final UpsertAttributeMutation mutation = new UpsertAttributeMutation(
+				new AttributeKey(ATTR_LOCAL_DATE_TIME), value
+			);
+			final Serializable storedValue = mutation.getAttributeValue();
+			assertInstanceOf(LocalDateTime[].class, storedValue);
+			assertEquals(FIRST_DATE_TIME, ((LocalDateTime[]) storedValue)[0]);
+			assertEquals(SECOND_DATE_TIME, ((LocalDateTime[]) storedValue)[1]);
+		}
+
+	}
+
+	@DisplayName("Declared schema")
+	@Nested
+	@Tag(ENGINE)
+	@Tag(ATTRIBUTE)
+	@Tag(DATA_TYPE)
+	class DeclaredSchema {
+
+		/**
+		 * Declares the schema, seeds three ascending values of the supplied attribute, then asserts
+		 * that the first value reads back bit-identical, that the declared schema type is
+		 * untouched, and that ascending natural ordering on the attribute yields the seeded order.
+		 */
+		private void assertRoundTripAndOrdering(
+			@Nonnull String storageSuffix,
+			@Nonnull String attributeName,
+			@Nonnull Class<? extends Serializable> expectedType,
+			@Nonnull Serializable first,
+			@Nonnull Serializable second,
+			@Nonnull Serializable third
+		) {
+			runWithCatalog(
+				storageSuffix,
+				session -> {
+					defineSchema(session);
+					seedAscending(session, attributeName, first, second, third);
+
+					final SealedEntity product = fetchProduct(session, 1);
+					final Serializable storedValue = product.getAttribute(attributeName);
+					assertInstanceOf(expectedType, storedValue);
+					// bit-identical read-back — a wall-clock shift introduced by an offset coercion
+					// on the write path would surface here and nowhere else
+					assertEquals(first, storedValue);
+
+					// the declared schema type must survive the write untouched as well
+					final SealedEntitySchema schema = session.getEntitySchema(ENTITY_PRODUCT).orElseThrow();
+					assertEquals(
+						expectedType,
+						schema.getAttribute(attributeName).orElseThrow().getType()
+					);
+
+					// sortable path proven end-to-end
+					assertEquals(List.of(1, 2, 3), primaryKeysOrderedBy(session, attributeName));
+
+					// filterable path proven end-to-end, for each seeded value
+					assertEquals(List.of(1), primaryKeysMatching(session, attributeName, first));
+					assertEquals(List.of(2), primaryKeysMatching(session, attributeName, second));
+					assertEquals(List.of(3), primaryKeysMatching(session, attributeName, third));
+
+					// range and comparison constraints take the same normalizer seam as equality
+					assertEquals(
+						List.of(1, 2),
+						primaryKeysMatchingConstraint(
+							session, attributeBetween(attributeName, first, second)
+						)
+					);
+					assertEquals(
+						List.of(2, 3),
+						primaryKeysMatchingConstraint(
+							session, attributeGreaterThanEquals(attributeName, second)
+						)
+					);
+					assertEquals(
+						List.of(1),
+						primaryKeysMatchingConstraint(
+							session, attributeLessThan(attributeName, second)
+						)
+					);
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("should store and read back a LocalDateTime attribute unchanged")
+		void shouldStoreAndReadBackLocalDateTimeAttribute() {
+			assertRoundTripAndOrdering(
+				"localTemporalDeclaredDateTime", ATTR_LOCAL_DATE_TIME, LocalDateTime.class,
+				FIRST_DATE_TIME, SECOND_DATE_TIME, THIRD_DATE_TIME
+			);
+		}
+
+		@Test
+		@DisplayName("should store and read back a LocalDate attribute unchanged")
+		void shouldStoreAndReadBackLocalDateAttribute() {
+			assertRoundTripAndOrdering(
+				"localTemporalDeclaredDate", ATTR_LOCAL_DATE, LocalDate.class,
+				FIRST_DATE, SECOND_DATE, THIRD_DATE
+			);
+		}
+
+		@Test
+		@DisplayName("should store and read back a LocalTime attribute unchanged")
+		void shouldStoreAndReadBackLocalTimeAttribute() {
+			assertRoundTripAndOrdering(
+				"localTemporalDeclaredTime", ATTR_LOCAL_TIME, LocalTime.class,
+				FIRST_TIME, SECOND_TIME, THIRD_TIME
+			);
+		}
+
+		@Test
+		@DisplayName("should store and read back a localized LocalDateTime attribute unchanged")
+		void shouldStoreAndReadBackLocalizedLocalDateTimeAttribute() {
+			runWithCatalog(
+				"localTemporalDeclaredLocalized",
+				session -> {
+					// a localized attribute reaches the third UpsertAttributeMutation constructor
+					// and the `isLocalized` branch of the schema verification, neither of which the
+					// non-localized scenarios above touch
+					session.defineEntitySchema(ENTITY_PRODUCT)
+						.withLocale(Locale.ENGLISH)
+						.withAttribute(
+							ATTR_LOCAL_DATE_TIME, LocalDateTime.class,
+							whichIs -> whichIs.localized().filterable().sortable().nullable()
+						)
+						.updateVia(session);
+
+					session.createNewEntity(ENTITY_PRODUCT, 1)
+						.setAttribute(ATTR_LOCAL_DATE_TIME, Locale.ENGLISH, FIRST_DATE_TIME)
+						.upsertVia(session);
+
+					final SealedEntity product = session
+						.getEntity(ENTITY_PRODUCT, 1, attributeContentAll(), dataInLocales(Locale.ENGLISH))
+						.orElseThrow();
+					final Serializable storedValue = product.getAttribute(ATTR_LOCAL_DATE_TIME, Locale.ENGLISH);
+					assertInstanceOf(LocalDateTime.class, storedValue);
+					assertEquals(FIRST_DATE_TIME, storedValue);
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("should keep a LocalDateTime attribute unchanged when the entity is updated")
+		void shouldKeepLocalDateTimeAttributeWhenEntityIsUpdated() {
+			runWithCatalog(
+				"localTemporalDeclaredUpdate",
+				session -> {
+					defineSchema(session);
+					seedAscending(
+						session, ATTR_LOCAL_DATE_TIME, FIRST_DATE_TIME, SECOND_DATE_TIME, THIRD_DATE_TIME
+					);
+
+					// second write goes through ExistingEntityBuilder rather than the initial one
+					fetchProduct(session, 1)
+						.openForWrite()
+						.setAttribute(ATTR_LOCAL_DATE_TIME, THIRD_DATE_TIME)
+						.upsertVia(session);
+
+					final Serializable storedValue = fetchProduct(session, 1).getAttribute(ATTR_LOCAL_DATE_TIME);
+					assertInstanceOf(LocalDateTime.class, storedValue);
+					assertEquals(THIRD_DATE_TIME, storedValue);
+				}
+			);
+		}
+
+	}
+
+	@DisplayName("Auto-evolved schema")
+	@Nested
+	@Tag(ENGINE)
+	@Tag(SCHEMA)
+	@Tag(DATA_TYPE)
+	class AutoEvolvedSchema {
+
+		/**
+		 * Upserts a single product carrying only the supplied attribute against a schema that does
+		 * not declare it, then returns the attribute schema the engine derived from the value.
+		 */
+		@Nonnull
+		private AttributeSchemaContract evolveAttributeSchemaFor(
+			@Nonnull EvitaSessionContract session,
+			@Nonnull String attributeName,
+			@Nonnull Serializable value
+		) {
+			session.defineEntitySchema(ENTITY_PRODUCT).updateVia(session);
+			session.createNewEntity(ENTITY_PRODUCT, 1)
+				.setAttribute(attributeName, value)
+				.upsertVia(session);
+
+			final SealedEntitySchema schema = session.getEntitySchema(ENTITY_PRODUCT).orElseThrow();
+			final AttributeSchemaContract attributeSchema = schema.getAttribute(attributeName).orElse(null);
+			assertNotNull(attributeSchema, "Attribute `" + attributeName + "` was not evolved into the schema!");
+			return attributeSchema;
+		}
+
+		@Test
+		@DisplayName("should derive a LocalDateTime attribute from a LocalDateTime value")
+		void shouldDeriveLocalDateTimeAttributeFromLocalDateTimeValue() {
+			runWithCatalog(
+				"localTemporalEvolvedDateTime",
+				session -> {
+					assertEquals(
+						LocalDateTime.class,
+						evolveAttributeSchemaFor(session, ATTR_LOCAL_DATE_TIME, FIRST_DATE_TIME).getType()
+					);
+					assertEquals(
+						FIRST_DATE_TIME,
+						session.getEntity(ENTITY_PRODUCT, 1, attributeContentAll())
+							.orElseThrow()
+							.getAttribute(ATTR_LOCAL_DATE_TIME)
+					);
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("should derive a LocalDate attribute from a LocalDate value")
+		void shouldDeriveLocalDateAttributeFromLocalDateValue() {
+			runWithCatalog(
+				"localTemporalEvolvedDate",
+				session -> assertEquals(
+					LocalDate.class,
+					evolveAttributeSchemaFor(session, ATTR_LOCAL_DATE, FIRST_DATE).getType()
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("should derive a LocalTime attribute from a LocalTime value")
+		void shouldDeriveLocalTimeAttributeFromLocalTimeValue() {
+			runWithCatalog(
+				"localTemporalEvolvedTime",
+				session -> assertEquals(
+					LocalTime.class,
+					evolveAttributeSchemaFor(session, ATTR_LOCAL_TIME, FIRST_TIME).getType()
+				)
+			);
+		}
+
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/LocalTemporalAttributeTypeFidelityFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/LocalTemporalAttributeTypeFidelityFunctionalTest.java
@@ -96,7 +96,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * rewritten and are expected to pass both before and after the fix. Their passing is what pins the
  * defect to the single `LocalDateTime` branch rather than to local temporal types as a family.
  *
- * Every end-to-end assertion reads the value back and compares it to the *exact* instance written.
+ * Every end-to-end assertion reads the value back and compares it to the *exact value* written — equality, not
+ * reference identity: the engine materializes a fresh instance on read.
  * That is deliberate: an assertion that merely expected "no exception" would also pass a fix that
  * kept a wall-clock-shifting conversion in the write path, which on a `sortable` attribute would
  * silently reorder listings rather than fail.

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/EvitaDataTypesTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/EvitaDataTypesTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -2504,6 +2505,65 @@ class EvitaDataTypesTest {
 					.toSupportedStoredType(
 						new HashMap<String, String>()
 					)
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should type a rebuilt array from the"
+			+ " first non-null element"
+		)
+		void shouldTypeRebuiltArrayFromFirstNonNullElement() {
+			// a leading `null` says nothing about what the
+			// remaining elements normalize to - deriving the
+			// component type from element zero alone rebuilt
+			// a Float[] and then threw on Array.set
+			final Float[] input = {null, 1.5f};
+
+			final Serializable result =
+				EvitaDataTypes
+					.toSupportedStoredTypeOrItsArray(
+						input
+					);
+
+			assertInstanceOf(
+				BigDecimal[].class, result
+			);
+			final BigDecimal[] normalized =
+				(BigDecimal[]) result;
+			assertNull(normalized[0]);
+			assertEquals(
+				new BigDecimal("1.5"), normalized[1]
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should type a rebuilt query-path array from"
+			+ " the first non-null element"
+		)
+		void shouldTypeRebuiltQueryArrayFromFirstNonNull() {
+			// same hazard on the query path, where a
+			// LocalDateTime element still normalizes away
+			final LocalDateTime[] input = {
+				null,
+				LocalDateTime.of(2026, 5, 20, 12, 19, 26)
+			};
+
+			final Serializable result =
+				EvitaDataTypes.toSupportedTypeOrItsArray(
+					input
+				);
+
+			assertInstanceOf(
+				OffsetDateTime[].class, result
+			);
+			final OffsetDateTime[] normalized =
+				(OffsetDateTime[]) result;
+			assertNull(normalized[0]);
+			assertEquals(
+				input[1].atOffset(ZoneOffset.UTC),
+				normalized[1]
 			);
 		}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/EvitaDataTypesTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/EvitaDataTypesTest.java
@@ -2415,6 +2415,126 @@ class EvitaDataTypesTest {
 	}
 
 	@Nested
+	@DisplayName("Conversion to supported stored type")
+	class ConversionToSupportedStoredType {
+
+		@Test
+		@DisplayName(
+			"should keep LocalDateTime as"
+			+ " LocalDateTime"
+		)
+		void shouldKeepLocalDateTime() {
+			// the query-path variant rewrites this
+			// value to an OffsetDateTime at UTC; a
+			// value on its way into storage must
+			// keep the type its schema declares
+			final LocalDateTime input =
+				LocalDateTime.of(
+					2021, 6, 15, 10, 30
+				);
+
+			assertSame(
+				input,
+				EvitaDataTypes.toSupportedStoredType(
+					input
+				)
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should keep a LocalDateTime array"
+			+ " untouched"
+		)
+		void shouldKeepLocalDateTimeArray() {
+			final LocalDateTime[] input = {
+				LocalDateTime.of(
+					2021, 6, 15, 10, 30
+				),
+				LocalDateTime.of(
+					2021, 6, 16, 11, 45
+				)
+			};
+
+			assertSame(
+				input,
+				EvitaDataTypes
+					.toSupportedStoredTypeOrItsArray(
+						input
+					)
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should still normalize Float to"
+			+ " BigDecimal"
+		)
+		void shouldStillNormalizeFloat() {
+			assertEquals(
+				new BigDecimal("3.14"),
+				EvitaDataTypes.toSupportedStoredType(
+					3.14f
+				)
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should still convert non-@SupportedEnum"
+			+ " to String"
+		)
+		void shouldStillConvertNonSupportedEnum() {
+			assertEquals(
+				"CATALOG",
+				EvitaDataTypes.toSupportedStoredType(
+					ClassifierType.CATALOG
+				)
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should still reject an unsupported type"
+		)
+		void shouldStillRejectUnsupportedType() {
+			assertThrows(
+				UnsupportedDataTypeException.class,
+				() -> EvitaDataTypes
+					.toSupportedStoredType(
+						new HashMap<String, String>()
+					)
+			);
+		}
+
+		@Test
+		@DisplayName(
+			"should keep LocalDate and LocalTime"
+			+ " untouched"
+		)
+		void shouldKeepLocalDateAndLocalTime() {
+			final LocalDate date =
+				LocalDate.of(2021, 6, 15);
+			final LocalTime time =
+				LocalTime.of(10, 30);
+
+			assertSame(
+				date,
+				EvitaDataTypes.toSupportedStoredType(
+					date
+				)
+			);
+			assertSame(
+				time,
+				EvitaDataTypes.toSupportedStoredType(
+					time
+				)
+			);
+		}
+
+	}
+
+	@Nested
 	@DisplayName("Size estimation")
 	class EstimateSizeTest {
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexTest.java
@@ -51,6 +51,9 @@ import org.junit.jupiter.api.Test;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.text.Normalizer;
@@ -69,6 +72,7 @@ import static io.evitadb.test.TestTags.HISTOGRAM;
 import static io.evitadb.test.TestTags.INDEXING;
 import static io.evitadb.test.TestTags.ATTRIBUTE;
 import static io.evitadb.test.TestTags.FILTER;
+import static io.evitadb.test.TestTags.DATA_TYPE;
 
 /**
  * This test verifies {@link FilterIndex} contract.
@@ -1581,6 +1585,68 @@ class FilterIndexTest {
 			assertSame(BigDecimal.class, EvitaDataTypes.resolveRangeInnerNumericType(BigDecimalNumberRange.class));
 			assertNull(EvitaDataTypes.resolveRangeInnerNumericType(Integer.class));
 			assertNull(EvitaDataTypes.resolveRangeInnerNumericType(DateTimeRange.class));
+		}
+
+	}
+
+	/**
+	 * Pins the index-side encoding of the temporal attribute types. `LocalDateTime` carries no offset of its own, so
+	 * it is anchored at UTC before it becomes a bucket key — the same `Instant` space `OffsetDateTime` already uses,
+	 * which is what lets the tree store it in the packed `InstantValueColumn` instead of boxing it. Because the
+	 * anchor is a *constant* offset the mapping is a lossless bijection and monotonic with `LocalDateTime`'s natural
+	 * order, so equality lookup and ordered iteration are unaffected. `LocalDate` and `LocalTime` are deliberately
+	 * left alone — each fits losslessly in a single `long`, so they take the cheaper `LongValueColumn`.
+	 */
+	@Nested
+	@DisplayName("Temporal attribute index encoding")
+	@Tag(ENGINE)
+	@Tag(INDEXING)
+	@Tag(ATTRIBUTE)
+	@Tag(DATA_TYPE)
+	class TemporalNormalization {
+
+		@Test
+		@DisplayName("LocalDateTime is normalized to its UTC instant")
+		void shouldNormalizeLocalDateTimeToUtcInstant() {
+			final LocalDateTime value = LocalDateTime.of(2026, 5, 20, 12, 19, 26);
+
+			assertEquals(
+				value.toInstant(ZoneOffset.UTC),
+				FilterIndex.getNormalizer(LocalDateTime.class, 0).apply(value)
+			);
+		}
+
+		@Test
+		@DisplayName("normalizing an already-normalized LocalDateTime value is a no-op")
+		void shouldBeIdempotentForLocalDateTime() {
+			// probe values are normalized more than once along a lookup path - a second pass must not throw
+			final Function<Object, Serializable> normalizer = FilterIndex.getNormalizer(LocalDateTime.class, 0);
+			final Serializable once = normalizer.apply(LocalDateTime.of(2026, 5, 20, 12, 19, 26));
+
+			assertEquals(once, normalizer.apply(once));
+		}
+
+		@Test
+		@DisplayName("LocalDateTime normalization preserves natural order")
+		void shouldPreserveOrderForLocalDateTime() {
+			// a constant offset cannot reorder values - this is precisely what a region time zone would not guarantee
+			final Function<Object, Serializable> normalizer = FilterIndex.getNormalizer(LocalDateTime.class, 0);
+			final LocalDateTime earlier = LocalDateTime.of(2026, 5, 20, 12, 19, 26);
+			final LocalDateTime later = LocalDateTime.of(2026, 5, 20, 14, 19, 26);
+
+			assertTrue(
+				((Instant) normalizer.apply(earlier)).isBefore((Instant) normalizer.apply(later))
+			);
+		}
+
+		@Test
+		@DisplayName("LocalDate and LocalTime pass through unnormalized")
+		void shouldLeaveLocalDateAndLocalTimeAlone() {
+			final LocalDate date = LocalDate.of(2026, 5, 20);
+			final LocalTime time = LocalTime.of(12, 19, 26);
+
+			assertSame(date, FilterIndex.getNormalizer(LocalDate.class, 0).apply(date));
+			assertSame(time, FilterIndex.getNormalizer(LocalTime.class, 0).apply(time));
 		}
 
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/InstantValueColumnTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/InstantValueColumnTest.java
@@ -31,6 +31,9 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -55,7 +58,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Verifies the temporal parallel-array value column: the lossless
  * {@code Instant ↔ (seconds, nanos)} decomposition, the {@link InstantValueColumn} array operations (proven equivalent
  * to the boxed {@link BoxedObjectColumn}, including the nano tiebreak), the {@link ValueColumnFactory} selection of the
- * column for {@code OffsetDateTime} / {@code Instant} natural-order keys, an end-to-end randomized workload on an
+ * column for {@code OffsetDateTime} / {@code Instant} / {@code LocalDateTime} natural-order keys (and its
+ * deliberate non-selection for {@code LocalDate} / {@code LocalTime}, which stay on the cheaper single-long
+ * column), an end-to-end randomized workload on an
  * {@link Instant}-keyed {@link TransactionalBucketBPlusTree} matched against a {@link TreeMap} oracle, and the MVCC
  * commit / rollback of such a tree (so the two-array lockstep deep copy runs across a real transaction layer).
  *
@@ -240,6 +245,37 @@ class InstantValueColumnTest {
 			assertInstanceOf(
 				InstantValueColumn.class,
 				ValueColumnFactory.forKey(Instant.class, null).create(BLOCK_SIZE)
+			);
+		}
+
+		@Test
+		@DisplayName("LocalDateTime natural-order keys select the Instant column too")
+		void shouldSelectInstantColumnForLocalDateTime() {
+			// `LocalDateTime` is normalized to an `Instant` at UTC by `FilterIndex#getNormalizer`, so the column
+			// selection in `ValueColumnFactory#normalizedTypeOf` has to agree - the two must stay in lockstep or the
+			// tree would be handed `Instant` keys while sizing itself for a boxed column
+			assertInstanceOf(
+				InstantValueColumn.class,
+				ValueColumnFactory.forKey(LocalDateTime.class, Comparator.naturalOrder()).create(BLOCK_SIZE)
+			);
+			assertInstanceOf(
+				InstantValueColumn.class,
+				ValueColumnFactory.forKey(LocalDateTime.class, null).create(BLOCK_SIZE)
+			);
+		}
+
+		@Test
+		@DisplayName("LocalDate / LocalTime keep the cheaper single-long column")
+		void shouldKeepLongColumnForLocalDateAndLocalTime() {
+			// both fit losslessly in one `long` (epoch-day / nano-of-day), so routing them through `Instant` would
+			// cost an extra all-but-unused `int[]` per leaf - they must NOT be swept into the temporal branch
+			assertInstanceOf(
+				LongValueColumn.class,
+				ValueColumnFactory.forKey(LocalDate.class, Comparator.naturalOrder()).create(BLOCK_SIZE)
+			);
+			assertInstanceOf(
+				LongValueColumn.class,
+				ValueColumnFactory.forKey(LocalTime.class, null).create(BLOCK_SIZE)
 			);
 		}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DeferredCheckpointPersistenceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DeferredCheckpointPersistenceTest.java
@@ -54,6 +54,7 @@ import java.util.EnumSet;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.evitadb.spi.store.catalog.persistence.CatalogPersistenceService.getCatalogBootstrapFileName;
 import static io.evitadb.test.TestTags.STORAGE;
 import static io.evitadb.test.TestTags.TRANSACTION;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -153,7 +154,7 @@ class DeferredCheckpointPersistenceTest implements EvitaTestSupport {
 	}
 
 	@Test
-	@DisplayName("should checkpoint on close so no service goes away owing a device flush")
+	@DisplayName("should publish an owed checkpoint on close so a clean restart need not replay it")
 	void shouldCheckpointPendingSyncsOnClose() {
 		try (DefaultCatalogPersistenceService cps = createService(NEVER_ELAPSES_MILLIS)) {
 			cps.getStoragePartPersistenceService(0L)
@@ -166,14 +167,50 @@ class DeferredCheckpointPersistenceTest implements EvitaTestSupport {
 		}
 		// must not throw - close settles the outstanding device flushes rather than abandoning them
 
-		// reopening lands on the last CHECKPOINTED version, which is the state a restart legitimately sees:
-		// everything past it is replayed from the write-ahead log
+		// The round that deferred had already built its bootstrap record and left the index at its own version, so
+		// close publishes that state as it stands. It waits for nothing and drains nothing - `TransactionManager`
+		// fails pending transactions on close rather than finishing them, so anything newer than the last completed
+		// round remains the write-ahead log's business. What this buys is that a clean restart resumes here instead
+		// of replaying from whichever checkpoint the ticker last happened to reach.
 		try (final DefaultCatalogPersistenceService reopened = createLoadingService(NEVER_ELAPSES_MILLIS)) {
-			assertTrue(
-				reopened.getLastCatalogVersion() < 2L,
-				"A version whose bootstrap record was never written must not come back as persisted."
+			assertEquals(
+				2L, reopened.getLastCatalogVersion(),
+				"The checkpoint owed when the service closed must have been published, so the restart resumes from it."
 			);
 		}
+	}
+
+	@Test
+	@DisplayName("should write no bootstrap record on close when no checkpoint is owed")
+	void shouldNotCheckpointOnCloseWhenNothingIsOwed() {
+		final Path bootstrapFile = getTestDirectory()
+			.resolve(DIR_DEFERRED_CHECKPOINT_TEST)
+			.resolve(CATALOG_NAME)
+			.resolve(getCatalogBootstrapFileName(CATALOG_NAME));
+
+		final long lengthBeforeClose;
+		// a real interval, so a coordinator genuinely exists - interval 0 creates none at all, and closing without
+		// one would prove nothing about whether close checkpoints only when it is owed
+		try (final DefaultCatalogPersistenceService cps = createService(NEVER_ELAPSES_MILLIS)) {
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+			storeHeaderAt(cps, 2L);
+			// settle the debt before closing, exactly as the ticker or a backup would
+			cps.checkpoint();
+			assertEquals(
+				2L, cps.getLastCatalogVersion(),
+				"Precondition: the checkpoint must be settled, leaving nothing owed at close."
+			);
+			lengthBeforeClose = bootstrapFile.toFile().length();
+		}
+
+		// the calibration for the test above: close publishes what is OWED, and a settled checkpoint owes nothing.
+		// Records here are fixed-size, so an unchanged length is an unchanged record count - without this assertion
+		// the test above would pass just as happily if close wrote a bootstrap record unconditionally.
+		assertEquals(
+			lengthBeforeClose, bootstrapFile.toFile().length(),
+			"Close must not append a bootstrap record when the last round already checkpointed."
+		);
 	}
 
 	@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DeferredCheckpointPersistenceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DeferredCheckpointPersistenceTest.java
@@ -195,6 +195,7 @@ class DeferredCheckpointPersistenceTest implements EvitaTestSupport {
 			cps.getStoragePartPersistenceService(0L)
 				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
 			storeHeaderAt(cps, 2L);
+			final long lengthBeforeCheckpoint = bootstrapFile.toFile().length();
 			// settle the debt before closing, exactly as the ticker or a backup would
 			cps.checkpoint();
 			assertEquals(
@@ -202,6 +203,15 @@ class DeferredCheckpointPersistenceTest implements EvitaTestSupport {
 				"Precondition: the checkpoint must be settled, leaving nothing owed at close."
 			);
 			lengthBeforeClose = bootstrapFile.toFile().length();
+			// `getLastCatalogVersion` answers from the in-memory `bootstrapUsed`, so on its own it cannot tell
+			// "the record was written" from "the service merely thinks so". Proving the checkpoint above grew the
+			// file is what makes the comparison after close meaningful: it establishes that this measurement
+			// detects an appended record, so an unchanged length afterwards is evidence of no append rather than
+			// evidence of a file nothing ever writes to.
+			assertTrue(
+				lengthBeforeClose > lengthBeforeCheckpoint,
+				"Precondition: settling a checkpoint must append a bootstrap record."
+			);
 		}
 
 		// the calibration for the test above: close publishes what is OWED, and a settled checkpoint owes nothing.

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/index/serializer/FilterIndexLegacyLocalDateTimeSerializerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/index/serializer/FilterIndexLegacyLocalDateTimeSerializerTest.java
@@ -1,0 +1,168 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.index.serializer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import io.evitadb.index.attribute.FilterIndex;
+import io.evitadb.index.invertedIndex.InvertedIndex;
+import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
+import io.evitadb.spi.store.catalog.persistence.storageParts.compressor.ReadWriteKeyCompressor;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.FilterIndexStoragePart;
+import io.evitadb.store.index.IndexStoragePartConfigurer;
+import io.evitadb.store.shared.kryo.KryoFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.ByteArrayOutputStream;
+import java.io.Serializable;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.function.Function;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.SERIALIZATION;
+import static io.evitadb.test.TestTags.STORAGE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Migration coverage for `2026.1` filter indexes built over a `LocalDateTime` attribute.
+ *
+ * `2026.1` had no `LocalDateTime` branch in `FilterIndex.getNormalizer`, so it persisted the raw wall-clock value as
+ * the bucket key. `2026.2` normalizes such an attribute to a UTC `Instant` so the B+ tree can store it in the packed
+ * `InstantValueColumn` — which means a legacy blob read verbatim would be fed `LocalDateTime` keys into a column that
+ * hard-casts to `Instant`, and the catalog would fail to load with a `ClassCastException`.
+ * {@link FilterIndexStoragePartSerializer_2026_1} therefore re-anchors those values on read.
+ *
+ * The rehydration assertion is the one that matters: it is the exact call `AttributeIndexLoader` makes, and it is what
+ * fails without the conversion.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("2026.1 LocalDateTime filter index migrates to the UTC instant key space")
+@Tag(STORAGE)
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
+@Tag(SERIALIZATION)
+class FilterIndexLegacyLocalDateTimeSerializerTest {
+	private static final AttributeIndexKey ATTRIBUTE_KEY = new AttributeIndexKey(null, "initialPublishedDate", null);
+	private static final LocalDateTime FIRST = LocalDateTime.of(2026, 5, 20, 12, 19, 26);
+	private static final LocalDateTime SECOND = LocalDateTime.of(2026, 5, 20, 14, 19, 26);
+	private static final LocalDateTime THIRD = LocalDateTime.of(2026, 5, 21, 8, 5, 0);
+
+	private Kryo kryo;
+	private FilterIndexStoragePartSerializer_2026_1 legacySerializer;
+
+	@BeforeEach
+	void setUp() {
+		final ReadWriteKeyCompressor keyCompressor = new ReadWriteKeyCompressor(Collections.emptyMap());
+		this.kryo = KryoFactory.createKryo(new IndexStoragePartConfigurer(keyCompressor));
+		this.legacySerializer = new FilterIndexStoragePartSerializer_2026_1(keyCompressor);
+	}
+
+	/**
+	 * Round-trips a part through the legacy serializer, mimicking a blob written by `2026.1`.
+	 */
+	@Nonnull
+	private FilterIndexStoragePart roundTrip(@Nonnull Class<?> attributeType, @Nonnull Serializable... values) {
+		final ValueToRecordBitmap[] points = new ValueToRecordBitmap[values.length];
+		for (int i = 0; i < values.length; i++) {
+			points[i] = new ValueToRecordBitmap(values[i], i + 1);
+		}
+		final FilterIndexStoragePart legacyPart = new FilterIndexStoragePart(
+			1, ATTRIBUTE_KEY, attributeType, points, null, 1L
+		);
+
+		final ByteArrayOutputStream buffer = new ByteArrayOutputStream(512);
+		try (final Output output = new Output(buffer)) {
+			this.legacySerializer.write(this.kryo, output, legacyPart);
+		}
+		try (final Input input = new Input(buffer.toByteArray())) {
+			return this.legacySerializer.read(this.kryo, input, FilterIndexStoragePart.class);
+		}
+	}
+
+	@Test
+	@DisplayName("should re-anchor legacy LocalDateTime bucket keys at UTC on read")
+	void shouldReAnchorLegacyLocalDateTimeKeys() {
+		final FilterIndexStoragePart migrated = roundTrip(LocalDateTime.class, FIRST, SECOND, THIRD);
+
+		final ValueToRecordBitmap[] points = migrated.getHistogramPoints();
+		assertEquals(3, points.length);
+		for (final ValueToRecordBitmap point : points) {
+			assertInstanceOf(Instant.class, point.getValue());
+		}
+		assertEquals(FIRST.toInstant(ZoneOffset.UTC), points[0].getValue());
+		assertEquals(SECOND.toInstant(ZoneOffset.UTC), points[1].getValue());
+		assertEquals(THIRD.toInstant(ZoneOffset.UTC), points[2].getValue());
+	}
+
+	@Test
+	@DisplayName("should rehydrate a migrated legacy part into an InvertedIndex and stay queryable")
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	void shouldRehydrateMigratedLegacyPart() {
+		final FilterIndexStoragePart migrated = roundTrip(LocalDateTime.class, FIRST, SECOND, THIRD);
+
+		// exactly what AttributeIndexLoader#loadInvertedIndex does - this throws ClassCastException when the
+		// legacy LocalDateTime keys are not re-anchored, because the tree picks InstantValueColumn for the type
+		final InvertedIndex reloaded = new InvertedIndex(
+			LocalDateTime.class,
+			migrated.getHistogramPoints(),
+			FilterIndex.getNormalizer(LocalDateTime.class, 0),
+			(Comparator) Comparator.naturalOrder(),
+			0
+		);
+
+		// `InvertedIndex#getRecordsEqualTo` takes an ALREADY-normalized probe (see its parameter name) - `FilterIndex`
+		// applies the normalizer before delegating, so mirror that here. Passing a raw `LocalDateTime` would reach the
+		// `Instant` column unconverted, which is a caller error rather than a migration defect
+		final Function<Object, Serializable> normalizer = FilterIndex.getNormalizer(LocalDateTime.class, 0);
+		assertArrayEquals(new int[]{1}, reloaded.getRecordsEqualTo(normalizer.apply(FIRST)).getArray());
+		assertArrayEquals(new int[]{2}, reloaded.getRecordsEqualTo(normalizer.apply(SECOND)).getArray());
+		assertArrayEquals(new int[]{3}, reloaded.getRecordsEqualTo(normalizer.apply(THIRD)).getArray());
+	}
+
+	@Test
+	@DisplayName("should leave non-temporal legacy bucket keys untouched")
+	void shouldLeaveOtherLegacyKeysUntouched() {
+		final FilterIndexStoragePart migrated = roundTrip(String.class, "alpha", "beta");
+
+		final ValueToRecordBitmap[] points = migrated.getHistogramPoints();
+		assertEquals(2, points.length);
+		assertEquals("alpha", points[0].getValue());
+		assertEquals("beta", points[1].getValue());
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
@@ -1075,6 +1075,12 @@ class OffsetIndexTest implements EvitaTestSupport {
 						offsetIndex.contains(1L, 1, EntityBodyStoragePart.class),
 						"contains at v1 should be false after put-then-remove in the same version"
 					);
+					// the two operations fold into a no-op, so the in-flight cardinality must be zero - never
+					// negative, which is what recording the removal of a record that was never published gives
+					assertEquals(
+						0, offsetIndex.count(1L),
+						"count at v1 should be zero after put-then-remove in the same version"
+					);
 				});
 			}
 
@@ -1098,6 +1104,34 @@ class OffsetIndexTest implements EvitaTestSupport {
 					assertTrue(
 						offsetIndex.contains(2L, 1, EntityBodyStoragePart.class),
 						"contains at v2 should be true after remove-then-reput"
+					);
+					// the removal is undone by the re-put, so the record stays counted - the in-flight count
+					// must agree with what the flush is about to publish
+					assertEquals(
+						1, offsetIndex.count(2L),
+						"count at v2 should still be one after remove-then-reput in the same version"
+					);
+				});
+			}
+
+			@DisplayName("remove then re-put of a still-unflushed record keeps the in-flight count at one")
+			@Test
+			void shouldCountRecordRePutAfterRemoveOverUnflushedRecord() {
+				runWithIndex((offsetIndex, decoder) -> {
+					// same shape as above, except the record key 1 stands on is itself still in-flight: it was
+					// created at v1 and never flushed on its own, so the fold at v2 has to be judged against
+					// v1's pending creation rather than against the (still empty) published state
+					offsetIndex.put(1L, bodyPartWithLocale(1, 1, Locale.ENGLISH));
+					offsetIndex.remove(2L, 1, EntityBodyStoragePart.class);
+					offsetIndex.put(2L, bodyPartWithLocale(2, 1, Locale.GERMAN));
+
+					assertEquals(
+						1, offsetIndex.count(1L),
+						"count at v1 should be one - the record created there is untouched by v2's fold"
+					);
+					assertEquals(
+						1, offsetIndex.count(2L),
+						"count at v2 should be one after remove-then-reput over a still-unflushed record"
 					);
 				});
 			}
@@ -1525,6 +1559,62 @@ class OffsetIndexTest implements EvitaTestSupport {
 					assertEquals(1, offsetIndex.count(1L), "count at v1 sees only key 1");
 					assertEquals(2, offsetIndex.count(2L), "count at v2 sees keys 1 and 2");
 					assertEquals(3, offsetIndex.count(3L), "count at v3 sees keys 1, 2 and 3");
+				});
+			}
+
+			@DisplayName("a flushed record removed at one version and re-added at the next survives the batch")
+			@Test
+			void shouldPromoteRemovalAndReAddOfFlushedRecordInOneBatch() {
+				runWithIndex((offsetIndex, decoder) -> {
+					final EntityBodyStoragePart original = bodyPartWithLocale(1, 1, Locale.ENGLISH);
+					final EntityBodyStoragePart reAdded = bodyPartWithLocale(3, 1, Locale.FRENCH);
+
+					// key 1 is published by its own flush, then dropped at v2 and re-created at v3 - both
+					// promoted by one flush. The re-add is a creation, not an overwrite: by the time v3 is
+					// applied, v2 has already taken the key out of the root the batch is folding into.
+					offsetIndex.put(1L, original);
+					offsetIndex.flush(1L);
+					offsetIndex.remove(2L, 1, EntityBodyStoragePart.class);
+					offsetIndex.put(3L, reAdded);
+					offsetIndex.flush(3L);
+
+					assertEquals(reAdded, offsetIndex.get(3L, 1, EntityBodyStoragePart.class),
+						"get key 1 at v3 resolves the re-added payload");
+					assertTrue(offsetIndex.contains(3L, 1, EntityBodyStoragePart.class),
+						"contains key 1 at v3 agrees with get");
+					assertFalse(offsetIndex.contains(2L, 1, EntityBodyStoragePart.class),
+						"key 1 stays absent at v2, where it was removed");
+					assertEquals(original, offsetIndex.get(1L, 1, EntityBodyStoragePart.class),
+						"get key 1 at v1 still resolves the payload flushed there");
+					assertEquals(1, offsetIndex.count(1L), "count at v1 sees key 1");
+					assertEquals(0, offsetIndex.count(2L), "count at v2 sees no key");
+					assertEquals(1, offsetIndex.count(3L), "count at v3 sees the re-added key 1");
+				});
+			}
+
+			@DisplayName("an in-flight record removed and re-added inside one later version survives the batch")
+			@Test
+			void shouldPromoteRemovalAndReAddOfInFlightRecordWithinOneVersion() {
+				runWithIndex((offsetIndex, decoder) -> {
+					final EntityBodyStoragePart original = bodyPartWithLocale(1, 1, Locale.ENGLISH);
+					final EntityBodyStoragePart reAdded = bodyPartWithLocale(2, 1, Locale.GERMAN);
+
+					// key 1 is created at v1 but never flushed on its own; v2 drops and immediately re-creates
+					// it, folding both into a single entry. That entry is an overwrite, not a creation: v1 puts
+					// the key into the root first when the whole batch is promoted by one flush.
+					offsetIndex.put(1L, original);
+					offsetIndex.remove(2L, 1, EntityBodyStoragePart.class);
+					offsetIndex.put(2L, reAdded);
+					offsetIndex.flush(2L);
+
+					assertEquals(reAdded, offsetIndex.get(2L, 1, EntityBodyStoragePart.class),
+						"get key 1 at v2 resolves the re-added payload");
+					assertTrue(offsetIndex.contains(2L, 1, EntityBodyStoragePart.class),
+						"contains key 1 at v2 agrees with get");
+					assertEquals(original, offsetIndex.get(1L, 1, EntityBodyStoragePart.class),
+						"get key 1 at v1 still resolves the payload written there");
+					assertEquals(1, offsetIndex.count(1L), "count at v1 sees key 1");
+					assertEquals(1, offsetIndex.count(2L), "count at v2 sees the re-added key 1");
 				});
 			}
 		}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
@@ -47,7 +47,6 @@ import io.evitadb.utils.FileUtils;
 import io.evitadb.utils.UUIDUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -56,7 +55,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -203,7 +201,7 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 			),
 			Mockito.mock(Scheduler.class),
 			offsetDateTime -> {},
-			null
+			AbstractMutationLog.WalPurgeCallback.NO_OP
 		);
 	}
 
@@ -220,7 +218,7 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 			new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)),
 			walFileSizeBytes,
 			10,
-			null
+			AbstractMutationLog.WalPurgeCallback.NO_OP
 		);
 	}
 
@@ -233,8 +231,9 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 	 * @param logFileRecordReference the reference the log is opened against
 	 * @param walFileSizeBytes       the maximum size of each WAL file in bytes
 	 * @param walFileCountKept       how many WAL files rotation leaves unqueued for removal
-	 * @param onWalPurgeCallback     invoked when a purge actually removes files; a test that lets the purge fire
-	 *                               must pass one, because `removeWalFiles` dereferences it unconditionally
+	 * @param onWalPurgeCallback     invoked when a purge actually removes files; `removeWalFiles` dereferences it
+	 *                               unconditionally, so a test that never purges still passes
+	 *                               {@link AbstractMutationLog.WalPurgeCallback#NO_OP} rather than `null`
 	 * @return a configured CatalogWriteAheadLog instance
 	 */
 	@Nonnull
@@ -243,7 +242,7 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 		@Nonnull LogFileRecordReference logFileRecordReference,
 		long walFileSizeBytes,
 		int walFileCountKept,
-		@Nullable AbstractMutationLog.WalPurgeCallback onWalPurgeCallback
+		@Nonnull AbstractMutationLog.WalPurgeCallback onWalPurgeCallback
 	) {
 		return new CatalogWriteAheadLog(
 			catalogVersion,

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
@@ -1103,12 +1103,60 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 	 *
 	 * Note what is deliberately **not** claimed here: that appends continue a checksum chain. Each transaction's
 	 * trailing checksum covers only its own bytes - the running value returns to a fixed constant after every
-	 * record, so no test in this class can distinguish one append-chain seed from another. See the punch list's
-	 * entry on the cumulative checksum for why.
+	 * record, so no test in this class can distinguish one append-chain seed from another. The authoritative
+	 * account of what that checksum does and does not cover is on `AbstractMutationLog#checksum`.
 	 */
 	@Nested
 	@DisplayName("Restart from a position the log has moved past")
 	class RestartAfterRotation {
+
+		@Test
+		@DisplayName("should resume replay when the reference is the last transaction of a rotated file")
+		void shouldResumeReplayWhenReferenceIsLastTransactionOfRotatedFile() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+
+			// small enough that a handful of 200-byte transactions rotate the file more than once
+			final long walFileSizeLimit = 1_000L;
+
+			LogFileRecordReference lastInFirstFile = null;
+			long lastVersionInFirstFile = -1L;
+			try (CatalogWriteAheadLog wal = createTestWal(
+				0L, new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)), walFileSizeLimit, 10,
+				AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				for (int version = 1; version <= 8; version++) {
+					final TransactionWithData txData = createTestTransaction(version - 1, 200);
+					final LogFileRecordReference reference = wal.append(txData.mutation(), txData.data());
+					if (reference.fileIndex() == 0) {
+						lastInFirstFile = reference;
+						lastVersionInFirstFile = version;
+					}
+				}
+			}
+			final LogFileRecordReference processedReference = Objects.requireNonNull(lastInFirstFile);
+			assertTrue(
+				CatalogWriteAheadLogTest.this.walDirectory.resolve(getWalFileName(TEST_CATALOG, 1)).toFile().exists(),
+				"Precondition: rotation must have produced a second WAL file."
+			);
+
+			// the checkpoint landed exactly on the rotation boundary: everything in file 0 is processed and the
+			// remainder lives in file 1. Replay must cross that boundary rather than read into the finalized tail
+			try (CatalogWriteAheadLog reopened = createTestWal(
+				lastVersionInFirstFile, processedReference, walFileSizeLimit, 10,
+				AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				assertEquals(
+					lastVersionInFirstFile + 1,
+					reopened.getFirstNonProcessedTransaction(processedReference)
+						.orElseThrow(() -> new AssertionError("Replay found nothing after the reference!"))
+						.transactionMutation()
+						.getVersion(),
+					"replay must continue into the next WAL file when the reference ends the previous one"
+				);
+			}
+		}
 
 		@Test
 		@DisplayName("should resume replay and keep appending when the reference lags inside the active file")

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
@@ -47,6 +47,7 @@ import io.evitadb.utils.FileUtils;
 import io.evitadb.utils.UUIDUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -64,6 +66,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Tag;
 
@@ -212,10 +215,40 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 	 */
 	@Nonnull
 	private CatalogWriteAheadLog createTestWalWithCustomSize(long walFileSizeBytes) {
-		return new CatalogWriteAheadLog(
+		return createTestWal(
 			0L,
-			TEST_CATALOG,
 			new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)),
+			walFileSizeBytes,
+			10,
+			null
+		);
+	}
+
+	/**
+	 * Creates a test instance of CatalogWriteAheadLog opened against an explicit log record reference. This is the
+	 * shape a restart takes: the reference is whatever the catalog header found through the last published bootstrap
+	 * record, and the WAL directory holds whatever rotation left behind since.
+	 *
+	 * @param catalogVersion         the catalog version the log resumes from
+	 * @param logFileRecordReference the reference the log is opened against
+	 * @param walFileSizeBytes       the maximum size of each WAL file in bytes
+	 * @param walFileCountKept       how many WAL files rotation leaves unqueued for removal
+	 * @param onWalPurgeCallback     invoked when a purge actually removes files; a test that lets the purge fire
+	 *                               must pass one, because `removeWalFiles` dereferences it unconditionally
+	 * @return a configured CatalogWriteAheadLog instance
+	 */
+	@Nonnull
+	private CatalogWriteAheadLog createTestWal(
+		long catalogVersion,
+		@Nonnull LogFileRecordReference logFileRecordReference,
+		long walFileSizeBytes,
+		int walFileCountKept,
+		@Nullable AbstractMutationLog.WalPurgeCallback onWalPurgeCallback
+	) {
+		return new CatalogWriteAheadLog(
+			catalogVersion,
+			TEST_CATALOG,
+			logFileRecordReference,
 			this.walDirectory,
 			this.catalogKryoPool,
 			new StorageSettings(
@@ -224,13 +257,62 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 					.build(),
 				TransactionOptions.builder()
 					.walFileSizeBytes(walFileSizeBytes)
-					.walFileCountKept(10)
+					.walFileCountKept(walFileCountKept)
 					.build()
 			),
 			Mockito.mock(Scheduler.class),
 			offsetDateTime -> {},
-			null
+			onWalPurgeCallback
 		);
+	}
+
+	/**
+	 * Appends 200-byte transactions, one catalog version each starting at 1, until the given WAL file appears -
+	 * i.e. until rotation has happened as many times as that file's index. Deterministic: the file size limit and
+	 * the transaction size decide the count, nothing timing-dependent.
+	 *
+	 * @param wal            the log to append to
+	 * @param awaitedWalFile the WAL file whose appearance ends the loop
+	 * @param referenceAt    catalog version whose append reference is captured and returned
+	 * @return the reference returned by the append of `referenceAt`, plus the last version written
+	 */
+	@Nonnull
+	private RotatedWal appendUntilWalFileAppears(
+		@Nonnull CatalogWriteAheadLog wal,
+		@Nonnull Path awaitedWalFile,
+		long referenceAt
+	) {
+		LogFileRecordReference capturedReference = null;
+		long transactionVersion = 1;
+		while (!Files.exists(awaitedWalFile)) {
+			final TransactionWithData txData = createTestTransaction((int) (transactionVersion - 1), 200);
+			final LogFileRecordReference reference = wal.append(txData.mutation(), txData.data());
+			if (transactionVersion == referenceAt) {
+				capturedReference = reference;
+			}
+			transactionVersion++;
+			if (transactionVersion > 500) {
+				throw new AssertionError(
+					"WAL did not rotate up to `" + awaitedWalFile + "` within the expected number of transactions!"
+				);
+			}
+		}
+		return new RotatedWal(
+			Objects.requireNonNull(capturedReference, "No reference was captured for version " + referenceAt + "!"),
+			transactionVersion - 1
+		);
+	}
+
+	/**
+	 * Outcome of {@link #appendUntilWalFileAppears(CatalogWriteAheadLog, Path, long)}.
+	 *
+	 * @param capturedReference reference of the append that was singled out as "the last checkpointed one"
+	 * @param lastVersion       the last catalog version actually written
+	 */
+	private record RotatedWal(
+		@Nonnull LogFileRecordReference capturedReference,
+		long lastVersion
+	) {
 	}
 
 	/**
@@ -693,6 +775,10 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 	/**
 	 * Nested tests for cumulative CRC32 checksum functionality.
 	 * These tests verify the checksum computation and storage in the WAL file.
+	 *
+	 * Before reading anything here as an integrity guarantee, see the `checksum` field of
+	 * {@link AbstractMutationLog} - it is the authoritative account of what these values detect, which is
+	 * narrower than "cumulative" suggests. In short: damage inside a transaction, and nothing about ordering.
 	 */
 	@Nested
 	@DisplayName("Cumulative CRC32 Tests")
@@ -773,6 +859,14 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 			CatalogWriteAheadLogTest.this.tested = createTestWal();
 		}
 
+		/**
+		 * Proves the stored checksum equals an independently computed CRC32C over every byte preceding it, which
+		 * is exactly what the format specifies.
+		 *
+		 * It does **not** prove that the file is tamper-evident or that its transactions are pinned in place, and
+		 * it must not be cited for either - `shouldNotDetectReorderedTransactions` below shows why. The two tests
+		 * are deliberately adjacent: this one is the reason the misreading is tempting, that one is the correction.
+		 */
 		@Test
 		@DisplayName("should write correct cumulative CRC32C checksum to WAL file")
 		void shouldWriteCorrectCumulativeCrc32ChecksumToWalFile() throws IOException {
@@ -820,6 +914,82 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 				);
 			}
 
+			CatalogWriteAheadLogTest.this.tested = createTestWal();
+		}
+
+		/**
+		 * Pins what the cumulative checksum actually detects, which is less than the chain suggests.
+		 *
+		 * Each stored checksum genuinely is the CRC32C of every byte preceding it - `shouldWriteCorrectCumulativeCrc32
+		 * ChecksumToWalFile` verifies exactly that against an independently computed CRC. The catch is that this
+		 * coverage includes the previous stored checksums, and `CRC(M ‖ CRC(M))` is the CRC residue: a constant,
+		 * whatever `M` was. The running register therefore returns to that same constant at every stored checksum, so
+		 * each value ends up determined by the constant plus its own transaction's bytes and nothing earlier.
+		 *
+		 * What that catches: damage **inside** a transaction whose stored checksum was not also rewritten. What it
+		 * cannot catch is below - whole transactions exchanged, duplicated, or spliced in from another file, since
+		 * each carries a checksum that verifies from the same constant wherever it is placed.
+		 *
+		 * **That gap is closed elsewhere, not here.** Every transaction carries the catalog version it produces, and
+		 * trunk incorporation asserts each one is exactly the next expected version
+		 * ({@link io.evitadb.core.transaction.TransactionManager}, "Unexpected catalog version!"). Exchanged,
+		 * duplicated, dropped and cross-file-spliced transactions all break that sequence and are rejected loudly.
+		 * So this test pins where the *checksum's* reach ends, not a hole in the engine - and the reason it asserts
+		 * acceptance rather than rejection is that the WAL layer is not the layer that says no.
+		 */
+		@Test
+		@DisplayName("should not detect two whole transactions exchanged - the chain resets at every checksum")
+		void shouldNotDetectReorderedTransactions() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+
+			final Path walPath = CatalogWriteAheadLogTest.this.walDirectory.resolve(getWalFileName(TEST_CATALOG, 0));
+
+			// three transactions with identical payload sizes, so each occupies exactly the same number of bytes and
+			// two of them can be exchanged without disturbing a single length prefix
+			try (CatalogWriteAheadLog wal = createTestWal()) {
+				for (int i = 0; i < 3; i++) {
+					final TransactionWithData txData = createTestTransaction(i, 200);
+					wal.append(txData.mutation(), txData.data());
+				}
+			}
+
+			final byte[] original = Files.readAllBytes(walPath);
+			final int header = AbstractMutationLog.CUMULATIVE_CRC32_SIZE;
+			final int blockLength = (original.length - header) / 3;
+			assertEquals(
+				header + blockLength * 3, original.length,
+				"Precondition: the three transactions must be equally long for the exchange to be byte-neutral."
+			);
+
+			// exchange the first two transactions, each carried over whole - its length prefix, its records and its
+			// own trailing cumulative checksum
+			final byte[] tampered = original.clone();
+			System.arraycopy(original, header + blockLength, tampered, header, blockLength);
+			System.arraycopy(original, header, tampered, header + blockLength, blockLength);
+			Files.write(walPath, tampered);
+
+			// reopening runs `checkAndTruncate`, which verifies every transaction's cumulative checksum in turn
+			try (CatalogWriteAheadLog ignored = createTestWal(
+				0L, new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)), 1_048_576L, 10,
+				AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				// nothing to do - construction is what scans the file
+			}
+
+			assertFalse(
+				Files.exists(CatalogWriteAheadLogTest.this.walDirectory.resolve("_damaged_wal.bck")),
+				"The swap is currently accepted, so no damaged-file backup may be produced - a backup here means " +
+					"the chain started detecting reordering and this test is now the one that is out of date."
+			);
+			assertEquals(
+				original.length, walPath.toFile().length(),
+				"The swap is currently accepted, so nothing may be truncated off the file."
+			);
+
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
 			CatalogWriteAheadLogTest.this.tested = createTestWal();
 		}
 
@@ -913,6 +1083,257 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 			}
 
 			// Clean directory and recreate WAL for tearDown
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+			CatalogWriteAheadLogTest.this.tested = createTestWal();
+		}
+	}
+
+	/**
+	 * Restart behaviour when the log has moved past the position a restart resumes from - either by rotating into
+	 * later files, or by appending transactions the trunk never incorporated.
+	 *
+	 * A catalog resumes from the last **published bootstrap record**, not from the newest state it had in memory:
+	 * `DefaultCatalogPersistenceService#close` deliberately leaves that pointer at the last checkpoint, "which
+	 * simply means restart resumes from there and replays the rest from the WAL". Everything appended since is the
+	 * tail replay consumes, and it may span several files.
+	 *
+	 * These tests pin the parts of that contract independently: rotation must never drop the file the reference
+	 * needs (which would leave an unbridgeable gap), reopening against such a reference must work, and a
+	 * transaction appended after the restart must survive the next restart intact.
+	 *
+	 * Note what is deliberately **not** claimed here: that appends continue a checksum chain. Each transaction's
+	 * trailing checksum covers only its own bytes - the running value returns to a fixed constant after every
+	 * record, so no test in this class can distinguish one append-chain seed from another. See the punch list's
+	 * entry on the cumulative checksum for why.
+	 */
+	@Nested
+	@DisplayName("Restart from a position the log has moved past")
+	class RestartAfterRotation {
+
+		@Test
+		@DisplayName("should resume replay and keep appending when the reference lags inside the active file")
+		void shouldResumeReplayAndAppendWhenReferenceLagsInsideActiveFile() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+
+			final Path walFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 0));
+			final long walFileSizeLimit = 1_048_576L;
+
+			// four transactions land in one file, but only the second was ever incorporated - which is what a
+			// crash leaves behind whenever appends outran the trunk rounds processing them
+			LogFileRecordReference afterSecond = null;
+			LogFileRecordReference afterFourth = null;
+			try (CatalogWriteAheadLog wal = createTestWal(
+				0L, new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)), walFileSizeLimit, 10,
+				AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				for (int version = 1; version <= 4; version++) {
+					final TransactionWithData txData = createTestTransaction(version - 1, 200);
+					final LogFileRecordReference reference = wal.append(txData.mutation(), txData.data());
+					if (version == 2) {
+						afterSecond = reference;
+					} else if (version == 4) {
+						afterFourth = reference;
+					}
+				}
+			}
+			final LogFileRecordReference processedReference = Objects.requireNonNull(afterSecond);
+			final LogFileRecordReference lastAppendedReference = Objects.requireNonNull(afterFourth);
+
+			// the restart resumes from transaction 2; transactions 3 and 4 are the tail replay consumes
+			final LogFileRecordReference postRestartReference;
+			try (CatalogWriteAheadLog reopened = createTestWal(
+				2L, processedReference, walFileSizeLimit, 10, AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				assertEquals(
+					3L,
+					reopened.getFirstNonProcessedTransaction(processedReference)
+						.orElseThrow(() -> new AssertionError("Replay found nothing after the reference!"))
+						.transactionMutation()
+						.getVersion(),
+					"replay must resume at the first transaction the trunk never incorporated"
+				);
+
+				final TransactionWithData txData = createTestTransaction(4, 200);
+				postRestartReference = reopened.append(txData.mutation(), txData.data());
+			}
+			final long walFileLengthAfterRestart = walFile.toFile().length();
+
+			// A third open is what would discover a transaction 5 the reopen wrote wrongly - a scan rejects the
+			// file outright, or quietly truncates the offending transaction back off it. Both assertions below
+			// are therefore needed: either outcome alone would let the other pass unnoticed. This covers the
+			// reopen path where `checkAndTruncate` mints a corrected reference and the constructor adopts it,
+			// which no other test in this class exercises.
+			try (CatalogWriteAheadLog reopenedAgain = createTestWal(
+				5L, postRestartReference, walFileSizeLimit, 10, AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				assertEquals(
+					5L,
+					reopenedAgain.getFirstNonProcessedTransaction(lastAppendedReference)
+						.orElseThrow(() -> new AssertionError("The transaction appended after the restart is gone!"))
+						.transactionMutation()
+						.getVersion(),
+					"the transaction appended after the restart must still be readable"
+				);
+			}
+			assertEquals(
+				walFileLengthAfterRestart, walFile.toFile().length(),
+				"reopening must not truncate the transaction appended after the restart - a shorter file means " +
+					"the scan rejected it and silently repaired the file"
+			);
+
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+			CatalogWriteAheadLogTest.this.tested = createTestWal();
+		}
+
+		@Test
+		@DisplayName("should keep the WAL file holding the first non-processed transaction")
+		void shouldKeepWalFileHoldingFirstNonProcessedTransaction() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+
+			final Path firstWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 0));
+			final Path fourthWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 3));
+
+			// only two files are kept, so rotation queues files 0 and 1 for removal - but the queue is
+			// version-gated, and version 4 (still unprocessed) lives in file 0
+			final CatalogWriteAheadLog wal = createTestWal(
+				0L, new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)), 4_096L, 2,
+				AbstractMutationLog.WalPurgeCallback.NO_OP
+			);
+			try {
+				appendUntilWalFileAppears(wal, fourthWalFile, 3L);
+				assertTrue(
+					wal.getFirstVersionOf(1) > 4L,
+					"test setup: version 4 must still live in file 0 for this assertion to mean anything"
+				);
+
+				wal.walProcessedUntil(3L);
+			} finally {
+				// close() runs the purge (AbstractMutationLog#close), so the assertions come after it
+				wal.close();
+			}
+
+			assertTrue(
+				Files.exists(firstWalFile),
+				"file 0 holds version 4, the first non-processed transaction - purging it would leave a gap " +
+					"that replay after a restart could never bridge"
+			);
+
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+			CatalogWriteAheadLogTest.this.tested = createTestWal();
+		}
+
+		@Test
+		@DisplayName("should purge rotated WAL files once every transaction in them is processed")
+		void shouldPurgeWalFilesOnceEveryTransactionInThemIsProcessed() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+
+			final Path firstWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 0));
+			final Path secondWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 1));
+			final Path fourthWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 3));
+
+			// the calibration of the test above: with the same rotation and the same kept-count, the two queued
+			// files DO disappear once nothing unprocessed is left in them. Without this, that test would pass
+			// just as happily if the purge never ran at all.
+			final CatalogWriteAheadLog wal = createTestWal(
+				0L, new LogFileRecordReference(index -> getWalFileName(TEST_CATALOG, index)), 4_096L, 2,
+				AbstractMutationLog.WalPurgeCallback.NO_OP
+			);
+			try {
+				appendUntilWalFileAppears(wal, fourthWalFile, 3L);
+				// every version below the first one in file 2 is contained in files 0 and 1
+				wal.walProcessedUntil(wal.getFirstVersionOf(2));
+			} finally {
+				wal.close();
+			}
+
+			assertFalse(Files.exists(firstWalFile), "file 0 is fully processed and must be purged");
+			assertFalse(Files.exists(secondWalFile), "file 1 is fully processed and must be purged");
+
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+			CatalogWriteAheadLogTest.this.tested = createTestWal();
+		}
+
+		@Test
+		@DisplayName("should reopen against a reference that sits several rotations back")
+		void shouldReopenAgainstReferenceSeveralRotationsBack() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+
+			final Path firstWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 0));
+			final Path fourthWalFile = CatalogWriteAheadLogTest.this.walDirectory
+				.resolve(getWalFileName(TEST_CATALOG, 3));
+
+			final LogFileRecordReference checkpointedReference;
+			final long lastWrittenVersion;
+			final long firstWalFileLengthBeforeRestart;
+
+			// nothing is purged here - the point is the reference's distance from the newest file, not its absence
+			try (CatalogWriteAheadLog wal = createTestWalWithCustomSize(4_096L)) {
+				final RotatedWal rotated = appendUntilWalFileAppears(wal, fourthWalFile, 3L);
+				checkpointedReference = rotated.capturedReference();
+				lastWrittenVersion = rotated.lastVersion();
+			}
+			firstWalFileLengthBeforeRestart = firstWalFile.toFile().length();
+
+			// this is what a restart does: open against the reference the last checkpoint left behind
+			final LogFileRecordReference postRestartReference;
+			try (CatalogWriteAheadLog reopened = createTestWal(
+				3L, checkpointedReference, 4_096L, 10, AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				assertEquals(
+					4L,
+					reopened.getFirstNonProcessedTransaction(checkpointedReference)
+						.orElseThrow(() -> new AssertionError("Replay found nothing after the reference!"))
+						.transactionMutation()
+						.getVersion(),
+					"replay must resume at the transaction right after the checkpointed one"
+				);
+
+				final TransactionWithData txData = createTestTransaction((int) lastWrittenVersion, 200);
+				postRestartReference = reopened.append(txData.mutation(), txData.data());
+			}
+
+			assertEquals(
+				firstWalFileLengthBeforeRestart, firstWalFile.toFile().length(),
+				"a restart must not truncate or append to an already rotated-away WAL file - appends belong in " +
+					"the newest file, and file 0's tail record is not a partially written transaction"
+			);
+			assertEquals(
+				3, postRestartReference.fileIndex(),
+				"the post-restart append belongs in the newest WAL file, not in the one the reference points at"
+			);
+
+			// Opening a third time is what proves the APPEND chain was seeded correctly: the scan recomputes each
+			// transaction's cumulative checksum from the file's stored seed and rejects the file when one does not
+			// match. A restart that continued the reference's chain instead of the active file's would write a
+			// transaction whose checksum is wrong, and this is the open that finds it.
+			try (CatalogWriteAheadLog reopenedAgain = createTestWal(
+				lastWrittenVersion + 1, postRestartReference, 4_096L, 10, AbstractMutationLog.WalPurgeCallback.NO_OP
+			)) {
+				assertTrue(
+					reopenedAgain.getFirstNonProcessedTransaction(postRestartReference).isEmpty(),
+					"nothing follows the transaction appended after the restart"
+				);
+			}
+
 			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
 			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
 			CatalogWriteAheadLogTest.this.tested = createTestWal();

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/EngineMutationLogTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/EngineMutationLogTest.java
@@ -660,6 +660,11 @@ class EngineMutationLogTest implements EvitaTestSupport {
 
 	/**
 	 * Nested tests for cumulative CRC32 checksum functionality.
+	 *
+	 * The engine log shares `AbstractMutationLog` with the catalog log, so the guarantee is identical - see the
+	 * `checksum` field there for what these values actually detect (damage inside a transaction, and nothing
+	 * about ordering). The behaviour is characterised once, by
+	 * `CatalogWriteAheadLogTest#shouldNotDetectReorderedTransactions`, rather than duplicated here.
 	 */
 	@Nested
 	@DisplayName("Cumulative CRC32 Tests")


### PR DESCRIPTION
Unification PR for the **2026.2.4 hotfix**. It merges the three fixes already approved against
`release_2026-2` into `master` as a single push, so exactly one release pipeline runs.

## What it carries

| Fix | Constituent PR (base `release_2026-2`) | Twin already on `dev` |
|---|---|---|
| `LocalDateTime` stays the declared attribute type through the write path (+ 2026.1 index migration) | #1405 | #1404 |
| OffsetIndex create-vs-update verdict for unflushed re-adds | #1408 | #1409 |
| WAL append position resolved from the newest file, not the log reference | #1410 | #1411 |

Refs #1403, #1406, #1407 — all three issues are already closed by their `dev`-side PRs.

## Why this shape

`ci-release.yml` fires on every push to `release_*` and has no `concurrency` guard, so merging the
three PRs into `release_2026-2` directly would start three release builds — potentially two of them
resolving the same version and both reaching the Maven Central deploy step. It would also leave
`release_2026-2` ahead of `master`, breaking the `git merge --ff-only origin/master` that
`ci-master.yml` uses to advance it.

Merging here instead gives one push to `master` → one `CI Master branch` run → one fast-forward of
`release_2026-2` → one dispatched `CI Release branch` build, cutting **v2026.2.4** (tags currently
end at `v2026.2.3`, no draft releases outstanding).

**Merge with a merge commit, not a squash** — the three constituent PRs close themselves only once
their head commits become reachable from `release_2026-2`.

## Verification

Nothing in CI covers this PR — `pr-review.yml` is scoped to `branches: [dev]`, and both
`ci-master.yml` and `ci-release.yml` build with `-Dmaven.test.skip=true`. The merged tree was
therefore verified locally:

- **Merge integrity** — the three branches touch no file in common; all three merges applied with no
  conflicts. Every one of the 24 changed files is byte-identical to `dev`, where these fixes are
  green, with one exception: `documentation/adr/README.md` lacks one unrelated index row for an ADR
  that exists only on `dev`.
- **Compile gate** — `mvn -T 1C -P full -Dmaven.test.skip=true package -pl '!:evita_long_running_tests'`,
  the exact gate `ci-master.yml` runs: **BUILD SUCCESS**, 29 modules.
- **Affected tests** — the nine test classes the three fixes touch, run against `master` + the fixes
  rather than against `dev`, with no `unitAndFunctional` profile so no `slow`/`flaky` tag could
  silently exclude one: **399 tests, 0 failures, 0 errors, 0 skipped**.

  | Test class | Tests |
  |---|---|
  | `EvitaDataTypesTest` | 138 |
  | `FilterIndexTest` | 87 |
  | `OffsetIndexTest` | 80 |
  | `CatalogWriteAheadLogTest` | 37 |
  | `EngineMutationLogTest` | 19 |
  | `LocalTemporalAttributeTypeFidelityFunctionalTest` | 13 |
  | `InstantValueColumnTest` | 11 |
  | `DeferredCheckpointPersistenceTest` | 11 |
  | `FilterIndexLegacyLocalDateTimeSerializerTest` | 3 |

The PGP Keys Check and Duplicate Classes Check were not reproduced locally — no pom or dependency
changed relative to the last successful `master` run.
