### PR TITLE
Make @Interruptible actually weave the check it promises

### DIFF
--- a/documentation/adr/2026-07-16-client-session-cancellation-cascade.md
+++ b/documentation/adr/2026-07-16-client-session-cancellation-cascade.md
@@ -1,7 +1,7 @@
 ---
 title: Fix the gRPC session-cancellation cascade, and move the test-only executor switch off public config into a per-dataset real-pool opt-in
 date: 2026-07-16
-updated: 2026-08-03 15:50
+updated: 2026-08-14 09:50
 status: accepted
 kind: fix
 issues: []
@@ -9,7 +9,7 @@ prs: [1284]
 areas: [evita_external_api_grpc/client/driver, evita_external_api_core/configuration, evita_engine/core, evita_api/exception, evita_api/configuration, evita_server, evita_test_support, evita_test/evita_functional_tests]
 supersedes: []
 superseded-by: []
-relates: [2026-08-03-driver-connection-resilience, 2026-08-04-http2-connection-teardown-observability]
+relates: [2026-08-03-driver-connection-resilience, 2026-08-04-http2-connection-teardown-observability, 2026-08-14-interruption-weaving-and-task-cancellation]
 ---
 
 # Fix the gRPC keep-alive self-kill and session-cancellation cascade
@@ -262,6 +262,11 @@ reconfirm them — they were the merge-gating numbers, not re-measured for this 
 ## Consequences & open follow-ups
 
 Re-checked against the current tree, not just carried from `RESULTS.md`:
+
+- **Unrecognized at the time — the far end of this chain read nothing.** The cancellation delivered here
+  set the thread interrupt flag correctly, but `@Interruptible` had never woven a single check, so no query
+  ever polled it. Closed in `2026-08-14-interruption-weaving-and-task-cancellation.md`, which also fixes the
+  discarded executor `Future` that left running background tasks uninterruptible.
 
 - **Still open — no dedicated real-pool CI stage.** `RESULTS.md` deferred "a dedicated sequential
   real-pool CI stage" as a separate follow-up; confirmed still absent from `.github/workflows/`.

--- a/documentation/adr/2026-08-14-interruption-weaving-and-task-cancellation.md
+++ b/documentation/adr/2026-08-14-interruption-weaving-and-task-cancellation.md
@@ -1,7 +1,7 @@
 ---
 title: Weave the interrupt poll with `visit` and a chained matcher union, and interrupt tasks through the executor's Future
 date: 2026-08-14
-updated: 2026-08-14 13:20
+updated: 2026-08-14 14:35
 status: accepted
 kind: fix
 issues: [1416]
@@ -153,6 +153,10 @@ by weaving `EvitaSession#getCatalogSchema` with the retention untouched.
   guard against regression is `InterruptionTransformerMatcherTest`, not these numbers.
 - Full functional suite with the weaving live: **21176 tests, 0 failures**, 39 skipped, 1 error
   (`ExportS3ServiceTest`, "Could not find a valid Docker environment" — environmental, no Docker available).
+  This belongs to the same pre-cancellation-fix build as the woven-site counts above: it proves the matcher fix
+  does not destabilise the suite, and nothing about the four cancellation defects, whose tests did not exist
+  yet. It has not been reproduced since — the full suite OOMs on this machine at the standard heap — so
+  post-fix full-suite green is CI's claim, not this record's.
 - `InterruptionTransformerMatcherTest` (new) asserts each of the **seven** engine matcher branches individually
   plus the GraphQL branch, and asserts that the abstract declarations and an unrelated method do **not** match.
   It needs no build artifacts and would have caught the `anyOf` defect in milliseconds. `InterruptionAdviceWovenTest`
@@ -166,7 +170,15 @@ by weaving `EvitaSession#getCatalogSchema` with the retention untouched.
   - `ObservableThreadExecutor` — `AbstractObservableTask#cancel()` could deliver its interrupt after the worker had
     finished and taken the next task. `ObservableThreadExecutorCancellationTest#shouldHoldFinishingWorkerUntilConcurrentCancelDeliveredInterrupt`.
   - `BackupTask#doBackup` — cleanup caught only `RuntimeException`.
-    `BackupTaskCancellationTest#shouldDeleteRegisteredExportFileWhenBackupInterrupted`.
+    `BackupTaskCancellationTest#shouldDeleteRegisteredExportFileWhenBackupInterrupted`. Its red came from an
+    independent Codex review of the pushed branch rather than from the revert here, for the reason recorded
+    under *Consequences* — the local calibration reverted this one fix and never restored it, so the branch was
+    committed and pushed carrying the explanatory comment without the code. The catch now mirrors
+    `FullBackupTask`: `Exception`, rethrowing a `RuntimeException` unchanged and wrapping anything checked in
+    `UnexpectedIOException`. That wrapping does not restore the interrupt flag, so an interrupted backup
+    surfaces to the caller as an IO failure rather than a cancellation — deliberately consistent with
+    `FullBackupTask`, and unlike `SequentialTask`, which transitions to FAILED carrying a `CancellationException`.
+    Worth revisiting only if a caller is found that needs to tell the two apart.
   - `SequentialTask#execute` — the completion block ran on a cancelled sequence.
     `SequentialTaskTest#shouldStopAtStepBoundaryWhenResultFutureCancelledDirectly`.
 - Tag-scoped regression run after all fixes: `-Dgroups="task & engine"` → **97 tests, 0 failures**.
@@ -193,6 +205,17 @@ by weaving `EvitaSession#getCatalogSchema` with the retention untouched.
   users as fetchable. Its sibling `FullBackupTask` already caught `Exception`, which is what settled it as an
   oversight rather than a choice. Any other cleanup block narrowed to `RuntimeException` on a path that can now
   be interrupted deserves the same look — this was not audited exhaustively.
+  An IDE will argue against the wider catch here, reporting the checked branch as unreachable because no
+  signature in scope declares it. That inspection is right about the source and wrong about the bytecode, and it
+  is how the narrowing got reintroduced once already; the catch site carries a comment saying so.
+- **Calibrating a fix by reverting it is how one of these fixes was lost.** The revert-and-observe-red step was
+  run on `BackupTask` and never undone, and the branch was committed, pushed and opened as a PR with the fix
+  absent. Two things made that survivable-looking: the explanatory comment sat immediately above the reverted
+  line, so the diff read as a completed fix, and the re-run happened against a jar built *before* the revert, so
+  it reported green. An independent review on a clean build caught it. The lesson is narrow and mechanical —
+  a revert used as a measuring instrument must be restored and then re-verified against a freshly built
+  artifact, and a comment is not evidence that the code beneath it exists. `mvn clean` on the woven module is
+  what makes the verification mean anything, because the ByteBuddy `transform` goal is incremental.
 - **The thread-tracking pattern this record rejects for new code was still live in the request path**, and is
   now fixed rather than merely noted. `AbstractObservableTask#cancel()` reads a `volatile Thread` and interrupts
   it directly; nothing ordered that interrupt against the worker clearing its flag and taking the next task, so

--- a/documentation/adr/2026-08-14-interruption-weaving-and-task-cancellation.md
+++ b/documentation/adr/2026-08-14-interruption-weaving-and-task-cancellation.md
@@ -1,0 +1,244 @@
+---
+title: Weave the interrupt poll with `visit` and a chained matcher union, and interrupt tasks through the executor's Future
+date: 2026-08-14
+updated: 2026-08-14 13:20
+status: accepted
+kind: fix
+issues: [1416]
+prs: []
+areas:
+  - evita_engine/src/main/java/io/evitadb/core/executor
+  - evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/async
+supersedes: []
+superseded-by: []
+relates: [2026-07-16-client-session-cancellation-cascade]
+---
+
+# Weave the interrupt poll with `visit` and a chained matcher union, and interrupt tasks through the executor's Future
+
+`@Interruptible` had never injected anything. The build-time ByteBuddy transformer assembled its matcher
+union with `ElementMatchers.anyOf(...)`, which is an **equality** matcher over values, so it matched no
+method in any module for the entire life of the annotation. Query cancellation and query timeouts were
+silently disabled engine-wide. Two further links in the cancellation chain were broken independently: the
+`Future` returned by the executor was discarded on submission, and `CompletableFuture#cancel(true)` ignores
+`mayInterruptIfRunning`, so nothing could interrupt a running background task even once the checkpoints
+existed. All three are fixed here.
+
+## Why
+
+`AbstractObservableTask#cancel()` interrupts the worker thread, and `CancellationSupport` wires Armeria's
+`whenRequestCancelling()` to it, so a client disconnect or request timeout *did* set the interrupt flag.
+Nothing read it. A runaway query kept burning CPU that no client was waiting for, and `Scheduler#cancelTask`
+could mark a restore cancelled without stopping it.
+
+What made this survive is that **a matcher that matches nothing is indistinguishable from one that works**.
+The plugin logs `Transformed 1454 type(s)` either way, the build stays green, and the whole test suite
+passes — nothing asserted on the woven output.
+
+### Previous state
+
+```java
+builder.method(
+    ElementMatchers.anyOf(          // ← binds to anyOf(Object...)
+        ElementMatchers.isAnnotatedWith(Interruptible.class)...,
+        ElementMatchers.isOverriddenFrom(Formula.class)...,
+        ...
+    )
+).intercept(Advice.to(InterruptionAdvice.class));
+```
+
+`anyOf` has no `ElementMatcher...` overload. The call binds to `anyOf(Object... value)`, documented as
+*"matches any of the given objects by the `Object#equals(Object)` method"* with an explicit warning that it
+"cannot be used interchangeably with any of its overloaded versions". Handed seven
+`ElementMatcher.Junction` instances, the union asked whether a `MethodDescription` **equals** one of seven
+matcher objects — never true.
+
+Four of the seven branches additionally ended in `.and(isAbstract())` instead of `.and(not(isAbstract()))`,
+targeting body-less methods; the GraphQL transformer's only branch had the same defect. Real, but
+secondary: `anyOf` discarded the union regardless.
+
+## Options considered
+
+### Option A — `builder.visit(Advice.to(...).on(matcher))` (chosen)
+
+Rewrites the body of every **declared** matching method in place.
+
+- **Pros:** no new methods; the check sits on the declaring implementation, where the work happens.
+- **Cons:** a subclass that inherits a matched method without declaring it gets no check of its own — which
+  is the desired outcome here, but is a behavioural difference worth knowing.
+
+### Option B — keep `builder.method(matcher).intercept(Advice.to(...))` (declined)
+
+- **Pros:** smallest possible diff; it does work.
+- **Cons:** matches *invokable* methods, so ByteBuddy synthesises an overriding method in every subclass
+  that merely inherits a match.
+- **Rejected because:** it added a synthetic `compute()` override to every `Formula` subclass — measured
+  172 woven sites versus 129 for `visit` — putting an extra frame on the hottest path in the engine for no
+  additional coverage. Revisit only if a matcher branch ever needs to instrument a method at a type that
+  does not declare it.
+
+Note that issue #1416 proposed switching to `visit` on the grounds that `intercept` **throws** under
+redefinition. That does not apply: `byte-buddy-maven-plugin` defaults to `REBASE` (confirmed by
+`Resolved entry point: REBASE` in the build log), where the original body is rebased and `SuperMethodCall`
+resolves to it. `intercept` was verified working before being replaced.
+
+### Guard against silent recurrence — asserted on the artifact (chosen) vs. inside the plugin (declined)
+
+The plugin-side variant was implemented and did work on clean builds: it tallied matches on the matcher
+ByteBuddy uses to weave and threw from `Plugin#close()` when a module wove nothing.
+
+- **Rejected because:** the `transform` goal is **incremental** (see its `staleMilliseconds` parameter).
+  A build where javac reports `Nothing to compile` processes zero types, so the assertion failed a
+  perfectly good `mvn install`; a partial rebuild touching one non-matching file would trip it too. The
+  plugin cannot distinguish a dead matcher from an up-to-date module. Revisit only if the goal gains a way
+  to report that it processed the whole module.
+
+`InterruptionAdviceWovenTest` asserts instead on the **built class files**, which is immune to incremental
+semantics.
+
+### Interrupting a running task — executor `Future` (chosen) vs. tracking the executing thread (declined)
+
+- **Rejected because:** tracking a `volatile Thread` and interrupting it directly — the existing
+  `AbstractObservableTask` pattern — races with completion, and an interrupt landing just after the task
+  finishes poisons the *next* task on that pooled thread. That was tolerable while nothing polled the flag;
+  now that the checkpoints are live it would abort an unrelated query. `FutureTask`'s cancel state machine
+  only delivers the interrupt while the task is genuinely running, and `ThreadPoolExecutor.runWorker`
+  clears a leftover flag before the next task. Revisit for submission paths that have no `Future` at all.
+
+## Decision
+
+**Chosen: Option A**, plus the artifact-level guard and the executor-`Future` cancellation.
+
+The matcher union is now assembled by chaining `ElementMatcher.Junction#or(...)`, with
+`not(isAbstract())` applied once to the whole union rather than per branch. `@Interruptible` keeps
+`RetentionPolicy.CLASS` — issue #1416 suggested promoting it to `RUNTIME`, but the plugin engine resolves
+types through a `TypePool`, so class-file annotations are visible to `isAnnotatedWith`; this was verified
+by weaving `EvitaSession#getCatalogSchema` with the retention untouched.
+
+## Key technical details
+
+- `AbstractInterruptionTransformer` (new) holds the shared weaving and the reasoning; `InterruptionTransformer`
+  in `io.evitadb.core.executor` and in `io.evitadb.externalApi.graphql.async` supply only their matchers.
+- **Never build a matcher union with `ElementMatchers.anyOf(...)`.** It compares by `equals` against values.
+  Chain `.or(...)` instead. This is the whole bug.
+- `InterruptibleServerTask` (new, package-private) is the seam by which `Scheduler#submitTaskInQueue` hands a
+  task the `Future` it previously discarded. `@InternallyScheduledTask` tasks deliberately get no handle —
+  they run inline on the submitter's thread.
+- `cancel()` cancels the result future **first**, then interrupts through the handle. Order matters: the
+  status must already carry the `CancellationException` before the interrupt unwinds `executeInternal()`,
+  otherwise `execute()`'s catch reports a cancelled task as failed.
+- Both `execute()` implementations now return early when the future is already cancelled — without this a
+  cancelled restore is logged at ERROR with a stack trace and reported as FAILED.
+- An interrupt now surfaces as an **undeclared checked** `InterruptedException` from deep inside query
+  internals. That is by design, and is why any stray interrupt flag aborts a query that previously ran to
+  completion.
+
+## Verification
+
+- `InterruptionAdviceWovenTest` — four assertions, one known-woven method per module, checked with ASM for a
+  `Thread.isInterrupted()` call: `AbstractFormula#compute`, `EvitaSession#getCatalogSchema`,
+  `RestoreTask#readBlock`, `AsyncDataFetcher#get`. All four fail on the pre-fix tree, where **zero** classes
+  in any module contained the advice.
+- `SchedulerTest#shouldInterruptWorkerThreadOfCancelledTask` (new) observes **only**
+  `Thread.currentThread().isInterrupted()`. The pre-existing `shouldCancelRunningTask` polls
+  `getFutureResult().isCancelled()` — a cooperative check that passed throughout the outage, which is why it
+  is not sufficient on its own.
+- Woven sites measured on the clean build **immediately after the matcher fix, before the four cancellation
+  defects below were addressed**: `evita_engine` 129, `evita_store_server` 7 (exactly the `@Interruptible`
+  methods in `BackupTask` 5, `RestoreTask` 1, `FullBackupTask` 1), `evita_external_api_graphql` 95; all four
+  classes declaring `compute()` carried exactly one check. Treat these as a snapshot of that build, not a
+  current figure — later work in this same record added methods to `AbstractServerTask`, `SequentialTask` and
+  `ObservableThreadExecutor`, and the transformed-type counts moved with it (1454 → 1456 in `evita_engine`).
+  Re-deriving the per-method counts needs the matcher temporarily wrapped in a counting decorator; the standing
+  guard against regression is `InterruptionTransformerMatcherTest`, not these numbers.
+- Full functional suite with the weaving live: **21176 tests, 0 failures**, 39 skipped, 1 error
+  (`ExportS3ServiceTest`, "Could not find a valid Docker environment" — environmental, no Docker available).
+- `InterruptionTransformerMatcherTest` (new) asserts each of the **seven** engine matcher branches individually
+  plus the GraphQL branch, and asserts that the abstract declarations and an unrelated method do **not** match.
+  It needs no build artifacts and would have caught the `anyOf` defect in milliseconds. `InterruptionAdviceWovenTest`
+  keeps exactly one assertion per module, owning the orthogonal claim that the plugin ran against the shipped
+  classes; the two are deliberately not merged.
+- Four further defects were found in the cancellation chain and fixed here, each calibrated by reverting the fix
+  and confirming its test fails with the predicted symptom:
+  - `AbstractServerTask#attachExecutionHandle` — a cancel arriving between `submit(...)` and the attach found no
+    handle and never interrupted, silently reinstating the defect this record exists to fix.
+    `SchedulerTest#shouldInterruptTaskCancelledBeforeHandleAttached`.
+  - `ObservableThreadExecutor` — `AbstractObservableTask#cancel()` could deliver its interrupt after the worker had
+    finished and taken the next task. `ObservableThreadExecutorCancellationTest#shouldHoldFinishingWorkerUntilConcurrentCancelDeliveredInterrupt`.
+  - `BackupTask#doBackup` — cleanup caught only `RuntimeException`.
+    `BackupTaskCancellationTest#shouldDeleteRegisteredExportFileWhenBackupInterrupted`.
+  - `SequentialTask#execute` — the completion block ran on a cancelled sequence.
+    `SequentialTaskTest#shouldStopAtStepBoundaryWhenResultFutureCancelledDirectly`.
+- Tag-scoped regression run after all fixes: `-Dgroups="task & engine"` → **97 tests, 0 failures**.
+- Request-path run, because the `ObservableThreadExecutor` fix executes on every task completion in the Armeria
+  request path and the tag scoping above is orthogonal to it: five GraphQL and REST end-to-end functional classes
+  → **123 tests, 0 failures**, and zero `InterruptedException` occurrences in the log, which is the signal that
+  matters — the woven checkpoints are live throughout that path, so a stray interrupt would abort queries rather
+  than pass silently.
+- The full suite is left to CI, which is green at the project's standard `-Xmx8g`; it OOMs on a developer
+  workstation, and raising the local heap would hide that divergence rather than explain it.
+
+## Consequences & open follow-ups
+
+- **Every interrupt now costs a query.** 231 checkpoints across three modules poll the flag for the first
+  time. Code that restores an interrupt flag and keeps working — rather than restoring it and unwinding —
+  will now abort the next `@Interruptible` method on that thread. The suite is clean, but this is the
+  failure mode to suspect first if queries start aborting spuriously.
+- **`Scheduler#shutdown()`/`shutdownNow()` now genuinely interrupt.** Both loop `cancel()` over the whole
+  queue; that was a no-op for running work before and is a real interrupt now.
+- **`catch (RuntimeException)` is now a class of latent bug, wherever it guards cleanup.** The woven advice
+  raises `InterruptedException` — a *checked* exception, thrown from bytecode out of methods whose signatures
+  never declare it, so it is invisible at the catch site and slips past any `RuntimeException`-only handler.
+  `BackupTask` was one such site and left a structurally valid but truncated archive registered and listed to
+  users as fetchable. Its sibling `FullBackupTask` already caught `Exception`, which is what settled it as an
+  oversight rather than a choice. Any other cleanup block narrowed to `RuntimeException` on a path that can now
+  be interrupted deserves the same look — this was not audited exhaustively.
+- **The thread-tracking pattern this record rejects for new code was still live in the request path**, and is
+  now fixed rather than merely noted. `AbstractObservableTask#cancel()` reads a `volatile Thread` and interrupts
+  it directly; nothing ordered that interrupt against the worker clearing its flag and taking the next task, so
+  a cancel could abort unrelated work — reachable from `CancellationSupport.wireCancellation`, i.e. every Armeria
+  client disconnect and request timeout. It now carries a `PENDING → RUNNING → {CANCELLING → INTERRUPTED | DONE}`
+  state machine, giving it the delivery guarantee `FutureTask` provides and this class previously lacked, with a
+  `deliverInterrupt` seam that makes the race deterministically testable.
+- **`TaskStatus` has no CANCELLED state.** A cancelled task lands in `FAILED` carrying a
+  `CancellationException`. Preserved as-is rather than widened here, but it makes cancellation
+  indistinguishable from failure to an API consumer reading `simplifiedState()` alone.
+- **`EvitaSession` carries 55 `@Interruptible` methods**, including trivial accessors such as
+  `getCatalogSchema()`. Left as found — narrowing the annotation to methods that actually do work is a
+  judgement call the original author may have made deliberately.
+- **The six structural branches still name their methods with string literals**, and a rename of
+  `Formula#compute`, `Sorter#sortAndSlice`, `ExtraResultProducer#fabricate`,
+  `FilteringConstraintTranslator#translate` or `OrderingConstraintTranslator#createSorter` is
+  compile-checked across every implementation while the matcher silently stops matching — the same
+  shape of failure that hid this bug for the annotation's whole lifetime. Deferred rather than
+  ignored: `InterruptionTransformerMatcherTest` asserts all seven branches individually, so a rename
+  now goes red in milliseconds without needing build artifacts.
+
+  The fix, when it is worth doing, is **not** to annotate the matched methods. Java does not inherit
+  method annotations (`@Inherited` covers class annotations only), so `@Interruptible` on an
+  interface method weaves nothing — the declaration is abstract and correctly excluded — and moving
+  it onto implementations would require every one of them to remember it. 56 types are in the
+  `Formula` lineage and only 4 declare a `compute()` body; the next implementation that declares one
+  and omits the annotation would be silently uninstrumented, which is exactly the failure this record
+  exists to prevent, merely relocated from one matcher to dozens of call sites.
+
+  What does work is annotating the **interface** method and replacing the six branches with a single
+  custom matcher — *"overrides a method declared in a supertype carrying `@Interruptible`"*. One
+  annotation per contract, no string literals, renames carried along by the compiler, and future
+  implementations covered by construction. ByteBuddy has no built-in for it, so it needs roughly
+  twenty-five lines walking supertypes through a `TypePool` (CLASS retention is visible there, which
+  is how `isAnnotatedWith` already resolves it).
+- **`Interruptible`'s JavaDoc does not say the annotation must sit on the concrete implementation.**
+  Given that method annotations are not inherited, and that `visit` rewrites declared methods only,
+  an override that omits it is not woven. That is a contract others code against.
+
+## Related work
+
+- `2026-07-16-client-session-cancellation-cascade` — built the client-facing half of this chain (Armeria
+  request cancellation wired through to executor tasks). That work delivered the interrupt correctly; this
+  record fixes the fact that nothing at the far end ever read it.
+
+## Timeline
+
+- **2026-08-14** — issue #1416 investigated, root cause corrected to the `anyOf` misuse, all three links
+  fixed, guard added

