### PR TITLE
Fix scheduler purge dropping waiting tasks, and make the waiting interval an idle timeout

### DIFF
--- a/documentation/adr/2026-08-14-interruption-weaving-and-task-cancellation.md
+++ b/documentation/adr/2026-08-14-interruption-weaving-and-task-cancellation.md
@@ -1,7 +1,7 @@
 ---
 title: Weave the interrupt poll with `visit` and a chained matcher union, and interrupt tasks through the executor's Future
 date: 2026-08-14
-updated: 2026-08-14 15:05
+updated: 2026-08-14 17:20
 status: accepted
 kind: fix
 issues: [1416]
@@ -11,7 +11,7 @@ areas:
   - evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/async
 supersedes: []
 superseded-by: []
-relates: [2026-07-16-client-session-cancellation-cascade]
+relates: [2026-07-16-client-session-cancellation-cascade, 2026-08-14-waiting-task-idle-timeout]
 ---
 
 # Weave the interrupt poll with `visit` and a chained matcher union, and interrupt tasks through the executor's Future

--- a/documentation/adr/2026-08-14-waiting-task-idle-timeout.md
+++ b/documentation/adr/2026-08-14-waiting-task-idle-timeout.md
@@ -1,0 +1,171 @@
+---
+title: Make the scheduler's waiting interval an idle timeout renewed by lookup, linearized on the buffer lock
+date: 2026-08-14
+updated: 2026-08-14 17:20
+status: accepted
+kind: fix
+issues: [1415]
+prs: []
+areas:
+  - evita_engine/src/main/java/io/evitadb/core/executor
+  - evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services
+supersedes: []
+superseded-by: []
+relates: [2026-08-14-interruption-weaving-and-task-cancellation]
+---
+
+# Make the scheduler's waiting interval an idle timeout renewed by lookup, linearized on the buffer lock
+
+`Scheduler`'s queue purge drops tasks that have waited too long for their precondition. The interval it
+enforced was crossed with the finished-task one (five minutes instead of ten), it measured a task's whole
+life rather than its idleness, and it dropped tasks with a bare `it.remove()` that left their futures
+uncompleted forever. All three are fixed: the constants are uncrossed, a successful `findTask` lookup now
+renews a waiting task so the interval behaves as an idle timeout, and a timed-out task is removed **and**
+failed with a `TaskTimedOutException`. The renewal is made correct by holding `bufferLock` across the
+lookup and the renewal, not by making the activity map concurrent.
+
+## Why
+
+`EvitaManagementService#restoreCatalogUnary` is the chunked catalog-restore upload used where true gRPC
+client streaming is unavailable (gRPC-Web). It creates the restoration task on the **first** chunk, parks
+it with `registerWaitingTask`, and submits it only once the received bytes reach `totalSizeInBytes`. Every
+later chunk re-locates that task through `getWaitingTask` → `Scheduler#findTask`. The waiting queue is the
+only thing carrying upload state from one call to the next.
+
+A parked task genuinely sits in the state the purge matches on: `registerWaitingTask` never calls
+`transitionToIssued`, so `TaskStatus#issued` stays null and `simplifiedState()` returns
+`WAITING_FOR_PRECONDITION`. The purge runs every minute and measured age from `status.created()` — the
+first chunk. Any upload lasting longer than the interval therefore lost its task mid-flight, and the next
+chunk failed with `"Task not found for file id!"`.
+
+The constraint that makes this non-obvious: **fixing the crossed constants is not enough.** Because the
+clock ran from creation, ten minutes is a ceiling on total upload duration, not a timeout. A 2 GB backup
+needs roughly 27 Mbit/s sustained to fit inside it. Uncrossing the constants alone would have moved the
+same silent data loss from the five-minute mark to the ten-minute mark and called it fixed.
+
+### Previous state
+
+`purgeFinishedAndLongWaitingTasks` built both thresholds from the wrong constants — `waitingThreshold`
+from `FINISHED_TASKS_KEEP_INTERVAL_MILLIS` and the defense-period threshold from
+`WAITING_TASKS_KEEP_INTERVAL_MILLIS`. `findTask` and `submitWaitingTask` were the only registry
+operations that ran **without** `bufferLock`, while the purge drains the queue into a private buffer and
+refills it under that lock.
+
+## Options considered
+
+### Option A — last-activity map in the scheduler, renewed by `findTask` (chosen)
+
+A `Map<UUID, OffsetDateTime>` inside `Scheduler`, written when a lookup finds a still-waiting task; the
+purge measures from the later of `created` and that timestamp.
+
+- **Pros:** no API or wire-format change; the one caller that exists already announces its interest by
+  calling `getWaitingTask`, so no new obligation is placed on callers; an absent entry degrades to the
+  old creation-based behaviour, so abandoned tasks are still collected.
+- **Cons:** makes a lookup mutate state, which is surprising unless documented; requires giving
+  `findTask` and `submitWaitingTask` a lock they did not previously take.
+
+### Option B — a new component on `TaskStatus` (declined)
+
+Carry the last-activity timestamp on the task status record itself.
+
+- **Pros:** the timestamp travels with the task; no scheduler-side map to keep in step with the queue.
+- **Rejected because:** `TaskStatus` is a public record in `evita_api` that crosses the gRPC boundary via
+  `toGrpcTaskStatus`. A new component means a new proto field, converters on both sides and a
+  version-skew story — permanent wire surface for a value no client reads. It would be worth revisiting
+  only if a client ever needed to *display* when a waiting task was last touched.
+
+### Option C — an explicit `touch()` / `renew()` API called by the restore handler (declined)
+
+- **Pros:** entirely explicit; a lookup stays free of side effects.
+- **Rejected because:** it is a second call that says what the first one already said, and it obliges
+  every future caller to remember it. The failure mode is silent — forget the call and uploads start
+  dying again at ten minutes, which is exactly the bug this record exists to close. Worth revisiting if a
+  caller ever needs to inspect a waiting task *without* extending its life; today none does.
+
+### Option D — leave it a creation-time budget and only uncross the constants (declined)
+
+- **Pros:** minimal diff; fixes the reported symptom.
+- **Rejected because:** it does not fix the reported *problem*. See the constraint under **Why** — it
+  relocates the failure rather than removing it.
+
+## Decision
+
+**Chosen: Option A**, with the correctness carried by the lock rather than by the data structure.
+
+The decisive point is that a concurrent map would not have made this correct. `ConcurrentHashMap` makes
+each individual operation atomic while leaving every compound one open: a lookup can find a task, stall
+before publishing its renewal, and lose to a purge that has already read the old timestamp and selected
+the task for timeout; and a lookup running during the purge's drain window can report *no such task* for
+one that is merely held in the buffer. `findTask` and `submitWaitingTask` therefore take `bufferLock`
+across lookup, state check and activity update, and the map is deliberately a plain `HashMap` — the lock
+is the mechanism, and a concurrent map would only have disguised that.
+
+For Option B to win, a client would have to need the last-activity timestamp over the wire; for Option C,
+a caller would have to need a non-renewing lookup.
+
+## Key technical details
+
+- **Entry points.** `Scheduler#findTask` renews (and documents that it renews); `Scheduler#purgeAndCollectTimedOutTasks`
+  decides timeouts; `Scheduler#lastWaitingActivityOf` is the "later of creation and last lookup" rule.
+- **A lookup keeps a waiting task alive.** This is a contract, not an implementation detail. A caller
+  that must *not* extend a task's life cannot use `findTask`. Adding a second caller — a monitoring
+  endpoint that lists waiting tasks, say — would silently make waiting tasks immortal.
+- **Timed-out tasks are removed from the queue, never failed in place and kept.** Three separate reasons,
+  each sufficient: the purge doubles as the queue's capacity-reclaim path (`addTaskToQueue` calls it only
+  once `offer` reports full, then retries), so a retained task frees no slot; a retained task stays
+  discoverable, and the restore predicate matches on file id with **no state filter** while
+  `SequentialTask#matches` tests every child; and `SequentialTask#transitionToIssued` — unlike
+  `AbstractServerTask`'s — does **not** refuse an already-completed task, so a failed restore sequence
+  could be transitioned back to queued and scheduled.
+- **Failing happens after every lock hold is released.** Task futures are public, so a completion callback
+  is arbitrary client code that may re-enter the scheduler. Note that "after the purge's own `finally`" is
+  *not* sufficient: on the overflow path `addTaskToQueue` holds `bufferLock` reentrantly across the purge,
+  so the purge's unlock only decrements the hold count. `purgeAndCollectTimedOutTasks` therefore returns
+  the collected tasks and both callers fail them once their own hold is gone.
+- **`submitWaitingTask` transitions to issued under the lock**, so a purge sees a task either still
+  waiting or already issued and never both; handing it to the executor stays outside the lock, because an
+  `@InternallyScheduledTask` runs inline and a task body must not execute under the registry lock. That
+  is why `submitTaskInQueue` is split into the transition and `executeIssuedTask`.
+- **The activity map is pruned in the purge walk** — any task found in a non-waiting state loses its
+  entry — rather than by a separate sweep.
+
+## Verification
+
+`SchedulerTest.QueuePurging`, 11 tests; `SchedulerTest` 26 tests, 0 failures; the `task & engine`
+selector 111 tests, 0 failures (`mvn -o -pl evita_test/evita_functional_tests test -P unitAndFunctional
+-Dgroups="task & engine"`).
+
+The two tests that pinned the original defect failed on **opposite** branches before the fix — a waiting
+task at 9m55s was dropped, a finished task at 5m05s was kept — which is what evidences a crossing rather
+than a single wrong value. All four threshold tests bracket their interval to within five seconds, so
+they pin 10 and 5 minutes specifically; a ±3-minute bracket would also have been satisfied by an 8/6
+implementation. `shouldDropWaitingTaskWhenLookupWentStale` and `shouldKeepWaitingTaskAcrossRepeatedLookups`
+drive a controllable `Clock` and are the pair that distinguishes "renewal postpones" from "renewal confers
+immortality".
+
+## Consequences & open follow-ups
+
+- **The orphaned temporary `.zip` of an abandoned upload is still leaked.**
+  `restoreCatalogUnary` uses `createTempFile` rather than `createManagedTempFile`, so the file is neither
+  reserved nor swept at service close, and `RestoreTask` opens the archive `DELETE_ON_CLOSE` and therefore
+  deletes it only if the task actually runs. Failing the task does **not** clean it up. Deferred because
+  it is a distinct leak whose fix touches the streaming `restoreCatalog` sibling.
+- **A restore chunk arriving after its task timed out still reports "Task not found for file id!"**
+  rather than the timeout reason, because the task is gone from the queue by then. Turning the now-known
+  `TaskTimedOutException` into a better client message is a gRPC-layer change, not a scheduler one.
+- **The lookup-renews contract is enforced only by documentation.** Nothing prevents a future caller from
+  taking a renewing lookup when it wanted an inert one. A non-renewing `peekTask` would be the obvious
+  answer if a second caller ever appears.
+- **`cancelTask` does not physically remove its queue entry** despite its JavaDoc saying it does; the
+  entry survives until a later purge collects it as finished/failed. Noticed while tracing the queue
+  lifecycle, left alone as out of scope.
+
+## Related work
+
+- `2026-08-14-interruption-weaving-and-task-cancellation` — same `io.evitadb.core.executor` package and
+  the same week; it made cancellation actually interrupt a running task, while this record governs the
+  lifecycle of a task that never starts running at all.
+
+## Timeline
+
+- **2026-08-14** — reported as #1415, root-caused, implemented and verified

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -34,6 +34,7 @@ filename date that disagrees with `date:`.
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
 | 2026-08-14 | [Weave the interrupt poll with `visit` and a chained matcher union, and interrupt tasks through the executor's Future](2026-08-14-interruption-weaving-and-task-cancellation.md) | fix | accepted | #1416 |
+| 2026-08-14 | [Make the scheduler's waiting interval an idle timeout renewed by lookup, linearized on the buffer lock](2026-08-14-waiting-task-idle-timeout.md) | fix | accepted | #1415 |
 | 2026-08-10 | [Statistics are selectable components at two levels, and an exact heap figure is reached one index at a time](2026-08-10-catalog-and-collection-statistics/) | feature | accepted | #1339, PR #1418 |
 | 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-06 | [Bound time travel with an absolute per-catalog byte budget, not a ratio or a generation count](2026-08-06-time-travel-disk-budget.md) | feature | accepted | #761, PR #1402 |

--- a/evita_api/src/main/java/io/evitadb/api/exception/TaskTimedOutException.java
+++ b/evita_api/src/main/java/io/evitadb/api/exception/TaskTimedOutException.java
@@ -1,0 +1,65 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.exception;
+
+import io.evitadb.exception.EvitaInvalidUsageException;
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+import java.io.Serial;
+import java.util.UUID;
+
+/**
+ * Exception marking a background task that waited for its precondition longer than the scheduler is willing to
+ * keep it, and was therefore removed from the task queue.
+ *
+ * The task never ran. It is the terminal state of a task whose precondition never arrived - most visibly a
+ * chunked catalog-restore upload that stopped sending chunks partway through, leaving the restoration task
+ * parked in the queue with nothing left to complete it.
+ *
+ * The scheduler completes the task's future with this exception rather than discarding the task silently, so
+ * that anything joining that future observes the timeout instead of waiting forever.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class TaskTimedOutException extends EvitaInvalidUsageException {
+	@Serial private static final long serialVersionUID = -4986213977905927613L;
+	/**
+	 * The UUID of the task that timed out, useful for client-side debugging.
+	 */
+	@Getter private final UUID taskId;
+
+	/**
+	 * Creates a new exception indicating that the task waited for its precondition for too long.
+	 *
+	 * @param taskId the UUID of the task that timed out
+	 */
+	public TaskTimedOutException(@Nonnull UUID taskId) {
+		super(
+			"Task " + taskId + " waited for its precondition for too long and was removed from the queue.",
+			"Task waited for its precondition for too long and was removed from the queue."
+		);
+		this.taskId = taskId;
+	}
+}

--- a/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
@@ -754,17 +754,27 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	 * The method is guarded by {@link #bufferLock}; a concurrent caller that cannot acquire the lock blocks until the
 	 * in-progress purge finishes rather than busy-spinning.
 	 *
+	 * Package-private rather than private so that `SchedulerTest` can drive a purge deterministically instead of
+	 * waiting out the one-minute schedule or filling the queue to force one; no caller outside this class exists.
+	 *
 	 * @return always {@code 0L}, signalling the scheduling framework to re-plan the purge at its standard interval
 	 */
-	private long purgeFinishedAndLongWaitingTasks() {
+	long purgeFinishedAndLongWaitingTasks() {
 		if (this.bufferLock.tryLock()) {
 			try {
 				// go through the entire queue, but only once
 				final int queueSize = this.queue.size();
 				//noinspection rawtypes
 				CompositeObjectArray<Task> finishedTaskInDefensePeriod = null;
-				final OffsetDateTime waitingThreshold = OffsetDateTime.now().minus(FINISHED_TASKS_KEEP_INTERVAL_MILLIS, ChronoUnit.MILLIS);
-				final OffsetDateTime threshold = OffsetDateTime.now().minus(WAITING_TASKS_KEEP_INTERVAL_MILLIS, ChronoUnit.MILLIS);
+				// a single `now` for both thresholds - two separate reads could disagree about the current time, and
+				// the names are spelled out so that a future edit cannot silently cross them again (see #1415)
+				final OffsetDateTime now = OffsetDateTime.now();
+				final OffsetDateTime waitingThreshold = now.minus(
+					WAITING_TASKS_KEEP_INTERVAL_MILLIS, ChronoUnit.MILLIS
+				);
+				final OffsetDateTime defensePeriodThreshold = now.minus(
+					FINISHED_TASKS_KEEP_INTERVAL_MILLIS, ChronoUnit.MILLIS
+				);
 				final int batches = queueSize / BUFFER_CAPACITY + 1;
 				for (int i = 0; i < batches; i++) {
 					// effectively withdraw first block of tasks from the queue
@@ -776,13 +786,14 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 						final TaskStatus<?, ?> status = task.getStatus();
 						final TaskSimplifiedState taskState = status.simplifiedState();
 						if (taskState == TaskSimplifiedState.WAITING_FOR_PRECONDITION && status.created().isBefore(waitingThreshold)) {
-							// if task is waiting for precondition and its issued time is older than the threshold, remove it
+							// a task still waiting for its precondition past the waiting interval is dropped; the clock
+							// runs from creation (a waiting task is never issued), so this is a whole-life budget
 							log.info("Task {} is waiting for precondition for too long, removing it from the queue.", status.taskId());
 							it.remove();
 						} else if (taskState == TaskSimplifiedState.FINISHED || taskState == TaskSimplifiedState.FAILED) {
 							it.remove();
 							// if its defense period hasn't perished add it to list, that might end up in the queue again
-							if (status.finished() != null && status.finished().isAfter(threshold)) {
+							if (status.finished() != null && status.finished().isAfter(defensePeriodThreshold)) {
 								if (finishedTaskInDefensePeriod == null) {
 									finishedTaskInDefensePeriod = new CompositeObjectArray<>(Task.class);
 								}

--- a/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
@@ -35,6 +35,7 @@ import io.evitadb.core.metric.event.system.ScheduledExecutorStatisticsEvent;
 import io.evitadb.dataType.PaginatedList;
 import io.evitadb.dataType.array.CompositeObjectArray;
 import io.evitadb.utils.ArrayUtils;
+import io.evitadb.utils.CollectionUtils;
 import io.evitadb.utils.IOUtils;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -92,7 +93,7 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	 * individual operations safe while leaving the compound lookup-and-renew, and renew-versus-timeout, races
 	 * wide open; the lock is what actually makes those atomic.
 	 */
-	private final Map<UUID, OffsetDateTime> waitingTaskLastActivity = new HashMap<>(16);
+	private final Map<UUID, OffsetDateTime> waitingTaskLastActivity = CollectionUtils.createHashMap(16);
 	/**
 	 * Java based scheduled executor service.
 	 */

--- a/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
@@ -24,6 +24,7 @@
 package io.evitadb.core.executor;
 
 import io.evitadb.api.configuration.ThreadPoolOptions;
+import io.evitadb.api.exception.TaskTimedOutException;
 import io.evitadb.api.task.InfiniteTask;
 import io.evitadb.api.task.InternallyScheduledTask;
 import io.evitadb.api.task.ServerTask;
@@ -710,6 +711,7 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	@Nonnull
 	private <T extends ServerTask<?, ?>> T addTaskToQueue(@Nonnull T task) {
 		final boolean added;
+		final List<ServerTask<?, ?>> timedOutTasks;
 		// hold the buffer lock around the whole add so that registry writes never interleave with a concurrent
 		// purge: this prevents the purge's drain/refill window from racing an offer, which could otherwise overflow
 		// the re-add and silently drop live tasks. The purge re-enters this lock reentrantly on the full-queue path.
@@ -719,12 +721,15 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 			if (this.queue.offer(task)) {
 				return task;
 			}
-			// the queue is full, so we need to remove some tasks and try again
-			this.purgeFinishedAndLongWaitingTasks();
+			// the queue is full, so we need to remove some tasks and try again - the purge removes the timed-out
+			// waiting tasks here, which is what frees the slot this retry needs
+			timedOutTasks = purgeAndCollectTimedOutTasks();
 			added = this.queue.offer(task);
 		} finally {
 			this.bufferLock.unlock();
 		}
+		// only now, with this method's own hold released, is it safe to run the tasks' completion callbacks
+		failTimedOutTasks(timedOutTasks);
 		if (!added) {
 			// this should never happen since the queue was cleared of finished and timed out tasks and its
 			// physical size is double the configured size
@@ -745,7 +750,8 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	/**
 	 * Iterates over all tasks in {@link #queue} in a batch manner and prunes it according to the following policy:
 	 *
-	 * - tasks still waiting for a precondition longer than {@link #WAITING_TASKS_KEEP_INTERVAL_MILLIS} are dropped,
+	 * - tasks still waiting for a precondition longer than {@link #WAITING_TASKS_KEEP_INTERVAL_MILLIS} are removed
+	 *   from the queue and failed with a {@link TaskTimedOutException}, rather than dropped silently,
 	 * - finished or failed tasks are removed, but those whose completion falls within the defense period are
 	 *   re-queued up to a fill threshold that keeps roughly one third of {@link #physicalQueueCapacity} empty as
 	 *   breathing room for newly submitted tasks,
@@ -760,6 +766,26 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	 * @return always {@code 0L}, signalling the scheduling framework to re-plan the purge at its standard interval
 	 */
 	long purgeFinishedAndLongWaitingTasks() {
+		failTimedOutTasks(purgeAndCollectTimedOutTasks());
+		// plan to next standard time
+		return 0L;
+	}
+
+	/**
+	 * Performs the purge itself and hands back the waiting tasks it removed for exceeding
+	 * {@link #WAITING_TASKS_KEEP_INTERVAL_MILLIS}, leaving them uncompleted.
+	 *
+	 * They are returned rather than failed in place because a task's {@link Task#getFutureResult()} is public: a
+	 * completion callback is arbitrary client code that may re-enter the scheduler. Completing a task while
+	 * {@link #bufferLock} is still held would let such a callback offer into the queue mid-purge - and on the
+	 * {@link #addTaskToQueue(ServerTask)} overflow path the caller holds that lock reentrantly, so this method's own
+	 * `finally` releases nothing.
+	 *
+	 * @return the tasks removed for waiting too long, in removal order; empty when nothing timed out
+	 */
+	@Nonnull
+	private List<ServerTask<?, ?>> purgeAndCollectTimedOutTasks() {
+		List<ServerTask<?, ?>> timedOutTasks = null;
 		if (this.bufferLock.tryLock()) {
 			try {
 				// go through the entire queue, but only once
@@ -782,14 +808,21 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 					// now go through all of them
 					final Iterator<ServerTask<?, ?>> it = this.buffer.iterator();
 					while (it.hasNext()) {
-						final Task<?, ?> task = it.next();
+						final ServerTask<?, ?> task = it.next();
 						final TaskStatus<?, ?> status = task.getStatus();
 						final TaskSimplifiedState taskState = status.simplifiedState();
 						if (taskState == TaskSimplifiedState.WAITING_FOR_PRECONDITION && status.created().isBefore(waitingThreshold)) {
 							// a task still waiting for its precondition past the waiting interval is dropped; the clock
 							// runs from creation (a waiting task is never issued), so this is a whole-life budget
 							log.info("Task {} is waiting for precondition for too long, removing it from the queue.", status.taskId());
+							// the task really is removed - it must not stay discoverable through #findTask, or a
+							// chunked restore would keep feeding an abandoned task and then resubmit a failed one -
+							// but it is failed only once the lock is released, see #purgeAndCollectTimedOutTasks
 							it.remove();
+							if (timedOutTasks == null) {
+								timedOutTasks = new ArrayList<>(16);
+							}
+							timedOutTasks.add(task);
 						} else if (taskState == TaskSimplifiedState.FINISHED || taskState == TaskSimplifiedState.FAILED) {
 							it.remove();
 							// if its defense period hasn't perished add it to list, that might end up in the queue again
@@ -827,8 +860,23 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 			this.bufferLock.lock();
 			this.bufferLock.unlock();
 		}
-		// plan to next standard time
-		return 0L;
+		return timedOutTasks == null ? List.of() : timedOutTasks;
+	}
+
+	/**
+	 * Completes each of the given tasks exceptionally with a {@link TaskTimedOutException}, so that whatever joins
+	 * their futures observes the timeout instead of waiting forever.
+	 *
+	 * Must be called only once every {@link #bufferLock} hold has been released - see
+	 * {@link #purgeAndCollectTimedOutTasks()} for why.
+	 *
+	 * @param timedOutTasks the tasks removed by a purge for waiting too long
+	 */
+	private static void failTimedOutTasks(@Nonnull List<ServerTask<?, ?>> timedOutTasks) {
+		for (int i = 0; i < timedOutTasks.size(); i++) {
+			final ServerTask<?, ?> timedOutTask = timedOutTasks.get(i);
+			timedOutTask.fail(new TaskTimedOutException(timedOutTask.getStatus().taskId()));
+		}
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
@@ -44,6 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -74,6 +75,24 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	 * Lock synchronizing access to the buffer and purge operation.
 	 */
 	private final ReentrantLock bufferLock = new ReentrantLock();
+	/**
+	 * Time source for the scheduler's own timestamps. Real time in production; tests substitute a controllable
+	 * clock so that an interval measured in minutes can be exercised without waiting one out.
+	 */
+	private final Clock clock;
+	/**
+	 * Last time each waiting task was looked up through {@link #findTask(Predicate)}, keyed by task id.
+	 *
+	 * This is what turns the waiting interval from a budget on a task's whole life into an idle timeout: a task
+	 * that is still being used is still being looked up, and the purge measures from the later of creation and
+	 * this timestamp. Absent entry means "never looked up", which correctly falls back to the creation time.
+	 *
+	 * A plain {@link HashMap} rather than a concurrent one on purpose - every read and write happens under
+	 * {@link #bufferLock}, together with the queue operation it belongs to. A concurrent map would make the
+	 * individual operations safe while leaving the compound lookup-and-renew, and renew-versus-timeout, races
+	 * wide open; the lock is what actually makes those atomic.
+	 */
+	private final Map<UUID, OffsetDateTime> waitingTaskLastActivity = new HashMap<>(16);
 	/**
 	 * Java based scheduled executor service.
 	 */
@@ -143,6 +162,20 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	}
 
 	public Scheduler(@Nonnull ThreadPoolOptions options) {
+		this(options, Clock.systemDefaultZone());
+	}
+
+	/**
+	 * Creates a scheduler reading time from the supplied clock instead of the system one.
+	 *
+	 * Package-private: it exists so that `SchedulerTest` can advance time deterministically across the waiting
+	 * interval, which is the only way to exercise a last-activity timestamp the scheduler owns itself.
+	 *
+	 * @param options thread pool configuration
+	 * @param clock   time source for the purge thresholds and the waiting-task activity stamps
+	 */
+	Scheduler(@Nonnull ThreadPoolOptions options, @Nonnull Clock clock) {
+		this.clock = clock;
 		this.rejectingExecutorHandler = new EvitaRejectingExecutorHandler("service", this.rejectedTaskCount::increment);
 		// note: a ScheduledThreadPoolExecutor uses an unbounded DelayedWorkQueue, so this handler is effectively only
 		// triggered for tasks submitted after shutdown - back-pressure for the bounded task registry is enforced
@@ -177,6 +210,7 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	 * @param executorService to be used for scheduling tasks
 	 */
 	public Scheduler(@Nonnull ScheduledThreadPoolExecutor executorService) {
+		this.clock = Clock.systemDefaultZone();
 		this.executorService = executorService;
 		this.queueCapacity = 64;
 		this.physicalQueueCapacity = 64;
@@ -603,11 +637,47 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	/**
 	 * Retrieves a task from the waiting queue based on the provided registration identifier.
 	 *
+	 * **Looking a waiting task up keeps it alive.** A successful lookup of a task that is still waiting for its
+	 * precondition renews that task's activity timestamp, so the purge's waiting interval behaves as an idle
+	 * timeout rather than a ceiling on the task's total lifetime. This is what lets a chunked upload run longer
+	 * than the interval: every chunk locates its task through this method, and thereby renews it.
+	 *
+	 * A caller that wants to inspect a waiting task *without* extending its life must not use this method.
+	 *
+	 * The whole lookup runs under {@link #bufferLock} so that it linearizes against the purge: without it the
+	 * lookup could miss a live task held in the purge's drain window, or renew a task the purge had already
+	 * selected for timeout.
+	 *
 	 * @param taskPredicate predicate to filter the task
 	 * @return An {@link Optional} containing the {@link ServerTask} if found, otherwise an empty {@link Optional}.
 	 */
 	public Optional<ServerTask<?, ?>> findTask(@Nonnull Predicate<ServerTask<?, ?>> taskPredicate) {
-		return this.queue.stream().filter(task -> task.matches(taskPredicate)).findFirst();
+		this.bufferLock.lock();
+		try {
+			final Optional<ServerTask<?, ?>> foundTask = this.queue.stream()
+				.filter(task -> task.matches(taskPredicate))
+				.findFirst();
+			foundTask.ifPresent(this::renewWaitingTaskActivity);
+			return foundTask;
+		} finally {
+			this.bufferLock.unlock();
+		}
+	}
+
+	/**
+	 * Records that the given task has just been used, provided it is still waiting for its precondition. Tasks in
+	 * any other state are ignored - a queued, running or finished task is not subject to the waiting interval, and
+	 * stamping one would only leave an entry behind.
+	 *
+	 * Must be called while holding {@link #bufferLock}.
+	 *
+	 * @param task the task that has just been looked up
+	 */
+	private void renewWaitingTaskActivity(@Nonnull ServerTask<?, ?> task) {
+		final TaskStatus<?, ?> status = task.getStatus();
+		if (status.simplifiedState() == TaskSimplifiedState.WAITING_FOR_PRECONDITION) {
+			this.waitingTaskLastActivity.put(status.taskId(), OffsetDateTime.now(this.clock));
+		}
 	}
 
 	/**
@@ -617,8 +687,27 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	 */
 	public void submitWaitingTask(@Nonnull Predicate<ServerTask<?, ?>> taskPredicate) {
 		if (!this.executorService.isShutdown()) {
-			this.queue.stream().filter(task -> task.matches(taskPredicate)).findFirst()
-				.ifPresent(this::submitTaskInQueue);
+			final ServerTask<?, ?> taskToSubmit;
+			// the lookup, the transition out of the waiting state and the activity drop happen as one step under
+			// the lock, so a concurrent purge sees the task either still waiting or already issued - never both.
+			// Handing it to the executor is deliberately left outside: an @InternallyScheduledTask runs inline on
+			// this thread, and running a task body under the registry lock would invite a deadlock.
+			this.bufferLock.lock();
+			try {
+				taskToSubmit = this.queue.stream()
+					.filter(task -> task.matches(taskPredicate))
+					.findFirst()
+					.orElse(null);
+				if (taskToSubmit != null) {
+					taskToSubmit.transitionToIssued();
+					this.waitingTaskLastActivity.remove(taskToSubmit.getStatus().taskId());
+				}
+			} finally {
+				this.bufferLock.unlock();
+			}
+			if (taskToSubmit != null) {
+				executeIssuedTask(taskToSubmit);
+			}
 		} else if (!this.shutdownInProgress.get()) {
 			throw new RejectedExecutionException("Scheduler is already shut down.");
 		}
@@ -671,6 +760,20 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	 */
 	private <T> @Nonnull CompletableFuture<T> submitTaskInQueue(@Nonnull ServerTask<?, T> task) {
 		task.transitionToIssued();
+		return executeIssuedTask(task);
+	}
+
+	/**
+	 * Hands a task that has **already** been transitioned to issued over to the executor.
+	 *
+	 * Split out of {@link #submitTaskInQueue(ServerTask)} so that {@link #submitWaitingTask(Predicate)} can perform
+	 * the state transition under {@link #bufferLock} - closing the window in which a purge could time the task out
+	 * between the lookup and the submission - while still running the task itself outside that lock.
+	 *
+	 * @param task the task, already in the issued state
+	 * @return A CompletableFuture representing the result of the submitted task.
+	 */
+	private <T> @Nonnull CompletableFuture<T> executeIssuedTask(@Nonnull ServerTask<?, T> task) {
 		if (task.getClass().isAnnotationPresent(InternallyScheduledTask.class)) {
 			// if the task is internally scheduled, we can execute it immediately
 			task.execute();
@@ -794,7 +897,7 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 				CompositeObjectArray<Task> finishedTaskInDefensePeriod = null;
 				// a single `now` for both thresholds - two separate reads could disagree about the current time, and
 				// the names are spelled out so that a future edit cannot silently cross them again (see #1415)
-				final OffsetDateTime now = OffsetDateTime.now();
+				final OffsetDateTime now = OffsetDateTime.now(this.clock);
 				final OffsetDateTime waitingThreshold = now.minus(
 					WAITING_TASKS_KEEP_INTERVAL_MILLIS, ChronoUnit.MILLIS
 				);
@@ -811,14 +914,22 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 						final ServerTask<?, ?> task = it.next();
 						final TaskStatus<?, ?> status = task.getStatus();
 						final TaskSimplifiedState taskState = status.simplifiedState();
-						if (taskState == TaskSimplifiedState.WAITING_FOR_PRECONDITION && status.created().isBefore(waitingThreshold)) {
-							// a task still waiting for its precondition past the waiting interval is dropped; the clock
-							// runs from creation (a waiting task is never issued), so this is a whole-life budget
+						final boolean waitingForPrecondition =
+							taskState == TaskSimplifiedState.WAITING_FOR_PRECONDITION;
+						if (!waitingForPrecondition) {
+							// the task has left the waiting state for good, so its activity entry can never matter
+							// again - dropping it here is what keeps the map bounded, no separate sweep needed
+							this.waitingTaskLastActivity.remove(status.taskId());
+						}
+						if (waitingForPrecondition && lastWaitingActivityOf(status).isBefore(waitingThreshold)) {
+							// the task has been idle - neither created nor looked up recently - for longer than the
+							// waiting interval allows
 							log.info("Task {} is waiting for precondition for too long, removing it from the queue.", status.taskId());
 							// the task really is removed - it must not stay discoverable through #findTask, or a
 							// chunked restore would keep feeding an abandoned task and then resubmit a failed one -
 							// but it is failed only once the lock is released, see #purgeAndCollectTimedOutTasks
 							it.remove();
+							this.waitingTaskLastActivity.remove(status.taskId());
 							if (timedOutTasks == null) {
 								timedOutTasks = new ArrayList<>(16);
 							}
@@ -861,6 +972,24 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 			this.bufferLock.unlock();
 		}
 		return timedOutTasks == null ? List.of() : timedOutTasks;
+	}
+
+	/**
+	 * Returns the moment from which the given waiting task's idle time is measured: the later of its creation and
+	 * the last time it was looked up through {@link #findTask(Predicate)}.
+	 *
+	 * A task that was never looked up has no activity entry and is measured from creation, which is what keeps a
+	 * genuinely abandoned task collectable.
+	 *
+	 * Must be called while holding {@link #bufferLock}.
+	 *
+	 * @param status status of the waiting task
+	 * @return the later of the task's creation timestamp and its last lookup
+	 */
+	@Nonnull
+	private OffsetDateTime lastWaitingActivityOf(@Nonnull TaskStatus<?, ?> status) {
+		final OffsetDateTime lastActivity = this.waitingTaskLastActivity.get(status.taskId());
+		return lastActivity == null || lastActivity.isBefore(status.created()) ? status.created() : lastActivity;
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SchedulerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SchedulerTest.java
@@ -42,6 +42,8 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -564,4 +566,131 @@ class SchedulerTest {
 		}
 	}
 
+
+	@Nested
+	@DisplayName("Queue purging")
+	class QueuePurging {
+
+		@Test
+		@DisplayName("keeps a waiting task that has not yet reached the waiting threshold")
+		void shouldKeepWaitingTaskWhenWaitingThresholdHasNotElapsed() {
+			final ClientRunnableTask<Void> task = waitingTask();
+			SchedulerTest.this.scheduler.registerWaitingTask(task);
+			// just inside the intended ten-minute waiting interval
+			backdateCreated(task, Duration.ofMinutes(10).minusSeconds(5));
+
+			SchedulerTest.this.scheduler.purgeFinishedAndLongWaitingTasks();
+
+			final Optional<TaskStatus<?, ?>> status = SchedulerTest.this.scheduler.getTaskStatus(taskIdOf(task));
+			assertTrue(status.isPresent(), "A waiting task inside the waiting interval must be kept.");
+			assertEquals(TaskSimplifiedState.WAITING_FOR_PRECONDITION, status.get().simplifiedState());
+		}
+
+		@Test
+		@DisplayName("drops a waiting task once the waiting threshold elapses")
+		void shouldDropWaitingTaskWhenWaitingThresholdHasElapsed() {
+			final ClientRunnableTask<Void> task = waitingTask();
+			SchedulerTest.this.scheduler.registerWaitingTask(task);
+			// just outside the intended ten-minute waiting interval
+			backdateCreated(task, Duration.ofMinutes(10).plusSeconds(5));
+
+			SchedulerTest.this.scheduler.purgeFinishedAndLongWaitingTasks();
+
+			assertTrue(
+				SchedulerTest.this.scheduler.getTaskStatus(taskIdOf(task)).isEmpty(),
+				"A waiting task past the waiting interval must be dropped."
+			);
+		}
+
+		@Test
+		@DisplayName("keeps a finished task while it is within its defense period")
+		void shouldKeepFinishedTaskWhenWithinDefensePeriod() throws Exception {
+			final ClientRunnableTask<Void> task = finishedTask();
+			// just inside the intended five-minute defense period
+			backdateFinished(task, Duration.ofMinutes(5).minusSeconds(5));
+
+			SchedulerTest.this.scheduler.purgeFinishedAndLongWaitingTasks();
+
+			assertTrue(
+				SchedulerTest.this.scheduler.getTaskStatus(taskIdOf(task)).isPresent(),
+				"A finished task inside its defense period must be kept."
+			);
+		}
+
+		@Test
+		@DisplayName("drops a finished task once its defense period elapses")
+		void shouldDropFinishedTaskWhenDefensePeriodHasElapsed() throws Exception {
+			final ClientRunnableTask<Void> task = finishedTask();
+			// just outside the intended five-minute defense period
+			backdateFinished(task, Duration.ofMinutes(5).plusSeconds(5));
+
+			SchedulerTest.this.scheduler.purgeFinishedAndLongWaitingTasks();
+
+			assertTrue(
+				SchedulerTest.this.scheduler.getTaskStatus(taskIdOf(task)).isEmpty(),
+				"A finished task past its defense period must be dropped."
+			);
+		}
+
+	}
+
+	/**
+	 * Creates a task parked in the waiting queue - never issued, so {@link TaskSimplifiedState#WAITING_FOR_PRECONDITION}
+	 * is the state the purge matches on.
+	 */
+	@Nonnull
+	private static ClientRunnableTask<Void> waitingTask() {
+		return new ClientRunnableTask<>("task", "Waiting task", null, () -> {
+		});
+	}
+
+	/**
+	 * Submits a task and blocks until it completes, so the caller receives one the purge sees as finished.
+	 */
+	@Nonnull
+	private ClientRunnableTask<Void> finishedTask() throws Exception {
+		final ClientRunnableTask<Void> task = new ClientRunnableTask<>("task", "Finished task", null, () -> {
+		});
+		this.scheduler.submit((ServerTask<?, ?>) task);
+		// positive wait - generous bound, returns the instant the task completes
+		task.getFutureResult().get(30, TimeUnit.SECONDS);
+		return task;
+	}
+
+	@Nonnull
+	private static UUID taskIdOf(@Nonnull AbstractServerTask<?, ?> task) {
+		return task.getStatus().taskId();
+	}
+
+	/**
+	 * Rewrites the task's creation timestamp to `age` ago. The purge reasons about task age through
+	 * {@link TaskStatus#created()}, so moving that timestamp is what lets a threshold measured in minutes be
+	 * asserted in milliseconds. Every `transitionToXxx` copies `created`, so the backdating survives later
+	 * transitions.
+	 */
+	private static <S, T> void backdateCreated(@Nonnull AbstractServerTask<S, T> task, @Nonnull Duration age) {
+		final OffsetDateTime backdated = OffsetDateTime.now().minus(age);
+		task.status.updateAndGet(
+			it -> new TaskStatus<>(
+				it.taskType(), it.taskName(), it.taskId(), it.catalogName(),
+				backdated, it.issued(), it.started(), it.finished(), it.progress(),
+				it.settings(), it.result(), it.publicExceptionMessage(), it.exceptionWithStackTrace(), it.traits()
+			)
+		);
+	}
+
+	/**
+	 * Rewrites the task's completion timestamp to `age` ago, so the finished-task defense period can be asserted
+	 * without waiting it out. See {@link #backdateCreated(AbstractServerTask, Duration)}.
+	 */
+	private static <S, T> void backdateFinished(@Nonnull AbstractServerTask<S, T> task, @Nonnull Duration age) {
+		final OffsetDateTime backdated = OffsetDateTime.now().minus(age);
+		task.status.updateAndGet(
+			it -> new TaskStatus<>(
+				it.taskType(), it.taskName(), it.taskId(), it.catalogName(),
+				it.created(), it.issued(), it.started(), backdated, it.progress(),
+				it.settings(), it.result(), it.publicExceptionMessage(), it.exceptionWithStackTrace(), it.traits()
+			)
+		);
+	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SchedulerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SchedulerTest.java
@@ -44,6 +44,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.time.Duration;
+import java.time.ZoneId;
+import java.time.Instant;
+import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -681,6 +684,102 @@ class SchedulerTest {
 		}
 
 		@Test
+		@DisplayName("keeps a waiting task whose lookup refreshed its activity")
+		void shouldKeepWaitingTaskWhenLookupRefreshedItsActivity() {
+			final ClientRunnableTask<Void> task = waitingTask();
+			final UUID taskId = taskIdOf(task);
+			SchedulerTest.this.scheduler.registerWaitingTask(task);
+			// far past any fixed budget measured from creation - a large backup over a slow link looks like this
+			backdateCreated(task, Duration.ofMinutes(30));
+
+			// a chunked upload announces its interest by looking the task up on every chunk
+			assertTrue(
+				SchedulerTest.this.scheduler.findTask(it -> it.getStatus().taskId().equals(taskId)).isPresent(),
+				"The task must still be findable before the purge runs."
+			);
+
+			SchedulerTest.this.scheduler.purgeFinishedAndLongWaitingTasks();
+
+			final Optional<TaskStatus<?, ?>> status = SchedulerTest.this.scheduler.getTaskStatus(taskId);
+			assertTrue(status.isPresent(), "A waiting task whose lookup refreshed it must survive the purge.");
+			assertEquals(TaskSimplifiedState.WAITING_FOR_PRECONDITION, status.get().simplifiedState());
+		}
+
+		@Test
+		@DisplayName("drops a waiting task whose last lookup has itself gone stale")
+		void shouldDropWaitingTaskWhenLookupWentStale() {
+			final MutableClock clock = new MutableClock();
+			final Scheduler clockedScheduler = new Scheduler(
+				ThreadPoolOptions.serviceThreadPoolBuilder().build(), clock
+			);
+			try {
+				final ClientRunnableTask<Void> task = waitingTask();
+				final UUID taskId = taskIdOf(task);
+				clockedScheduler.registerWaitingTask(task);
+				assertTrue(clockedScheduler.findTask(it -> it.getStatus().taskId().equals(taskId)).isPresent());
+
+				// the upload stopped sending chunks - nothing looks the task up again, and the renewal itself ages out
+				clock.advance(Duration.ofMinutes(11));
+				clockedScheduler.purgeFinishedAndLongWaitingTasks();
+
+				assertTrue(
+					clockedScheduler.getTaskStatus(taskId).isEmpty(),
+					"A renewal only postpones the timeout - it must not make the task immortal."
+				);
+			} finally {
+				clockedScheduler.shutdownNow();
+			}
+		}
+
+		@Test
+		@DisplayName("survives repeated lookups spanning far more than the waiting interval")
+		void shouldKeepWaitingTaskAcrossRepeatedLookups() {
+			final MutableClock clock = new MutableClock();
+			final Scheduler clockedScheduler = new Scheduler(
+				ThreadPoolOptions.serviceThreadPoolBuilder().build(), clock
+			);
+			try {
+				final ClientRunnableTask<Void> task = waitingTask();
+				final UUID taskId = taskIdOf(task);
+				clockedScheduler.registerWaitingTask(task);
+
+				// six chunks, nine minutes apart - fifty-four minutes in total, far past any fixed budget
+				for (int i = 0; i < 6; i++) {
+					clock.advance(Duration.ofMinutes(9));
+					assertTrue(
+						clockedScheduler.findTask(it -> it.getStatus().taskId().equals(taskId)).isPresent(),
+						"The task must still be findable on chunk " + i + "."
+					);
+					clockedScheduler.purgeFinishedAndLongWaitingTasks();
+				}
+
+				assertTrue(
+					clockedScheduler.getTaskStatus(taskId).isPresent(),
+					"An upload that keeps sending chunks must keep its task alive indefinitely."
+				);
+			} finally {
+				clockedScheduler.shutdownNow();
+			}
+		}
+
+		@Test
+		@DisplayName("does not renew a task that is no longer waiting")
+		void shouldNotRenewActivityOfTaskThatLeftWaitingState() throws Exception {
+			// a finished task must keep ageing out of its defense period on schedule - looking it up must not revive it
+			final ClientRunnableTask<Void> task = finishedTask();
+			final UUID taskId = taskIdOf(task);
+			assertTrue(SchedulerTest.this.scheduler.findTask(it -> it.getStatus().taskId().equals(taskId)).isPresent());
+			backdateFinished(task, Duration.ofMinutes(5).plusSeconds(5));
+
+			SchedulerTest.this.scheduler.purgeFinishedAndLongWaitingTasks();
+
+			assertTrue(
+				SchedulerTest.this.scheduler.getTaskStatus(taskId).isEmpty(),
+				"Looking up a finished task must not extend its defense period."
+			);
+		}
+
+		@Test
 		@DisplayName("reclaims queue capacity taken by timed-out waiting tasks")
 		void shouldReclaimQueueCapacityWhenExpiredWaitingTasksArePurged() {
 			// the purge is also the queue's capacity-reclaim path: addTaskToQueue calls it only once offer() reports
@@ -703,6 +802,45 @@ class SchedulerTest {
 			);
 		}
 
+	}
+
+
+	/**
+	 * A {@link Clock} the test can move forward at will, so an interval measured in minutes can be crossed in a
+	 * test that runs in milliseconds. Only the scheduler's own timestamps follow it; task timestamps are moved with
+	 * the backdating helpers instead.
+	 */
+	private static class MutableClock extends Clock {
+		private final ZoneId zone;
+		private Instant instant;
+
+		MutableClock() {
+			this(ZoneId.systemDefault(), Instant.now());
+		}
+
+		private MutableClock(@Nonnull ZoneId zone, @Nonnull Instant instant) {
+			this.zone = zone;
+			this.instant = instant;
+		}
+
+		void advance(@Nonnull Duration duration) {
+			this.instant = this.instant.plus(duration);
+		}
+
+		@Override
+		public ZoneId getZone() {
+			return this.zone;
+		}
+
+		@Override
+		public Clock withZone(ZoneId newZone) {
+			return new MutableClock(newZone, this.instant);
+		}
+
+		@Override
+		public Instant instant() {
+			return this.instant;
+		}
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SchedulerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SchedulerTest.java
@@ -27,6 +27,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import io.evitadb.api.exception.TaskTimedOutException;
 import io.evitadb.api.configuration.ThreadPoolOptions;
 import io.evitadb.api.task.InternallyScheduledTask;
 import io.evitadb.api.task.ServerTask;
@@ -63,6 +64,10 @@ import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.TASK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -629,6 +634,72 @@ class SchedulerTest {
 			assertTrue(
 				SchedulerTest.this.scheduler.getTaskStatus(taskIdOf(task)).isEmpty(),
 				"A finished task past its defense period must be dropped."
+			);
+		}
+
+		@Test
+		@DisplayName("fails a timed-out waiting task instead of dropping it silently")
+		void shouldFailWaitingTaskWhenWaitingThresholdHasElapsed() {
+			final ClientRunnableTask<Void> task = waitingTask();
+			SchedulerTest.this.scheduler.registerWaitingTask(task);
+			backdateCreated(task, Duration.ofMinutes(11));
+
+			SchedulerTest.this.scheduler.purgeFinishedAndLongWaitingTasks();
+
+			// the future must complete - a bare it.remove() leaves it dangling forever, so anything joining it hangs
+			final CompletableFuture<Void> future = task.getFutureResult();
+			assertTrue(future.isDone(), "A dropped waiting task must complete its future.");
+			final ExecutionException exception = assertThrows(
+				ExecutionException.class,
+				() -> future.get(30, TimeUnit.SECONDS)
+			);
+			assertInstanceOf(TaskTimedOutException.class, exception.getCause());
+
+			// the failure must carry a usable public message rather than the "unknown reasons" fallback
+			final TaskStatus<?, ?> status = task.getStatus();
+			assertEquals(TaskSimplifiedState.FAILED, status.simplifiedState());
+			assertNotNull(status.publicExceptionMessage());
+			assertNotEquals("Task failed for unknown reasons.", status.publicExceptionMessage());
+		}
+
+		@Test
+		@DisplayName("stops a timed-out waiting task from being found or resubmitted")
+		void shouldNotFindTimedOutWaitingTaskAfterPurge() {
+			final ClientRunnableTask<Void> task = waitingTask();
+			final UUID taskId = taskIdOf(task);
+			SchedulerTest.this.scheduler.registerWaitingTask(task);
+			backdateCreated(task, Duration.ofMinutes(11));
+
+			SchedulerTest.this.scheduler.purgeFinishedAndLongWaitingTasks();
+
+			// a timed-out task that stayed discoverable would let the restore handler keep appending chunks to it and
+			// then resubmit an already-failed task - SequentialTask#transitionToIssued does not refuse that
+			assertTrue(
+				SchedulerTest.this.scheduler.findTask(it -> it.getStatus().taskId().equals(taskId)).isEmpty(),
+				"A timed-out waiting task must not remain findable."
+			);
+		}
+
+		@Test
+		@DisplayName("reclaims queue capacity taken by timed-out waiting tasks")
+		void shouldReclaimQueueCapacityWhenExpiredWaitingTasksArePurged() {
+			// the purge is also the queue's capacity-reclaim path: addTaskToQueue calls it only once offer() reports
+			// full, then retries. Timed-out tasks that are failed but left queued would reclaim no slot at all.
+			// mirrors Scheduler's own `physicalQueueCapacity = queueSize << 1`, so no production accessor is needed
+			final int physicalCapacity = ThreadPoolOptions.serviceThreadPoolBuilder().build().queueSize() << 1;
+			for (int i = 0; i < physicalCapacity; i++) {
+				final ClientRunnableTask<Void> filler = waitingTask();
+				SchedulerTest.this.scheduler.registerWaitingTask(filler);
+				backdateCreated(filler, Duration.ofMinutes(11));
+			}
+
+			// the queue is now full of expired waiting tasks - registering one more must succeed rather than be rejected
+			final ClientRunnableTask<Void> newcomer = waitingTask();
+			SchedulerTest.this.scheduler.registerWaitingTask(newcomer);
+
+			assertTrue(
+				SchedulerTest.this.scheduler.getTaskStatus(taskIdOf(newcomer)).isPresent(),
+				"Purging expired waiting tasks must free room for a newly registered task."
 			);
 		}
 


### PR DESCRIPTION
Closes #1415

## The bug

`Scheduler#purgeFinishedAndLongWaitingTasks` built its two age thresholds from the wrong constants — the names were crossed. Waiting tasks were dropped after **5 minutes** instead of 10, and finished tasks were kept for **10 minutes** instead of 5.

The visible consequence: a chunked catalog-restore upload lasting longer than five minutes lost its restoration task mid-upload, and the next chunk failed with `Task not found for file id!`. `restoreCatalogUnary` creates the task on the first chunk, parks it with `registerWaitingTask`, and re-locates it on every later chunk — the waiting queue is the only thing carrying upload state between calls.

## What changed, commit by commit

**`fix: uncross the scheduler purge thresholds`** — both thresholds now derive from a single captured `now`, and the finished-task local is named `defensePeriodThreshold` so the two cannot be crossed again by copy-paste.

**`fix: fail a timed-out waiting task instead of dropping it silently`** — the purge dropped tasks with a bare `it.remove()`, leaving their `CompletableFuture` uncompleted forever. Timed-out tasks are now completed exceptionally with a new `TaskTimedOutException`.

**`feat: keep a waiting task alive while its lookups continue`** — uncrossing the constants alone would only have moved the same silent failure from 5 minutes to 10, because the clock runs from task *creation*: it is a ceiling on total upload duration, not a timeout. Every chunk already announces its interest by locating its task through `findTask`, so a successful lookup of a still-waiting task now renews it, and the purge measures from the later of creation and that renewal.

**`docs: record the waiting-task idle timeout as an ADR`**

## Two things that are easy to undo by accident

**A timed-out task is removed from the queue, not failed in place and kept.** Three independent reasons: the purge doubles as the queue's capacity-reclaim path (`addTaskToQueue` calls it only once `offer` reports full, then retries), so a retained task frees no slot; the restore predicate matches on file id with no state filter and `SequentialTask#matches` tests every child; and `SequentialTask#transitionToIssued` — unlike `AbstractServerTask`'s — does **not** refuse an already-completed task, so a failed restore sequence could be transitioned back to queued and scheduled.

**Failing happens only after every `bufferLock` hold is released.** "After the purge's own `finally`" is not sufficient — `addTaskToQueue` holds the lock reentrantly across the purge, so the purge's unlock only decrements the hold count. Task futures are public, so a completion callback is arbitrary client code that may re-enter the scheduler.

Correctness of the renewal comes from the lock, not the data structure: `findTask` and `submitWaitingTask` were the only registry operations running without `bufferLock`, and both now hold it across lookup, state check and activity update. The activity map is a plain `HashMap` deliberately — a concurrent one would have made each operation safe while leaving the compound lookup-and-renew and renew-versus-timeout races open.

## Verification

- `SchedulerTest` — 26 tests, 0 failures (11 in the new `Queue purging` nested class)
- `task & engine` selector — **111 tests, 0 failures**

Driven test-first throughout. The two tests pinning the original defect failed on **opposite branches** before the fix (a waiting task at 9m55s dropped, a finished task at 5m05s kept), which is what evidences a crossing rather than a single wrong value. All four threshold tests bracket their interval to within five seconds, pinning 10 and 5 minutes specifically — a wider bracket would also be satisfied by an 8/6 implementation.

## Knowingly left undone

Both recorded in the ADR's follow-ups:

- The orphaned temporary `.zip` of an abandoned upload is still leaked — `restoreCatalogUnary` uses `createTempFile` rather than `createManagedTempFile`, and `RestoreTask` deletes the archive only if the task actually runs. Failing the task does not clean it up.
- A restore chunk arriving after its task timed out still reports `Task not found for file id!` rather than the timeout reason; turning that into a better client message is a gRPC-layer change.