--- a/documentation/adr/2026-08-14-interruption-weaving-and-task-cancellation.md
+++ b/documentation/adr/2026-08-14-interruption-weaving-and-task-cancellation.md
@@ -1,7 +1,7 @@
 ---
 title: Weave the interrupt poll with `visit` and a chained matcher union, and interrupt tasks through the executor's Future
 date: 2026-08-14
-updated: 2026-08-14 14:35
+updated: 2026-08-14 14:50
 status: accepted
 kind: fix
 issues: [1416]
@@ -162,8 +162,10 @@ by weaving `EvitaSession#getCatalogSchema` with the retention untouched.
   It needs no build artifacts and would have caught the `anyOf` defect in milliseconds. `InterruptionAdviceWovenTest`
   keeps exactly one assertion per module, owning the orthogonal claim that the plugin ran against the shipped
   classes; the two are deliberately not merged.
-- Four further defects were found in the cancellation chain and fixed here, each calibrated by reverting the fix
-  and confirming its test fails with the predicted symptom:
+- Six further defects were found in the cancellation chain and fixed here, each calibrated by confirming its test
+  fails with the predicted symptom before the fix goes in. The last two were written test-first, which is the
+  preferable order for the reason recorded under *Consequences*: a test written red needs no revert step, so
+  there is nothing to forget to undo.
   - `AbstractServerTask#attachExecutionHandle` — a cancel arriving between `submit(...)` and the attach found no
     handle and never interrupted, silently reinstating the defect this record exists to fix.
     `SchedulerTest#shouldInterruptTaskCancelledBeforeHandleAttached`.
@@ -181,7 +183,22 @@ by weaving `EvitaSession#getCatalogSchema` with the retention untouched.
     Worth revisiting only if a caller is found that needs to tell the two apart.
   - `SequentialTask#execute` — the completion block ran on a cancelled sequence.
     `SequentialTaskTest#shouldStopAtStepBoundaryWhenResultFutureCancelledDirectly`.
-- Tag-scoped regression run after all fixes: `-Dgroups="task & engine"` → **97 tests, 0 failures**.
+  - `ObservableThreadExecutor#finishExecution` — the state machine above closed only half the window. Interrupt
+    *delivery* is gated on `executionState`, but flag *clearing* was gated on `future.isCancelled()`, and the two
+    disagree in a real ordering: once the delegate completes the future normally, a cancel can no longer cancel it
+    yet still wins `RUNNING -> CANCELLING` and genuinely interrupts the worker — which then left
+    `finishExecution()` with the flag set, leaking it onto the next task. Precisely the failure this record exists
+    to close, in the code added to close it. Clearing is now keyed on delivery
+    (`isCancelled() || state == INTERRUPTED`).
+    `ObservableThreadExecutorCancellationTest#shouldClearInterruptWhenCancelArrivedAfterFutureCompleted`.
+  - `AbstractServerTask#execute` — a body failing for its own reason while a cancel won the race was reported as a
+    routine cancellation: the real exception was discarded at `debug` and the status kept the
+    `CancellationException`, so a genuine production bug read as deliberate cancellation. `isCancelled()` answers
+    "was a cancel requested", never "is this why the body threw"; the branch now also requires the throwable to be
+    (or wrap) a `CancellationException`/`InterruptedException`.
+    `AbstractServerTaskCancellationTest#shouldKeepRealExceptionWhenUnrelatedFailureRacedCancellation`.
+- Tag-scoped regression run after all fixes: `-Dgroups="task & engine"` → **99 tests, 0 failures**; targeted
+  classes → **77 tests, 0 failures**. Both on a `mvn clean` rebuild of the woven modules.
 - Request-path run, because the `ObservableThreadExecutor` fix executes on every task completion in the Armeria
   request path and the tag scoping above is orthogonal to it: five GraphQL and REST end-to-end functional classes
   → **123 tests, 0 failures**, and zero `InterruptedException` occurrences in the log, which is the signal that
@@ -216,6 +233,16 @@ by weaving `EvitaSession#getCatalogSchema` with the retention untouched.
   a revert used as a measuring instrument must be restored and then re-verified against a freshly built
   artifact, and a comment is not evidence that the code beneath it exists. `mvn clean` on the woven module is
   what makes the verification mean anything, because the ByteBuddy `transform` goal is incremental.
+  The two fixes that followed were written test-first instead, which removes the hazard rather than managing it:
+  a red produced by a new test leaves nothing to restore.
+- **A cancelled task that fails for an unrelated reason keeps its exception but not its exception handler.** The
+  review that found this suggested falling through to the ordinary failure path. That path also invokes
+  `exceptionHandler`, whose sole purpose is to supply a default result — and the result future is already
+  cancelled, so it can never accept one; the handler would run for its side effects alone, against the documented
+  contract asserted by `shouldNotInvokeExceptionHandlerWhenTaskWasCancelled`. The narrower fix records the real
+  exception in the status and returns the cancelled outcome. Revisit if a caller ever needs the handler's side
+  effects on a cancelled task, which would make the two contracts genuinely incompatible rather than merely
+  adjacent.
 - **The thread-tracking pattern this record rejects for new code was still live in the request path**, and is
   now fixed rather than merely noted. `AbstractObservableTask#cancel()` reads a `volatile Thread` and interrupts
   it directly; nothing ordered that interrupt against the worker clearing its flag and taking the next task, so

--- a/documentation/adr/2026-08-14-interruption-weaving-and-task-cancellation.md
+++ b/documentation/adr/2026-08-14-interruption-weaving-and-task-cancellation.md
@@ -1,7 +1,7 @@
 ---
 title: Weave the interrupt poll with `visit` and a chained matcher union, and interrupt tasks through the executor's Future
 date: 2026-08-14
-updated: 2026-08-14 14:55
+updated: 2026-08-14 15:05
 status: accepted
 kind: fix
 issues: [1416]
@@ -155,8 +155,8 @@ by weaving `EvitaSession#getCatalogSchema` with the retention untouched.
   (`ExportS3ServiceTest`, "Could not find a valid Docker environment" — environmental, no Docker available).
   This belongs to the same pre-cancellation-fix build as the woven-site counts above: it proves the matcher fix
   does not destabilise the suite, and nothing about the four cancellation defects, whose tests did not exist
-  yet. It has not been reproduced since — the full suite OOMs on this machine at the standard heap — so
-  post-fix full-suite green is CI's claim, not this record's.
+  yet. It has not been reproduced since — the full suite OOMs on this machine at the standard heap — and it was
+  **not** re-run against the seven cancellation fixes before merge. See the note on CI timing below.
 - `InterruptionTransformerMatcherTest` (new) asserts each of the **seven** engine matcher branches individually
   plus the GraphQL branch, and asserts that the abstract declarations and an unrelated method do **not** match.
   It needs no build artifacts and would have caught the `anyOf` defect in milliseconds. `InterruptionAdviceWovenTest`
@@ -210,8 +210,14 @@ by weaving `EvitaSession#getCatalogSchema` with the retention untouched.
   → **123 tests, 0 failures**, and zero `InterruptedException` occurrences in the log, which is the signal that
   matters — the woven checkpoints are live throughout that path, so a stray interrupt would abort queries rather
   than pass silently.
-- The full suite is left to CI, which is green at the project's standard `-Xmx8g`; it OOMs on a developer
-  workstation, and raising the local heap would hide that divergence rather than explain it.
+- **The full suite never ran against these fixes before merge, and CI cannot have run it.** The only
+  `pull_request`-triggered workflows are `pr-review.yml` and CodeQL; neither executes a test. The Maven
+  invocation that runs the suite (`-P unitAndFunctional,full … -Dmaven.test.skip=false`) lives in `ci-dev.yml`,
+  which triggers on **push to `dev`** — so in this repository a pull request is validated *after* it merges, not
+  before. Recorded because "CI will catch it" is the natural assumption and it is wrong here: on a PR branch the
+  green checks are a code scan, not a test run. Local full-suite verification is the only pre-merge option and it
+  OOMs on a developer workstation at the project's standard `-Xmx8g`; raising the local heap would hide that
+  divergence rather than explain it, so the gap was left open knowingly rather than papered over.
 
 ## Consequences & open follow-ups
 

--- a/documentation/adr/2026-08-14-interruption-weaving-and-task-cancellation.md
+++ b/documentation/adr/2026-08-14-interruption-weaving-and-task-cancellation.md
@@ -1,7 +1,7 @@
 ---
 title: Weave the interrupt poll with `visit` and a chained matcher union, and interrupt tasks through the executor's Future
 date: 2026-08-14
-updated: 2026-08-14 14:50
+updated: 2026-08-14 14:55
 status: accepted
 kind: fix
 issues: [1416]
@@ -162,9 +162,9 @@ by weaving `EvitaSession#getCatalogSchema` with the retention untouched.
   It needs no build artifacts and would have caught the `anyOf` defect in milliseconds. `InterruptionAdviceWovenTest`
   keeps exactly one assertion per module, owning the orthogonal claim that the plugin ran against the shipped
   classes; the two are deliberately not merged.
-- Six further defects were found in the cancellation chain and fixed here, each calibrated by confirming its test
-  fails with the predicted symptom before the fix goes in. The last two were written test-first, which is the
-  preferable order for the reason recorded under *Consequences*: a test written red needs no revert step, so
+- Seven further defects were found in the cancellation chain and fixed here, each calibrated by confirming its
+  test fails with the predicted symptom before the fix goes in. The last three were written test-first, which is
+  the preferable order for the reason recorded under *Consequences*: a test written red needs no revert step, so
   there is nothing to forget to undo.
   - `AbstractServerTask#attachExecutionHandle` — a cancel arriving between `submit(...)` and the attach found no
     handle and never interrupted, silently reinstating the defect this record exists to fix.
@@ -197,8 +197,14 @@ by weaving `EvitaSession#getCatalogSchema` with the retention untouched.
     "was a cancel requested", never "is this why the body threw"; the branch now also requires the throwable to be
     (or wrap) a `CancellationException`/`InterruptedException`.
     `AbstractServerTaskCancellationTest#shouldKeepRealExceptionWhenUnrelatedFailureRacedCancellation`.
-- Tag-scoped regression run after all fixes: `-Dgroups="task & engine"` → **99 tests, 0 failures**; targeted
-  classes → **77 tests, 0 failures**. Both on a `mvn clean` rebuild of the woven modules.
+  - `SequentialTask#execute` again, one window further on — the guard added above stops a cancel that arrives
+    *before* the post-loop check, but a cancel landing after it was stamped back to FINISHED. `complete()`
+    correctly no-ops on the cancelled future, yet the status transition that followed ran unconditionally and
+    `transitionToFinished` does not inspect what it replaces, so the sequence reported FINISHED with a real
+    result while its own future reported cancelled. `complete()`'s return value is now the race arbiter.
+    `SequentialTaskTest#shouldNotReportFinishedWhenCancelLandedAfterLastStep`.
+- Tag-scoped regression run after all fixes: `-Dgroups="task & engine"` → **100 tests, 0 failures**; targeted
+  classes → **78 tests, 0 failures**. Both on a `mvn clean` rebuild of the woven modules.
 - Request-path run, because the `ObservableThreadExecutor` fix executes on every task completion in the Armeria
   request path and the tag scoping above is orthogonal to it: five GraphQL and REST end-to-end functional classes
   → **123 tests, 0 failures**, and zero `InterruptedException` occurrences in the log, which is the signal that
@@ -243,6 +249,15 @@ by weaving `EvitaSession#getCatalogSchema` with the retention untouched.
   exception in the status and returns the cancelled outcome. Revisit if a caller ever needs the handler's side
   effects on a cancelled task, which would make the two contracts genuinely incompatible rather than merely
   adjacent.
+- **`isCancelled()` is a check-then-act hazard, and it produced three separate defects in this one record.**
+  Reading it and then acting on the answer is only correct while nothing can cancel in between — and on every
+  path here something can. The three instances failed in different ways for the same reason: clearing the
+  interrupt flag on it missed an interrupt that was genuinely delivered; branching on it attributed an unrelated
+  failure to cancellation; guarding a completion block with it left a window on the far side of the check. The
+  general shape of the fix is to act on something atomic and then read the outcome — `complete()`'s return value,
+  a CAS on an explicit state — rather than to ask a question whose answer is stale by the next line. Treat a bare
+  `isCancelled()` on a concurrent path as suspect; the reliable uses left in this code are the ones where the
+  answer being stale is harmless.
 - **The thread-tracking pattern this record rejects for new code was still live in the request path**, and is
   now fixed rather than merely noted. `AbstractObservableTask#cancel()` reads a `volatile Thread` and interrupts
   it directly; nothing ordered that interrupt against the worker clearing its flag and taking the next task, so

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-14 | [Weave the interrupt poll with `visit` and a chained matcher union, and interrupt tasks through the executor's Future](2026-08-14-interruption-weaving-and-task-cancellation.md) | fix | accepted | #1416 |
 | 2026-08-10 | [Statistics are selectable components at two levels, and an exact heap figure is reached one index at a time](2026-08-10-catalog-and-collection-statistics/) | feature | accepted | #1339, PR #1418 |
 | 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-06 | [Bound time travel with an absolute per-catalog byte budget, not a ratio or a generation count](2026-08-06-time-travel-disk-budget.md) | feature | accepted | #761, PR #1402 |

--- a/evita_engine/src/main/java/io/evitadb/core/executor/AbstractInterruptionTransformer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/AbstractInterruptionTransformer.java
@@ -1,0 +1,120 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.executor;
+
+import io.evitadb.core.executor.InterruptionTransformer.InterruptionAdvice;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.AsmVisitorWrapper;
+import net.bytebuddy.build.Plugin;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Base class for the build-time ByteBuddy plugins that weave {@link InterruptionAdvice} into methods which must poll
+ * the thread interrupt flag on entry. Subclasses only supply the matcher describing *which* methods those are.
+ *
+ * ## Why the advice is applied via `visit` rather than `intercept`
+ *
+ * `builder.visit(Advice.to(...).on(matcher))` rewrites the body of every **declared** method that matches, in place.
+ * The alternative — `builder.method(matcher).intercept(Advice.to(...))` — instead matches *invokable* methods,
+ * including inherited ones, and therefore generates a synthetic override in every subclass that merely inherits a
+ * matching method. On `Formula#compute`, the hottest path in the engine, that added one extra frame per formula node
+ * for no additional coverage: the check already sits on the declaring implementation. Both forms work under the
+ * `byte-buddy-maven-plugin` default `REBASE` entry point; `visit` is chosen purely because it is the leaner of the
+ * two.
+ *
+ * ## A matcher that matches nothing fails silently
+ *
+ * A ByteBuddy matcher that matches nothing is indistinguishable from one that works — the plugin logs
+ * `Transformed N type(s)` either way. That is exactly how the original defect stayed hidden for the whole lifetime of
+ * the annotation: the matcher union was built with `ElementMatchers.anyOf(...)`, whose `Object...` overload compares
+ * candidates using {@link Object#equals(Object)} against the supplied values, so passing matcher instances to it
+ * matched no method anywhere, in any module, ever.
+ *
+ * Nothing here can detect that, because the `transform` goal is incremental: when nothing recompiled it processes
+ * zero types, so a "this plugin wove nothing" assertion cannot tell a dead matcher from an up-to-date build. The
+ * guard therefore lives in `InterruptionAdviceWovenTest`, which asserts the poll is present in the **built**
+ * class files of each module.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+public abstract class AbstractInterruptionTransformer implements Plugin {
+	/**
+	 * The advice visitor, resolved once per plugin instance because
+	 * {@link #apply(DynamicType.Builder, TypeDescription, ClassFileLocator)} is invoked for every type in the module.
+	 */
+	@Nonnull private final AsmVisitorWrapper advice;
+
+	/**
+	 * Resolves the matcher and the advice visitor once, because
+	 * {@link #apply(DynamicType.Builder, TypeDescription, ClassFileLocator)} runs for every type in the module.
+	 *
+	 * Note that {@link #interruptibleMethods()} is invoked from here and therefore must not depend on subclass state.
+	 */
+	protected AbstractInterruptionTransformer() {
+		this.advice = Advice.to(InterruptionAdvice.class).on(interruptibleMethods());
+	}
+
+	/**
+	 * Returns the matcher selecting the methods that must poll the thread interrupt flag on entry.
+	 *
+	 * Assemble a union by chaining {@link ElementMatcher.Junction#or(ElementMatcher)} — never via
+	 * `ElementMatchers.anyOf(...)`, which is an equality matcher over values and silently matches nothing when handed
+	 * matcher instances.
+	 *
+	 * The returned matcher must exclude abstract methods; they have no body to instrument.
+	 *
+	 * Invoked from the constructor, so implementations must not read subclass state.
+	 *
+	 * @return matcher applied to the declared methods of every type in the module
+	 */
+	@Nonnull
+	protected abstract ElementMatcher.Junction<MethodDescription> interruptibleMethods();
+
+	@Override
+	public boolean matches(@Nonnull TypeDescription target) {
+		return true;
+	}
+
+	@Nonnull
+	@Override
+	public DynamicType.Builder<?> apply(
+		@Nonnull DynamicType.Builder<?> builder,
+		@Nonnull TypeDescription typeDescription,
+		@Nonnull ClassFileLocator classFileLocator
+	) {
+		return builder.visit(this.advice);
+	}
+
+	@Override
+	public void close() {
+		// no resources to release
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/core/executor/AbstractServerTask.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/AbstractServerTask.java
@@ -53,6 +53,11 @@ import java.util.function.Predicate;
 @Slf4j
 abstract class AbstractServerTask<S, T> implements ServerTask<S, T>, InterruptibleServerTask {
 	/**
+	 * Upper bound on how far {@link #isCancellationDriven(Throwable)} walks a cause chain, so a self-referential or
+	 * looping chain cannot spin the worker thread forever.
+	 */
+	private static final int MAX_CAUSE_CHAIN_DEPTH = 32;
+	/**
 	 * The exception handler that is called when an exception is thrown during the task execution.
 	 * When the exception handler doesn't throw exception and instead returns a compatible value it's considered as a
 	 * successful handling of the exception and value is returned as a result of the task.
@@ -233,11 +238,24 @@ abstract class AbstractServerTask<S, T> implements ServerTask<S, T>, Interruptib
 				return executeAndCompleteFuture();
 			} catch (Throwable e) {
 				if (this.future.isCancelled()) {
-					// the task was cancelled and the interrupt unwound it - that is the requested outcome, not a
-					// failure. The status already carries the CancellationException from ServerTaskCompletableFuture
-					// #cancel, and overwriting it here would report a cancelled task as failed and log a stack trace
-					// for work the caller deliberately stopped.
-					log.debug("Task cancelled: {}", theStatus.taskName());
+					if (isCancellationDriven(e)) {
+						// the task was cancelled and the interrupt unwound it - that is the requested outcome, not a
+						// failure. The status already carries the CancellationException from
+						// ServerTaskCompletableFuture#cancel, and overwriting it here would report a cancelled task
+						// as failed and log a stack trace for work the caller deliberately stopped.
+						log.debug("Task cancelled: {}", theStatus.taskName());
+						return null;
+					}
+					// cancelled, but this exception is not the cancellation unwinding: the body failed for its own
+					// reason while a cancel happened to win the race. Trusting isCancelled() alone here would discard a
+					// genuine production failure at debug level and leave the status carrying a CancellationException,
+					// making a real bug read as a routine cancellation. Record the real exception - but do not run the
+					// exception handler, whose only purpose is to supply a default result the cancelled future can no
+					// longer accept, and return the cancelled outcome the caller asked for.
+					log.error("Task failed while being cancelled: {}", theStatus.taskName(), e);
+					this.status.updateAndGet(
+						currentStatus -> currentStatus.transitionToFailed(e)
+					);
 					return null;
 				}
 				log.error("Task failed: {}", theStatus.taskName(), e);
@@ -264,6 +282,35 @@ abstract class AbstractServerTask<S, T> implements ServerTask<S, T>, Interruptib
 		} else {
 			return null;
 		}
+	}
+
+	/**
+	 * Tells whether the given throwable is the cancellation unwinding this task, rather than an independent failure
+	 * that merely coincided with one.
+	 *
+	 * `Future#isCancelled` answers "was a cancel requested", never "is this why the body threw" — so it cannot
+	 * distinguish an interrupt tearing the task down from a genuine `IOException` raised microseconds before some
+	 * other thread called `cancel()`. Both cancellation routes are recognised here: `CancellationException`, raised
+	 * when the already-cancelled result future is read, and `InterruptedException`, raised by the `@Interruptible`
+	 * checkpoints woven into the task body — the latter typically arrives wrapped, hence the walk down the cause
+	 * chain.
+	 *
+	 * The chain walk is depth-bounded because a cause chain is not guaranteed acyclic: a throwable may be its own
+	 * cause, and hand-assembled chains can loop.
+	 *
+	 * @param throwable the throwable the task body unwound with
+	 * @return true when the throwable is (or wraps) the cancellation itself
+	 */
+	private static boolean isCancellationDriven(@Nonnull Throwable throwable) {
+		Throwable current = throwable;
+		for (int depth = 0; current != null && depth < MAX_CAUSE_CHAIN_DEPTH; depth++) {
+			if (current instanceof CancellationException || current instanceof InterruptedException) {
+				return true;
+			}
+			final Throwable cause = current.getCause();
+			current = cause == current ? null : cause;
+		}
+		return false;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/executor/AbstractServerTask.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/AbstractServerTask.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -50,7 +51,7 @@ import java.util.function.Predicate;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
 @Slf4j
-abstract class AbstractServerTask<S, T> implements ServerTask<S, T> {
+abstract class AbstractServerTask<S, T> implements ServerTask<S, T>, InterruptibleServerTask {
 	/**
 	 * The exception handler that is called when an exception is thrown during the task execution.
 	 * When the exception handler doesn't throw exception and instead returns a compatible value it's considered as a
@@ -69,6 +70,13 @@ abstract class AbstractServerTask<S, T> implements ServerTask<S, T> {
 	 * The type of the task.
 	 */
 	protected final String taskType;
+	/**
+	 * The executor's handle for this task, attached by {@link Scheduler#submitTaskInQueue} after submission. It is the
+	 * only handle capable of interrupting the worker thread — see {@link InterruptibleServerTask} for why
+	 * {@link #future} cannot do it. Remains `null` for tasks that were never submitted through the scheduler (e.g.
+	 * `@InternallyScheduledTask`, executed inline on the submitter's thread).
+	 */
+	@Nullable private volatile Future<?> executionHandle;
 
 	protected AbstractServerTask(@Nonnull String taskType, @Nonnull String taskName, @Nonnull S settings, @Nonnull TaskTrait... traits) {
 		this.taskType = taskType;
@@ -179,11 +187,30 @@ abstract class AbstractServerTask<S, T> implements ServerTask<S, T> {
 	}
 
 	@Override
+	public void attachExecutionHandle(@Nonnull Future<?> handle) {
+		// publish the handle first, then re-read the result future - the mirror image of cancel(), which cancels the
+		// result future first and only then reads the handle. Both sides touch the same two volatile locations in
+		// opposite order, so at least one of them observes the other and a cancel racing the attachment cannot be lost
+		this.executionHandle = handle;
+		if (this.future.isCancelled()) {
+			handle.cancel(true);
+		}
+	}
+
+	@Override
 	public boolean cancel() {
 		if (this.future.isDone() || this.future.isCancelled()) {
 			return false;
 		} else {
-			return this.future.cancel(true);
+			// cancel the result future first, so the status carries the CancellationException before the interrupt
+			// unwinds executeInternal() - otherwise execute() would report the cancellation as an ordinary failure
+			final boolean cancelled = this.future.cancel(true);
+			// ... and only then interrupt the worker, which the result future alone cannot do
+			final Future<?> handle = this.executionHandle;
+			if (handle != null) {
+				handle.cancel(true);
+			}
+			return cancelled;
 		}
 	}
 
@@ -205,6 +232,14 @@ abstract class AbstractServerTask<S, T> implements ServerTask<S, T> {
 			try {
 				return executeAndCompleteFuture();
 			} catch (Throwable e) {
+				if (this.future.isCancelled()) {
+					// the task was cancelled and the interrupt unwound it - that is the requested outcome, not a
+					// failure. The status already carries the CancellationException from ServerTaskCompletableFuture
+					// #cancel, and overwriting it here would report a cancelled task as failed and log a stack trace
+					// for work the caller deliberately stopped.
+					log.debug("Task cancelled: {}", theStatus.taskName());
+					return null;
+				}
 				log.error("Task failed: {}", theStatus.taskName(), e);
 				this.status.updateAndGet(
 					currentStatus -> currentStatus.transitionToFailed(e)

--- a/evita_engine/src/main/java/io/evitadb/core/executor/Interruptible.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/Interruptible.java
@@ -29,7 +29,26 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Methods annotated with this annotation will have automatically injected this code
+ * Marks a method whose body must poll the thread interrupt flag on entry, so that cancelling the owning task or
+ * query can unwind it promptly instead of letting it run to completion. Build-time ByteBuddy weaving
+ * (`AbstractInterruptionTransformer`) injects that poll into every method this annotation selects - see that
+ * class for the weaving mechanics and the matcher-union pitfall it guards against.
+ *
+ * ## The annotation must sit on the concrete implementation
+ *
+ * The weaving rewrites only **declared** methods of the type being processed; inherited methods are left alone.
+ * Combined with the fact that Java does not inherit method annotations at all (`@Inherited` governs class-level
+ * annotations only, never method-level ones), this annotation has to be repeated on every override that needs the
+ * poll:
+ *
+ * - Placing it on an abstract method - whether declared on an interface or an abstract class - weaves nothing:
+ *   there is no body to instrument, and the matcher that selects `@Interruptible` methods explicitly excludes
+ *   abstract methods.
+ * - Placing it on a base implementation does not carry over to a subclass that overrides the method without
+ *   repeating the annotation - that override is silently left unwoven, with no compiler or build warning.
+ *
+ * `EvitaSession#getCatalogSchema` carries this annotation on exactly that basis: the method it implements is
+ * declared on `EvitaSessionContract`, and only the concrete override in `EvitaSession` is ever woven.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */

--- a/evita_engine/src/main/java/io/evitadb/core/executor/InterruptibleServerTask.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/InterruptibleServerTask.java
@@ -1,0 +1,83 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.executor;
+
+import io.evitadb.api.task.ServerTask;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+/**
+ * Implemented by {@link ServerTask}s whose cancellation must be able to interrupt the worker thread that is currently
+ * running them.
+ *
+ * ## Why the executor's handle is needed
+ *
+ * A task's own {@link ServerTask#getFutureResult()} is a {@link CompletableFuture}, and
+ * {@link CompletableFuture#cancel(boolean)} documents that `mayInterruptIfRunning` **has no effect** — that
+ * implementation does not use interrupts at all. Cancelling through it therefore marks the result cancelled while the
+ * worker thread keeps running to completion, burning CPU nobody is waiting for.
+ *
+ * The only handle that can interrupt the worker is the {@link Future} returned by the executor's `submit(...)`, which
+ * is backed by a `FutureTask`. {@link Scheduler#submitTaskInQueue} used to discard it. It now hands it here instead,
+ * so {@link ServerTask#cancel()} can interrupt for real.
+ *
+ * A `FutureTask` is preferred over tracking the executing thread and interrupting it directly: its cancel state machine
+ * only delivers the interrupt while the task is genuinely running, so a cancel racing with completion cannot poison the
+ * next task that the pooled thread picks up. That distinction matters now that the `@Interruptible` checkpoints
+ * actually poll the flag.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+interface InterruptibleServerTask {
+
+	/**
+	 * Attaches the executor handle that {@link ServerTask#cancel()} uses to interrupt the running worker thread.
+	 *
+	 * Called by {@link Scheduler#submitTaskInQueue} right after submission — which means the task may already be
+	 * running, or even finished, by the time this arrives. Implementations must therefore accept the handle at any
+	 * point in the lifecycle.
+	 *
+	 * ## The handshake implementations must honour
+	 *
+	 * A cancel arriving in the window between `submit(...)` and this call cannot rely on the `QUEUED` guard in the
+	 * task's `execute()` to stop the body: once the worker has read the status and transitioned the task to STARTED,
+	 * that guard is already behind it and nothing else stops the work. Losing the cancel there would leave the task
+	 * running to completion with a cancelled result future — the outcome this interface exists to prevent.
+	 *
+	 * The two sides therefore touch the same two volatile locations in **opposite** order:
+	 *
+	 * - `cancel()` cancels the result future first, then reads the handle,
+	 * - this method publishes the handle first, then re-reads the result future and cancels the handle when it finds
+	 *   the task already cancelled.
+	 *
+	 * At least one side is then guaranteed to observe the other, so a cancel racing the attachment is never lost.
+	 * Implementations must keep both fields volatile and must not reorder these two steps.
+	 *
+	 * @param handle the executor's handle for the submitted task
+	 */
+	void attachExecutionHandle(@Nonnull Future<?> handle);
+
+}

--- a/evita_engine/src/main/java/io/evitadb/core/executor/InterruptionTransformer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/InterruptionTransformer.java
@@ -30,10 +30,8 @@ import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
 import io.evitadb.core.query.sort.Sorter;
 import io.evitadb.core.query.sort.translator.OrderingConstraintTranslator;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.build.Plugin;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.ClassFileLocator;
-import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 
 import javax.annotation.Nonnull;
@@ -42,58 +40,56 @@ import javax.annotation.Nonnull;
  * ByteBuddy transformer that injects {@link InterruptionAdvice} into specific methods used during query execution
  * shared logic that checks for thread interruption. If the thread is interrupted, the method throws an
  * {@link InterruptedException} and effectively stops the query execution.
+ *
+ * Weaving mechanics and the build-time guard against a matcher that stops matching live in
+ * {@link AbstractInterruptionTransformer}.
  */
-public class InterruptionTransformer implements Plugin {
+public class InterruptionTransformer extends AbstractInterruptionTransformer {
 
-	@Override
-	public boolean matches(TypeDescription target) {
-		return true;
-	}
-
+	/**
+	 * Matches every method that must poll the thread interrupt flag on entry.
+	 *
+	 * The union is assembled by chaining {@link ElementMatcher.Junction#or(ElementMatcher)} — deliberately **not**
+	 * via `ElementMatchers.anyOf(...)`, which compares candidates with {@link Object#equals(Object)} against the
+	 * supplied values and therefore silently matches nothing when handed matcher instances.
+	 *
+	 * Abstract methods are excluded last, so the exclusion applies to the whole union rather than to a single branch.
+	 */
 	@Nonnull
 	@Override
-	public DynamicType.Builder<?> apply(
-		DynamicType.Builder<?> builder,
-		@Nonnull TypeDescription typeDescription,
-		@Nonnull ClassFileLocator classFileLocator
-	) {
-		return builder.method(
-				ElementMatchers.anyOf(
-					/* any interruptible method */
-					ElementMatchers.isAnnotatedWith(Interruptible.class)
-						.and(ElementMatchers.not(ElementMatchers.isAbstract())),
-					/* analysis of filtering constraints and conversion to Formulas */
-					ElementMatchers.isOverriddenFrom(FilteringConstraintTranslator.class)
-						.and(ElementMatchers.named("translate"))
-						.and(ElementMatchers.not(ElementMatchers.isAbstract())),
-					/* Formula calculation */
-					ElementMatchers.isOverriddenFrom(Formula.class)
-						.and(ElementMatchers.named("compute"))
-						.and(ElementMatchers.not(ElementMatchers.isAbstract())),
-					/* analysis of ordering constraints and conversion to Sorters */
-					ElementMatchers.isOverriddenFrom(OrderingConstraintTranslator.class)
-						.and(ElementMatchers.named("createSorter"))
-						.and(ElementMatchers.isAbstract()),
-					/* Sorters application */
-					ElementMatchers.isOverriddenFrom(Sorter.class)
-						.and(ElementMatchers.named("sortAndSlice"))
-						.and(ElementMatchers.isAbstract()),
-					/* analysis of require constraints and conversion to ExtraResultComputers */
-					ElementMatchers.isOverriddenFrom(ExtraResultProducer.class)
-						.and(ElementMatchers.named("fabricate"))
-						.and(ElementMatchers.isAbstract()),
-					/* ExtraResultComputers invocation */
-					ElementMatchers.isOverriddenFrom(EvitaResponseExtraResultComputer.class)
-						.and(ElementMatchers.named("compute"))
-						.and(ElementMatchers.isAbstract())
-				)
+	protected ElementMatcher.Junction<MethodDescription> interruptibleMethods() {
+		return ElementMatchers.<MethodDescription>isAnnotatedWith(Interruptible.class)
+			/* analysis of filtering constraints and conversion to Formulas */
+			.or(
+				ElementMatchers.<MethodDescription>isOverriddenFrom(FilteringConstraintTranslator.class)
+					.and(ElementMatchers.named("translate"))
 			)
-			.intercept(Advice.to(InterruptionAdvice.class));
-	}
-
-	@Override
-	public void close() {
-		// No resources to release
+			/* Formula calculation */
+			.or(
+				ElementMatchers.<MethodDescription>isOverriddenFrom(Formula.class)
+					.and(ElementMatchers.named("compute"))
+			)
+			/* analysis of ordering constraints and conversion to Sorters */
+			.or(
+				ElementMatchers.<MethodDescription>isOverriddenFrom(OrderingConstraintTranslator.class)
+					.and(ElementMatchers.named("createSorter"))
+			)
+			/* Sorters application */
+			.or(
+				ElementMatchers.<MethodDescription>isOverriddenFrom(Sorter.class)
+					.and(ElementMatchers.named("sortAndSlice"))
+			)
+			/* analysis of require constraints and conversion to ExtraResultComputers */
+			.or(
+				ElementMatchers.<MethodDescription>isOverriddenFrom(ExtraResultProducer.class)
+					.and(ElementMatchers.named("fabricate"))
+			)
+			/* ExtraResultComputers invocation */
+			.or(
+				ElementMatchers.<MethodDescription>isOverriddenFrom(EvitaResponseExtraResultComputer.class)
+					.and(ElementMatchers.named("compute"))
+			)
+			.and(ElementMatchers.not(ElementMatchers.isAbstract()));
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/executor/ObservableThreadExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/ObservableThreadExecutor.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -717,6 +718,21 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 		 * Volatile ensures visibility between the worker thread and any cancelling thread.
 		 */
 		@Nullable protected volatile Thread executingThread;
+		/**
+		 * Where this task stands as interrupt delivery sees it.
+		 *
+		 * The {@link #executingThread} reference alone cannot make delivery safe: nothing orders a canceller's
+		 * `Thread#interrupt()` call against the worker clearing that field and moving on, so a cancel arriving just as
+		 * the task finishes can land its interrupt inside the *next*, unrelated task the pooled thread picks up. Now
+		 * that the `@Interruptible` checkpoints actually poll the flag, that aborts a healthy request with an
+		 * `InterruptedException` its signatures never declared.
+		 *
+		 * This state machine closes the window the way `FutureTask` does: only a canceller that wins the
+		 * `RUNNING -> CANCELLING` transition delivers an interrupt at all, and {@link #finishExecution()} waits that
+		 * transition out before clearing the flag. The interrupt is therefore delivered inside the delegate's own
+		 * execution, or not at all.
+		 */
+		private final AtomicReference<ExecutionState> executionState = new AtomicReference<>(ExecutionState.PENDING);
 
 		/**
 		 * @param name         human-readable task identifier returned by {@link #toString()}, or {@code null}
@@ -761,19 +777,49 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 		 * In both cases {@link #onCompletion} is fired (at most once) and the internal future is transitioned to
 		 * the cancelled state.
 		 *
+		 * The interrupt is only ever sent by the caller that wins the `RUNNING -> CANCELLING` transition, and the
+		 * worker cannot leave {@link #finishExecution()} until that transition completes — see
+		 * {@link #executionState} for why a bare `executingThread.interrupt()` is not enough.
+		 *
 		 * This method is safe to call from any thread and is idempotent.
 		 */
 		@Override
 		public void cancel() {
 			this.future.cancel(true);
 			fireCompletion();
-			final Thread t = this.executingThread;
-			if (t != null) {
-				t.interrupt();
+			// outside RUNNING there is nothing safe to interrupt: the worker either has not started (its run/call
+			// method will return without touching the delegate) or has already left, and an interrupt sent then lands
+			// on whatever that pooled thread runs next
+			if (this.executionState.compareAndSet(ExecutionState.RUNNING, ExecutionState.CANCELLING)) {
+				try {
+					final Thread t = this.executingThread;
+					if (t != null) {
+						deliverInterrupt(t);
+					}
+				} finally {
+					// in a finally because finishExecution() parks while this task is CANCELLING - a delivery that
+					// threw would otherwise leave the worker spinning for the life of the process
+					this.executionState.set(ExecutionState.INTERRUPTED);
+				}
 			}
 			new BackgroundTaskTimedOutEvent(
 				this.name == null ? "Unknown" : this.name, 1
 			).commit();
+		}
+
+		/**
+		 * Delivers the cancellation interrupt to the worker thread running this task.
+		 *
+		 * Invoked by {@link #cancel()} while the task is held in `CANCELLING`, which is precisely what guarantees the
+		 * interrupt lands inside the delegate's own execution rather than in whatever the pooled thread runs next.
+		 *
+		 * Carved out as its own method so a test can hold the delivery open and observe that a finishing worker waits
+		 * for it; production code has no reason to override it.
+		 *
+		 * @param thread the worker thread to interrupt
+		 */
+		protected void deliverInterrupt(@Nonnull Thread thread) {
+			thread.interrupt();
 		}
 
 		@Nonnull
@@ -798,13 +844,37 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 		}
 
 		/**
+		 * Pre-execution bookkeeping invoked at the very start of the subclass's run/call method: publishes the worker
+		 * thread, then moves the task into `RUNNING`.
+		 *
+		 * That order is what makes {@link #cancel()} safe — a canceller winning the `RUNNING -> CANCELLING`
+		 * transition is thereby guaranteed to find a thread to interrupt rather than a `null`.
+		 */
+		protected void beginExecution() {
+			this.executingThread = Thread.currentThread();
+			this.executionState.compareAndSet(ExecutionState.PENDING, ExecutionState.RUNNING);
+		}
+
+		/**
 		 * Post-execution cleanup invoked from the {@code finally} block of the subclass's run/call method: fires
-		 * the completion callback exactly once, clears the executing-thread reference, and clears the worker
-		 * thread's interrupt flag when the task was cancelled so the interrupt does not leak into the next task
-		 * picked up by the same worker thread.
+		 * the completion callback exactly once, closes the task to further interrupt delivery, clears the
+		 * executing-thread reference, and clears the worker thread's interrupt flag when the task was cancelled so
+		 * the interrupt does not leak into the next task picked up by the same worker thread.
+		 *
+		 * When a concurrent {@link #cancel()} has already claimed the task, this method parks until that cancel has
+		 * finished delivering — clearing the flag while an interrupt is still in flight would let it arrive after the
+		 * worker has moved on, which is the whole failure mode {@link #executionState} exists to rule out.
 		 */
 		protected void finishExecution() {
 			fireCompletion();
+			if (!this.executionState.compareAndSet(ExecutionState.RUNNING, ExecutionState.DONE)) {
+				// a canceller claimed this task and is delivering its interrupt right now. `Thread#yield` rather than
+				// `Thread#onSpinWait`: what is being waited for is another thread being scheduled, not a cache line
+				// arriving - `FutureTask#handlePossibleCancellationInterrupt` waits the same way for the same reason
+				while (this.executionState.get() == ExecutionState.CANCELLING) {
+					Thread.yield();
+				}
+			}
 			this.executingThread = null;
 			// clear interrupt flag to prevent leaking to the next task on this worker thread
 			if (this.future.isCancelled()) {
@@ -817,6 +887,21 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 		public String toString() {
 			return this.name == null ? getDelegate().toString() : this.name;
 		}
+
+		/**
+		 * Lifecycle of a single task run, as {@link #cancel()} and {@link #finishExecution()} see it.
+		 *
+		 * - `PENDING` — no worker has picked the task up; a cancel must not interrupt anything.
+		 * - `RUNNING` — the delegate is executing on {@link #executingThread}; the only state an interrupt may be
+		 *   delivered from.
+		 * - `CANCELLING` — a canceller has claimed the interrupt and is delivering it; the worker must not clear the
+		 *   flag nor leave {@link #finishExecution()} while this holds.
+		 * - `INTERRUPTED` — the interrupt has been delivered and the worker is free to finish.
+		 * - `DONE` — the task finished before any cancel claimed it, so no interrupt will ever be delivered.
+		 */
+		private enum ExecutionState {
+			PENDING, RUNNING, CANCELLING, INTERRUPTED, DONE
+		}
 	}
 
 	/**
@@ -826,7 +911,8 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 	 *
 	 * - Captures the caller's MDC / tracing context at construction time and restores it on the worker thread
 	 *   for the duration of {@link #run()}, enabling correlated log entries across thread boundaries.
-	 * - Tracks the executing thread via a volatile field so that {@link #cancel()} can interrupt it at any time.
+	 * - Tracks the executing thread and the task's execution state so that {@link #cancel()} can interrupt it for
+	 *   exactly as long as the delegate is running, and no longer.
 	 * - Exposes a {@link CompletableFuture} that is completed (normally, exceptionally, or via cancellation)
 	 *   when the task finishes, allowing callers to chain dependent actions.
 	 * - Decrements the outer executor's queue-size counter exactly once when the task either completes or is
@@ -884,22 +970,22 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 		 *
 		 * Execution sequence:
 		 *
-		 * 1. Records the current thread in {@link #executingThread} so that a concurrent {@link #cancel()}
-		 *    call can interrupt it.
+		 * 1. Runs the shared {@link #beginExecution()} bookkeeping, which publishes the current thread and opens the
+		 *    window in which a concurrent {@link #cancel()} call may interrupt it.
 		 * 2. Returns immediately if the future was already cancelled.
 		 * 3. Restores the captured tracing context (MDC + thread-local) if one was present at construction time.
 		 * 4. Invokes the delegate. On success the future is completed normally; on exception the future is
 		 *    completed exceptionally, the error is logged, and the exception is rethrown wrapped in
 		 *    {@link ObservableExecutionException}.
 		 * 5. Clears the tracing context in a {@code finally} block.
-		 * 6. Runs the shared {@link #finishExecution()} cleanup (fires {@link #onCompletion} exactly once,
-		 *    clears {@link #executingThread}, and clears a leftover interrupt flag on cancellation).
+		 * 6. Runs the shared {@link #finishExecution()} cleanup (fires {@link #onCompletion} exactly once, closes the
+		 *    interrupt window, clears {@link #executingThread}, and clears a leftover flag on cancellation).
 		 *
 		 * @throws ObservableExecutionException wrapping any exception thrown by the delegate
 		 */
 		@Override
 		public void run() {
-			this.executingThread = Thread.currentThread();
+			beginExecution();
 			try {
 				if (this.future.isCancelled()) {
 					return;
@@ -995,7 +1081,7 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 		@Nullable
 		@Override
 		public V call() throws Exception {
-			this.executingThread = Thread.currentThread();
+			beginExecution();
 			try {
 				if (this.future.isCancelled()) {
 					return null;

--- a/evita_engine/src/main/java/io/evitadb/core/executor/ObservableThreadExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/ObservableThreadExecutor.java
@@ -858,8 +858,8 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 		/**
 		 * Post-execution cleanup invoked from the {@code finally} block of the subclass's run/call method: fires
 		 * the completion callback exactly once, closes the task to further interrupt delivery, clears the
-		 * executing-thread reference, and clears the worker thread's interrupt flag when the task was cancelled so
-		 * the interrupt does not leak into the next task picked up by the same worker thread.
+		 * executing-thread reference, and clears the worker thread's interrupt flag when an interrupt was or could
+		 * have been delivered, so it does not leak into the next task picked up by the same worker thread.
 		 *
 		 * When a concurrent {@link #cancel()} has already claimed the task, this method parks until that cancel has
 		 * finished delivering — clearing the flag while an interrupt is still in flight would let it arrive after the
@@ -876,8 +876,16 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 				}
 			}
 			this.executingThread = null;
-			// clear interrupt flag to prevent leaking to the next task on this worker thread
-			if (this.future.isCancelled()) {
+			// clear the interrupt flag so it cannot leak into the next task this worker picks up. The condition has to
+			// track *delivery*, which is what `executionState` governs - not the future's outcome. A cancel arriving
+			// after the delegate already completed the future normally fails `future.cancel(true)`, yet still wins
+			// `RUNNING -> CANCELLING` and genuinely interrupts this thread; gating on `isCancelled()` alone left that
+			// flag set, which is the exact leak this state machine exists to prevent. `isCancelled()` is still needed
+			// for the mirror case, where the task was cancelled before it ever reached RUNNING and no interrupt was
+			// ever delivered - clearing there is harmless and keeps the pre-start path unchanged.
+			// Covered by ObservableThreadExecutorCancellationTest
+			// #shouldClearInterruptWhenCancelArrivedAfterFutureCompleted
+			if (this.future.isCancelled() || this.executionState.get() == ExecutionState.INTERRUPTED) {
 				//noinspection ResultOfMethodCallIgnored
 				Thread.interrupted();
 			}

--- a/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
@@ -657,6 +657,14 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	/**
 	 * Submits a given server task to the internal queue for execution.
 	 *
+	 * The {@link Future} handed back by the executor is retained on the task (when it implements
+	 * {@link InterruptibleServerTask}) rather than discarded: it is the only handle that can interrupt the worker
+	 * thread, because the task's own {@link CompletableFuture} ignores `mayInterruptIfRunning`. Without it
+	 * {@link #cancelTask(UUID)} could mark a running task cancelled but never stop it.
+	 *
+	 * `@InternallyScheduledTask` tasks are deliberately left without a handle: they run inline on the submitter's
+	 * thread, where interrupting from another thread has no well-defined target.
+	 *
 	 * @param task The server task to be submitted. Must not be null.
 	 * @return A CompletableFuture representing the result of the submitted task.
 	 */
@@ -665,11 +673,18 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 		if (task.getClass().isAnnotationPresent(InternallyScheduledTask.class)) {
 			// if the task is internally scheduled, we can execute it immediately
 			task.execute();
-		} else if (task instanceof Callable<?>) {
-			//noinspection unchecked
-			this.executorService.submit((Callable<T>)task);
 		} else {
-			this.executorService.submit(task::execute);
+			final Future<?> handle;
+			if (task instanceof Callable<?>) {
+				//noinspection unchecked
+				handle = this.executorService.submit((Callable<T>) task);
+			} else {
+				handle = this.executorService.submit(task::execute);
+			}
+			// the task may already be running - or finished - by the time this lands; cancel() tolerates both
+			if (task instanceof InterruptibleServerTask ist) {
+				ist.attachExecutionHandle(handle);
+			}
 		}
 		this.submittedTaskCount.increment();
 		return task.getFutureResult();

--- a/evita_engine/src/main/java/io/evitadb/core/executor/SequentialTask.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/SequentialTask.java
@@ -185,7 +185,17 @@ public class SequentialTask<T> implements ServerTask<Void, T>, InterruptibleServ
 				final T theFinalResult = (T) this.steps[this.steps.length - 1]
 					.getFutureResult()
 					.getNow(null);
-				this.futureResult.complete(theFinalResult);
+				// `complete` is the arbiter of the one window the guard above cannot see - a cancel landing after
+				// that check has already passed. It returns false there, having lost to `cancel()`. The status
+				// transition must therefore follow the future instead of running unconditionally:
+				// `transitionToFinished` does not inspect the state it replaces, so a cancel arriving here used to be
+				// stamped back to FINISHED, reporting a real result on a task whose own future says cancelled - the
+				// same future/status mismatch this class's cancellation guard exists to rule out. `cancel()` has
+				// already recorded the CancellationException, so nothing needs stamping on this path.
+				// Covered by SequentialTaskTest#shouldNotReportFinishedWhenCancelLandedAfterLastStep
+				if (!this.futureResult.complete(theFinalResult)) {
+					return null;
+				}
 
 				this.status.updateAndGet(current -> current.transitionToFinished(theFinalResult));
 

--- a/evita_engine/src/main/java/io/evitadb/core/executor/SequentialTask.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/SequentialTask.java
@@ -36,6 +36,7 @@ import java.time.OffsetDateTime;
 import java.util.EnumSet;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -47,12 +48,41 @@ import java.util.stream.Stream;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
-public class SequentialTask<T> implements ServerTask<Void, T> {
+public class SequentialTask<T> implements ServerTask<Void, T>, InterruptibleServerTask {
+	/**
+	 * The name of this task, as displayed to clients; exposed publicly via the Lombok-generated getter.
+	 */
 	@Getter private final String taskName;
+	/**
+	 * The current status of this task, updated atomically as the steps progress and as the task moves between
+	 * lifecycle states.
+	 */
 	private final AtomicReference<TaskStatus<Void, T>> status;
+	/**
+	 * The two steps executed in sequence by {@link #execute()}, in declaration order. The last step's result becomes
+	 * this task's result.
+	 */
 	private final ServerTask<?, ?>[] steps;
+	/**
+	 * The step currently being executed, set right before {@link Task#execute()} is invoked on it and cleared again
+	 * in {@link #execute()}'s `finally` block - only meaningful while {@link #execute()} is on the call stack.
+	 * Nothing in this class currently reads it back; it is written but never queried.
+	 */
 	private final AtomicReference<Task<?, ?>> currentStep;
+	/**
+	 * The result of this task, exposed via {@link #getFutureResult()}. A plain {@link CompletableFuture} - unlike
+	 * {@link AbstractServerTask}'s status-aware future, cancelling it does not by itself update {@link #status}:
+	 * {@link #cancel()} stamps the status directly, and {@link #execute()} reconciles it whenever it observes this
+	 * future already cancelled. A direct {@link CompletableFuture#cancel(boolean)} arriving after the sequence has
+	 * already finished is never reconciled, because {@link #execute()} does not run again.
+	 */
 	private final CompletableFuture<T> futureResult;
+	/**
+	 * The executor's handle for this task, attached by {@link Scheduler#submitTaskInQueue} after submission. The steps
+	 * run inline on this task's own worker thread, so interrupting it through this handle is what actually stops the
+	 * step currently in flight — see {@link InterruptibleServerTask}.
+	 */
+	@Nullable private volatile Future<?> executionHandle;
 
 	public SequentialTask(@Nullable String catalogName, @Nonnull String taskName, @Nonnull ServerTask<?, ?> step1, @Nonnull ServerTask<?, T> step2) {
 		this.taskName = taskName;
@@ -129,10 +159,27 @@ public class SequentialTask<T> implements ServerTask<Void, T> {
 				this.status.updateAndGet(TaskStatus::transitionToStarted);
 
 				for (ServerTask<?, ?> step : this.steps) {
+					// stop at the first step boundary after a cancellation instead of walking the remaining steps
+					if (this.futureResult.isCancelled()) {
+						break;
+					}
 					if (step.getStatus().simplifiedState() == TaskSimplifiedState.QUEUED) {
 						this.currentStep.set(step);
 						step.execute();
 					}
+				}
+				if (this.futureResult.isCancelled()) {
+					// a cancelled sequence must never reach the completion block below. Falling into it is harmless
+					// only while `getNow(null)` happens to raise CancellationException on an already-cancelled step;
+					// where it does not - a direct `getFutureResult().cancel(true)` leaves every step untouched - it
+					// hands back null and `transitionToFinished` records the sequence as FINISHED while this task's
+					// own future reports cancelled. Cancellation is stamped here rather than left to that exception,
+					// because the project does not route control flow through exceptions.
+					this.status.updateAndGet(
+						current -> current.simplifiedState() == TaskSimplifiedState.FAILED ?
+							current : current.transitionToFailed(new CancellationException("Task was canceled."))
+					);
+					return null;
 				}
 				//noinspection unchecked
 				final T theFinalResult = (T) this.steps[this.steps.length - 1]
@@ -144,6 +191,11 @@ public class SequentialTask<T> implements ServerTask<Void, T> {
 
 				return theFinalResult;
 			} catch (Exception ex) {
+				if (this.futureResult.isCancelled()) {
+					// cancellation unwound the sequence - the requested outcome, not a failure. The status already
+					// carries the CancellationException set by cancel(), so leave it alone.
+					return null;
+				}
 				fail(ex);
 				throw ex;
 			} finally {
@@ -151,6 +203,30 @@ public class SequentialTask<T> implements ServerTask<Void, T> {
 			}
 		} else {
 			return null;
+		}
+	}
+
+	/**
+	 * Attaches the executor handle that {@link #cancel()} uses to interrupt the worker thread currently executing
+	 * this task's steps.
+	 *
+	 * Called by {@link Scheduler#submitTaskInQueue} right after submission - which means the step loop in
+	 * {@link #execute()} may already be running, or even finished, by the time this arrives. {@link #cancel()}
+	 * cancels {@link #futureResult} first and only then reads the handle; this method publishes the handle first
+	 * and only then re-reads {@link #futureResult}, cancelling the handle if it finds the task already cancelled.
+	 * Touching the same two locations in opposite order means at least one side observes the other, so a cancel
+	 * racing this call is never lost.
+	 *
+	 * @param handle the executor's handle for the submitted task
+	 */
+	@Override
+	public void attachExecutionHandle(@Nonnull Future<?> handle) {
+		// publish the handle first, then re-read the result future - the mirror image of cancel(), which cancels the
+		// result future first and only then reads the handle. Both sides touch the same two volatile locations in
+		// opposite order, so at least one of them observes the other and a cancel racing the attachment cannot be lost
+		this.executionHandle = handle;
+		if (this.futureResult.isCancelled()) {
+			handle.cancel(true);
 		}
 	}
 
@@ -166,6 +242,12 @@ public class SequentialTask<T> implements ServerTask<Void, T> {
 				current -> current.transitionToFailed(new CancellationException("Task was canceled."))
 			);
 			this.futureResult.cancel(true);
+			// the steps run inline on this task's worker thread, so only the executor handle can interrupt the step
+			// currently in flight - the futures cancelled above cannot (see InterruptibleServerTask)
+			final Future<?> handle = this.executionHandle;
+			if (handle != null) {
+				handle.cancel(true);
+			}
 			return canceled;
 		} else {
 			return false;

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/async/InterruptionTransformer.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/async/InterruptionTransformer.java
@@ -24,12 +24,10 @@
 package io.evitadb.externalApi.graphql.async;
 
 import graphql.schema.DataFetcher;
+import io.evitadb.core.executor.AbstractInterruptionTransformer;
 import io.evitadb.core.executor.InterruptionTransformer.InterruptionAdvice;
-import net.bytebuddy.asm.Advice;
-import net.bytebuddy.build.Plugin;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.dynamic.ClassFileLocator;
-import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 
 import javax.annotation.Nonnull;
@@ -38,34 +36,19 @@ import javax.annotation.Nonnull;
  * ByteBuddy transformer that injects {@link InterruptionAdvice} into specific methods used during query execution
  * shared logic that checks for thread interruption. If the thread is interrupted, the method throws an
  * {@link InterruptedException} and effectively stops the query execution.
+ *
+ * Weaving mechanics — and why a matcher that stops matching cannot be detected at build time — live in
+ * {@link AbstractInterruptionTransformer}.
  */
-public class InterruptionTransformer implements Plugin {
-
-	@Override
-	public boolean matches(TypeDescription target) {
-		return true;
-	}
+public class InterruptionTransformer extends AbstractInterruptionTransformer {
 
 	@Nonnull
 	@Override
-	public DynamicType.Builder<?> apply(
-		DynamicType.Builder<?> builder,
-		@Nonnull TypeDescription typeDescription,
-		@Nonnull ClassFileLocator classFileLocator
-	) {
-		return builder.method(
-				/* Data fetcher invocation */
-				ElementMatchers.isOverriddenFrom(DataFetcher.class)
-					.and(ElementMatchers.named("get"))
-					.and(ElementMatchers.isAbstract())
-
-			)
-			.intercept(Advice.to(InterruptionAdvice.class));
-	}
-
-	@Override
-	public void close() {
-		// No resources to release
+	protected ElementMatcher.Junction<MethodDescription> interruptibleMethods() {
+		/* Data fetcher invocation */
+		return ElementMatchers.isOverriddenFrom(DataFetcher.class)
+			.and(ElementMatchers.named("get"))
+			.and(ElementMatchers.not(ElementMatchers.isAbstract()));
 	}
 
 }

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/task/BackupTask.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/task/BackupTask.java
@@ -290,16 +290,29 @@ public class BackupTask extends ClientCallableTask<BackupSettings, FileForFetch>
 						e
 					);
 				}
-			} catch (RuntimeException exception) {
-				// `Exception` rather than `RuntimeException`, mirroring FullBackupTask: the `@Interruptible`
-				// checkpoints woven into the helpers below raise the *checked* InterruptedException from bytecode, so
-				// it is invisible in these signatures and a narrower catch lets it slip past this cleanup. The archive
-				// left behind is not merely a stray temp file - closing the stream still writes a valid central
-				// directory and registers the file for fetch, so users are offered a backup missing most of its entries
+			} catch (Exception exception) {
+				// `Exception` rather than `RuntimeException`, mirroring FullBackupTask - and do not let an IDE talk you
+				// out of it. Inspections call the checked half of this catch unreachable, because nothing in the
+				// signatures below declares a checked exception. They are reading the source; the exception is not in
+				// the source. The `@Interruptible` checkpoints woven into these helpers raise the *checked*
+				// InterruptedException straight from bytecode, long after javac has stopped looking, so narrowing this
+				// to RuntimeException lets an interrupted backup slip past the cleanup. What it leaves behind is not
+				// merely a stray temp file - closing the stream still writes a valid central directory and registers
+				// the file for fetch, so users are offered a backup missing most of its entries.
+				// Covered by BackupTaskCancellationTest#shouldDeleteRegisteredExportFileWhenBackupInterrupted, which
+				// only fails against a freshly woven module - a stale jar reports it green
 				ofNullable(exportFileHandle.fileForFetchFuture().getNow(null))
 					.ifPresent(it -> exportService.deleteFile(it.fileId()));
 
-				throw exception;
+				if (exception instanceof RuntimeException re) {
+					throw re;
+				} else {
+					throw new UnexpectedIOException(
+						"Failed to backup catalog `" + this.catalogName + "`!",
+						"Failed to backup catalog!",
+						exception
+					);
+				}
 			}
 		} finally {
 			tearDown();

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/task/BackupTask.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/task/BackupTask.java
@@ -291,7 +291,11 @@ public class BackupTask extends ClientCallableTask<BackupSettings, FileForFetch>
 					);
 				}
 			} catch (RuntimeException exception) {
-				// remove the files
+				// `Exception` rather than `RuntimeException`, mirroring FullBackupTask: the `@Interruptible`
+				// checkpoints woven into the helpers below raise the *checked* InterruptedException from bytecode, so
+				// it is invisible in these signatures and a narrower catch lets it slip past this cleanup. The archive
+				// left behind is not merely a stray temp file - closing the stream still writes a valid central
+				// directory and registers the file for fetch, so users are offered a backup missing most of its entries
 				ofNullable(exportFileHandle.fileForFetchFuture().getNow(null))
 					.ifPresent(it -> exportService.deleteFile(it.fileId()));
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/AbstractServerTaskCancellationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/AbstractServerTaskCancellationTest.java
@@ -127,6 +127,42 @@ class AbstractServerTaskCancellationTest {
 				"the status does not carry the exception the body threw"
 			);
 		}
+
+		@Test
+		@DisplayName("keeps the real exception when the body failed for a reason unrelated to the cancellation")
+		void shouldKeepRealExceptionWhenUnrelatedFailureRacedCancellation() {
+			// the race from the two tests above compressed into one deterministic body: the result future is
+			// cancelled AND the body then fails for a reason that has nothing to do with the cancellation. Deciding
+			// on `future.isCancelled()` alone files a genuine production failure away as a routine cancellation and
+			// discards it at debug level, where nobody reading the task status will ever find it.
+			final AtomicBoolean handlerInvoked = new AtomicBoolean(false);
+			final ClientCallableTask<Void, Integer> task = new ClientCallableTask<Void, Integer>(
+				"task", "Cancelled task that failed on its own", null,
+				theTask -> {
+					theTask.cancel();
+					throw new IllegalStateException("boom");
+				},
+				throwable -> {
+					handlerInvoked.set(true);
+					return -1;
+				}
+			);
+			task.transitionToIssued();
+
+			assertNull(task.execute(), "a cancelled task must still report no result");
+			assertTrue(task.getFutureResult().isCancelled(), "the result future was not cancelled");
+			assertFalse(
+				handlerInvoked.get(),
+				"the exception handler ran for a cancelled task, whose future can no longer accept a default result"
+			);
+
+			final TaskStatus<Void, Integer> status = task.getStatus();
+			assertEquals(TaskSimplifiedState.FAILED, status.simplifiedState());
+			assertTrue(
+				status.exceptionWithStackTrace().startsWith(IllegalStateException.class.getName()),
+				"the genuine failure was reported as a routine cancellation and lost"
+			);
+		}
 	}
 
 	@Nested

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/AbstractServerTaskCancellationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/AbstractServerTaskCancellationTest.java
@@ -1,0 +1,165 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.executor;
+
+import io.evitadb.api.task.TaskStatus;
+import io.evitadb.api.task.TaskStatus.TaskSimplifiedState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.TASK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the early-return-on-cancellation branch of `AbstractServerTask#execute()` — the branch that distinguishes
+ * "the caller stopped this on purpose" from "this failed", and that must not run the task's exception handler.
+ *
+ * Every case here runs single-threaded on the test thread: a task body that cancels its own task reaches both branches
+ * without a pool, a latch or a timing window, which makes these the deterministic counterpart to the scheduler-level
+ * cancellation tests in {@link SchedulerTest}.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(ENGINE)
+@Tag(TASK)
+@DisplayName("Server task cancellation")
+class AbstractServerTaskCancellationTest {
+
+	@Nested
+	@DisplayName("Cancelled task")
+	class CancelledTask {
+
+		@Test
+		@DisplayName("does not invoke the exception handler when the task was cancelled")
+		void shouldNotInvokeExceptionHandlerWhenTaskWasCancelled() {
+			final AtomicBoolean handlerInvoked = new AtomicBoolean(false);
+			// the Function-based constructor deliberately bypasses wrapCallable, so nothing between the body and
+			// execute() swallows, logs or rewraps what the body does
+			final ClientCallableTask<Void, Integer> task = new ClientCallableTask<Void, Integer>(
+				"task", "Self-cancelling task", null,
+				theTask -> {
+					theTask.cancel();
+					// returning normally is the realistic route into the branch: the cancelled result future makes
+					// executeAndCompleteFuture's getNow(null) raise the CancellationException that execute() catches
+					return 42;
+				},
+				throwable -> {
+					handlerInvoked.set(true);
+					return -1;
+				}
+			);
+			// execute() gates on QUEUED and a freshly built status is WAITING_FOR_PRECONDITION
+			task.transitionToIssued();
+
+			assertNull(task.execute(), "a cancelled task must report no result");
+			assertFalse(handlerInvoked.get(), "the exception handler ran for a deliberately cancelled task");
+			assertTrue(task.getFutureResult().isCancelled(), "the result future was not cancelled");
+
+			final TaskStatus<Void, Integer> status = task.getStatus();
+			assertEquals(TaskSimplifiedState.FAILED, status.simplifiedState());
+			assertEquals(
+				"Task was cancelled.", status.publicExceptionMessage(),
+				"cancellation was overwritten and reported as an ordinary failure"
+			);
+			assertTrue(
+				status.exceptionWithStackTrace().startsWith(CancellationException.class.getName()),
+				"the status carries something other than the CancellationException raised by cancel()"
+			);
+		}
+
+		@Test
+		@DisplayName("invokes the exception handler when the task failed without being cancelled")
+		void shouldInvokeExceptionHandlerWhenTaskFailedWithoutCancellation() {
+			// the counterfactual that keeps the case above from being a tautology: the same fixture, the same failure
+			// route into execute()'s catch, and the handler DOES run because nothing was cancelled
+			final AtomicBoolean handlerInvoked = new AtomicBoolean(false);
+			final ClientCallableTask<Void, Integer> task = new ClientCallableTask<Void, Integer>(
+				"task", "Failing task", null,
+				theTask -> {
+					throw new IllegalStateException("boom");
+				},
+				throwable -> {
+					handlerInvoked.set(true);
+					return -1;
+				}
+			);
+			task.transitionToIssued();
+
+			assertEquals(-1, task.execute(), "the handler's default result was not returned");
+			assertTrue(handlerInvoked.get(), "the exception handler never ran for a genuine failure");
+			assertFalse(task.getFutureResult().isCancelled(), "the result future must not be cancelled");
+			assertTrue(task.getFutureResult().isDone(), "the result future was never completed");
+
+			final TaskStatus<Void, Integer> status = task.getStatus();
+			assertEquals(TaskSimplifiedState.FAILED, status.simplifiedState());
+			assertTrue(
+				status.exceptionWithStackTrace().startsWith(IllegalStateException.class.getName()),
+				"the status does not carry the exception the body threw"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Task that was never submitted")
+	class NeverSubmittedTask {
+
+		@Test
+		@DisplayName("cancels a task that never received an execution handle")
+		void shouldCancelTaskThatWasNeverSubmitted() {
+			// the documented contract of AbstractServerTask#cancel: the executor handle is absent for any task that
+			// never went through the scheduler, and cancel() must tolerate that rather than dereference null
+			final ClientCallableTask<Void, Integer> task = new ClientCallableTask<Void, Integer>(
+				"task", "Never submitted task", null, theTask -> 42
+			);
+
+			assertTrue(task.cancel(), "cancelling a fresh task must answer true");
+			assertTrue(task.getFutureResult().isCancelled(), "the result future was not cancelled");
+			// the cancel moved the status out of QUEUED, so the body can no longer run
+			assertNull(task.execute(), "a cancelled task must not execute its body");
+		}
+
+		@Test
+		@DisplayName("refuses to cancel a task that already completed")
+		void shouldRefuseToCancelCompletedTask() {
+			final ClientCallableTask<Void, Integer> task = new ClientCallableTask<Void, Integer>(
+				"task", "Completed task", null, theTask -> 42
+			);
+			task.transitionToIssued();
+
+			assertEquals(42, task.execute());
+			assertFalse(task.cancel(), "cancelling an already-completed task must answer false");
+			assertEquals(TaskSimplifiedState.FINISHED, task.getStatus().simplifiedState());
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/InterruptionAdviceWovenTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/InterruptionAdviceWovenTest.java
@@ -1,0 +1,250 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.executor;
+
+import io.evitadb.core.query.algebra.AbstractFormula;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.session.EvitaSession;
+import io.evitadb.externalApi.graphql.api.resolver.dataFetcher.AsyncDataFetcher;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.store.catalog.task.RestoreTask;
+import net.bytebuddy.jar.asm.ClassReader;
+import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.jar.asm.MethodVisitor;
+import net.bytebuddy.jar.asm.Opcodes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRAPHQL;
+import static io.evitadb.test.TestTags.STORAGE;
+import static io.evitadb.test.TestTags.TASK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the build-time ByteBuddy weaving performed by {@link AbstractInterruptionTransformer} actually
+ * injected the interrupt poll into the shipped class files.
+ *
+ * ## Why this test exists
+ *
+ * A ByteBuddy matcher that matches nothing is indistinguishable from one that works — the plugin logs
+ * `Transformed N type(s)` either way. The matcher union had originally been assembled with
+ * `ElementMatchers.anyOf(...)`, whose `Object...` overload compares candidates by {@link Object#equals(Object)}
+ * against the supplied *values*; handed matcher instances it matched no method anywhere, in any module. Query
+ * cancellation and query timeouts were silently disabled for the entire lifetime of the annotation, and every test in
+ * the suite still passed, because nothing asserted on the woven output.
+ *
+ * The check cannot live inside the transformer: `byte-buddy-maven-plugin`'s `transform` goal is incremental (see its
+ * `staleMilliseconds` parameter), so a build in which nothing recompiled processes zero types — a plugin-side "I wove
+ * nothing" assertion cannot distinguish a dead matcher from an up-to-date module. Asserting on the **built artifact**
+ * is immune to that.
+ *
+ * ## One assertion per module is the intended granularity, not an oversight
+ *
+ * This class owns exactly one claim — *the plugin ran against the shipped classes of this module* — and one
+ * known-woven method per module is enough to carry it. Per-branch matcher semantics are owned by
+ * {@link InterruptionTransformerMatcherTest}, which needs no build artifacts and would have caught the `anyOf` defect
+ * in milliseconds. Adding more branches here would duplicate that class without strengthening this claim. Should a
+ * matcher branch be narrowed deliberately, move the assertion to another method the branch still covers rather than
+ * deleting it.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+@Tag(ENGINE)
+@Tag(TASK)
+@DisplayName("Interruption advice weaving")
+class InterruptionAdviceWovenTest {
+	/**
+	 * Appended to every assertion message in this class. These assertions read the **built** class files, so a stale
+	 * artifact produces a red that is indistinguishable from a dead matcher.
+	 */
+	private static final String STALE_ARTIFACT_HINT =
+		" - note this reads the BUILT class file, so a stale ~/.m2 artifact produces the identical failure; rebuild " +
+			"with `mvn -o install -DskipTests -pl <module>` before concluding the matcher is broken";
+
+	/**
+	 * Reads the class file of the given type from the classpath and reports whether the named method polls the thread
+	 * interrupt flag, i.e. whether {@link Thread#isInterrupted()} is invoked anywhere in its body.
+	 *
+	 * Exactly one method of that name must exist in the class file. Matching by name alone would let an overload that
+	 * happens to hand-poll the flag vouch for a sibling that was never woven, so the count is asserted rather than
+	 * assumed — a new overload turns into an explicit failure asking for a descriptor-aware assertion.
+	 *
+	 * @param type       the type whose class file is inspected
+	 * @param methodName the method to look for
+	 * @return true when that method calls {@link Thread#isInterrupted()}
+	 */
+	private static boolean pollsInterruptFlag(@Nonnull Class<?> type, @Nonnull String methodName) {
+		final String resource = type.getName().replace('.', '/') + ".class";
+		try (InputStream is = type.getClassLoader().getResourceAsStream(resource)) {
+			assertNotNull(is, "class file not found on classpath: " + resource + STALE_ARTIFACT_HINT);
+			final boolean[] found = new boolean[1];
+			final int[] inspected = new int[1];
+			new ClassReader(is).accept(
+				new ClassVisitor(Opcodes.ASM9) {
+					@Override
+					public MethodVisitor visitMethod(
+						int access, String name, String descriptor, String signature, String[] exceptions
+					) {
+						if (!methodName.equals(name)) {
+							return null;
+						}
+						inspected[0]++;
+						return new MethodVisitor(Opcodes.ASM9) {
+							@Override
+							public void visitMethodInsn(
+								int opcode, String owner, String mName, String mDescriptor, boolean isInterface
+							) {
+								if ("java/lang/Thread".equals(owner) && "isInterrupted".equals(mName)) {
+									found[0] = true;
+								}
+							}
+						};
+					}
+				},
+				ClassReader.SKIP_FRAMES
+			);
+			assertEquals(
+				1, inspected[0],
+				"expected exactly one method named `" + methodName + "` in " + type.getName() + " - the assertion " +
+					"below cannot tell which overload it vouched for" + STALE_ARTIFACT_HINT
+			);
+			return found[0];
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	@Nested
+	@DisplayName("evita_engine")
+	class Engine {
+
+		@Test
+		@DisplayName("weaves the interrupt poll into Formula#compute")
+		void shouldWeaveInterruptPollIntoFormulaCompute() {
+			// the single concrete implementation of Formula#compute - the gate every formula node passes through,
+			// and therefore the checkpoint that makes a runaway query interruptible
+			assertTrue(
+				pollsInterruptFlag(AbstractFormula.class, "compute"),
+				"AbstractFormula#compute carries no interrupt poll - query cancellation is silently disabled"
+					+ STALE_ARTIFACT_HINT
+			);
+		}
+
+		@Test
+		@DisplayName("weaves the interrupt poll into an @Interruptible method")
+		void shouldWeaveInterruptPollIntoAnnotatedMethod() {
+			// covers the isAnnotatedWith(Interruptible.class) branch, which is the only branch driven by the
+			// annotation rather than by a type hierarchy
+			assertTrue(
+				pollsInterruptFlag(EvitaSession.class, "getCatalogSchema"),
+				"@Interruptible on EvitaSession#getCatalogSchema was not woven" + STALE_ARTIFACT_HINT
+			);
+		}
+	}
+
+	@Nested
+	@Tag(STORAGE)
+	@DisplayName("evita_store_server")
+	class StoreServer {
+
+		@Test
+		@DisplayName("weaves the interrupt poll into an @Interruptible task method")
+		void shouldWeaveInterruptPollIntoRestoreTask() {
+			assertTrue(
+				pollsInterruptFlag(RestoreTask.class, "readBlock"),
+				"@Interruptible on RestoreTask#readBlock was not woven" + STALE_ARTIFACT_HINT
+			);
+		}
+	}
+
+	@Nested
+	@Tag(GRAPHQL)
+	@Tag(EXTERNAL_API)
+	@DisplayName("evita_external_api_graphql")
+	class GraphQl {
+
+		@Test
+		@DisplayName("weaves the interrupt poll into DataFetcher#get")
+		void shouldWeaveInterruptPollIntoDataFetcherGet() {
+			assertTrue(
+				pollsInterruptFlag(AsyncDataFetcher.class, "get"),
+				"AsyncDataFetcher#get carries no interrupt poll - GraphQL cancellation is silently disabled"
+					+ STALE_ARTIFACT_HINT
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Runtime behaviour")
+	class RuntimeBehaviour {
+
+		/**
+		 * Clears the thread interrupt flag after every test in this class.
+		 *
+		 * This is a hard requirement rather than tidiness: `EvitaSession` alone carries 55 `@Interruptible` methods, so
+		 * a flag left set on a surefire worker thread aborts every subsequent test in the same fork that touches a
+		 * session — with a failure that points nowhere near this class.
+		 */
+		@AfterEach
+		void clearInterruptFlag() {
+			//noinspection ResultOfMethodCallIgnored
+			Thread.interrupted();
+		}
+
+		@Test
+		@DisplayName("throws InterruptedException from a woven method when the flag is already set")
+		void shouldThrowInterruptedExceptionWhenFlagIsSetOnEntry() {
+			final Formula formula = new ConstantFormula(new BaseBitmap(1, 2, 3));
+			try {
+				Thread.currentThread().interrupt();
+				// Formula#compute declares no checked exception - the woven advice throws one anyway, straight from
+				// bytecode. That undeclared surfacing IS the contract: it is what unwinds a running query, and it
+				// compiles here only because JUnit's Executable declares `throws Throwable`.
+				assertThrows(
+					InterruptedException.class,
+					formula::compute,
+					"the woven poll did not fire - the advice is present in the class file but does not throw"
+				);
+			} finally {
+				//noinspection ResultOfMethodCallIgnored
+				Thread.interrupted();
+			}
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/InterruptionTransformerMatcherTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/InterruptionTransformerMatcherTest.java
@@ -1,0 +1,326 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.executor;
+
+import graphql.schema.DataFetcher;
+import io.evitadb.core.query.algebra.AbstractFormula;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.extraResult.ExtraResultProducer;
+import io.evitadb.core.query.extraResult.translator.histogram.cache.FlattenedHistogramComputer;
+import io.evitadb.core.query.extraResult.translator.histogram.producer.AttributeHistogramProducer;
+import io.evitadb.core.query.filter.translator.FilterByTranslator;
+import io.evitadb.core.query.sort.NoSorter;
+import io.evitadb.core.query.sort.Sorter;
+import io.evitadb.core.query.sort.translator.OrderByTranslator;
+import io.evitadb.core.session.EvitaSession;
+import io.evitadb.externalApi.graphql.api.resolver.dataFetcher.AsyncDataFetcher;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+import net.bytebuddy.pool.TypePool;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.TASK;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Asserts the per-branch semantics of the matcher returned by `interruptibleMethods()` in both
+ * {@link AbstractInterruptionTransformer} implementations — the engine one and the GraphQL one.
+ *
+ * ## Division of labour — do not "consolidate" this class with the woven test
+ *
+ * Three tests guard the interruption weaving, and each owns an orthogonal claim:
+ *
+ * - **This class owns per-branch matcher semantics.** The engine matcher is a union of seven branches; this class
+ *   asserts each one individually, plus the negative cases that pin the trailing `not(isAbstract())` clause. It needs
+ *   no build artifacts and runs in milliseconds, which is what makes it the right place to catch a branch that stopped
+ *   matching — the original `ElementMatchers.anyOf(...)` defect would have failed every positive assertion here
+ *   instantly.
+ * - **{@link InterruptionAdviceWovenTest} owns the orthogonal claim that the plugin actually ran** against the shipped
+ *   class files, with exactly one assertion per module carrying the transformer. A matcher can be perfect and the
+ *   build still ship un-woven classes.
+ * - Its `Runtime behaviour` nested class owns the claim that the woven poll actually throws.
+ *
+ * Extending any of the three into another's territory is redundant, not thorough.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(ENGINE)
+@Tag(TASK)
+@DisplayName("Interruption matcher")
+class InterruptionTransformerMatcherTest {
+
+	/**
+	 * Resolves the declared methods of the given type through a {@link TypePool} rather than through reflection.
+	 *
+	 * {@link Interruptible} is `RetentionPolicy.CLASS`, so it is present in the class file but invisible to
+	 * {@link java.lang.reflect.Method#getDeclaredAnnotations()}. A {@link MethodDescription} built from
+	 * `ForLoadedMethod` would therefore report the `isAnnotatedWith(Interruptible.class)` branch dead — a false red
+	 * that reads exactly like a genuinely broken matcher. Parsing the class file preserves the annotation.
+	 *
+	 * The pool is opened on the **type's own** class loader, never `ofSystemLoader()`: under surefire's manifest-only
+	 * classpath jar the system loader resolves nothing, which surfaces as "method not found" — i.e. as the very false
+	 * red this helper exists to prevent.
+	 *
+	 * @param type       the type whose declared methods are resolved
+	 * @param methodName the method name to filter by
+	 * @return the declared methods of that name, parsed from the class file
+	 */
+	@Nonnull
+	private static MethodList<MethodDescription.InDefinedShape> declaredMethods(
+		@Nonnull Class<?> type,
+		@Nonnull String methodName
+	) {
+		final TypeDescription description = TypePool.Default.of(type.getClassLoader())
+			.describe(type.getName())
+			.resolve();
+		final MethodList<MethodDescription.InDefinedShape> declared = description
+			.getDeclaredMethods()
+			.filter(ElementMatchers.named(methodName));
+		// fail as "the method is gone" rather than as "the branch is dead" when someone renames the target
+		assertFalse(
+			declared.isEmpty(),
+			type.getName() + " declares no method named `" + methodName + "` - the assertion target was renamed or " +
+				"moved, which is not the same thing as the matcher branch having died"
+		);
+		return declared;
+	}
+
+	/**
+	 * Reports whether the given matcher selects at least one method of the given name declared by the given type.
+	 *
+	 * A generic override (`FilterByTranslator#translate`, `OrderByTranslator#createSorter`,
+	 * `FlattenedHistogramComputer#compute`) is accompanied in the class file by a javac-generated bridge carrying the
+	 * erased signature, and it is the bridge that matches `isOverriddenFrom(...)`. Weaving the bridge is equally
+	 * effective — it polls before delegating — so "at least one declared method of this name matches" is the honest
+	 * question to ask.
+	 *
+	 * @param matcher    the matcher under test
+	 * @param type       the declaring type
+	 * @param methodName the method name
+	 * @return true when at least one declared method of that name matches
+	 */
+	private static boolean matches(
+		@Nonnull ElementMatcher<? super MethodDescription> matcher,
+		@Nonnull Class<?> type,
+		@Nonnull String methodName
+	) {
+		for (MethodDescription method : declaredMethods(type, methodName)) {
+			if (matcher.matches(method)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Widens the engine transformer's `protected` matcher accessor to this test.
+	 *
+	 * Subclassing rather than relying on package placement is deliberate: it is what lets the GraphQL half of the
+	 * matcher be asserted from this same class instead of forcing a second test class into
+	 * `io.evitadb.externalApi.graphql.async`.
+	 */
+	private static final class EngineTransformerProbe extends InterruptionTransformer {
+
+		@Nonnull
+		@Override
+		public ElementMatcher.Junction<MethodDescription> interruptibleMethods() {
+			return super.interruptibleMethods();
+		}
+
+	}
+
+	/**
+	 * Widens the GraphQL transformer's `protected` matcher accessor to this test — see {@link EngineTransformerProbe}.
+	 */
+	private static final class GraphQlTransformerProbe
+		extends io.evitadb.externalApi.graphql.async.InterruptionTransformer {
+
+		@Nonnull
+		@Override
+		public ElementMatcher.Junction<MethodDescription> interruptibleMethods() {
+			return super.interruptibleMethods();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Engine matcher")
+	class EngineMatcher {
+		private final ElementMatcher.Junction<MethodDescription> matcher =
+			new EngineTransformerProbe().interruptibleMethods();
+
+		@Test
+		@DisplayName("selects a method carrying the @Interruptible annotation")
+		void shouldSelectAnnotatedMethod() {
+			assertTrue(
+				matches(this.matcher, EvitaSession.class, "getCatalogSchema"),
+				"the isAnnotatedWith(Interruptible.class) branch selects nothing - session-level interruption is off"
+			);
+		}
+
+		@Test
+		@DisplayName("selects a filtering constraint translator")
+		void shouldSelectFilteringConstraintTranslator() {
+			assertTrue(
+				matches(this.matcher, FilterByTranslator.class, "translate"),
+				"the FilteringConstraintTranslator#translate branch selects nothing - filter planning is not " +
+					"interruptible"
+			);
+		}
+
+		@Test
+		@DisplayName("selects a formula computation")
+		void shouldSelectFormulaComputation() {
+			assertTrue(
+				matches(this.matcher, AbstractFormula.class, "compute"),
+				"the Formula#compute branch selects nothing - the hottest checkpoint in the engine is not " +
+					"interruptible"
+			);
+		}
+
+		@Test
+		@DisplayName("selects an ordering constraint translator")
+		void shouldSelectOrderingConstraintTranslator() {
+			assertTrue(
+				matches(this.matcher, OrderByTranslator.class, "createSorter"),
+				"the OrderingConstraintTranslator#createSorter branch selects nothing - order planning is not " +
+					"interruptible"
+			);
+		}
+
+		@Test
+		@DisplayName("selects a sorter application")
+		void shouldSelectSorterApplication() {
+			assertTrue(
+				matches(this.matcher, NoSorter.class, "sortAndSlice"),
+				"the Sorter#sortAndSlice branch selects nothing - sorting is not interruptible"
+			);
+		}
+
+		@Test
+		@DisplayName("selects an extra result producer")
+		void shouldSelectExtraResultProducer() {
+			assertTrue(
+				matches(this.matcher, AttributeHistogramProducer.class, "fabricate"),
+				"the ExtraResultProducer#fabricate branch selects nothing - require planning is not interruptible"
+			);
+		}
+
+		@Test
+		@DisplayName("selects an extra result computer")
+		void shouldSelectExtraResultComputer() {
+			assertTrue(
+				matches(this.matcher, FlattenedHistogramComputer.class, "compute"),
+				"the EvitaResponseExtraResultComputer#compute branch selects nothing - extra result computation is " +
+					"not interruptible"
+			);
+		}
+
+		@Test
+		@DisplayName("rejects the abstract declarations of the matched methods")
+		void shouldRejectAbstractDeclarations() {
+			// the trailing not(isAbstract()) clause - an abstract method has no body to instrument, and weaving one
+			// is a hard build failure rather than a silent no-op
+			assertFalse(
+				matches(this.matcher, Formula.class, "compute"),
+				"the abstract Formula#compute declaration must not be selected"
+			);
+			assertFalse(
+				matches(this.matcher, Sorter.class, "sortAndSlice"),
+				"the abstract Sorter#sortAndSlice declaration must not be selected"
+			);
+			assertFalse(
+				matches(this.matcher, ExtraResultProducer.class, "fabricate"),
+				"the abstract ExtraResultProducer#fabricate declaration must not be selected"
+			);
+		}
+
+		@Test
+		@DisplayName("rejects a method unrelated to query execution")
+		void shouldRejectUnrelatedMethod() {
+			// the assertion that fails if a future edit widens the union to everything - getEstimatedCost sits on the
+			// very class whose compute() the matcher does select, so nothing but the branch conditions separates them
+			assertFalse(
+				matches(this.matcher, AbstractFormula.class, "getEstimatedCost"),
+				"the matcher selects a method that is not a query-execution checkpoint - the union was widened"
+			);
+		}
+
+		@Test
+		@DisplayName("applies to every type in the module")
+		void shouldApplyToEveryType() {
+			// the plugin filters methods, not types - apply(...) is invoked for each type and the advice visitor
+			// decides what gets rewritten
+			assertTrue(
+				new EngineTransformerProbe().matches(TypeDescription.ForLoadedType.of(AbstractFormula.class)),
+				"the transformer must accept every type in the module"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("GraphQL matcher")
+	class GraphQlMatcher {
+		private final ElementMatcher.Junction<MethodDescription> matcher =
+			new GraphQlTransformerProbe().interruptibleMethods();
+
+		@Test
+		@DisplayName("selects a data fetcher invocation")
+		void shouldSelectDataFetcherInvocation() {
+			assertTrue(
+				matches(this.matcher, AsyncDataFetcher.class, "get"),
+				"the DataFetcher#get branch selects nothing - GraphQL cancellation is off"
+			);
+		}
+
+		@Test
+		@DisplayName("rejects the abstract declaration of the matched method")
+		void shouldRejectAbstractDeclaration() {
+			assertFalse(
+				matches(this.matcher, DataFetcher.class, "get"),
+				"the abstract DataFetcher#get declaration must not be selected"
+			);
+		}
+
+		@Test
+		@DisplayName("applies to every type in the module")
+		void shouldApplyToEveryType() {
+			assertTrue(
+				new GraphQlTransformerProbe().matches(TypeDescription.ForLoadedType.of(AsyncDataFetcher.class)),
+				"the transformer must accept every type in the module"
+			);
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/ObservableThreadExecutorCancellationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/ObservableThreadExecutorCancellationTest.java
@@ -228,6 +228,61 @@ class ObservableThreadExecutorCancellationTest {
 		}
 	}
 
+	/**
+	 * An {@link ObservableRunnable} that holds the worker *inside* `finishExecution()`, after the delegate has
+	 * returned and the result future has completed normally, but while the task is still `RUNNING`.
+	 *
+	 * That window is the one a late cancel slips into: `future.cancel(true)` fails against an already-completed
+	 * future, yet the `RUNNING -> CANCELLING` transition still succeeds and a real interrupt reaches this worker.
+	 * The seam turns that ordering into something deterministic rather than a probabilistic sweep.
+	 */
+	private static class HeldFinishRunnable extends ObservableRunnable {
+		/** Counted down once the delegate has returned and the worker has entered `finishExecution()`. */
+		private final CountDownLatch finishReached;
+		/** Awaited before `super.finishExecution()` runs, so the test decides when the worker proceeds. */
+		private final CountDownLatch finishRelease;
+		/** The worker's interrupt flag as observed immediately after `super.finishExecution()` returned. */
+		private final AtomicBoolean interruptedAfterFinish = new AtomicBoolean(false);
+
+		private HeldFinishRunnable(@Nonnull CountDownLatch finishReached, @Nonnull CountDownLatch finishRelease) {
+			super("test-held-finish", Functions.noOpRunnable(), Functions.noOpRunnable());
+			this.finishReached = finishReached;
+			this.finishRelease = finishRelease;
+		}
+
+		@Override
+		protected void finishExecution() {
+			this.finishReached.countDown();
+			awaitKeepingInterruptFlag(this.finishRelease);
+			super.finishExecution();
+			this.interruptedAfterFinish.set(Thread.currentThread().isInterrupted());
+		}
+
+		/**
+		 * Waits for the latch without consuming the interrupt flag this fixture exists to observe. The cancel under
+		 * test lands while the worker is parked here, and a bare {@link CountDownLatch#await(long, TimeUnit)} would
+		 * both throw and clear the flag, erasing the very state the assertion is about. The flag is restored before
+		 * returning, which is what a worker interrupted mid-window genuinely carries into `finishExecution()`.
+		 */
+		private static void awaitKeepingInterruptFlag(@Nonnull CountDownLatch latch) {
+			boolean interrupted = false;
+			while (true) {
+				try {
+					assertTrue(
+						latch.await(AWAIT_SECONDS, TimeUnit.SECONDS),
+						"the worker was never released from finishExecution()"
+					);
+					break;
+				} catch (InterruptedException e) {
+					interrupted = true;
+				}
+			}
+			if (interrupted) {
+				Thread.currentThread().interrupt();
+			}
+		}
+	}
+
 	@Nested
 	@DisplayName("Completion propagation on pre-start cancellation")
 	class CompletionPropagation {
@@ -458,6 +513,44 @@ class ObservableThreadExecutorCancellationTest {
 			assertFalse(
 				Thread.currentThread().isInterrupted(),
 				"the late cancel interrupted the thread that happened to call it"
+			);
+		}
+
+		@Test
+		@DisplayName("clears a delivered interrupt even when the cancel lost the race to the completed future")
+		void shouldClearInterruptWhenCancelArrivedAfterFutureCompleted() throws Exception {
+			// the gap the executionState machine leaves open on its own: interrupt *delivery* is gated on the state,
+			// but flag *clearing* is gated on the future. A cancel arriving after the delegate completed normally
+			// cannot cancel the future, yet still wins RUNNING -> CANCELLING and really does interrupt the worker -
+			// so the two gates disagree and the flag rides out of finishExecution() into the next task.
+			// The sibling test above covers the other side of the same window, where the cancel arrives first.
+			final CountDownLatch finishReached = new CountDownLatch(1);
+			final CountDownLatch finishRelease = new CountDownLatch(1);
+			final HeldFinishRunnable task = new HeldFinishRunnable(finishReached, finishRelease);
+
+			final Thread worker = new Thread(task, "test-worker");
+			worker.setDaemon(true);
+			worker.start();
+
+			assertTrue(
+				finishReached.await(AWAIT_SECONDS, TimeUnit.SECONDS),
+				"the worker never reached finishExecution()"
+			);
+
+			task.cancel();
+			assertFalse(
+				task.completionStage().isCancelled(),
+				"the delegate had already completed the future, so this cancel must not have cancelled it - without "
+					+ "that the test would be exercising the ordinary cancelled-future path instead of this window"
+			);
+
+			finishRelease.countDown();
+			worker.join(AWAIT_SECONDS * 1_000);
+			assertFalse(worker.isAlive(), "the worker never finished the task");
+
+			assertFalse(
+				task.interruptedAfterFinish.get(),
+				"the worker left finishExecution() still interrupted - the flag leaks onto whatever it runs next"
 			);
 		}
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/ObservableThreadExecutorCancellationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/ObservableThreadExecutorCancellationTest.java
@@ -189,6 +189,45 @@ class ObservableThreadExecutorCancellationTest {
 		fail("Executor backlog did not drain within " + AWAIT_SECONDS + " seconds — cancelled tombstone tasks were never reclaimed by a worker");
 	}
 
+	/**
+	 * An {@link ObservableRunnable} whose interrupt delivery the test can hold open: it signals the moment the cancel
+	 * has claimed the task and is about to interrupt, then waits for permission before the interrupt actually lands.
+	 *
+	 * This is the seam that turns the finishing-worker race into a deterministic test. Without it the window between
+	 * "the delegate returned" and "the interrupt arrives" can only be swept probabilistically, which belongs in the
+	 * long-running module rather than the fast loop.
+	 */
+	private static class HeldInterruptRunnable extends ObservableRunnable {
+		/** Counted down once the cancel has claimed the running task and reached the delivery point. */
+		private final CountDownLatch deliveryReached;
+		/** Awaited before the interrupt is delivered, so the test decides how long the delivery stays pending. */
+		private final CountDownLatch deliveryRelease;
+
+		private HeldInterruptRunnable(
+			@Nonnull Runnable delegate,
+			@Nonnull CountDownLatch deliveryReached,
+			@Nonnull CountDownLatch deliveryRelease
+		) {
+			super("test-held-interrupt", delegate, Functions.noOpRunnable());
+			this.deliveryReached = deliveryReached;
+			this.deliveryRelease = deliveryRelease;
+		}
+
+		@Override
+		protected void deliverInterrupt(@Nonnull Thread thread) {
+			this.deliveryReached.countDown();
+			try {
+				assertTrue(
+					this.deliveryRelease.await(AWAIT_SECONDS, TimeUnit.SECONDS),
+					"interrupt delivery was never released"
+				);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			super.deliverInterrupt(thread);
+		}
+	}
+
 	@Nested
 	@DisplayName("Completion propagation on pre-start cancellation")
 	class CompletionPropagation {
@@ -313,6 +352,113 @@ class ObservableThreadExecutorCancellationTest {
 			assertFalse(worker.isAlive(), "Worker thread should have finished");
 			assertTrue(wasInterrupted.get(), "Worker thread should have been interrupted");
 			assertTrue(task.isFinished(), "Task should be marked as finished (cancelled)");
+		}
+	}
+
+	@Nested
+	@DisplayName("Interrupt delivery stays inside the cancelled task")
+	class InterruptDeliveryConfinement {
+
+		@Test
+		@DisplayName("holds a finishing worker until a concurrent cancel has delivered its interrupt")
+		void shouldHoldFinishingWorkerUntilConcurrentCancelDeliveredInterrupt() throws Exception {
+			// the failure this pins: a cancel reads the executing thread, gets preempted, and calls interrupt() only
+			// after the worker has finished this task and picked up the next one - so an unrelated piece of work dies
+			// at its first interrupt checkpoint. Nothing but the wait in finishExecution() rules that out.
+			final CountDownLatch bodyEntered = new CountDownLatch(1);
+			final CountDownLatch bodyRelease = new CountDownLatch(1);
+			final CountDownLatch deliveryReached = new CountDownLatch(1);
+			final CountDownLatch deliveryRelease = new CountDownLatch(1);
+			final CountDownLatch workerReturned = new CountDownLatch(1);
+			final AtomicBoolean flagLeaked = new AtomicBoolean(false);
+
+			final HeldInterruptRunnable task = new HeldInterruptRunnable(
+				() -> {
+					bodyEntered.countDown();
+					try {
+						// released only once the cancel has parked at the delivery point, so the delegate is
+						// guaranteed to finish while the task is still held open for an interrupt
+						assertTrue(bodyRelease.await(AWAIT_SECONDS, TimeUnit.SECONDS), "body was never released");
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				},
+				deliveryReached, deliveryRelease
+			);
+
+			final Thread worker = new Thread(
+				() -> {
+					task.run();
+					// read on the worker itself once run() has returned - this is the thread that would carry a
+					// leaked interrupt into whatever the pool hands it next
+					flagLeaked.set(Thread.currentThread().isInterrupted());
+					workerReturned.countDown();
+				},
+				"test-worker"
+			);
+			worker.setDaemon(true);
+			worker.start();
+			assertTrue(bodyEntered.await(AWAIT_SECONDS, TimeUnit.SECONDS), "task never started");
+
+			// cancel from its own thread: the delivery parks, so it cannot run on the test thread
+			final Thread canceller = new Thread(task::cancel, "test-canceller");
+			canceller.setDaemon(true);
+			canceller.start();
+			assertTrue(
+				deliveryReached.await(AWAIT_SECONDS, TimeUnit.SECONDS),
+				"the cancel never claimed the running task, so it never had an interrupt to deliver"
+			);
+
+			// the interrupt is now claimed but undelivered - let the delegate finish underneath it
+			bodyRelease.countDown();
+
+			// negative wait - correct short, and it cannot fail spuriously: a loaded machine can only delay a worker
+			// that is already free to leave, never make a blocked one leave early
+			assertFalse(
+				workerReturned.await(250, TimeUnit.MILLISECONDS),
+				"the worker left the finished task while a cancellation interrupt was still in flight towards it"
+			);
+
+			deliveryRelease.countDown();
+			assertTrue(workerReturned.await(AWAIT_SECONDS, TimeUnit.SECONDS), "the worker never finished");
+			canceller.join(AWAIT_SECONDS * 1_000);
+			assertFalse(
+				flagLeaked.get(),
+				"the cancellation interrupt outlived its task and would abort the worker's next piece of work"
+			);
+		}
+
+		@Test
+		@DisplayName("does not interrupt a worker that already finished the cancelled task")
+		void shouldNotInterruptWorkerThatAlreadyFinishedCancelledTask() throws Exception {
+			// the counterfactual: once the task is over, a cancel must deliver nothing at all rather than deliver
+			// late. deliverInterrupt is never reached, so the seam's latch staying at one is the assertion.
+			final CountDownLatch deliveryReached = new CountDownLatch(1);
+			final AtomicBoolean bodyRan = new AtomicBoolean(false);
+
+			final HeldInterruptRunnable task = new HeldInterruptRunnable(
+				() -> bodyRan.set(true), deliveryReached, new CountDownLatch(0)
+			);
+
+			final Thread worker = new Thread(task, "test-worker");
+			worker.setDaemon(true);
+			worker.start();
+			worker.join(AWAIT_SECONDS * 1_000);
+			assertFalse(worker.isAlive(), "the worker never finished the task");
+			assertTrue(bodyRan.get(), "the delegate never ran");
+
+			task.cancel();
+
+			// negative wait against a latch the delivery point would have counted down - it stays at one because the
+			// task reached DONE before the cancel could claim it
+			assertFalse(
+				deliveryReached.await(250, TimeUnit.MILLISECONDS),
+				"a cancel arriving after the task finished still tried to interrupt the worker thread"
+			);
+			assertFalse(
+				Thread.currentThread().isInterrupted(),
+				"the late cancel interrupted the thread that happened to call it"
+			);
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SchedulerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SchedulerTest.java
@@ -28,10 +28,12 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import io.evitadb.api.configuration.ThreadPoolOptions;
+import io.evitadb.api.task.InternallyScheduledTask;
 import io.evitadb.api.task.ServerTask;
 import io.evitadb.api.task.TaskStatus;
 import io.evitadb.api.task.TaskStatus.TaskSimplifiedState;
 import io.evitadb.dataType.PaginatedList;
+import io.evitadb.exception.GenericEvitaInternalError;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -42,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -51,11 +54,15 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.TASK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -78,6 +85,61 @@ class SchedulerTest {
 	@AfterEach
 	void tearDown() {
 		this.scheduler.shutdownNow();
+	}
+
+	/**
+	 * A task whose handle attachment can be held open by the test, so a cancellation can be made to land in the window
+	 * between `executorService.submit(...)` and `attachExecutionHandle(...)` deterministically.
+	 *
+	 * `attachExecutionHandle` is public on `AbstractServerTask`, so widening it is unnecessary — this subclass only
+	 * inserts the two latches around the `super` call. Note the attach runs on the **submitting** thread, so a test
+	 * using this class must submit from a thread other than the one that drives the cancellation.
+	 */
+	private static class LateAttachingTask extends ClientCallableTask<Void, Integer> {
+		/** Counted down once the attachment is reached, i.e. once the executor has been handed the task. */
+		private final CountDownLatch attachReached;
+		/** Awaited before the attachment proceeds, so the test controls how long the window stays open. */
+		private final CountDownLatch attachReleased;
+		/** Counted down once the attachment has actually been applied. */
+		private final CountDownLatch attachCompleted;
+
+		LateAttachingTask(
+			@Nonnull Function<ClientCallableTask<Void, Integer>, Integer> body,
+			@Nonnull CountDownLatch attachReached,
+			@Nonnull CountDownLatch attachReleased,
+			@Nonnull CountDownLatch attachCompleted
+		) {
+			super("task", "Late attaching task", null, body);
+			this.attachReached = attachReached;
+			this.attachReleased = attachReleased;
+			this.attachCompleted = attachCompleted;
+		}
+
+		@Override
+		public void attachExecutionHandle(@Nonnull Future<?> handle) {
+			this.attachReached.countDown();
+			try {
+				assertTrue(this.attachReleased.await(30, TimeUnit.SECONDS), "attachment was never released");
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new GenericEvitaInternalError("Attachment wait interrupted.", "Attachment failed.", e);
+			}
+			super.attachExecutionHandle(handle);
+			this.attachCompleted.countDown();
+		}
+	}
+
+	/**
+	 * A task carrying `@InternallyScheduledTask`, which makes {@link Scheduler} run it inline on the submitting thread
+	 * and deliberately leave it without an executor handle.
+	 */
+	@InternallyScheduledTask
+	private static class InternallyScheduledRunnableTask extends ClientRunnableTask<Void> {
+
+		InternallyScheduledRunnableTask(@Nonnull Runnable body) {
+			super("task", "Internally scheduled task", null, body);
+		}
+
 	}
 
 	@Nested
@@ -208,6 +270,190 @@ class SchedulerTest {
 			});
 			assertTrue(interrupted.get() || !started.get());
 		}
+
+		@Test
+		@DisplayName("interrupts the worker thread of a running task on cancellation")
+		void shouldInterruptWorkerThreadOfCancelledTask() throws InterruptedException {
+			// deliberately observes ONLY the thread interrupt flag - never getFutureResult().isCancelled(). A task
+			// polling the result future cooperates with cancellation regardless of whether the interrupt was ever
+			// delivered, which is why the broken cancellation chain went unnoticed for so long: the executor
+			// Future returned by submit(...) was discarded, and CompletableFuture#cancel(true) ignores
+			// mayInterruptIfRunning, so nothing ever interrupted the worker.
+			final CountDownLatch started = new CountDownLatch(1);
+			final CountDownLatch interrupted = new CountDownLatch(1);
+			final CompletableFuture<Integer> result = SchedulerTest.this.scheduler.submit(
+				(ServerTask<Void, Integer>) new ClientCallableTask<Void, Integer>(
+					"task", "Test task", null, theTask -> {
+						started.countDown();
+						try {
+							// park rather than spin: a spin pins a core for the whole positive wait inside parallel
+							// surefire forks and can cause flakes in sibling tests, and it observes the flag rather
+							// than the delivery. A latch nobody counts down stays interruptible and costs nothing.
+							new CountDownLatch(1).await(30, TimeUnit.SECONDS);
+						} catch (InterruptedException e) {
+							interrupted.countDown();
+							// the task body is a Function and cannot rethrow a checked exception - wrapping it is
+							// what lets the test observe the real unwind path through execute()
+							throw new GenericEvitaInternalError("Task interrupted.", "Task interrupted.", e);
+						}
+						return -1;
+					}
+				)
+			);
+
+			// positive wait - generous, returns as soon as the task actually starts
+			assertTrue(started.await(30, TimeUnit.SECONDS), "task never started");
+
+			final PaginatedList<TaskStatus<?, ?>> jobStatuses =
+				SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null);
+			assertEquals(1, jobStatuses.getTotalRecordCount());
+			final UUID taskId = jobStatuses.getData().get(0).taskId();
+			SchedulerTest.this.scheduler.cancelTask(taskId);
+
+			// the assertion that matters: the interrupt reached the worker thread
+			assertTrue(interrupted.await(30, TimeUnit.SECONDS), "worker thread was never interrupted by cancellation");
+
+			// cancel() must cancel the result future BEFORE interrupting the worker, so the status is already stamped
+			// with the CancellationException by the time the interrupt unwinds executeInternal(); execute()'s catch
+			// can then only preserve it. Under the reverse order the catch overwrites both fields with the wrapped
+			// InterruptedException and "Task failed for unknown reasons.". Deterministic in the green direction - the
+			// stamping happens synchronously inside cancelTask(...) above - but it only catches a reversal
+			// probabilistically, because the overwrite would land some time after the latch fires. The deterministic
+			// guard for the early-return branch itself is AbstractServerTaskCancellationTest.
+			final TaskStatus<?, ?> statusAfterCancel = SchedulerTest.this.scheduler.getTaskStatus(taskId).orElseThrow();
+			assertEquals(
+				"Task was cancelled.", statusAfterCancel.publicExceptionMessage(),
+				"cancellation was reported as an ordinary failure - the interrupt outran the future cancellation"
+			);
+			assertTrue(
+				statusAfterCancel.exceptionWithStackTrace().startsWith(CancellationException.class.getName()),
+				"the status carries something other than the CancellationException raised by cancel()"
+			);
+
+			try {
+				result.get();
+				fail("Exception expected");
+			} catch (CancellationException | ExecutionException e) {
+				// expected - the task was cancelled
+			}
+		}
+
+		@Test
+		@DisplayName("interrupts the worker thread of a cancelled runnable task")
+		void shouldInterruptWorkerThreadOfCancelledRunnableTask() throws InterruptedException {
+			// the mirror of the callable case above for a task that implements Runnable but NOT Callable, which is
+			// what routes it through the executorService.submit(task::execute) branch of Scheduler#submitTaskInQueue.
+			// Both branches had to start retaining the executor handle; only the Callable one was covered.
+			final CountDownLatch started = new CountDownLatch(1);
+			final CountDownLatch interrupted = new CountDownLatch(1);
+			SchedulerTest.this.scheduler.submit(
+				(ServerTask<?, ?>) new ClientRunnableTask<Void>(
+					"task", "Test task", null, () -> {
+						started.countDown();
+						try {
+							new CountDownLatch(1).await(30, TimeUnit.SECONDS);
+						} catch (InterruptedException e) {
+							interrupted.countDown();
+							// a Runnable body cannot rethrow the checked exception either - see the callable case
+							throw new GenericEvitaInternalError("Task interrupted.", "Task interrupted.", e);
+						}
+					}
+				)
+			);
+
+			assertTrue(started.await(30, TimeUnit.SECONDS), "task never started");
+
+			final PaginatedList<TaskStatus<?, ?>> jobStatuses =
+				SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null);
+			assertEquals(1, jobStatuses.getTotalRecordCount());
+			SchedulerTest.this.scheduler.cancelTask(jobStatuses.getData().get(0).taskId());
+
+			assertTrue(
+				interrupted.await(30, TimeUnit.SECONDS),
+				"the non-Callable submit branch retained no executor handle - cancellation cannot interrupt it"
+			);
+		}
+
+		@Test
+		@DisplayName("runs an internally scheduled task inline without an execution handle")
+		void shouldRunInternallyScheduledTaskInlineWithoutExecutionHandle() {
+			// the branch Scheduler#submitTaskInQueue carves out explicitly: an internally scheduled task runs on the
+			// submitting thread, so it deliberately never receives an executor handle - interrupting from another
+			// thread would land on an arbitrary caller's thread with no well-defined target
+			final AtomicReference<Thread> executingThread = new AtomicReference<>();
+			final InternallyScheduledRunnableTask task =
+				new InternallyScheduledRunnableTask(() -> executingThread.set(Thread.currentThread()));
+
+			SchedulerTest.this.scheduler.submit((ServerTask<?, ?>) task);
+
+			assertSame(
+				Thread.currentThread(), executingThread.get(),
+				"an internally scheduled task must run inline on the submitting thread"
+			);
+			// no handle was attached and the future is already done, so a later cancel is a no-op rather than an NPE
+			assertFalse(task.cancel(), "cancelling an already-completed internally scheduled task must answer false");
+		}
+
+		@Test
+		@DisplayName("interrupts a task cancelled between submission and handle attachment")
+		void shouldInterruptTaskCancelledBeforeHandleAttached() throws InterruptedException {
+			// a cancel arriving after the worker started the task but before the executor handle is attached must still
+			// interrupt it: cancel() cancels the result future and only then reads the handle, so an attachment that
+			// publishes the handle and only then re-reads the future cannot miss it.
+			//
+			// The seam that makes this deterministic is entirely test-side: attachExecutionHandle is public on
+			// AbstractServerTask, so a subclass can hold the attach open for exactly as long as the test needs.
+			final CountDownLatch started = new CountDownLatch(1);
+			final CountDownLatch interrupted = new CountDownLatch(1);
+			final CountDownLatch attachReached = new CountDownLatch(1);
+			final CountDownLatch attachReleased = new CountDownLatch(1);
+			final CountDownLatch attachCompleted = new CountDownLatch(1);
+
+			final LateAttachingTask task = new LateAttachingTask(
+				theTask -> {
+					started.countDown();
+					try {
+						new CountDownLatch(1).await(30, TimeUnit.SECONDS);
+					} catch (InterruptedException e) {
+						interrupted.countDown();
+						throw new GenericEvitaInternalError("Task interrupted.", "Task interrupted.", e);
+					}
+					return -1;
+				},
+				attachReached, attachReleased, attachCompleted
+			);
+
+			// submit(...) blocks inside the overridden attachExecutionHandle, so it cannot run on the test thread
+			final Thread submitter = new Thread(
+				() -> SchedulerTest.this.scheduler.submit((ServerTask<?, ?>) task), "late-attach-submitter"
+			);
+			submitter.setDaemon(true);
+			submitter.start();
+
+			assertTrue(started.await(30, TimeUnit.SECONDS), "task never started");
+			assertTrue(attachReached.await(30, TimeUnit.SECONDS), "handle attachment was never reached");
+
+			// the task is registered in the queue before submitTaskInQueue runs, so it is cancellable in this window
+			final PaginatedList<TaskStatus<?, ?>> jobStatuses =
+				SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null);
+			assertEquals(1, jobStatuses.getTotalRecordCount());
+			// without this the absence of an interrupt below could just as well mean the cancel never found the task,
+			// which would make the whole test pass for a reason its name does not claim
+			assertTrue(
+				SchedulerTest.this.scheduler.cancelTask(jobStatuses.getData().get(0).taskId()),
+				"the cancel never reached the task - this proves nothing about the attachment window"
+			);
+
+			attachReleased.countDown();
+			assertTrue(attachCompleted.await(30, TimeUnit.SECONDS), "handle attachment never completed");
+
+			// positive wait - the attachment re-reads the already-cancelled result future and cancels the handle it
+			// just published, so the interrupt is delivered even though the cancel arrived while the handle was null
+			assertTrue(
+				interrupted.await(30, TimeUnit.SECONDS),
+				"a cancel that landed before the executor handle was attached never interrupted the running task"
+			);
+		}
 	}
 
 	@Nested
@@ -294,7 +540,7 @@ class SchedulerTest {
 			final CountDownLatch errorLogged = new CountDownLatch(1);
 			final ListAppender<ILoggingEvent> appender = new ListAppender<>() {
 				@Override
-				protected void append(@Nonnull ILoggingEvent eventObject) {
+				protected void append(ILoggingEvent eventObject) {
 					super.append(eventObject);
 					if (eventObject.getLevel() == Level.ERROR && eventObject.getThrowableProxy() != null) {
 						errorLogged.countDown();

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SequentialTaskTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SequentialTaskTest.java
@@ -40,6 +40,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -189,6 +190,44 @@ class SequentialTaskTest {
 			assertEquals(
 				TaskSimplifiedState.FAILED, status.simplifiedState(),
 				"a sequence whose result future is cancelled reported a state other than FAILED"
+			);
+			assertEquals("Task was cancelled.", status.publicExceptionMessage());
+			assertTrue(status.exceptionWithStackTrace().startsWith(CancellationException.class.getName()));
+		}
+
+		@Test
+		@DisplayName("does not report FINISHED when the cancel landed after the last step completed")
+		void shouldNotReportFinishedWhenCancelLandedAfterLastStep() {
+			// the one window the post-loop guard cannot see: the cancel arrives after that check has already passed.
+			// `complete()` then correctly no-ops on the cancelled future, but the status transition that follows it
+			// was unconditional, stamping FINISHED with a real result over a future that reports cancelled.
+			final AtomicReference<SequentialTask<Integer>> holder = new AtomicReference<>();
+			final ClientRunnableTask<Void> step1 = recordingStep("first", new ArrayList<>(1));
+			// the seam: SequentialTask reads the last step's future exactly once, between the post-loop cancellation
+			// guard and `futureResult.complete(...)` - nothing else in the engine calls a step's getFutureResult()
+			// during execution. Cancelling from that read lands the cancel inside the window deterministically and on
+			// a single thread, where a second thread could only sweep for it probabilistically.
+			final ClientCallableTask<Void, Integer> step2 = new ClientCallableTask<Void, Integer>(
+				"step", "second", null, theTask -> 42, TaskTrait.CAN_BE_CANCELLED
+			) {
+				@Nonnull
+				@Override
+				public CompletableFuture<Integer> getFutureResult() {
+					holder.get().cancel();
+					return super.getFutureResult();
+				}
+			};
+			final SequentialTask<Integer> sequence = new SequentialTask<>(null, "Sequence", step1, step2);
+			holder.set(sequence);
+			sequence.transitionToIssued();
+
+			assertNull(sequence.execute(), "a sequence cancelled before it completed must report no result");
+			assertTrue(sequence.getFutureResult().isCancelled(), "the result future was not cancelled");
+
+			final TaskStatus<Void, Integer> status = sequence.getStatus();
+			assertEquals(
+				TaskSimplifiedState.FAILED, status.simplifiedState(),
+				"the sequence reported FINISHED while its own future reports cancelled"
 			);
 			assertEquals("Task was cancelled.", status.publicExceptionMessage());
 			assertTrue(status.exceptionWithStackTrace().startsWith(CancellationException.class.getName()));

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SequentialTaskTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SequentialTaskTest.java
@@ -1,0 +1,327 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.executor;
+
+import io.evitadb.api.configuration.ThreadPoolOptions;
+import io.evitadb.api.task.ServerTask;
+import io.evitadb.api.task.TaskStatus;
+import io.evitadb.api.task.TaskStatus.TaskSimplifiedState;
+import io.evitadb.api.task.TaskStatus.TaskTrait;
+import io.evitadb.dataType.PaginatedList;
+import io.evitadb.exception.GenericEvitaInternalError;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.TASK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers {@link SequentialTask} — the two-step sequence wrapper — with emphasis on what happens when a cancellation
+ * lands at a step boundary.
+ *
+ * Both cancellation cases run single-threaded on the test thread: a step body that cancels the sequence it belongs to
+ * reaches the step-boundary check without a pool or a timing window. The two are not interchangeable — one cancels
+ * the sequence (which also cancels every step, so the pre-existing `QUEUED` guard would stop the remaining steps
+ * anyway), the other cancels only the sequence's result future and therefore isolates the boundary check itself.
+ *
+ * No assertion in this class touches {@link SequentialTask#getStatus()}'s progress value: it aggregates step progress
+ * with a bitwise OR rather than a sum, so two steps at 50 % and 100 % report 59 %. A "between min and max" assertion
+ * would hold for both that and a correct average, and would read to the next person as deliberate coverage of
+ * behaviour nobody actually asserted.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(ENGINE)
+@Tag(TASK)
+@DisplayName("Sequential task")
+class SequentialTaskTest {
+
+	/**
+	 * Builds a step that records its own execution in the given list.
+	 *
+	 * Every step carries at least one {@link TaskTrait}, because {@link SequentialTask}'s constructor funnels the union
+	 * of its steps' traits through `EnumSet.copyOf(Collection)`, which rejects an empty collection.
+	 *
+	 * @param name       the step name
+	 * @param executions the list each execution appends its name to
+	 * @return the step
+	 */
+	@Nonnull
+	private static ClientRunnableTask<Void> recordingStep(@Nonnull String name, @Nonnull List<String> executions) {
+		return new ClientRunnableTask<>(
+			"step", name, null, () -> executions.add(name), TaskTrait.CAN_BE_CANCELLED
+		);
+	}
+
+	@Nested
+	@DisplayName("Execution")
+	class Execution {
+
+		@Test
+		@DisplayName("runs both steps in declaration order and reports the last step's result")
+		void shouldRunBothStepsInDeclarationOrder() {
+			final List<String> executions = new ArrayList<>(2);
+			final ClientRunnableTask<Void> step1 = recordingStep("first", executions);
+			final ClientCallableTask<Void, Integer> step2 = new ClientCallableTask<>(
+				"step", "second", null,
+				theTask -> {
+					executions.add("second");
+					return 42;
+				},
+				TaskTrait.CAN_BE_CANCELLED
+			);
+			final SequentialTask<Integer> sequence = new SequentialTask<>(null, "Sequence", step1, step2);
+			sequence.transitionToIssued();
+
+			assertEquals(42, sequence.execute(), "the sequence must report the last step's result");
+			assertEquals(List.of("first", "second"), executions, "the steps ran out of order or not at all");
+			assertEquals(TaskSimplifiedState.FINISHED, sequence.getStatus().simplifiedState());
+			assertEquals(42, sequence.getFutureResult().getNow(null));
+		}
+	}
+
+	@Nested
+	@DisplayName("Step boundary cancellation")
+	class StepBoundaryCancellation {
+
+		@Test
+		@DisplayName("stops at the step boundary when the whole task was cancelled")
+		void shouldStopAtStepBoundaryWhenParentTaskCancelled() {
+			final AtomicReference<SequentialTask<Integer>> holder = new AtomicReference<>();
+			final AtomicBoolean secondStepRan = new AtomicBoolean(false);
+			final ClientRunnableTask<Void> step1 = new ClientRunnableTask<>(
+				"step", "first", null, () -> holder.get().cancel(), TaskTrait.CAN_BE_CANCELLED
+			);
+			final ClientCallableTask<Void, Integer> step2 = new ClientCallableTask<>(
+				"step", "second", null,
+				theTask -> {
+					secondStepRan.set(true);
+					return 42;
+				},
+				TaskTrait.CAN_BE_CANCELLED
+			);
+			final SequentialTask<Integer> sequence = new SequentialTask<>(null, "Sequence", step1, step2);
+			holder.set(sequence);
+			sequence.transitionToIssued();
+
+			// cancel() cancels every step too, so the pre-existing QUEUED guard would also have stopped step 2 here -
+			// this case pins the whole-task route rather than the boundary break, and the status it asserts is the one
+			// cancel() itself stamped. The case below isolates the break.
+			assertNull(sequence.execute(), "a cancelled sequence must report no result");
+			assertFalse(secondStepRan.get(), "the second step ran after the sequence was cancelled");
+			assertTrue(sequence.getFutureResult().isCancelled(), "the result future was not cancelled");
+
+			final TaskStatus<Void, Integer> status = sequence.getStatus();
+			assertEquals(TaskSimplifiedState.FAILED, status.simplifiedState());
+			assertEquals("Task was cancelled.", status.publicExceptionMessage());
+			assertTrue(status.exceptionWithStackTrace().startsWith(CancellationException.class.getName()));
+		}
+
+		@Test
+		@DisplayName("stops at the step boundary when only the result future was cancelled")
+		void shouldStopAtStepBoundaryWhenResultFutureCancelledDirectly() {
+			final AtomicReference<SequentialTask<Integer>> holder = new AtomicReference<>();
+			final AtomicBoolean secondStepRan = new AtomicBoolean(false);
+			final ClientRunnableTask<Void> step1 = new ClientRunnableTask<>(
+				"step", "first", null,
+				() -> holder.get().getFutureResult().cancel(true),
+				TaskTrait.CAN_BE_CANCELLED
+			);
+			final ClientCallableTask<Void, Integer> step2 = new ClientCallableTask<>(
+				"step", "second", null,
+				theTask -> {
+					secondStepRan.set(true);
+					return 42;
+				},
+				TaskTrait.CAN_BE_CANCELLED
+			);
+			final SequentialTask<Integer> sequence = new SequentialTask<>(null, "Sequence", step1, step2);
+			holder.set(sequence);
+			sequence.transitionToIssued();
+
+			assertNull(sequence.execute(), "a cancelled sequence must report no result");
+			// cancelling the result future directly leaves every step untouched, so step 2 is still QUEUED and the
+			// boundary check is the only thing that can stop it
+			assertFalse(secondStepRan.get(), "the second step ran after the result future was cancelled");
+			assertTrue(sequence.getFutureResult().isCancelled(), "the result future was not cancelled");
+
+			// the reported state must agree with the future: cancelling the result future directly leaves every step
+			// untouched, so nothing but the guard on the completion block keeps the sequence from reporting FINISHED
+			// with a null result while its own future is cancelled
+			final TaskStatus<Void, Integer> status = sequence.getStatus();
+			assertEquals(
+				TaskSimplifiedState.FAILED, status.simplifiedState(),
+				"a sequence whose result future is cancelled reported a state other than FAILED"
+			);
+			assertEquals("Task was cancelled.", status.publicExceptionMessage());
+			assertTrue(status.exceptionWithStackTrace().startsWith(CancellationException.class.getName()));
+		}
+	}
+
+	@Nested
+	@DisplayName("Lifecycle")
+	class Lifecycle {
+
+		@Test
+		@DisplayName("does not execute a task that was never issued")
+		void shouldNotExecuteTaskThatWasNeverIssued() {
+			final List<String> executions = new ArrayList<>(2);
+			final SequentialTask<Void> sequence = new SequentialTask<>(
+				null, "Sequence", recordingStep("first", executions), recordingStep("second", executions)
+			);
+
+			assertNull(sequence.execute(), "a task that is not QUEUED must not execute");
+			assertTrue(executions.isEmpty(), "steps ran for a task that was never issued");
+		}
+
+		@Test
+		@DisplayName("refuses to cancel an already completed task")
+		void shouldRefuseToCancelAlreadyCompletedTask() {
+			final List<String> executions = new ArrayList<>(2);
+			final SequentialTask<Void> sequence = new SequentialTask<>(
+				null, "Sequence", recordingStep("first", executions), recordingStep("second", executions)
+			);
+			sequence.transitionToIssued();
+			sequence.execute();
+
+			assertFalse(sequence.cancel(), "cancelling a completed sequence must answer false");
+		}
+
+		@Test
+		@DisplayName("propagates a failure to every step")
+		void shouldPropagateFailureToEveryStep() {
+			final List<String> executions = new ArrayList<>(2);
+			final ClientRunnableTask<Void> step1 = recordingStep("first", executions);
+			final ClientRunnableTask<Void> step2 = recordingStep("second", executions);
+			final SequentialTask<Void> sequence = new SequentialTask<>(null, "Sequence", step1, step2);
+
+			sequence.fail(new IllegalStateException("boom"));
+
+			assertEquals(TaskSimplifiedState.FAILED, sequence.getStatus().simplifiedState());
+			assertEquals(TaskSimplifiedState.FAILED, step1.getStatus().simplifiedState());
+			assertEquals(TaskSimplifiedState.FAILED, step2.getStatus().simplifiedState());
+			assertTrue(sequence.getFutureResult().isCompletedExceptionally());
+		}
+
+		@Test
+		@DisplayName("matches itself and any of its steps")
+		void shouldMatchItselfAndAnyStep() {
+			final List<String> executions = new ArrayList<>(2);
+			final ClientRunnableTask<Void> step1 = recordingStep("first", executions);
+			final ClientRunnableTask<Void> step2 = recordingStep("second", executions);
+			final SequentialTask<Void> sequence = new SequentialTask<>(null, "Sequence", step1, step2);
+
+			assertTrue(sequence.matches(task -> task == sequence), "the sequence must match itself");
+			assertTrue(sequence.matches(task -> task == step1), "the sequence must match its first step");
+			assertTrue(sequence.matches(task -> task == step2), "the sequence must match its second step");
+			assertFalse(sequence.matches(task -> false), "the sequence matched a predicate nothing satisfies");
+		}
+
+		@Test
+		@DisplayName("cancels a task that never received an execution handle")
+		void shouldCancelTaskWithoutExecutionHandle() {
+			final List<String> executions = new ArrayList<>(2);
+			final SequentialTask<Void> sequence = new SequentialTask<>(
+				null, "Sequence", recordingStep("first", executions), recordingStep("second", executions)
+			);
+
+			assertTrue(sequence.cancel(), "cancelling a fresh sequence must answer true");
+			assertTrue(sequence.getFutureResult().isCancelled(), "the result future was not cancelled");
+		}
+	}
+
+	@Nested
+	@DisplayName("Through the scheduler")
+	class ThroughScheduler {
+		private final Scheduler scheduler = new Scheduler(
+			ThreadPoolOptions
+				.serviceThreadPoolBuilder()
+				.build()
+		);
+
+		@AfterEach
+		void tearDown() {
+			this.scheduler.shutdownNow();
+		}
+
+		@Test
+		@DisplayName("interrupts the in-flight step when the sequence is cancelled")
+		void shouldInterruptInFlightStepWhenSequentialTaskCancelled() throws InterruptedException {
+			// covers two otherwise untested things at once: the executor handle attachment on SequentialTask, and the
+			// executorService.submit(task::execute) branch of Scheduler#submitTaskInQueue - SequentialTask implements
+			// ServerTask but, unlike ClientCallableTask, not Callable
+			final CountDownLatch started = new CountDownLatch(1);
+			final CountDownLatch interrupted = new CountDownLatch(1);
+			final ClientRunnableTask<Void> step1 = new ClientRunnableTask<>(
+				"step", "first", null,
+				() -> {
+					started.countDown();
+					try {
+						new CountDownLatch(1).await(30, TimeUnit.SECONDS);
+					} catch (InterruptedException e) {
+						interrupted.countDown();
+						// a Runnable body cannot rethrow the checked exception - wrapping it is what lets the test
+						// observe the real unwind path
+						throw new GenericEvitaInternalError("Step interrupted.", "Step interrupted.", e);
+					}
+				},
+				TaskTrait.CAN_BE_CANCELLED
+			);
+			final List<String> executions = new ArrayList<>(1);
+			final SequentialTask<Void> sequence = new SequentialTask<>(
+				null, "Sequence", step1, recordingStep("second", executions)
+			);
+
+			this.scheduler.submit((ServerTask<?, ?>) sequence);
+
+			assertTrue(started.await(30, TimeUnit.SECONDS), "the first step never started");
+
+			final PaginatedList<TaskStatus<?, ?>> statuses = this.scheduler.listTaskStatuses(1, 20, null);
+			assertEquals(1, statuses.getTotalRecordCount());
+			this.scheduler.cancelTask(statuses.getData().get(0).taskId());
+
+			assertTrue(
+				interrupted.await(30, TimeUnit.SECONDS),
+				"the in-flight step was never interrupted - the sequence retained no executor handle"
+			);
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/task/BackupTaskCancellationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/task/BackupTaskCancellationTest.java
@@ -1,0 +1,333 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.catalog.task;
+
+import io.evitadb.api.exception.FileForFetchNotFoundException;
+import io.evitadb.api.file.FileForFetch;
+import io.evitadb.dataType.PaginatedList;
+import io.evitadb.exception.UnexpectedIOException;
+import io.evitadb.spi.export.ExportService;
+import io.evitadb.spi.export.model.ExportFileHandle;
+import io.evitadb.store.catalog.DefaultCatalogPersistenceService;
+import io.evitadb.store.catalog.model.CatalogBootstrap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static io.evitadb.test.TestTags.EXPORT;
+import static io.evitadb.test.TestTags.STORAGE;
+import static io.evitadb.test.TestTags.TASK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Pins what {@link BackupTask}'s failure cleanup does with the partially written export file when the backup is
+ * aborted by an interrupt rather than by an ordinary runtime failure.
+ *
+ * The distinction matters because the interrupt checkpoints woven into the backup's helpers raise
+ * {@link InterruptedException} — a **checked** exception, thrown from bytecode out of methods whose signatures never
+ * mention it. It is invisible in the source, so the cleanup's exception type is the only thing that decides whether a
+ * cancelled backup leaves its half-written archive behind. Both cases below drive the failure through the same
+ * injection point and differ only in the type thrown, which is what makes the pair conclusive.
+ *
+ * The fixture is deliberately free of an embedded evitaDB instance: the persistence service is stubbed and fails on
+ * the first call the backup makes against it, so nothing here depends on timing or on a catalog existing on disk.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(STORAGE)
+@Tag(TASK)
+@Tag(EXPORT)
+@DisplayName("Backup task cancellation cleanup")
+class BackupTaskCancellationTest {
+	private static final String CATALOG_NAME = "testCatalog";
+	/** Any non-zero version keeps the constructor off the warm-up path, which would need a real directory hold. */
+	private static final long CATALOG_VERSION = 1L;
+
+	private Path zipFile;
+
+	/**
+	 * Throws the given checked exception without declaring it — precisely what the woven interrupt advice does. Type
+	 * erasure makes the cast to `E` unchecked at the throw site, so the compiler never sees the checked type.
+	 *
+	 * @param throwable the exception to raise
+	 * @param <E>       the type the caller pretends is being thrown
+	 * @throws E always
+	 */
+	@SuppressWarnings("unchecked")
+	private static <E extends Throwable> void sneakyThrow(@Nonnull Throwable throwable) throws E {
+		throw (E) throwable;
+	}
+
+	@Nonnull
+	private static FileForFetch fileForFetch(@Nonnull UUID fileId) {
+		return new FileForFetch(
+			fileId, "backup_" + CATALOG_NAME + ".zip", null, "application/zip",
+			1L, OffsetDateTime.now(), null
+		);
+	}
+
+	@Nonnull
+	private static CatalogBootstrap bootstrapRecord() {
+		return new CatalogBootstrap(1, CATALOG_VERSION, 0, OffsetDateTime.now(), null);
+	}
+
+	/**
+	 * Builds a backup task whose first interaction with the persistence service raises the given exception, so the
+	 * failure lands inside the block guarded by the export-file cleanup.
+	 *
+	 * @param exportService the export service the task registers its file with
+	 * @param failure       the exception the persistence service raises
+	 * @return the task, already moved into the QUEUED state so `call()` runs its body
+	 */
+	@Nonnull
+	private static BackupTask failingBackupTask(
+		@Nonnull ExportService exportService,
+		@Nonnull Throwable failure
+	) {
+		final DefaultCatalogPersistenceService persistenceService =
+			Mockito.mock(DefaultCatalogPersistenceService.class);
+		Mockito.when(persistenceService.getStoragePartPersistenceService(ArgumentMatchers.anyLong()))
+			.thenAnswer(invocation -> {
+				sneakyThrow(failure);
+				return null;
+			});
+
+		final BackupTask task = new BackupTask(
+			CATALOG_NAME, null, null, false, bootstrapRecord(), exportService, persistenceService, null
+		);
+		// execute() gates on QUEUED and a freshly built status is WAITING_FOR_PRECONDITION
+		task.transitionToIssued();
+		return task;
+	}
+
+	@BeforeEach
+	void setUp() throws IOException {
+		this.zipFile = Files.createTempFile("BackupTaskCancellationTest", ".zip");
+	}
+
+	@AfterEach
+	void tearDown() throws IOException {
+		Files.deleteIfExists(this.zipFile);
+	}
+
+	@Nested
+	@DisplayName("Aborted by an interrupt")
+	class AbortedByInterrupt {
+
+		@Test
+		@DisplayName("deletes the registered export file when the backup is interrupted")
+		void shouldDeleteRegisteredExportFileWhenBackupInterrupted() {
+			// an interrupt must clean up exactly like any other failure: the archive written so far is structurally
+			// valid but missing most of its entries, and leaving it registered lists it to users as a fetchable backup
+			final UUID fileId = UUID.randomUUID();
+			final FakeExportFileHandle handle = new FakeExportFileHandle(
+				fileId, BackupTaskCancellationTest.this.zipFile
+			);
+			// the file is registered before the backup starts writing entries into it
+			handle.fileForFetchFuture().complete(fileForFetch(fileId));
+			final RecordingExportService exportService = new RecordingExportService(handle);
+
+			final InterruptedException interrupt = new InterruptedException("simulated interrupt");
+			final BackupTask task = failingBackupTask(exportService, interrupt);
+
+			// the cleanup rewraps a non-runtime cause, so the checked interrupt surfaces as an UnexpectedIOException
+			final UnexpectedIOException raised = assertThrows(
+				UnexpectedIOException.class, task::call,
+				"the interrupt must unwind the backup"
+			);
+			assertSame(interrupt, raised.getCause(), "the rewrap lost the interrupt that aborted the backup");
+			assertEquals(
+				List.of(fileId), exportService.deletedFileIds,
+				"an interrupted backup left its partially written file registered as a fetchable backup"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Aborted by a runtime failure")
+	class AbortedByRuntimeFailure {
+
+		@Test
+		@DisplayName("deletes the registered export file when the backup fails at runtime")
+		void shouldDeleteRegisteredExportFileWhenBackupFailsAtRuntime() {
+			// the counterfactual that makes the case above conclusive: the identical injection point, reached the
+			// identical way, and the cleanup DOES run because the exception is a RuntimeException
+			final UUID fileId = UUID.randomUUID();
+			final FakeExportFileHandle handle = new FakeExportFileHandle(
+				fileId, BackupTaskCancellationTest.this.zipFile
+			);
+			handle.fileForFetchFuture().complete(fileForFetch(fileId));
+			final RecordingExportService exportService = new RecordingExportService(handle);
+
+			final BackupTask task = failingBackupTask(exportService, new IllegalStateException("simulated failure"));
+
+			assertThrows(IllegalStateException.class, task::call, "the runtime failure must unwind the backup");
+			assertEquals(
+				List.of(fileId), exportService.deletedFileIds,
+				"a backup that failed at runtime must delete its partially written file"
+			);
+		}
+	}
+
+	/**
+	 * Minimal {@link ExportService} that hands out a single pre-built {@link ExportFileHandle} on `storeFile` and
+	 * records every `deleteFile` call, so the test can assert whether the partial-file cleanup ran. Every other
+	 * operation is irrelevant here.
+	 */
+	private static class RecordingExportService implements ExportService {
+		private final ExportFileHandle handle;
+		private final List<UUID> deletedFileIds = new ArrayList<>();
+
+		private RecordingExportService(@Nonnull ExportFileHandle handle) {
+			this.handle = handle;
+		}
+
+		@Nonnull
+		@Override
+		public ExportFileHandle storeFile(
+			@Nonnull String fileName, @Nullable String description,
+			@Nonnull String contentType, @Nullable String origin
+		) {
+			return this.handle;
+		}
+
+		@Override
+		public void deleteFile(@Nonnull UUID fileId) throws FileForFetchNotFoundException {
+			this.deletedFileIds.add(fileId);
+		}
+
+		@Nonnull
+		@Override
+		public PaginatedList<FileForFetch> listFilesToFetch(int page, int pageSize, @Nonnull Set<String> origin) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Nonnull
+		@Override
+		public Optional<FileForFetch> getFile(@Nonnull UUID fileId) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Nonnull
+		@Override
+		public InputStream fetchFile(@Nonnull UUID fileId) throws FileForFetchNotFoundException {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public long purgeFiles() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void purgeFiles(@Nonnull OffsetDateTime thresholdDate) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void close() {
+			// no-op
+		}
+	}
+
+	/**
+	 * {@link ExportFileHandle} backed by a real temporary file, so the backup's zip machinery has a genuine sink, with
+	 * a caller-controllable file-for-fetch future modelling a file that is already registered when the failure lands.
+	 */
+	private static class FakeExportFileHandle implements ExportFileHandle {
+		private final UUID fileId;
+		private final Path targetFile;
+		private final CompletableFuture<FileForFetch> future = new CompletableFuture<>();
+
+		private FakeExportFileHandle(@Nonnull UUID fileId, @Nonnull Path targetFile) {
+			this.fileId = fileId;
+			this.targetFile = targetFile;
+		}
+
+		@Nonnull
+		@Override
+		public UUID fileId() {
+			return this.fileId;
+		}
+
+		@Nonnull
+		@Override
+		public CompletableFuture<FileForFetch> fileForFetchFuture() {
+			return this.future;
+		}
+
+		@Override
+		public long size() {
+			try {
+				return Files.size(this.targetFile);
+			} catch (IOException e) {
+				throw new UnexpectedIOException(
+					"Failed to read the size of the test export file.",
+					"Failed to read the size of the test export file.", e
+				);
+			}
+		}
+
+		@Nonnull
+		@Override
+		public OutputStream outputStream() {
+			try {
+				return Files.newOutputStream(this.targetFile);
+			} catch (IOException e) {
+				throw new UnexpectedIOException(
+					"Failed to open the test export file for writing.",
+					"Failed to open the test export file for writing.", e
+				);
+			}
+		}
+
+		@Override
+		public void close() {
+			// no-op
+		}
+	}
+
+}


### PR DESCRIPTION
Closes #1416

`@Interruptible` has never injected anything. The build-time ByteBuddy weaver assembled its method union with `ElementMatchers.anyOf(...)`, whose `Object...` overload compares candidates with `equals()` against the values it is handed — given matcher instances it matched no method anywhere, in any module, ever. Every annotation and every hand-listed hot method has been decorative for the whole lifetime of the annotation, so no query ever polled the interrupt flag and a disconnected client kept paying for CPU until the query finished on its own.

A matcher that matches nothing is indistinguishable from one that works: the plugin logs `Transformed N type(s)` either way. That is why this stayed hidden.

## What changed

**The weaving itself.** The union is chained with `.or()`, excluding abstract methods once at the end. Both weaving plugins now share `AbstractInterruptionTransformer`, which carries the reasoning for `visit` over `intercept` and an explicit warning against `anyOf`.

The guard against a silent regression cannot live in the plugin — the `transform` goal is incremental, so when nothing recompiled it processes zero types and a "this wove nothing" assertion cannot tell a dead matcher from an up-to-date build. `InterruptionAdviceWovenTest` therefore reads the poll out of the **built class files** of both modules.

**Three further broken links in the same chain.** Repairing the weaving alone would still have left cancellation going nowhere:

- `Scheduler#submitTaskInQueue` discarded the executor `Future`, and `CompletableFuture#cancel(true)` ignores `mayInterruptIfRunning` entirely — only a `FutureTask` can interrupt. A running background task was uninterruptible. The handle is now retained and cancelled through.
- A cancel arriving between submission and handle attachment was lost. Both sides now touch the same two volatile fields in opposite order, so at least one observes the other.
- `AbstractObservableTask#cancel()` could deliver the interrupt after the worker had moved on, leaving a stale flag to be raised against the next request on that pooled thread. Guarded by an explicit execution state machine.

**Two defects that only became reachable once the interrupt arrived:**

- `BackupTask` caught only `RuntimeException` while cleaning up. The woven `InterruptedException` is *checked*, so it slipped past and left a truncated-but-valid ZIP registered as fetchable.
- `SequentialTask` reported a cancelled sequence as `FINISHED`.

The `catch (RuntimeException)` case generalises and **was not swept for**: any cleanup block narrowed to `RuntimeException` on a now-interruptible path has the same hole, and it is invisible at the catch site because the exception is thrown from woven bytecode. The ADR records the class of bug.

## Verification

Every fix was calibrated by reverting it and confirming the predicted failure, then restoring it:

- 97 tests — `-Dgroups="task & engine"`
- 123 tests — GraphQL/REST request path, where the `ObservableThreadExecutor` fix actually executes; zero interrupt leakage into subsequent requests
- 75 tests — targeted classes
- Compile green across all four affected modules

Full-suite green is left to CI at the standard heap; the suite OOMs on this machine at the same setting, and raising the local heap would hide that divergence rather than explain it.

## Notes for review

`interruptibleMethods()` still names the engine's hot methods by string. Replacing it with `@Interruptible` on each was considered and deferred: Java does not inherit method annotations, so the annotation would have to be repeated on every concrete implementation, and there is no build-time check that a new one carries it. Of the 56 types in the `Formula` lineage only 4 declare a `compute()` body, so the string list is small and now directly covered by `InterruptionTransformerMatcherTest`. Reasoning recorded in the ADR.