### PR TITLE
Fix the session registries a catalog rename or replace strands

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/Evita.java
+++ b/evita_engine/src/main/java/io/evitadb/core/Evita.java
@@ -1673,8 +1673,13 @@ public final class Evita implements EvitaContract {
 	 * {@link CatalogNotFoundException} rather than the "terminated" that a placeholder would produce — a replace
 	 * is allowed to target a catalog that does not exist.
 	 *
-	 * The caller is responsible for what happens next: a registry this call created must be **removed** if the
-	 * operation fails, never restored, or the name is left permanently refusing sessions.
+	 * The caller is responsible for what happens next: a registry this call created must be **resumed or
+	 * removed** if the operation fails, or the name is left permanently refusing sessions.
+	 *
+	 * **An operation that has to undo the suspension cannot use this method**, because the drain it performs
+	 * throws when the sessions refuse to leave — and it throws with the suspension already published, so the
+	 * caller never learns which registry it now owns. Such a caller takes ownership through
+	 * {@link #obtainCatalogSessionRegistry(String)} first and drains the registry itself.
 	 *
 	 * @param catalogName      catalog whose sessions are to be closed and suspended
 	 * @param suspendOperation how requests arriving during the suspension are to be treated
@@ -1685,17 +1690,37 @@ public final class Evita implements EvitaContract {
 		@Nonnull String catalogName,
 		@Nonnull SuspendOperation suspendOperation
 	) {
-		final SessionRegistry registry = this.catalogSessionRegistries.computeIfAbsent(
-			catalogName,
-			name -> getCatalogInstance(name)
-				.map(__ -> createSessionNewRegistry(new SessionTraits(name)))
-				.orElse(null)
+		final Optional<SessionRegistry> registry = obtainCatalogSessionRegistry(catalogName);
+		registry.ifPresent(it -> it.closeAllActiveSessionsAndSuspend(suspendOperation));
+		return registry;
+	}
+
+	/**
+	 * Returns the session registry of the passed catalog, **installing one when it has none**.
+	 *
+	 * This is the half of {@link #suspendCatalogSessions(String, SuspendOperation)} that cannot fail: it takes
+	 * ownership of a registry without touching the sessions inside it. An operation that must be able to lift its
+	 * own suspension calls this first, records what it now owns, and only then drains — because the drain
+	 * publishes the suspension before it waits, and a drain that gives up throws with that suspension standing.
+	 *
+	 * The registry is installed through `computeIfAbsent` on the very map session creation uses, so a racing
+	 * request either finds the registry this call installed or is the one that installed it, and this call then
+	 * returns that same instance. **A name that names no catalog gets no registry**, so a request for it keeps
+	 * answering {@link CatalogNotFoundException} rather than the "terminated" a placeholder would produce.
+	 *
+	 * @param catalogName catalog whose registry is to be obtained
+	 * @return the registry registered under that name, or empty when the name names no catalog
+	 */
+	@Nonnull
+	public Optional<SessionRegistry> obtainCatalogSessionRegistry(@Nonnull String catalogName) {
+		return ofNullable(
+			this.catalogSessionRegistries.computeIfAbsent(
+				catalogName,
+				name -> getCatalogInstance(name)
+					.map(__ -> createSessionNewRegistry(new SessionTraits(name)))
+					.orElse(null)
+			)
 		);
-		if (registry == null) {
-			return empty();
-		}
-		registry.closeAllActiveSessionsAndSuspend(suspendOperation);
-		return of(registry);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/Evita.java
+++ b/evita_engine/src/main/java/io/evitadb/core/Evita.java
@@ -105,7 +105,6 @@ import io.evitadb.core.transaction.engine.EngineTransactionManager;
 import io.evitadb.core.transaction.engine.operators.DefaultUpgradeExecutor;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.function.Functions;
-import io.evitadb.spi.store.catalog.persistence.CatalogHandoverFailedException;
 import io.evitadb.spi.store.catalog.shared.model.LogRecordReference;
 import io.evitadb.spi.store.engine.EnginePersistenceService;
 import io.evitadb.spi.store.engine.EnginePersistenceServiceFactory;
@@ -1603,17 +1602,10 @@ public final class Evita implements EvitaContract {
 	 * onFailure callback so the auto-upgrade path can reuse the same terminal-failure bookkeeping
 	 * when a retry fails.
 	 *
-	 * Also reached from a rename or replace that failed past its point of no return
-	 * ({@link CatalogHandoverFailedException}), where the catalog is left with no persistence service behind
-	 * it and refusing sessions legibly is the only honest answer until a restart rebuilds it from its folder.
-	 * The registry serving the name resolves the catalog through the engine state on every session, so
-	 * binding the placeholder here is what turns the next session into a `CatalogCorruptedException` rather
-	 * than a use of a catalog that cannot read its own data.
-	 *
 	 * @param catalogName name of the catalog to mark CORRUPTED
 	 * @param cause       the failure carried by the resulting {@link CatalogCorruptedException}
 	 */
-	public void markCatalogCorrupted(@Nonnull String catalogName, @Nonnull Throwable cause) {
+	private void markCatalogCorrupted(@Nonnull String catalogName, @Nonnull Throwable cause) {
 		final ExpandedEngineState updated = this.engineState.updateAndGet(
 			existingState -> {
 				if (existingState == null) {

--- a/evita_engine/src/main/java/io/evitadb/core/Evita.java
+++ b/evita_engine/src/main/java/io/evitadb/core/Evita.java
@@ -1724,32 +1724,6 @@ public final class Evita implements EvitaContract {
 	}
 
 	/**
-	 * Registers a session registry for a specific catalog. This ensures that a session
-	 * registry is associated with the provided catalog name. If a session registry
-	 * for the given catalog name already exists, an error is thrown to prevent overwriting.
-	 *
-	 * @param catalogName the name of the catalog to associate with the session registry
-	 * @param sessionRegistry the session registry to register with the catalog
-	 * @throws GenericEvitaInternalError if a session registry for the specified catalog name already exists
-	 */
-	public void registerCatalogSessionRegistry(@Nonnull String catalogName, @Nonnull SessionRegistry sessionRegistry) {
-		this.catalogSessionRegistries.compute(
-			catalogName,
-			(__, existingRegistry) -> {
-				if (existingRegistry != null && existingRegistry != sessionRegistry) {
-					throw new GenericEvitaInternalError(
-						"Catalog session registry for catalog `" + catalogName + "` already exists! " +
-							"Cannot overwrite it with another one!"
-					);
-				} else {
-					// otherwise we register the new one
-					return sessionRegistry;
-				}
-			}
-		);
-	}
-
-	/**
 	 * Registers a session registry for a specific catalog replacing any potentially existing registry under particular
 	 * catalog name. This ensures that a session registry is associated with the provided catalog name.
 	 *

--- a/evita_engine/src/main/java/io/evitadb/core/Evita.java
+++ b/evita_engine/src/main/java/io/evitadb/core/Evita.java
@@ -105,6 +105,7 @@ import io.evitadb.core.transaction.engine.EngineTransactionManager;
 import io.evitadb.core.transaction.engine.operators.DefaultUpgradeExecutor;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.function.Functions;
+import io.evitadb.spi.store.catalog.persistence.CatalogHandoverFailedException;
 import io.evitadb.spi.store.catalog.shared.model.LogRecordReference;
 import io.evitadb.spi.store.engine.EnginePersistenceService;
 import io.evitadb.spi.store.engine.EnginePersistenceServiceFactory;
@@ -1602,10 +1603,17 @@ public final class Evita implements EvitaContract {
 	 * onFailure callback so the auto-upgrade path can reuse the same terminal-failure bookkeeping
 	 * when a retry fails.
 	 *
+	 * Also reached from a rename or replace that failed past its point of no return
+	 * ({@link CatalogHandoverFailedException}), where the catalog is left with no persistence service behind
+	 * it and refusing sessions legibly is the only honest answer until a restart rebuilds it from its folder.
+	 * The registry serving the name resolves the catalog through the engine state on every session, so
+	 * binding the placeholder here is what turns the next session into a `CatalogCorruptedException` rather
+	 * than a use of a catalog that cannot read its own data.
+	 *
 	 * @param catalogName name of the catalog to mark CORRUPTED
 	 * @param cause       the failure carried by the resulting {@link CatalogCorruptedException}
 	 */
-	private void markCatalogCorrupted(@Nonnull String catalogName, @Nonnull Throwable cause) {
+	public void markCatalogCorrupted(@Nonnull String catalogName, @Nonnull Throwable cause) {
 		final ExpandedEngineState updated = this.engineState.updateAndGet(
 			existingState -> {
 				if (existingState == null) {

--- a/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
@@ -1178,6 +1178,9 @@ public final class Catalog
 			100,
 			theFuture -> {
 				final long catalogVersion = getVersion();
+				// Read before the handover, because `exchangeCatalogSchema` below rewrites what `getName()`
+				// answers - so a failure past that point would otherwise report the new name as the old one.
+				final String currentCatalogName = getName();
 				final CatalogSchema renamedSchema = CatalogSchema._internalBuild(updatedSchema);
 				final CatalogPersistenceService<LogRecordReference, CollectionReference, EntityCollectionHeader> newIoService =
 					this.persistenceService.replaceWith(
@@ -1246,13 +1249,16 @@ public final class Catalog
 					// failure being reported is the one worth reporting.
 					try {
 						newIoService.close();
-					} catch (RuntimeException suppressed) {
+					} catch (Throwable suppressed) {
+						// `Throwable`, so that an `Error` raised while closing cannot *replace* the marked
+						// failure below - which would send the operator down the compensating path for a
+						// handover that has already relabelled the folder.
 						ex.addSuppressed(suppressed);
 					}
 					// `Throwable` above rather than `RuntimeException` for the same reason the storage layer
 					// uses it: past the relabel an `Error` leaves the identical disagreement behind, and
 					// compensating for it is the wrong answer however unsurvivable it is.
-					throw new CatalogHandoverFailedException(updatedSchema.getName(), ex);
+					throw new CatalogHandoverFailedException(currentCatalogName, updatedSchema.getName(), ex);
 				}
 			}
 		);

--- a/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
@@ -152,6 +152,7 @@ import io.evitadb.spi.store.catalog.header.model.CatalogHeader;
 import io.evitadb.spi.store.catalog.header.model.CollectionReference;
 import io.evitadb.spi.store.catalog.header.model.EntityCollectionHeader;
 import io.evitadb.spi.store.catalog.persistence.CatalogFragmentationSnapshot;
+import io.evitadb.spi.store.catalog.persistence.CatalogHandoverFailedException;
 import io.evitadb.spi.store.catalog.persistence.CatalogPersistenceService;
 import io.evitadb.spi.store.catalog.persistence.DurabilitySnapshot;
 import io.evitadb.spi.store.catalog.persistence.CatalogPersistenceServiceFactory;
@@ -1188,47 +1189,71 @@ public final class Catalog
 						// recalculate to percentages
 						(done, total) -> theFuture.updateProgress((int) (((double) done / total) * 100))
 					);
-				final long catalogVersionAfterRename = newIoService.getLastCatalogVersion();
-				final CatalogState catalogState = getCatalogState();
-				final List<EntityCollection> newCollections = this.entityCollections
-					.values()
-					.stream()
-					.map(
-						it -> new EntityCollection(
-							updatedSchema.getName(),
-							catalogVersionAfterRename,
-							catalogState,
-							it,
-							newIoService,
-							this.sequenceService
+				// **Everything below is as irreversible as `replaceWith` itself, and is marked to say so.** By
+				// the time that call returns, the folder has been relabelled *and* the service that served this
+				// catalog has been closed - so a failure in the rebuild that follows leaves `this` catalog, the
+				// one still published under the name being renamed away from, holding a closed persistence
+				// service in a folder whose stored identity no longer agrees with engine state. Left unmarked,
+				// such a failure takes the operator's ordinary compensating path, which resumes session
+				// admission and hands callers exactly that catalog: the failure mode the marker exists to
+				// prevent, reached by a route that never enters `replaceWith`.
+				try {
+					final long catalogVersionAfterRename = newIoService.getLastCatalogVersion();
+					final CatalogState catalogState = getCatalogState();
+					final List<EntityCollection> newCollections = this.entityCollections
+						.values()
+						.stream()
+						.map(
+							it -> new EntityCollection(
+								updatedSchema.getName(),
+								catalogVersionAfterRename,
+								catalogState,
+								it,
+								newIoService,
+								this.sequenceService
+							)
 						)
-					)
-					.toList();
+						.toList();
 
-				this.transactionManager.advanceVersion(catalogVersionAfterRename);
-				// Exchanged **here**, not before the handover above, and this ordering is load-bearing. The
-				// exchange mutates *this* catalog - the one still published under the name it is being renamed
-				// away from - so performed early it hands a live catalog a schema naming a rename that has not
-				// happened yet, and every failure between the two leaves it there for the life of the process.
-				// The damage is not cosmetic: the commit pipeline looks a catalog up by the name its schema
-				// reports (`ExpandedEngineState#replaceCatalogReference`), so a write accepted afterwards is
-				// appended to the write-ahead log and then dies against a name the engine state has never
-				// heard of - and the next boot fails replaying it. Deferred to here, no failure in the
-				// handover can reach that state, because the only step left is the constructor below, which
-				// is what reads the exchanged schema through `previousCatalogVersion.getInternalSchema()`.
-				exchangeCatalogSchema(renamedSchema, getInternalSchema());
-				return new Catalog(
-					catalogVersionAfterRename,
-					catalogState,
-					this.catalogIndex.createShallowCopyWithResetDirtyFlag(),
-					this.archiveCatalogIndex.get() == null ?
-						null :
-						this.archiveCatalogIndex.get().createShallowCopyWithResetDirtyFlag(),
-					newCollections,
-					newIoService,
-					this,
-					true
-				);
+					this.transactionManager.advanceVersion(catalogVersionAfterRename);
+					// Exchanged **here**, not before the handover above, and this ordering is load-bearing. The
+					// exchange mutates *this* catalog - the one still published under the name it is being
+					// renamed away from - so performed early it hands a live catalog a schema naming a rename
+					// that has not happened yet, and a failure between the two leaves it there. The damage is
+					// not cosmetic: the commit pipeline looks a catalog up by the name its schema reports
+					// (`ExpandedEngineState#replaceCatalogReference`), so a write accepted afterwards is
+					// appended to the write-ahead log and then dies against a name the engine state has never
+					// heard of - and the next boot fails replaying it. That matters most for the failures that
+					// are *compensable*, where the catalog goes on serving; past the relabel the marker below
+					// keeps it from serving at all.
+					exchangeCatalogSchema(renamedSchema, getInternalSchema());
+					return new Catalog(
+						catalogVersionAfterRename,
+						catalogState,
+						this.catalogIndex.createShallowCopyWithResetDirtyFlag(),
+						this.archiveCatalogIndex.get() == null ?
+							null :
+							this.archiveCatalogIndex.get().createShallowCopyWithResetDirtyFlag(),
+						newCollections,
+						newIoService,
+						this,
+						true
+					);
+				} catch (Throwable ex) {
+					// The replacement service never reached a catalog that could close it, so it is closed
+					// here or its handles into the folder outlive the operation - and the folder is one a
+					// later drop or replace will want to delete. Suppressed rather than propagated: the
+					// failure being reported is the one worth reporting.
+					try {
+						newIoService.close();
+					} catch (RuntimeException suppressed) {
+						ex.addSuppressed(suppressed);
+					}
+					// `Throwable` above rather than `RuntimeException` for the same reason the storage layer
+					// uses it: past the relabel an `Error` leaves the identical disagreement behind, and
+					// compensating for it is the wrong answer however unsurvivable it is.
+					throw new CatalogHandoverFailedException(updatedSchema.getName(), ex);
+				}
 			}
 		);
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
@@ -1178,7 +1178,6 @@ public final class Catalog
 			theFuture -> {
 				final long catalogVersion = getVersion();
 				final CatalogSchema renamedSchema = CatalogSchema._internalBuild(updatedSchema);
-				exchangeCatalogSchema(renamedSchema, getInternalSchema());
 				final CatalogPersistenceService<LogRecordReference, CollectionReference, EntityCollectionHeader> newIoService =
 					this.persistenceService.replaceWith(
 						catalogVersion,
@@ -1207,6 +1206,17 @@ public final class Catalog
 					.toList();
 
 				this.transactionManager.advanceVersion(catalogVersionAfterRename);
+				// Exchanged **here**, not before the handover above, and this ordering is load-bearing. The
+				// exchange mutates *this* catalog - the one still published under the name it is being renamed
+				// away from - so performed early it hands a live catalog a schema naming a rename that has not
+				// happened yet, and every failure between the two leaves it there for the life of the process.
+				// The damage is not cosmetic: the commit pipeline looks a catalog up by the name its schema
+				// reports (`ExpandedEngineState#replaceCatalogReference`), so a write accepted afterwards is
+				// appended to the write-ahead log and then dies against a name the engine state has never
+				// heard of - and the next boot fails replaying it. Deferred to here, no failure in the
+				// handover can reach that state, because the only step left is the constructor below, which
+				// is what reads the exchanged schema through `previousCatalogVersion.getInternalSchema()`.
+				exchangeCatalogSchema(renamedSchema, getInternalSchema());
 				return new Catalog(
 					catalogVersionAfterRename,
 					catalogState,

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/EngineTransactionManager.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/EngineTransactionManager.java
@@ -176,6 +176,11 @@ public class EngineTransactionManager implements Closeable {
 	 * wedged, every public mutation-issuing entry point refuses to run until an operator intervenes
 	 * and hand-reconciles the bootstrap file.
 	 *
+	 * Also set at runtime by `updateEngineStateAfterEngineMutation` when a commit that is already
+	 * durable cannot be published in memory. That is the same hazard arriving by a different route:
+	 * the durable version has moved and the live state has not, so the next append would build on a
+	 * snapshot the engine can no longer vouch for.
+	 *
 	 * Structural WAL corruption (header without body) is NOT routed through this flag; the
 	 * persistence layer throws `WriteAheadLogCorruptedException` (with `WalKind.ENGINE`) directly, aborting the
 	 * `EngineTransactionManager` constructor and failing engine boot — a corrupt WAL cannot be
@@ -187,9 +192,9 @@ public class EngineTransactionManager implements Closeable {
 	 * `stateV + 1` again — duplicating (or clobbering) the crashed mutation. A loud fail-fast is
 	 * always better than silent corruption, so we gate every mutation entry on this flag.
 	 *
-	 * Marked `volatile` defensively: today the flag is only set during construction (so safe
-	 * publication via the constructor's happens-before is sufficient), but `volatile` hardens
-	 * the field against future refactorings that move wedge-setting onto a runtime path.
+	 * Marked `volatile` because it is genuinely set on a runtime path (the post-durability publish
+	 * failure above), not only during construction — a mutation on one thread must be refused by
+	 * the wedge another thread has just raised.
 	 */
 	private volatile boolean wedged;
 
@@ -358,9 +363,10 @@ public class EngineTransactionManager implements Closeable {
 		@Nonnull EngineMutation<T> engineMutation,
 		@Nullable IntConsumer progressObserver
 	) {
-		// Fail fast if forward WAL replay during startup wedged the engine — see `wedged`.
-		// Continuing would let the next append reuse a version that the WAL already committed,
-		// clobbering the crashed record and masking the original incident.
+		// Fail fast if the engine is wedged — by forward WAL replay during startup, or by a durable
+		// commit that could not be published in memory; see `wedged`. Continuing would let the next
+		// append build on a stale snapshot and reuse a version the WAL already committed, clobbering
+		// that record and masking the original incident.
 		if (this.wedged) {
 			throw new GenericEvitaInternalError(
 				"Engine is wedged and refuses further mutations: "
@@ -839,6 +845,9 @@ public class EngineTransactionManager implements Closeable {
 					nextStateVersion, ex
 				);
 			}
+			// **The publish, alone in its own guard.** It is the only statement past the boundary whose failure
+			// is not survivable, so it is the only one allowed to wedge - see the catch below for why, and the
+			// second block for why nothing else may join it there.
 			try {
 				// Published unconditionally, whatever the observers did: durable state sitting ahead of the state
 				// every reader resolves against is a split brain nobody can compensate for, and - because the
@@ -846,21 +855,12 @@ public class EngineTransactionManager implements Closeable {
 				// already holds.
 				this.lastStoredEngineStateVersion++;
 				this.evita.setNextEngineState(nextEngineState);
-				// only now is the pruning durable, so the confirmations that produced it can be forgotten
-				this.folderContext.forgetDrainedFolders(drainedFolders);
-				// and only now can a generation counter be retired, for the same reason: the evidence that the name
-				// holds nothing any more is exactly the pruned state that was just made durable
-				retireGenerationSequences(mutatedEngineState, nextEngineState, drainedFolders);
-				// finally, notify the change observer about the new version
-				this.changeObserver.notifyVersionPresentInLiveView(nextStateVersion);
 			} catch (Throwable ex) {
 				// **Wedged rather than merely logged**, and this is the one post-durability failure that earns
-				// it. Everything else in this block is bookkeeping whose loss the next commit heals; losing the
-				// publish is different in kind, because the version counter has already moved. The next mutation
-				// would then derive its snapshot from `evita.getEngineState()` - still the pre-commit state -
-				// and persist it at the advanced version, durably erasing whatever this commit recorded: a
-				// catalog binding, a tombstone. And it would do so silently, once per commit, for as long as the
-				// process runs.
+				// it, because the version counter has already moved. The next mutation would then derive its
+				// snapshot from `evita.getEngineState()` - still the pre-commit state - and persist it at the
+				// advanced version, durably erasing whatever this commit recorded: a catalog binding, a
+				// tombstone. And it would do so silently, once per commit, for as long as the process runs.
 				//
 				// Refusing further mutations is what stops that, and it is the same escalation the forward-replay
 				// path already uses for a state it cannot reconcile on its own. The caller of *this* mutation is
@@ -874,6 +874,37 @@ public class EngineTransactionManager implements Closeable {
 					"Publishing engine state version `{}` in memory failed after it had been made durable. The " +
 						"mutation survives a restart, but this process now refuses further engine mutations - " +
 						"restart it to resume from the durable state.",
+					nextStateVersion, ex
+				);
+				// Returned rather than fallen through: every statement below reads `nextEngineState` as the state
+				// that is now live, and it is not. Their work is retention bookkeeping for a version no reader
+				// can see, and the engine accepts no further mutation to make use of it.
+				return;
+			}
+			try {
+				// only now is the pruning durable, so the confirmations that produced it can be forgotten
+				this.folderContext.forgetDrainedFolders(drainedFolders);
+				// and only now can a generation counter be retired, for the same reason: the evidence that the name
+				// holds nothing any more is exactly the pruned state that was just made durable
+				retireGenerationSequences(mutatedEngineState, nextEngineState, drainedFolders);
+				// finally, notify the change observer about the new version
+				this.changeObserver.notifyVersionPresentInLiveView(nextStateVersion);
+			} catch (Throwable ex) {
+				// **Logged and never wedged**, in deliberate contrast to the publish above. These three are
+				// retention bookkeeping and a notification, and the next commit performs all of them again from
+				// the state it publishes then - a drained folder stays confirmed, a generation counter stays
+				// unretired, a subscriber wakes one version late. Nothing here can put the durable and live
+				// halves out of step, which is the only thing the wedge exists to prevent.
+				//
+				// The distinction is not academic: `notifyVersionPresentInLiveView` walks change-capture
+				// subscribers and `SystemChangeObserver` refuses it outright once closed, exactly as
+				// `processMutation` does two blocks above. Wedging on that would refuse every future mutation
+				// across every catalog because a subscriber went away during a shutdown - stopping the engine to
+				// protect state that is, by then, perfectly in step.
+				log.error(
+					"Post-publish bookkeeping for engine state version `{}` did not complete. The version is " +
+						"durable and live, so this costs only retention work and a change-capture wake-up that " +
+						"the next commit performs again.",
 					nextStateVersion, ex
 				);
 			}

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/EngineTransactionManager.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/EngineTransactionManager.java
@@ -854,10 +854,26 @@ public class EngineTransactionManager implements Closeable {
 				// finally, notify the change observer about the new version
 				this.changeObserver.notifyVersionPresentInLiveView(nextStateVersion);
 			} catch (Throwable ex) {
+				// **Wedged rather than merely logged**, and this is the one post-durability failure that earns
+				// it. Everything else in this block is bookkeeping whose loss the next commit heals; losing the
+				// publish is different in kind, because the version counter has already moved. The next mutation
+				// would then derive its snapshot from `evita.getEngineState()` - still the pre-commit state -
+				// and persist it at the advanced version, durably erasing whatever this commit recorded: a
+				// catalog binding, a tombstone. And it would do so silently, once per commit, for as long as the
+				// process runs.
+				//
+				// Refusing further mutations is what stops that, and it is the same escalation the forward-replay
+				// path already uses for a state it cannot reconcile on its own. The caller of *this* mutation is
+				// still not told it failed - it did not, it is durable - but nothing else is allowed to build on
+				// a snapshot the engine can no longer vouch for.
+				wedge(
+					"engine state version `" + nextStateVersion + "` was committed durably but could not be " +
+						"published in memory: " + ex.getMessage()
+				);
 				log.error(
 					"Publishing engine state version `{}` in memory failed after it had been made durable. The " +
-						"mutation survives a restart, but this process may answer from the state that preceded " +
-						"it until then.",
+						"mutation survives a restart, but this process now refuses further engine mutations - " +
+						"restart it to resume from the durable state.",
 					nextStateVersion, ex
 				);
 			}

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/EngineTransactionManager.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/EngineTransactionManager.java
@@ -816,19 +816,51 @@ public class EngineTransactionManager implements Closeable {
 					)
 				);
 
-			// notify system observer about the mutation
-			this.changeObserver.processMutation(txMutationWithWalReference.transactionMutation());
-			this.changeObserver.processMutation(engineMutation);
-
-			this.lastStoredEngineStateVersion++;
-			this.evita.setNextEngineState(nextEngineState);
-			// only now is the pruning durable, so the confirmations that produced it can be forgotten
-			this.folderContext.forgetDrainedFolders(drainedFolders);
-			// and only now can a generation counter be retired, for the same reason: the evidence that the name
-			// holds nothing any more is exactly the pruned state that was just made durable
-			retireGenerationSequences(mutatedEngineState, nextEngineState, drainedFolders);
-			// finally, notify the change observer about the new version
-			this.changeObserver.notifyVersionPresentInLiveView(nextStateVersion);
+			// **The mutation is durable from here, and nothing below may report failure.** The write-ahead log
+			// record is appended and the bootstrap rewritten, so it survives a restart whatever happens next.
+			// A caller told "this failed" would be told something untrue, and would act on it: an operator
+			// undoes bookkeeping the durable state has already recorded, and a client retries an operation that
+			// has already happened. Everything after this line is therefore best-effort and logged - the same
+			// rule the operators apply to their own post-commit work, and for the same reason.
+			//
+			// Reporting nothing costs nothing that reporting would have recovered. The realistic failure here is
+			// a change observer closing underneath an in-flight operation, and the capture it refuses is lost
+			// either way: `processMutation` is what fills the replay buffer, so failing the caller's future
+			// neither redelivers the event nor lets anyone else recover it. It only adds a lie to a loss.
+			try {
+				// notify system observer about the mutation - before the publish, as it always has been
+				this.changeObserver.processMutation(txMutationWithWalReference.transactionMutation());
+				this.changeObserver.processMutation(engineMutation);
+			} catch (Throwable ex) {
+				log.error(
+					"Change data capture dispatch failed for engine state version `{}`, which is already " +
+						"durable - subscribers have missed this mutation and cannot replay it, because the " +
+						"buffer they would replay from is filled by the dispatch that just failed.",
+					nextStateVersion, ex
+				);
+			}
+			try {
+				// Published unconditionally, whatever the observers did: durable state sitting ahead of the state
+				// every reader resolves against is a split brain nobody can compensate for, and - because the
+				// version counter moves with it - the next mutation would otherwise append at a version the log
+				// already holds.
+				this.lastStoredEngineStateVersion++;
+				this.evita.setNextEngineState(nextEngineState);
+				// only now is the pruning durable, so the confirmations that produced it can be forgotten
+				this.folderContext.forgetDrainedFolders(drainedFolders);
+				// and only now can a generation counter be retired, for the same reason: the evidence that the name
+				// holds nothing any more is exactly the pruned state that was just made durable
+				retireGenerationSequences(mutatedEngineState, nextEngineState, drainedFolders);
+				// finally, notify the change observer about the new version
+				this.changeObserver.notifyVersionPresentInLiveView(nextStateVersion);
+			} catch (Throwable ex) {
+				log.error(
+					"Publishing engine state version `{}` in memory failed after it had been made durable. The " +
+						"mutation survives a restart, but this process may answer from the state that preceded " +
+						"it until then.",
+					nextStateVersion, ex
+				);
+			}
 		} finally {
 			this.engineStateLock.unlock();
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/EngineMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/EngineMutationOperator.java
@@ -85,8 +85,15 @@ public interface EngineMutationOperator<S, T extends EngineMutation<S>> {
 	 * - The operator may perform long‑running work asynchronously and must return a
 	 *   {@link io.evitadb.api.requestResponse.progress.ProgressingFuture} that completes with the
 	 *   mutation result.
-	 * - The {@code transitionEngineStateUpdater} must be invoked exactly once before the heavy work
-	 *   starts to update in‑memory state (pre‑mutation phase).
+	 * - The {@code transitionEngineStateUpdater} is invoked at most once, and normally exactly once
+	 *   before the heavy work starts, to update in‑memory state (pre‑mutation phase). It is the only
+	 *   route by which an operator may write engine state, because it is the only one that runs under
+	 *   {@link io.evitadb.core.transaction.engine.EngineTransactionManager}'s engine state lock — a
+	 *   bare read‑derive‑write loses to a concurrent commit across the fsync that commit performs.
+	 *   An operator whose failure cannot be compensated for may therefore invoke it instead from its
+	 *   failure path, to declare a terminal state for what it damaged; see
+	 *   {@link ModifyCatalogSchemaNameMutationOperator}, which does exactly that and consequently
+	 *   invokes this updater zero times on the path that succeeds.
 	 * - The {@code completionEngineStateUpdater} must be invoked exactly once after the mutation
 	 *   finishes successfully so the transaction manager can append persistent log, persist the new state and
 	 *   publish the new version (post‑mutation phase).

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
@@ -167,21 +167,16 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 
 		final Runnable undoOperations = () -> {
 			// What belongs under the target name is decided by what answered to it when the operation started,
-			// never by what answers to it now - the completion phase publishes the surviving catalog's registry
-			// there before the commit, so by this point the name may legitimately carry a registry this operation
-			// put there itself.
+			// never by what answers to it now.
 			if (quiescedTargetRegistry.isPresent()) {
-				// A replace: the target is still there and still answers to this name, so its own registry goes
-				// back under it. Restored rather than merely resumed, because the pre-commit publication may have
-				// displaced it - and with `registerWithReplace` rather than `register` for the same reason, since
-				// the stricter call refuses a name occupied by a registry other than the one being restored, which
-				// on that path is exactly what it is.
+				// A replace onto a name that already had a catalog: its registry has held that name throughout -
+				// the completion phase deliberately does not displace it before the commit - so there is nothing
+				// to put back, only a suspension to lift.
 				//
-				// The registry may be one this operation installed rather than found, and it is put back either
-				// way: a drain can give up with sessions still inside it, and a registry that cannot be reached
-				// through the map is invisible to every later quiesce - replace, delete, engine shutdown - so those
-				// sessions would outlive the catalog they are bound to.
-				evita.registerWithReplaceCatalogSessionRegistry(catalogNameToBeReplaced, quiescedTargetRegistry.get());
+				// Resumed **in place**, never unpublished: a drain can give up with sessions still inside it, and
+				// a registry that cannot be reached through the map is invisible to every later quiesce - replace,
+				// delete, engine shutdown - so those sessions would outlive the catalog they are bound to.
+				//
 				// A replace quiesces its target with REJECT before touching anything, and a failure leaves that
 				// target standing - the operation changed nothing. Resuming it is therefore part of undoing, or
 				// the catalog that was *not* replaced spends the rest of the process answering
@@ -193,7 +188,9 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 				// A rename, whose target names nothing until the commit lands, or a replace onto a name that names
 				// no catalog. Nothing outside this operation can have installed a registry under such a name -
 				// session creation refuses a name it cannot resolve to a catalog - so whatever answers to it now is
-				// the registry the completion phase published, and it goes back with the rest of it. The surviving
+				// the registry the completion phase published ahead of the commit, and it goes back with the rest
+				// of it. Anyone already waiting on it is released by the resume below and then finds that the name
+				// still resolves to no catalog, which is the answer a failed operation owes them. The surviving
 				// catalog keeps serving through the source name, whose registry stays published until the commit.
 				evita.removeCatalogSessionRegistryIfPresent(catalogNameToBeReplaced);
 			}
@@ -274,46 +271,56 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 				(theFuture, replacedCatalogs) -> {
 					final CatalogContract replacedCatalog = replacedCatalogs.iterator().next();
 
-					// The surviving catalog's registry is published under the target name *before* the commit, and
-					// stays suspended until after it. The commit is what makes that name resolve, and it does so
-					// synchronously - `updateEngineStateAfterEngineMutation` sets the next engine state under the
-					// engine-state lock and returns - so from the instant it returns the name is servable. Published
-					// after the commit, as it used to be, there is a window in which the name resolves to a live
-					// catalog that has no registry behind it: `createSessionInternal` builds a fresh and
-					// *unsuspended* one through `computeIfAbsent` and admits a session into it, the handoff below
-					// then displaces that registry, and the session inside it is reachable through no name at all -
-					// invisible to every later quiesce, and still bound to a catalog a subsequent rename, delete or
-					// shutdown will destroy underneath it.
-					//
-					// Publishing early is only safe because a registry built by `withDifferentCatalogSupplier`
-					// shares its active sessions, its suspension and its registration gate with the one it was
-					// derived from. What is published here is therefore already suspended, and a caller that
-					// resolves the target name inside the window waits out the POSTPONE and is then served by the
-					// very registry the catalog keeps afterwards, rather than by one about to be thrown away.
-					final SessionRegistry displacedRegistry = prevailingCatalogSessionRegistry
+					// The registry the target name is to be served through once this operation completes. It shares
+					// its active sessions, its suspension and its registration gate with the registry it is derived
+					// from, so it is already suspended and stays so until the resume at the end.
+					final SessionRegistry targetRegistry = prevailingCatalogSessionRegistry
 						.map(
-							sessionRegistry -> evita.registerWithReplaceCatalogSessionRegistry(
-								catalogNameToBeReplaced,
-								sessionRegistry.withDifferentCatalogSupplier(
-									() -> (Catalog) evita.getCatalogInstanceOrThrowException(catalogNameToBeReplaced)
-								)
+							sessionRegistry -> sessionRegistry.withDifferentCatalogSupplier(
+								() -> (Catalog) evita.getCatalogInstanceOrThrowException(catalogNameToBeReplaced)
 							)
 						)
 						.orElse(null);
-					// Nothing else can be occupying the target name here: a rename's target names no catalog until
-					// the commit below lands and session creation refuses a name it cannot resolve, while a
-					// replace's target carries the registry this operation quiesced above. Asserted rather than
-					// cleaned up after, because the only available cleanup - draining a registry full of live
-					// sessions and giving up after five seconds - is the silent half-measure this whole ordering
-					// exists to remove. Throwing is safe at this point precisely because the commit has not run
-					// yet, so it reaches `undoOperations` like any other pre-commit failure.
-					Assert.isPremiseValid(
-						displacedRegistry == null || displacedRegistry == quiescedTargetRegistry.orElse(null),
-						() -> new GenericEvitaInternalError(
-							"Catalog `" + catalogNameToBeReplaced + "` gained a session registry while it was " +
-								"being renamed or replaced - the sessions it holds would be orphaned by the handoff!"
-						)
-					);
+
+					// **When the target name has no registry of its own, it gets this one before the commit.** The
+					// commit is what makes that name resolve, and it does so synchronously -
+					// `updateEngineStateAfterEngineMutation` sets the next engine state under the engine-state lock
+					// and returns - so from the instant it returns the name is servable. Published only afterwards,
+					// there is a window in which the name resolves to a live catalog with no registry behind it:
+					// `createSessionInternal` builds a fresh and *unsuspended* one through `computeIfAbsent` and
+					// admits a session into it, the handoff below then displaces that registry, and the session
+					// inside it is reachable through no name at all - invisible to every later quiesce, and still
+					// bound to a catalog a subsequent rename, delete or shutdown will destroy underneath it.
+					//
+					// **A replace onto a name that already had a catalog is left alone**, and deliberately so. Its
+					// own registry holds that name from the read-only phase to the handoff, so the window above
+					// never opens there and publishing early would buy nothing - while costing something real. The
+					// published registry is what a caller captures before waiting out a suspension, and neither
+					// `handleSuspension` nor `registerWhileNotSuspended` looks at the map again once it has waited.
+					// An early publication that a failed commit then took back would leave such a caller holding an
+					// unpublished alias, resolving a target catalog the failure left standing, and registering into
+					// the *source* registry's session map - orphaned from the very name it asked for. The two cases
+					// that do publish early are immune to that: a rename's target and a replace onto a name that
+					// names nothing both still name no catalog once the operation has failed, so such a waiter is
+					// released into a `CatalogNotFoundException` rather than into a session.
+					final boolean publishedAheadOfCommit = quiescedTargetRegistry.isEmpty() && targetRegistry != null;
+					if (publishedAheadOfCommit) {
+						final SessionRegistry displacedRegistry =
+							evita.registerWithReplaceCatalogSessionRegistry(catalogNameToBeReplaced, targetRegistry);
+						// Nothing can be occupying this name: it names no catalog until the commit below lands, and
+						// session creation refuses a name it cannot resolve. Asserted rather than cleaned up after,
+						// because the only available cleanup - draining a registry full of live sessions and giving
+						// up after five seconds - is the silent half-measure this whole ordering exists to remove.
+						// Throwing is safe here precisely because the commit has not run yet, so it reaches
+						// `undoOperations` like any other pre-commit failure.
+						Assert.isPremiseValid(
+							displacedRegistry == null,
+							() -> new GenericEvitaInternalError(
+								"Catalog `" + catalogNameToBeReplaced + "` gained a session registry while it was " +
+									"being renamed - the sessions it holds would be orphaned by the handoff!"
+							)
+						);
+					}
 
 					completionEngineStateUpdater.accept(
 						new AbstractEngineStateUpdater(transactionId, mutation) {
@@ -381,12 +388,19 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 					// The catalog survives under the target name in BOTH operations, so its session registry
 					// follows it there - it carries the active sessions, the FIFO queue and the consumed-version
 					// census that backups pin against, all of which belong to the catalog rather than to the name
-					// it happened to be reached by. The registry is already published under the target name above;
-					// what is left here is retiring the name it used to answer to, and lifting the suspension.
+					// it happened to be reached by. For a rename it is already published under the target name above,
+					// and what is left here is retiring the name it used to answer to and lifting the suspension;
+					// for a replace onto an existing catalog the swap happens here, where taking it back is no
+					// longer something a failure can ask for.
 					prevailingCatalogSessionRegistry.ifPresentOrElse(
 						sessionRegistry -> {
-							// Dropped only now, never alongside the publication above: until the commit lands the
-							// source name still resolves to the live catalog, and a name left empty is a name the
+							if (!publishedAheadOfCommit) {
+								evita.registerWithReplaceCatalogSessionRegistry(
+									catalogNameToBeReplaced, targetRegistry
+								);
+							}
+							// Dropped only now, never before the commit: until the commit lands the source
+							// name still resolves to the live catalog, and a name left empty is a name the
 							// next `createSessionInternal` fills with a fresh, unsuspended registry - serving
 							// sessions against the very catalog this operation is renaming. Past the commit the
 							// name resolves to nothing, so the same call answers `CatalogNotFoundException`

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
@@ -74,10 +74,15 @@ import static io.evitadb.utils.Assert.isTrue;
  * "unknown and should be treated as damaged" no longer describes any failure that is not a crash of the commit
  * itself. After it, the worst residue is a folder that outlived its tombstone, which the next boot drains.
  *
- * Forward-replay is still **not** implemented, but the reason has changed and narrowed: the disk work is now
- * idempotent, and what blocks replay is the completion phase's need for a live catalog instance to stage, which
- * does not exist at replay time when every catalog is still a stub. The default `Optional.empty()` in
- * `EngineMutationOperator` causes the transaction manager to wedge loudly.
+ * Forward-replay **is** implemented — see `replayCompletionState`. What made it possible is that ordering: the
+ * disk work is idempotent and already done by the time the commit record exists, so replay is purely the three
+ * state edits, with a placeholder standing in for the catalog instance the crash lost. It still declines rather
+ * than guesses where the recorded state cannot be rebuilt safely — an unbound source, or two names resolving to
+ * one folder — and those paths return `Optional.empty()`, which wedges the transaction manager loudly.
+ *
+ * That matters to anyone reasoning about a failed rename: a commit record left durable at `walV == stateV + 1`
+ * is **completed** by the next boot, not discarded. A failure the engine reports and declares in memory can
+ * therefore still turn into a finished rename after a restart.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
  */

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
@@ -152,18 +152,31 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 		final AtomicReference<SessionRegistry> quiescedTargetRegistryHolder = new AtomicReference<>();
 
 		final Runnable undoOperations = () -> {
-			// A replace quiesces its target with REJECT before touching anything, and a failure leaves that
-			// target standing - the operation changed nothing. Resuming it is therefore part of undoing, or the
-			// catalog that was *not* replaced spends the rest of the process answering
-			// `InstanceTerminatedException` to every session opened against it.
-			final SessionRegistry quiescedTargetRegistry = quiescedTargetRegistryHolder.get();
-			if (quiescedTargetRegistry != null) {
-				quiescedTargetRegistry.resumeOperations();
-			}
-			// revert session registry swap
+			// The registry map is put back the way it was *before* anything is resumed, and a registry dropped
+			// here is never resumed at all. Session creation goes through `computeIfAbsent` on this very map, so
+			// a registry that is both reachable and running accepts sessions: resuming first opens a window in
+			// which a racing `createSession` lands a live session in a registry the next line then unpublishes.
+			// Every later quiesce - replace, delete, engine shutdown - walks the map, so that session would be
+			// invisible to all of them and its catalog could be terminated underneath it.
 			if (removedCatalogSessionRegistry.isPresent()) {
+				// revert session registry swap
 				evita.registerCatalogSessionRegistry(catalogNameToBeReplaced, removedCatalogSessionRegistry.get());
+				// A replace quiesces its target with REJECT before touching anything, and a failure leaves that
+				// target standing - the operation changed nothing. Resuming it is therefore part of undoing, or
+				// the catalog that was *not* replaced spends the rest of the process answering
+				// `InstanceTerminatedException` to every session opened against it. Guarded on the holder rather
+				// than resumed unconditionally, so that a suspension this operation did not install - one a
+				// concurrent operation is holding - is never cleared on its behalf.
+				final SessionRegistry quiescedTargetRegistry = quiescedTargetRegistryHolder.get();
+				if (quiescedTargetRegistry != null) {
+					quiescedTargetRegistry.resumeOperations();
+				}
 			} else {
+				// Whatever answers to this name is the registry `suspendCatalogSessions` installed purely to
+				// quiesce the target. It is dropped rather than resumed into service - the rule the success path
+				// and `retireStragglerRegistry` already follow - so the next request builds a clean one through
+				// the map, while a thread still holding a stale reference keeps being refused instead of
+				// populating a registry nobody can reach any more.
 				evita.removeCatalogSessionRegistryIfPresent(catalogNameToBeReplaced);
 			}
 			// and revert the suspension the operation opened with. Resuming used to happen on the success path
@@ -336,12 +349,17 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 						// rejecting sessions for the life of the process: the catalog would survive the replace
 						// and be unreachable afterwards. Dropped rather than resumed into service, so the next
 						// request builds a clean one against the catalog that now answers to this name.
-						() -> quiescedTargetRegistry.ifPresent(
-							quiesced -> {
+						//
+						// Unpublished and left suspended, never resumed: a resumed registry that no longer answers
+						// to any name still accepts sessions from whoever holds a reference to it, and those
+						// sessions are then invisible to every later quiesce - which walks the registry map. The
+						// caller that loses this race is refused rather than served, which is precisely what
+						// quiescing the target is for.
+						() -> {
+							if (quiescedTargetRegistry.isPresent()) {
 								evita.removeCatalogSessionRegistryIfPresent(catalogNameToBeReplaced);
-								quiesced.resumeOperations();
 							}
-						)
+						}
 					);
 
 					// Terminate the catalog that was replaced. A failure here costs open handles into a folder

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
@@ -52,6 +52,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static io.evitadb.utils.Assert.isTrue;
@@ -146,13 +147,34 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 		prevailingCatalogSessionRegistry
 			.ifPresent(sessionRegistry -> sessionRegistry.closeAllActiveSessionsAndSuspend(SuspendOperation.POSTPONE));
 
+		// Written to as soon as the target is quiesced below, and read only by `undoOperations` - which is
+		// declared before that point and therefore cannot capture the local the quiescing produces.
+		final AtomicReference<SessionRegistry> quiescedTargetRegistryHolder = new AtomicReference<>();
+
 		final Runnable undoOperations = () -> {
+			// A replace quiesces its target with REJECT before touching anything, and a failure leaves that
+			// target standing - the operation changed nothing. Resuming it is therefore part of undoing, or the
+			// catalog that was *not* replaced spends the rest of the process answering
+			// `InstanceTerminatedException` to every session opened against it.
+			final SessionRegistry quiescedTargetRegistry = quiescedTargetRegistryHolder.get();
+			if (quiescedTargetRegistry != null) {
+				quiescedTargetRegistry.resumeOperations();
+			}
 			// revert session registry swap
 			if (removedCatalogSessionRegistry.isPresent()) {
 				evita.registerCatalogSessionRegistry(catalogNameToBeReplaced, removedCatalogSessionRegistry.get());
 			} else {
 				evita.removeCatalogSessionRegistryIfPresent(catalogNameToBeReplaced);
 			}
+			// and revert the suspension the operation opened with. Resuming used to happen on the success path
+			// only, so any failure between the suspend above and that resume left the surviving catalog listed
+			// but unusable: every session against it answered `SessionBusyException` for the life of the
+			// process, with no way back short of a restart. That is the session half of issue #1414, and it
+			// outlived the folder decoupling that removed the operation's other failure modes.
+			//
+			// Unconditional because `resumeOperations` clears a suspension if one is standing and does nothing
+			// otherwise - and this runs on paths that failed before the suspend could take effect as well.
+			prevailingCatalogSessionRegistry.ifPresent(SessionRegistry::resumeOperations);
 		};
 
 		try {
@@ -194,6 +216,8 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 				quiescedTargetRegistry = evita.suspendCatalogSessions(
 					catalogNameToBeReplaced, SuspendOperation.REJECT
 				);
+				// handed to the undo path, which has to lift this suspension when the operation fails
+				quiescedTargetRegistry.ifPresent(quiescedTargetRegistryHolder::set);
 			} else {
 				Assert.isPremiseValid(removedCatalogSessionRegistry.isEmpty(), "Expectation failed!");
 				quiescedTargetRegistry = Optional.empty();

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
@@ -52,7 +52,6 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static io.evitadb.utils.Assert.isTrue;
@@ -151,14 +150,21 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 		final Optional<SessionRegistry> removedCatalogSessionRegistry =
 			evita.getCatalogSessionRegistry(catalogNameToBeReplaced);
 
-		// Written as soon as the target registry is owned - before it is drained, never after - and read only by
-		// `undoOperations`, which is declared above that point and cannot capture the local it produces.
-		final AtomicReference<SessionRegistry> quiescedTargetRegistryHolder = new AtomicReference<>();
+		final boolean replaceOperation = catalogToBeReplaced != catalogToBeReplacedWith;
+		// Owned here, above everything that can fail, and drained further down. Ownership cannot wait for the
+		// drain that establishes it: `closeAllActiveSessionsAndSuspend` publishes the suspension before waiting
+		// for the sessions to leave, so it throws with that suspension standing. Nor can it wait for anything
+		// else inside the `try` - the surviving catalog's own drain runs ahead of it and can spend five seconds
+		// failing, and throughout all of it the target is a live, unquiesced catalog. A session opened against it
+		// in that window installs a registry through the same `computeIfAbsent`, and an undo that had not
+		// recorded ownership would mistake that registry for its own leftover and unpublish it - splitting the
+		// catalog's session bookkeeping across two registries and hiding one of them from every later quiesce.
+		final Optional<SessionRegistry> quiescedTargetRegistry = replaceOperation ?
+			evita.obtainCatalogSessionRegistry(catalogNameToBeReplaced) : Optional.empty();
 
 		final Runnable undoOperations = () -> {
 			// Which of the three outcomes applies is decided by what answered to the target name when the
 			// operation started, never by what answers to it now.
-			final SessionRegistry quiescedTargetRegistry = quiescedTargetRegistryHolder.get();
 			if (removedCatalogSessionRegistry.isPresent()) {
 				// A registry that predates the operation: restored under its name first, resumed after, in that
 				// order. Session creation goes through `computeIfAbsent` on this same map, so a name left empty
@@ -168,26 +174,28 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 				// A replace quiesces its target with REJECT before touching anything, and a failure leaves that
 				// target standing - the operation changed nothing. Resuming it is therefore part of undoing, or
 				// the catalog that was *not* replaced spends the rest of the process answering
-				// `InstanceTerminatedException` to every session opened against it. Guarded on the holder so that
-				// a suspension this operation never installed is not cleared on someone else's behalf.
-				if (quiescedTargetRegistry != null) {
-					quiescedTargetRegistry.resumeOperations();
-				}
-			} else if (quiescedTargetRegistry != null) {
-				// A registry this operation installed itself, purely to quiesce the target. The replace failed,
-				// so that catalog is still there and still answers to this name - which makes a resumed registry
-				// under it exactly what the first session would have built anyway.
+				// `InstanceTerminatedException` to every session opened against it. Safe on the paths that failed
+				// before the drain ran, because `resumeOperations` lifts a suspension if one is standing and does
+				// nothing at all otherwise.
+				quiescedTargetRegistry.ifPresent(SessionRegistry::resumeOperations);
+			} else if (quiescedTargetRegistry.isPresent()) {
+				// A registry this operation owns without having found one: either it installed it, or a session
+				// that raced the obtain above did and this operation adopted it. The replace failed, so that
+				// catalog is still there and still answers to this name - which makes a resumed registry under
+				// it exactly what the first session would have left behind anyway.
 				//
 				// Resumed **in place**, never unpublished: the drain can give up with sessions still inside it,
 				// and a registry that cannot be reached through the map is invisible to every later quiesce -
 				// replace, delete, engine shutdown - so those sessions would outlive the catalog they are bound
 				// to. Unpublishing while suspended has the mirror-image cost, since a resume that follows the
 				// removal lets a racing `createSession` populate a registry nobody can reach any more.
-				quiescedTargetRegistry.resumeOperations();
+				quiescedTargetRegistry.get().resumeOperations();
 			} else {
-				// Nothing was quiesced under this name: a rename, whose target names nothing until the commit
-				// lands, or a replace onto a name that names no catalog. Whatever answers to it can only have
-				// been put there by the registry swap on the success path, and goes back with the rest of it.
+				// This name was never a catalog this operation could quiesce: a rename, whose target names
+				// nothing until the commit lands, or a replace onto a name that names no catalog. Nothing can
+				// have installed a registry under it in the meantime for the same reason - session creation
+				// refuses a name it cannot resolve to a catalog - so whatever answers to it now was put there by
+				// the registry swap on the success path, and goes back with the rest of it.
 				evita.removeCatalogSessionRegistryIfPresent(catalogNameToBeReplaced);
 			}
 			// and revert the suspension the operation opened with. Resuming used to happen on the success path
@@ -211,7 +219,6 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 				sessionRegistry -> sessionRegistry.closeAllActiveSessionsAndSuspend(SuspendOperation.POSTPONE)
 			);
 
-			final boolean replaceOperation = catalogToBeReplaced != catalogToBeReplacedWith;
 			// Both folders are resolved here, in the read-only phase, and never again. The commit below repoints
 			// the target name at the source folder, so re-reading either afterwards would answer about the world
 			// the commit has just created rather than the one it acted on.
@@ -234,31 +241,20 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 				)
 			);
 			// first terminate the catalog that is being replaced (unless it's the very same catalog)
-			final Optional<SessionRegistry> quiescedTargetRegistry;
 			if (replaceOperation) {
-				// Obtained rather than looked up, for the reason the surviving catalog is: a target nobody has
-				// opened a session on since boot has no registry, so suspending what `getCatalogSessionRegistry`
-				// finds quiesces nothing at all - which is how sessions came to be served against a catalog while
-				// it was being destroyed. A registry is installed only when the name names a catalog, so a
-				// replace onto a target that does not exist keeps answering `CatalogNotFoundException` rather
-				// than reporting a terminated instance.
+				// The registry was obtained above, before anything that can fail; only the drain belongs here.
+				// Draining it is what stops sessions being served against a catalog that is being destroyed, and
+				// the registry it drains may be one this operation installed - a target nobody has opened a
+				// session on since boot has none, so a name-keyed lookup would have quiesced nothing at all.
 				//
-				// Ownership is recorded *between* obtaining and draining, deliberately. The drain publishes the
-				// suspension before it waits, so it throws with the suspension standing; recording afterwards
-				// would leave `undoOperations` unaware of a registry it has to resume, and the catalog that was
-				// not replaced would reject every session until the process ended.
-				//
-				// Held apart from `removedCatalogSessionRegistry`, which stays the *pre-existing* registry: the
-				// captured Optional is empty exactly when this operation installed the registry itself, and undo
-				// resumes that one in place rather than restoring anything.
-				quiescedTargetRegistry = evita.obtainCatalogSessionRegistry(catalogNameToBeReplaced);
-				quiescedTargetRegistry.ifPresent(quiescedTargetRegistryHolder::set);
+				// Kept apart from `removedCatalogSessionRegistry`, which stays the *pre-existing* registry: that
+				// Optional is empty exactly when this operation, rather than an earlier session, put the registry
+				// there, and undo resumes such a registry in place rather than restoring anything.
 				quiescedTargetRegistry.ifPresent(
 					sessionRegistry -> sessionRegistry.closeAllActiveSessionsAndSuspend(SuspendOperation.REJECT)
 				);
 			} else {
 				Assert.isPremiseValid(removedCatalogSessionRegistry.isEmpty(), "Expectation failed!");
-				quiescedTargetRegistry = Optional.empty();
 			}
 
 			final CatalogSchemaWithImpactOnEntitySchemas updatedSchemaWrapper = mutation.mutate(catalogToBeReplacedWith.getSchema());

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
@@ -54,6 +54,8 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static io.evitadb.utils.Assert.isTrue;
@@ -174,6 +176,19 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 		final Optional<SessionRegistry> quiescedTargetRegistry = replaceOperation ?
 			evita.obtainCatalogSessionRegistry(catalogNameToBeReplaced) : Optional.empty();
 
+		// **Whether the storage handover has run**, which is what separates compensating from declaring - and it
+		// is recorded as a fact here rather than read off the failure, because past the handover most failures
+		// are raised by code that has never heard of it: the engine-state commit, the premise check guarding the
+		// registry handoff, the bookkeeping either side of them. Marking each such site individually was tried
+		// and does not hold - three successive review rounds found three further unmarked exits, each one a
+		// catalog served through a persistence service the handover had already closed. Asking "did we get that
+		// far" once, where the answer is known, closes the class rather than another instance of it.
+		final AtomicBoolean handoverCompleted = new AtomicBoolean();
+		// The replacement catalog, once the handover has built one. Recorded so the declaration below can close
+		// it: it holds the *new* persistence service, opened by `replaceWith` and handed to a catalog that the
+		// failed commit never published, so nothing else will ever close it.
+		final AtomicReference<CatalogContract> replacementCatalog = new AtomicReference<>();
+
 		final Consumer<Throwable> undoOperations = failure -> {
 			// **Past the point of no return, compensating is the wrong verb.** Everything below puts session
 			// bookkeeping back, which is the whole of what a failure before the handover disturbed. Once the
@@ -183,7 +198,7 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 			// rename that merely failed becomes a catalog that serves reads, accepts a write, appends it to
 			// the write-ahead log and then wedges the next boot replaying it against a name engine state has
 			// never heard of - the very symptom this issue is named after, re-created by the code that fixes
-			// it. Where the line falls is the storage layer's to know and it marks the failures past it.
+			// it.
 			//
 			// So the name is declared unusable instead, and **declared before the resume below**, never
 			// after: the resume is what lets the waiting callers through, and there must be nothing usable
@@ -191,7 +206,17 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 			// naming the handover as its cause - refused, legibly, until a restart rebuilds the catalog
 			// from its folder, which it can, because the commit never ran and the load path reconciles the
 			// name the folder was left carrying.
-			if (isHandoverFailure(failure)) {
+			//
+			// **Nothing that reaches here can be a committed operation.** Neither the engine commit nor the
+			// completion work after it reports failure any more - the commit is best-effort and logged from
+			// the moment it becomes durable, and the block that follows it is wrapped for the same reason - so
+			// a failure arriving here is always one the durable state has no record of. That is what lets this
+			// path choose between exactly two answers instead of having to recognise a third.
+			//
+			// Either the storage layer marked the failure, or the handover had already completed and whatever
+			// failed afterwards is past the same line without knowing it. The latch is the load-bearing half:
+			// the marker only ever covers failures raised *inside* the handover.
+			if (handoverCompleted.get() || isHandoverFailure(failure)) {
 				// Routed through the *transition* updater rather than mutating engine state directly, because
 				// this is a read-derive-write on shared state and every other writer performs it under
 				// `EngineTransactionManager#engineStateLock`. A bare CAS loses to them by construction: a
@@ -211,6 +236,7 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 				// throw in here should be impossible, and if one happens anyway the worst outcome available is
 				// a catalog left serving - not both registries suspended for the life of the process, which is
 				// the very symptom this operation exists to stop producing.
+				boolean declared = false;
 				try {
 					transitionEngineStateUpdater.accept(
 						new AbstractEngineStateUpdater(transactionId, mutation) {
@@ -235,13 +261,44 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 						}
 					);
 					evita.notifyCatalogStateSettled(catalogNameToBeReplacedWith, CatalogState.CORRUPTED);
-				} catch (RuntimeException declarationFailure) {
+					declared = true;
+				} catch (Throwable declarationFailure) {
+					// `Throwable`, because narrowing this to `RuntimeException` does not make an `Error` any
+					// louder: it would be caught by `ProgressingFuture#completeExceptionally` and logged under
+					// a generic message anyway, and the only thing the narrower catch buys is skipping the
+					// resumes below - leaving both registries suspended for the life of the process, which
+					// this comment's own reasoning ranks as the worse of the two outcomes.
 					log.error(
 						"Failed to declare catalog `{}` unusable after its handover failed past the point of no " +
 							"return - it stays published and may serve sessions against storage that no longer " +
 							"agrees with the engine state, until the server is restarted.",
 						catalogNameToBeReplacedWith, declarationFailure
 					);
+				}
+				// The declaration swapped an `UnusableCatalog` in behind the name, so nothing reaches the
+				// instances that used to answer to it - but dropping the last reference to a catalog does not
+				// close what it holds open, and a failed handover can leave *two* services open. Best-effort
+				// and after the declaration, never before it: releasing handles is hygiene, and a failure to
+				// do it must not cost the refusal that keeps the damaged catalog off the wire.
+				//
+				// **Only once the declaration actually succeeded.** If it did not, the catalog is still
+				// published and still serving - the worst case the log above accepts - and terminating it then
+				// would convert "left serving" into "published and throwing", which is worse than either.
+				if (declared) {
+					// The original service, still open when the failure landed before `replaceWith` reached its
+					// own `close()` - the header write and the bootstrap publish are both inside that window.
+					// Guarded rather than caught, so the already-closed windows do not log a warning about
+					// handles that are not held.
+					if (!catalogToBeReplacedWith.isTerminated()) {
+						terminateQuietly(catalogToBeReplacedWith, catalogNameToBeReplacedWith);
+					}
+					// The *replacement* service, which is what leaks when the handover succeeded and the commit
+					// failed: `replaceWith` opened it and handed it to a catalog the commit never published, so
+					// nothing else holds a reference that would ever close it.
+					final CatalogContract replacement = replacementCatalog.get();
+					if (replacement != null && !replacement.isTerminated()) {
+						terminateQuietly(replacement, catalogNameToBeReplaced);
+					}
 				}
 			}
 			// What belongs under the target name is decided by what answered to it when the operation started,
@@ -347,7 +404,14 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 						)
 				),
 				(theFuture, replacedCatalogs) -> {
+					// Reaching here at all means the nested `replace(...)` completed, so the folder has been
+					// relabelled, the previous persistence service closed and the source catalog's schema
+					// exchanged for the target's. **Recorded as the first statement**, before anything below can
+					// fail: everything from this line on is as irreversible as the handover itself, whether or
+					// not the failure that interrupts it knows so.
+					handoverCompleted.set(true);
 					final CatalogContract replacedCatalog = replacedCatalogs.iterator().next();
+					replacementCatalog.set(replacedCatalog);
 
 					// The registry the target name is to be served through once this operation completes. It shares
 					// its active sessions, its suspension and its registration gate with the registry it is derived
@@ -389,8 +453,11 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 						// session creation refuses a name it cannot resolve. Asserted rather than cleaned up after,
 						// because the only available cleanup - draining a registry full of live sessions and giving
 						// up after five seconds - is the silent half-measure this whole ordering exists to remove.
-						// Throwing is safe here precisely because the commit has not run yet, so it reaches
-						// `undoOperations` like any other pre-commit failure.
+						// Throwing here reaches `undoOperations` with the handover latch already set, so the
+						// catalog is declared unusable rather than compensated for - which is what this window
+						// needs. Being ahead of the commit does not make a failure reversible: the relabel is
+						// already on disk by the time this runs, and it is the relabel, not the commit, that
+						// decides which of the two the failure path owes its caller.
 						Assert.isPremiseValid(
 							displacedRegistry == null,
 							() -> new GenericEvitaInternalError(
@@ -438,104 +505,157 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 						}
 					);
 
-					// The folder now holds a different catalog than it did a moment ago, so its label has to
-					// move with it or disaster recovery reads the previous occupant's name. Written after the
-					// commit rather than inside it: the state updater runs under the engine-state lock, and a
-					// file only humans read has no business being written while every other mutation waits.
-					//
-					// The catch is here so that "nothing after the commit may report failure" can be verified by
-					// reading this method, rather than by tracing three layers into the store module and hoping
-					// nobody changes them. It is not, however, what absorbs an I/O failure: the write itself is
-					// best-effort at its own site, so a full disk or an unwritable folder never reaches this far.
-					// What can is a `CatalogFolderOperations` implementation that refuses the call outright - a
-					// wiring error rather than an operational one - and even that must not turn a rename that has
-					// already committed into a reported failure.
+					// **The commit above has landed, and nothing below may report failure.** Past that point the
+					// operation has happened: the durable state records it and the next boot will bring it up. A
+					// throw from here would reach `undoOperations` with the handover latch set and be answered by
+					// declaring the catalog unusable - taking a rename that *succeeded* off the wire, removing the
+					// committed name's registry and orphaning the sessions inside it. Each step below already
+					// tolerates its own failure; this wrap is what makes that a property of the block rather than a
+					// habit its statements happen to share, so a statement added later cannot quietly undo it.
 					try {
-						this.folderContext.recordCatalogName(catalogNameToBeReplaced, prevailingFolderId);
-					} catch (RuntimeException ex) {
-						log.warn(
-							"Failed to relabel storage folder `{}` as catalog `{}` - the folder still carries its " +
-								"previous occupant's name, which only affects a human reading it directly.",
-							prevailingFolderId.id(), catalogNameToBeReplaced, ex
-						);
-					}
-
-					// notify callback that it's now a live snapshot
-					((Catalog) replacedCatalog).notifyCatalogPresentInLiveView();
-
-					// The catalog survives under the target name in BOTH operations, so its session registry
-					// follows it there - it carries the active sessions, the FIFO queue and the consumed-version
-					// census that backups pin against, all of which belong to the catalog rather than to the name
-					// it happened to be reached by. For a rename it is already published under the target name above,
-					// and what is left here is retiring the name it used to answer to and lifting the suspension;
-					// for a replace onto an existing catalog the swap happens here, where taking it back is no
-					// longer something a failure can ask for.
-					prevailingCatalogSessionRegistry.ifPresentOrElse(
-						sessionRegistry -> {
-							if (!publishedAheadOfCommit) {
-								evita.registerWithReplaceCatalogSessionRegistry(
-									catalogNameToBeReplaced, targetRegistry
-								);
-							}
-							// Dropped only now, never before the commit: until the commit lands the source
-							// name still resolves to the live catalog, and a name left empty is a name the
-							// next `createSessionInternal` fills with a fresh, unsuspended registry - serving
-							// sessions against the very catalog this operation is renaming. Past the commit the
-							// name resolves to nothing, so the same call answers `CatalogNotFoundException`
-							// instead, which is what a renamed-away name owes its callers. This used to run for a
-							// replace only, and the rename branch resumed `removedCatalogSessionRegistry` - always
-							// empty for a rename, because the target name must not exist - so the source name was
-							// left holding a registry suspended for ever, answering `SessionBusyException`.
-							evita.removeCatalogSessionRegistryIfPresent(catalogNameToBeReplacedWith);
-							// One suspension is shared by both views of this registry, so this single call releases
-							// the callers waiting on either name, and it is the last thing the handoff owes them.
-							sessionRegistry.resumeOperations();
-						},
-						// The surviving catalog has no registry to hand over. Reachable only if it stopped being a
-						// catalog between the `obtainCatalogSessionRegistry` that opens this method and here,
-						// which the engine's serialised mutations should make impossible - kept as cleanup rather
-						// than an assertion because this runs *after* the commit, where reporting a failure is
-						// worse than tidying up. Whatever is registered under the target name is then the registry
-						// this operation installed purely to quiesce it, and leaving that behind would keep the
-						// name rejecting sessions for the life of the process.
+						// The folder now holds a different catalog than it did a moment ago, so its label has to
+						// move with it or disaster recovery reads the previous occupant's name. Written after the
+						// commit rather than inside it: the state updater runs under the engine-state lock, and a
+						// file only humans read has no business being written while every other mutation waits.
 						//
-						// Unpublished and left suspended, never resumed: a resumed registry that no longer answers
-						// to any name still accepts sessions from whoever holds a reference to it, and those
-						// sessions are then invisible to every later quiesce - which walks the registry map. The
-						// caller that loses this race is refused rather than served, which is precisely what
-						// quiescing the target is for.
-						() -> {
-							if (quiescedTargetRegistry.isPresent()) {
-								evita.removeCatalogSessionRegistryIfPresent(catalogNameToBeReplaced);
-							}
-						}
-					);
-
-					// Terminate the catalog that was replaced. A failure here costs open handles into a folder
-					// that is about to be deleted, which makes the delete below more likely to be refused - and
-					// that is already accounted for, because a refused delete leaves the tombstone standing for
-					// the next boot drain. What must not happen is propagating: the replace has committed.
-					if (replaceOperation && catalogToBeReplaced != null) {
+						// The catch is here so that "nothing after the commit may report failure" can be verified by
+						// reading this method, rather than by tracing three layers into the store module and hoping
+						// nobody changes them. It is not, however, what absorbs an I/O failure: the write itself is
+						// best-effort at its own site, so a full disk or an unwritable folder never reaches this far.
+						// What can is a `CatalogFolderOperations` implementation that refuses the call outright - a
+						// wiring error rather than an operational one - and even that must not turn a rename that has
+						// already committed into a reported failure.
 						try {
-							catalogToBeReplaced.terminate();
-						} catch (RuntimeException ex) {
+							this.folderContext.recordCatalogName(catalogNameToBeReplaced, prevailingFolderId);
+						} catch (Throwable ex) {
 							log.warn(
-								"Failed to terminate the superseded catalog `{}` - its handles stay open until the " +
-									"process ends, and the folder deletion below may be refused as a result.",
+								"Failed to relabel storage folder `{}` as catalog `{}` - the folder still " +
+									"carries its previous occupant's name, which only affects a human reading " +
+									"it directly.",
+								prevailingFolderId.id(), catalogNameToBeReplaced, ex
+							);
+						}
+
+						// notify callback that it's now a live snapshot
+						//
+						// Caught at the site rather than left to the wrap below, because this statement sits
+						// *before* the registry handover and the two cannot be reordered: the handover admits
+						// sessions, and admitting one before the transaction manager points at the replacement
+						// lets a write commit against a pipeline still based on the old instance. So the
+						// ordering stays and the failure is contained instead. Left to the wrap, a throw here
+						// would skip the handover entirely - and for a replace onto an existing catalog that
+						// leaves the quiesced target still in the map under the committed name, REJECT-suspended
+						// and answering `InstanceTerminatedException` for the life of the process, beneath an
+						// operation that reported success. The `finally` below does not reach it, and must not:
+						// once the swap *has* happened that registry answers to no name and resuming it would
+						// admit sessions nothing can later quiesce.
+						try {
+							((Catalog) replacedCatalog).notifyCatalogPresentInLiveView();
+						} catch (Throwable ex) {
+							log.error(
+								"Catalog `{}` could not be published to its transaction manager after the rename " +
+									"committed - transaction processing may still resolve the instance it " +
+									"replaced until the server is restarted.",
 								catalogNameToBeReplaced, ex
 							);
 						}
-					}
 
-					// Strictly after `terminate()`, never before: the delete has to follow the close of every
-					// handle into that folder, or an operating system that refuses to remove an open directory
-					// turns this into an intermittent failure - the exact class of bug the pointer-only design
-					// exists to remove. A refusal here is not an error either way; the tombstone staged above
-					// survives the run and the next boot drains it.
-					if (supersededFolderId != null) {
-						this.folderContext.deleteRetiredFolder(supersededFolderId);
-					}
+						// The catalog survives under the target name in BOTH operations, so its session registry
+						// follows it there - it carries the active sessions, the FIFO queue and the consumed-version
+						// census that backups pin against, all of which belong to the catalog rather than to the name
+						// it happened to be reached by. For a rename it is already published under the target
+						// name above, and what is left here is retiring the name it used to answer to and
+						// lifting the suspension;
+						// for a replace onto an existing catalog the swap happens here, where taking it back is no
+						// longer something a failure can ask for.
+						prevailingCatalogSessionRegistry.ifPresentOrElse(
+							sessionRegistry -> {
+								if (!publishedAheadOfCommit) {
+									evita.registerWithReplaceCatalogSessionRegistry(
+										catalogNameToBeReplaced, targetRegistry
+									);
+								}
+								// Dropped only now, never before the commit: until the commit lands the source
+								// name still resolves to the live catalog, and a name left empty is a name the
+								// next `createSessionInternal` fills with a fresh, unsuspended registry - serving
+								// sessions against the very catalog this operation is renaming. Past the commit the
+								// name resolves to nothing, so the same call answers `CatalogNotFoundException`
+								// instead, which is what a renamed-away name owes its callers. This used to run for a
+								// replace only, and the rename branch resumed `removedCatalogSessionRegistry` - always
+								// empty for a rename, because the target name must not exist - so the source name was
+								// left holding a registry suspended for ever, answering `SessionBusyException`.
+								evita.removeCatalogSessionRegistryIfPresent(catalogNameToBeReplacedWith);
+								// One suspension is shared by both views of this registry, so this single call releases
+								// the callers waiting on either name, and it is the last thing the handoff owes them.
+								sessionRegistry.resumeOperations();
+							},
+							// The surviving catalog has no registry to hand over. Reachable only if it stopped being a
+							// catalog between the `obtainCatalogSessionRegistry` that opens this method and here,
+							// which the engine's serialised mutations should make impossible - kept as cleanup rather
+							// than an assertion because this runs *after* the commit, where reporting a failure is
+							// worse than tidying up. Whatever is registered under the target name is then the registry
+							// this operation installed purely to quiesce it, and leaving that behind would keep the
+							// name rejecting sessions for the life of the process.
+							//
+							// Unpublished and left suspended, never resumed: a resumed registry that no longer answers
+							// to any name still accepts sessions from whoever holds a reference to it, and those
+							// sessions are then invisible to every later quiesce - which walks the registry map. The
+							// caller that loses this race is refused rather than served, which is precisely what
+							// quiescing the target is for.
+							() -> {
+								if (quiescedTargetRegistry.isPresent()) {
+									evita.removeCatalogSessionRegistryIfPresent(catalogNameToBeReplaced);
+								}
+							}
+						);
 
+						// Terminate the catalog that was replaced. A failure here costs open handles into a folder
+						// that is about to be deleted, which makes the delete below more likely to be refused - and
+						// that is already accounted for, because a refused delete leaves the tombstone standing for
+						// the next boot drain. What must not happen is propagating: the replace has committed.
+						if (replaceOperation && catalogToBeReplaced != null) {
+							try {
+								catalogToBeReplaced.terminate();
+							} catch (Throwable ex) {
+								log.warn(
+									"Failed to terminate the superseded catalog `{}` - its handles stay open " +
+										"until the process ends, and the folder deletion below may be refused as " +
+										"a result.",
+									catalogNameToBeReplaced, ex
+								);
+							}
+						}
+
+						// Strictly after `terminate()`, never before: the delete has to follow the close of every
+						// handle into that folder, or an operating system that refuses to remove an open directory
+						// turns this into an intermittent failure - the exact class of bug the pointer-only design
+						// exists to remove. A refusal here is not an error either way; the tombstone staged above
+						// survives the run and the next boot drains it.
+						if (supersededFolderId != null) {
+							this.folderContext.deleteRetiredFolder(supersededFolderId);
+						}
+
+					} catch (Throwable ex) {
+						log.error(
+							"Catalog `{}` now answers to `{}` and that is durable, but the work that follows the " +
+								"commit did not finish - a superseded folder may be left for the next boot to " +
+								"drain, and change data capture subscribers may have missed the rename.",
+							catalogNameToBeReplacedWith, catalogNameToBeReplaced, ex
+						);
+					} finally {
+						// **The resume is owed unconditionally once the commit has landed**, and the block above
+						// is the only place that performs it - so a throw anywhere before it would leave both
+						// names answering `SessionBusyException` for the life of the process, beneath an
+						// operation that reported success. That is this issue's own headline symptom, restored
+						// on the one path that claims to have worked, and swallowing the failure is what would
+						// have hidden it. Idempotent, so the ordinary path pays nothing for running it twice:
+						// `resumeOperations` lifts a suspension if one stands and does nothing otherwise.
+						//
+						// Only the surviving catalog's registry. A replace's quiesced target holds a *different*
+						// suspension, which the handover above leaves standing on purpose - a registry that no
+						// longer answers to any name must not start admitting sessions again.
+						prevailingCatalogSessionRegistry.ifPresent(SessionRegistry::resumeOperations);
+					}
 					return new CommitVersions(
 						replacedCatalog.getVersion(),
 						replacedCatalog.getSchema().version()
@@ -543,7 +663,13 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 				},
 				undoOperations::accept
 			);
-		} catch (RuntimeException ex) {
+		} catch (Throwable ex) {
+			// `Throwable` rather than `RuntimeException` for the same reason the handover uses it: the drain and
+			// the schema mutation above run with both registries suspended, and an `Error` escaping without
+			// reaching `undoOperations` leaves them suspended for the life of the process - answering
+			// `SessionBusyException` to every session, which is the session half of issue #1414 restored by the
+			// code that fixes it. Rethrown unchanged; nothing in the block above throws a checked exception, so
+			// precise rethrow keeps the declared signature.
 			undoOperations.accept(ex);
 			throw ex;
 		}
@@ -554,9 +680,10 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 	 * `replaceWith` where the folder's stored identity becomes the incoming catalog's and stops agreeing with
 	 * engine state.
 	 *
-	 * The cause chain is walked rather than the top exception inspected, because the failure travels out of a
-	 * nested {@link ProgressingFuture} and arrives wrapped. Only the storage layer can raise the marker, and
-	 * it raises it at exactly one place, so finding it anywhere in the chain is proof the line was crossed.
+	 * **This is the narrower of the two things the failure path asks.** It recognises only failures raised
+	 * *inside* the handover; a failure raised after it returned carries no marker and is recognised by the
+	 * latch the completion phase sets instead. Both lead to the same answer, and the latch is the one that
+	 * covers the open-ended half.
 	 *
 	 * @param failure failure reported by the operation, if any
 	 * @return true when the failure crossed the point of no return
@@ -573,6 +700,26 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 			current = cause == current ? null : cause;
 		}
 		return false;
+	}
+
+	/**
+	 * Terminates a catalog whose failed handover left its persistence service open, reporting a refusal rather
+	 * than propagating it.
+	 *
+	 * @param catalog     catalog to release
+	 * @param catalogName name to report it under, which is the name it answered to rather than the one it holds
+	 */
+	private static void terminateQuietly(@Nonnull CatalogContract catalog, @Nonnull String catalogName) {
+		try {
+			catalog.terminate();
+		} catch (Throwable terminationFailure) {
+			log.warn(
+				"Failed to terminate catalog `{}` after declaring it unusable - the handles its persistence " +
+					"service holds into the storage folder stay open until the server is restarted, and a " +
+					"later attempt to delete that folder may be refused as a result.",
+				catalogName, terminationFailure
+			);
+		}
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
@@ -139,44 +139,55 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 		@Nonnull Evita evita,
 		@Nonnull Consumer<EngineStateUpdater> completionEngineStateUpdater
 	) {
-		// close all active sessions to the catalog that will replace the original one
-		final Optional<SessionRegistry> prevailingCatalogSessionRegistry = evita.getCatalogSessionRegistry(catalogNameToBeReplacedWith);
+		// Obtained rather than merely looked up, so that a catalog which has no registry gets one installed here:
+		// registries are built lazily by the first session, so a catalog nobody has opened one on since boot has
+		// none at all, and suspending "whatever is registered" then suspends nothing. A session racing the
+		// operation would bind to the very catalog whose persistence service `replace` is about to close, and the
+		// completion path - which captured an empty Optional - would neither hand that late registry to the new
+		// name nor drain it.
+		final Optional<SessionRegistry> prevailingCatalogSessionRegistry =
+			evita.obtainCatalogSessionRegistry(catalogNameToBeReplacedWith);
 		// this will be always empty if catalogToBeReplaced == catalogToBeReplacedWith
-		Optional<SessionRegistry> removedCatalogSessionRegistry = evita.getCatalogSessionRegistry(catalogNameToBeReplaced);
+		final Optional<SessionRegistry> removedCatalogSessionRegistry =
+			evita.getCatalogSessionRegistry(catalogNameToBeReplaced);
 
-		prevailingCatalogSessionRegistry
-			.ifPresent(sessionRegistry -> sessionRegistry.closeAllActiveSessionsAndSuspend(SuspendOperation.POSTPONE));
-
-		// Written to as soon as the target is quiesced below, and read only by `undoOperations` - which is
-		// declared before that point and therefore cannot capture the local the quiescing produces.
+		// Written as soon as the target registry is owned - before it is drained, never after - and read only by
+		// `undoOperations`, which is declared above that point and cannot capture the local it produces.
 		final AtomicReference<SessionRegistry> quiescedTargetRegistryHolder = new AtomicReference<>();
 
 		final Runnable undoOperations = () -> {
-			// The registry map is put back the way it was *before* anything is resumed, and a registry dropped
-			// here is never resumed at all. Session creation goes through `computeIfAbsent` on this very map, so
-			// a registry that is both reachable and running accepts sessions: resuming first opens a window in
-			// which a racing `createSession` lands a live session in a registry the next line then unpublishes.
-			// Every later quiesce - replace, delete, engine shutdown - walks the map, so that session would be
-			// invisible to all of them and its catalog could be terminated underneath it.
+			// Which of the three outcomes applies is decided by what answered to the target name when the
+			// operation started, never by what answers to it now.
+			final SessionRegistry quiescedTargetRegistry = quiescedTargetRegistryHolder.get();
 			if (removedCatalogSessionRegistry.isPresent()) {
-				// revert session registry swap
+				// A registry that predates the operation: restored under its name first, resumed after, in that
+				// order. Session creation goes through `computeIfAbsent` on this same map, so a name left empty
+				// for the length of a resume is a name a racing request can register a *different* registry
+				// under - which the restore then refuses, throwing out of the undo path itself.
 				evita.registerCatalogSessionRegistry(catalogNameToBeReplaced, removedCatalogSessionRegistry.get());
 				// A replace quiesces its target with REJECT before touching anything, and a failure leaves that
 				// target standing - the operation changed nothing. Resuming it is therefore part of undoing, or
 				// the catalog that was *not* replaced spends the rest of the process answering
-				// `InstanceTerminatedException` to every session opened against it. Guarded on the holder rather
-				// than resumed unconditionally, so that a suspension this operation did not install - one a
-				// concurrent operation is holding - is never cleared on its behalf.
-				final SessionRegistry quiescedTargetRegistry = quiescedTargetRegistryHolder.get();
+				// `InstanceTerminatedException` to every session opened against it. Guarded on the holder so that
+				// a suspension this operation never installed is not cleared on someone else's behalf.
 				if (quiescedTargetRegistry != null) {
 					quiescedTargetRegistry.resumeOperations();
 				}
+			} else if (quiescedTargetRegistry != null) {
+				// A registry this operation installed itself, purely to quiesce the target. The replace failed,
+				// so that catalog is still there and still answers to this name - which makes a resumed registry
+				// under it exactly what the first session would have built anyway.
+				//
+				// Resumed **in place**, never unpublished: the drain can give up with sessions still inside it,
+				// and a registry that cannot be reached through the map is invisible to every later quiesce -
+				// replace, delete, engine shutdown - so those sessions would outlive the catalog they are bound
+				// to. Unpublishing while suspended has the mirror-image cost, since a resume that follows the
+				// removal lets a racing `createSession` populate a registry nobody can reach any more.
+				quiescedTargetRegistry.resumeOperations();
 			} else {
-				// Whatever answers to this name is the registry `suspendCatalogSessions` installed purely to
-				// quiesce the target. It is dropped rather than resumed into service - the rule the success path
-				// and `retireStragglerRegistry` already follow - so the next request builds a clean one through
-				// the map, while a thread still holding a stale reference keeps being refused instead of
-				// populating a registry nobody can reach any more.
+				// Nothing was quiesced under this name: a rename, whose target names nothing until the commit
+				// lands, or a replace onto a name that names no catalog. Whatever answers to it can only have
+				// been put there by the registry swap on the success path, and goes back with the rest of it.
 				evita.removeCatalogSessionRegistryIfPresent(catalogNameToBeReplaced);
 			}
 			// and revert the suspension the operation opened with. Resuming used to happen on the success path
@@ -191,6 +202,15 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 		};
 
 		try {
+			// Drained inside the `try`, so that a drain which gives up reaches `undoOperations` at all.
+			// `closeAllActiveSessionsAndSuspend` publishes the suspension and only then waits for the sessions to
+			// leave, and throws when they do not - with that suspension standing. Published before the `try`
+			// began, as it used to be, a session that outlasted the five-second drain left the surviving catalog
+			// answering `SessionBusyException` to everything for the rest of the process.
+			prevailingCatalogSessionRegistry.ifPresent(
+				sessionRegistry -> sessionRegistry.closeAllActiveSessionsAndSuspend(SuspendOperation.POSTPONE)
+			);
+
 			final boolean replaceOperation = catalogToBeReplaced != catalogToBeReplacedWith;
 			// Both folders are resolved here, in the read-only phase, and never again. The commit below repoints
 			// the target name at the source folder, so re-reading either afterwards would answer about the world
@@ -216,21 +236,26 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 			// first terminate the catalog that is being replaced (unless it's the very same catalog)
 			final Optional<SessionRegistry> quiescedTargetRegistry;
 			if (replaceOperation) {
-				// `suspendCatalogSessions` rather than suspending only what `getCatalogSessionRegistry` already
-				// found: a target nobody has opened a session on since boot has no registry, so the captured
-				// Optional is empty and nothing is quiesced at all - which is how sessions came to be served
-				// against a catalog while it was being destroyed. It installs one only when the name names a
-				// catalog, so a replace onto a target that does not exist keeps answering
-				// `CatalogNotFoundException` rather than reporting a terminated instance.
+				// Obtained rather than looked up, for the reason the surviving catalog is: a target nobody has
+				// opened a session on since boot has no registry, so suspending what `getCatalogSessionRegistry`
+				// finds quiesces nothing at all - which is how sessions came to be served against a catalog while
+				// it was being destroyed. A registry is installed only when the name names a catalog, so a
+				// replace onto a target that does not exist keeps answering `CatalogNotFoundException` rather
+				// than reporting a terminated instance.
 				//
-				// Held apart from `removedCatalogSessionRegistry`, which stays the *pre-existing* registry:
-				// `undoOperations` must remove a registry this call created rather than restore it, and the
-				// captured Optional is empty exactly when we created it ourselves.
-				quiescedTargetRegistry = evita.suspendCatalogSessions(
-					catalogNameToBeReplaced, SuspendOperation.REJECT
-				);
-				// handed to the undo path, which has to lift this suspension when the operation fails
+				// Ownership is recorded *between* obtaining and draining, deliberately. The drain publishes the
+				// suspension before it waits, so it throws with the suspension standing; recording afterwards
+				// would leave `undoOperations` unaware of a registry it has to resume, and the catalog that was
+				// not replaced would reject every session until the process ended.
+				//
+				// Held apart from `removedCatalogSessionRegistry`, which stays the *pre-existing* registry: the
+				// captured Optional is empty exactly when this operation installed the registry itself, and undo
+				// resumes that one in place rather than restoring anything.
+				quiescedTargetRegistry = evita.obtainCatalogSessionRegistry(catalogNameToBeReplaced);
 				quiescedTargetRegistry.ifPresent(quiescedTargetRegistryHolder::set);
+				quiescedTargetRegistry.ifPresent(
+					sessionRegistry -> sessionRegistry.closeAllActiveSessionsAndSuspend(SuspendOperation.REJECT)
+				);
 			} else {
 				Assert.isPremiseValid(removedCatalogSessionRegistry.isEmpty(), "Expectation failed!");
 				quiescedTargetRegistry = Optional.empty();
@@ -343,12 +368,13 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 								previous, quiescedTargetRegistry.orElse(null), catalogNameToBeReplaced
 							);
 						},
-						// The surviving catalog has no registry to hand over - nothing had opened a session on it
-						// since boot. Whatever is registered under the target name is then the registry this
-						// operation installed *purely to quiesce it*, and leaving that behind would keep the name
-						// rejecting sessions for the life of the process: the catalog would survive the replace
-						// and be unreachable afterwards. Dropped rather than resumed into service, so the next
-						// request builds a clean one against the catalog that now answers to this name.
+						// The surviving catalog has no registry to hand over. Reachable only if it stopped being a
+						// catalog between the `obtainCatalogSessionRegistry` that opens this method and here,
+						// which the engine's serialised mutations should make impossible - kept as cleanup rather
+						// than an assertion because this runs *after* the commit, where reporting a failure is
+						// worse than tidying up. Whatever is registered under the target name is then the registry
+						// this operation installed purely to quiesce it, and leaving that behind would keep the
+						// name rejecting sessions for the life of the process.
 						//
 						// Unpublished and left suspended, never resumed: a resumed registry that no longer answers
 						// to any name still accepts sessions from whoever holds a reference to it, and those

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
@@ -42,6 +42,7 @@ import io.evitadb.core.session.SuspendOperation;
 import io.evitadb.core.transaction.engine.AbstractEngineStateUpdater;
 import io.evitadb.core.transaction.engine.EngineStateUpdater;
 import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.spi.store.catalog.persistence.CatalogHandoverFailedException;
 import io.evitadb.spi.store.engine.model.CatalogFolderId;
 import io.evitadb.utils.Assert;
 import lombok.RequiredArgsConstructor;
@@ -80,6 +81,12 @@ import static io.evitadb.utils.Assert.isTrue;
 @Slf4j
 @RequiredArgsConstructor
 public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOperator<CommitVersions, ModifyCatalogSchemaNameMutation> {
+	/**
+	 * How far down a failure's cause chain the handover marker is looked for. Generous enough for the few
+	 * wrappers a nested future adds, and finite so a self-referencing chain cannot hang the failure path.
+	 */
+	private static final int MAX_INSPECTED_CAUSE_DEPTH = 32;
+
 	private final CatalogFolderContext folderContext;
 
 	@Nonnull
@@ -165,7 +172,26 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 		final Optional<SessionRegistry> quiescedTargetRegistry = replaceOperation ?
 			evita.obtainCatalogSessionRegistry(catalogNameToBeReplaced) : Optional.empty();
 
-		final Runnable undoOperations = () -> {
+		final Consumer<Throwable> undoOperations = failure -> {
+			// **Past the point of no return, compensating is the wrong verb.** Everything below puts session
+			// bookkeeping back, which is the whole of what a failure before the handover disturbed. Once the
+			// handover has relabelled the folder, it has disturbed something no bookkeeping reaches: the
+			// folder's stored identity no longer agrees with engine state, and the commit that would have
+			// settled the disagreement is never going to run. Resuming its sessions regardless is how a
+			// rename that merely failed becomes a catalog that serves reads, accepts a write, appends it to
+			// the write-ahead log and then wedges the next boot replaying it against a name engine state has
+			// never heard of - the very symptom this issue is named after, re-created by the code that fixes
+			// it. Where the line falls is the storage layer's to know and it marks the failures past it.
+			//
+			// So the name is declared unusable instead, and **declared before the resume below**, never
+			// after: the resume is what lets the waiting callers through, and there must be nothing usable
+			// on the other side of it when they arrive. What they get is a `CatalogCorruptedException`
+			// naming the handover as its cause - refused, legibly, until a restart rebuilds the catalog
+			// from its folder, which it can, because the commit never ran and the load path reconciles the
+			// name the folder was left carrying.
+			if (isHandoverFailure(failure)) {
+				evita.markCatalogCorrupted(catalogNameToBeReplacedWith, failure);
+			}
 			// What belongs under the target name is decided by what answered to it when the operation started,
 			// never by what answers to it now.
 			if (quiescedTargetRegistry.isPresent()) {
@@ -316,8 +342,8 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 						Assert.isPremiseValid(
 							displacedRegistry == null,
 							() -> new GenericEvitaInternalError(
-								"Catalog `" + catalogNameToBeReplaced + "` gained a session registry while it was " +
-									"being renamed - the sessions it holds would be orphaned by the handoff!"
+								"Catalog `" + catalogNameToBeReplaced + "` gained a session registry while its name " +
+									"was being claimed - the sessions it holds would be orphaned by the handoff!"
 							)
 						);
 					}
@@ -463,12 +489,38 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 						replacedCatalog.getSchema().version()
 					);
 				},
-				ex -> undoOperations.run()
+				undoOperations::accept
 			);
 		} catch (RuntimeException ex) {
-			undoOperations.run();
+			undoOperations.accept(ex);
 			throw ex;
 		}
+	}
+
+	/**
+	 * Tells whether a failure was raised at or after the handover's point of no return - the moment inside
+	 * `replaceWith` where the folder's stored identity becomes the incoming catalog's and stops agreeing with
+	 * engine state.
+	 *
+	 * The cause chain is walked rather than the top exception inspected, because the failure travels out of a
+	 * nested {@link ProgressingFuture} and arrives wrapped. Only the storage layer can raise the marker, and
+	 * it raises it at exactly one place, so finding it anywhere in the chain is proof the line was crossed.
+	 *
+	 * @param failure failure reported by the operation, if any
+	 * @return true when the failure crossed the point of no return
+	 */
+	private static boolean isHandoverFailure(@Nullable Throwable failure) {
+		Throwable current = failure;
+		// bounded rather than "until null": a cause chain that refers back into itself would otherwise spin
+		// here forever, and a failure path is the worst possible place to discover that
+		for (int depth = 0; current != null && depth < MAX_INSPECTED_CAUSE_DEPTH; depth++) {
+			if (current instanceof CatalogHandoverFailedException) {
+				return true;
+			}
+			final Throwable cause = current.getCause();
+			current = cause == current ? null : cause;
+		}
+		return false;
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
@@ -36,6 +36,7 @@ import io.evitadb.core.catalog.Catalog;
 import io.evitadb.core.engine.CatalogFolderContext;
 import io.evitadb.core.engine.ExpandedEngineState;
 import io.evitadb.core.engine.ExpandedEngineState.Builder;
+import io.evitadb.core.exception.CatalogCorruptedException;
 import io.evitadb.core.exception.CatalogTransitioningException;
 import io.evitadb.core.session.SessionRegistry;
 import io.evitadb.core.session.SuspendOperation;
@@ -116,7 +117,7 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 			return doReplaceCatalogInternal(
 				catalogNameToBeReplaced, catalogNameToBeReplacedWith,
 				catalogToBeReplaced, catalogToBeReplacedWith,
-				transactionId, mutation, evita, completionEngineStateUpdater
+				transactionId, mutation, evita, transitionEngineStateUpdater, completionEngineStateUpdater
 			);
 		} else {
 			final String currentName = mutation.getCatalogName();
@@ -126,7 +127,7 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 			return doReplaceCatalogInternal(
 				newName, currentName,
 				catalogToBeRenamed, catalogToBeRenamed,
-				transactionId, mutation, evita, completionEngineStateUpdater
+				transactionId, mutation, evita, transitionEngineStateUpdater, completionEngineStateUpdater
 			);
 		}
 	}
@@ -143,6 +144,7 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 		@Nonnull UUID transactionId,
 		@Nonnull ModifyCatalogSchemaNameMutation mutation,
 		@Nonnull Evita evita,
+		@Nonnull Consumer<EngineStateUpdater> transitionEngineStateUpdater,
 		@Nonnull Consumer<EngineStateUpdater> completionEngineStateUpdater
 	) {
 		// Obtained rather than merely looked up, so that a catalog which has no registry gets one installed here:
@@ -190,7 +192,57 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 			// from its folder, which it can, because the commit never ran and the load path reconciles the
 			// name the folder was left carrying.
 			if (isHandoverFailure(failure)) {
-				evita.markCatalogCorrupted(catalogNameToBeReplacedWith, failure);
+				// Routed through the *transition* updater rather than mutating engine state directly, because
+				// this is a read-derive-write on shared state and every other writer performs it under
+				// `EngineTransactionManager#engineStateLock`. A bare CAS loses to them by construction: a
+				// concurrent engine mutation reads the state, appends and fsyncs its WAL record, then calls
+				// `setNextEngineState`, whose accumulator returns its own derived value regardless of what
+				// landed in between. A declaration made outside the lock inside that window is simply erased -
+				// and the window spans an fsync - which puts the damaged catalog back to serving with nothing
+				// to show that it ever stopped. This is the idiom `SetCatalogStateMutationOperator` already
+				// uses to publish its placeholder.
+				//
+				// The version deliberately stays where it is: nothing is being committed here, the operation
+				// failed. `setNextEngineState` accepts an unchanged version, so the swap is an in-place
+				// exchange of the instance behind the name rather than a state version a failed operation has
+				// no business consuming.
+				//
+				// Wrapped so that a failure *declaring* the failure cannot cancel the resumes below. Every
+				// throw in here should be impossible, and if one happens anyway the worst outcome available is
+				// a catalog left serving - not both registries suspended for the life of the process, which is
+				// the very symptom this operation exists to stop producing.
+				try {
+					transitionEngineStateUpdater.accept(
+						new AbstractEngineStateUpdater(transactionId, mutation) {
+							@Nonnull
+							@Override
+							public ExpandedEngineState apply(
+								long version, @Nonnull ExpandedEngineState expandedEngineState
+							) {
+								return ExpandedEngineState
+									.builder(expandedEngineState)
+									.withCatalog(
+										ModifyCatalogSchemaNameMutationOperator.this.folderContext
+											.createUnusableCatalog(
+												catalogNameToBeReplacedWith,
+												CatalogState.CORRUPTED,
+												(cn, folderId, root) ->
+													new CatalogCorruptedException(cn, folderId, root, failure)
+											)
+									)
+									.build();
+							}
+						}
+					);
+					evita.notifyCatalogStateSettled(catalogNameToBeReplacedWith, CatalogState.CORRUPTED);
+				} catch (RuntimeException declarationFailure) {
+					log.error(
+						"Failed to declare catalog `{}` unusable after its handover failed past the point of no " +
+							"return - it stays published and may serve sessions against storage that no longer " +
+							"agrees with the engine state, until the server is restarted.",
+						catalogNameToBeReplacedWith, declarationFailure
+					);
+				}
 			}
 			// What belongs under the target name is decided by what answered to it when the operation started,
 			// never by what answers to it now.

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
@@ -232,6 +232,13 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 				// to show that it ever stopped. This is the idiom `SetCatalogStateMutationOperator` already
 				// uses to publish its placeholder.
 				//
+				// **A deliberate exception to the updater's usual timing**, and the only one in the codebase:
+				// `EngineMutationOperator#applyMutation` describes this updater as running once before the heavy
+				// work, and this operator instead runs it zero times on the path that succeeds and once here, on
+				// the path that cannot be compensated for. The contract is written that way because the updater
+				// is the only route that holds the engine state lock, and a terminal declaration needs that lock
+				// for the same reason a pre-mutation transition does.
+				//
 				// The version deliberately stays where it is: nothing is being committed here, the operation
 				// failed. `setNextEngineState` accepts an unchanged version, so the swap is an in-place
 				// exchange of the instance behind the name rather than a state version a failed operation has

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
@@ -146,7 +146,10 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 		// name nor drain it.
 		final Optional<SessionRegistry> prevailingCatalogSessionRegistry =
 			evita.obtainCatalogSessionRegistry(catalogNameToBeReplacedWith);
-		// this will be always empty if catalogToBeReplaced == catalogToBeReplacedWith
+		// Read before the target is obtained below, and used for the rename invariant asserted further down and for
+		// nothing else - obtaining installs a registry where a catalog has none, so the same read afterwards could
+		// no longer tell "the target already had one" from "this operation has just made one". Always empty when
+		// catalogToBeReplaced == catalogToBeReplacedWith.
 		final Optional<SessionRegistry> removedCatalogSessionRegistry =
 			evita.getCatalogSessionRegistry(catalogNameToBeReplaced);
 
@@ -163,39 +166,35 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 			evita.obtainCatalogSessionRegistry(catalogNameToBeReplaced) : Optional.empty();
 
 		final Runnable undoOperations = () -> {
-			// Which of the three outcomes applies is decided by what answered to the target name when the
-			// operation started, never by what answers to it now.
-			if (removedCatalogSessionRegistry.isPresent()) {
-				// A registry that predates the operation: restored under its name first, resumed after, in that
-				// order. Session creation goes through `computeIfAbsent` on this same map, so a name left empty
-				// for the length of a resume is a name a racing request can register a *different* registry
-				// under - which the restore then refuses, throwing out of the undo path itself.
-				evita.registerCatalogSessionRegistry(catalogNameToBeReplaced, removedCatalogSessionRegistry.get());
+			// What belongs under the target name is decided by what answered to it when the operation started,
+			// never by what answers to it now - the completion phase publishes the surviving catalog's registry
+			// there before the commit, so by this point the name may legitimately carry a registry this operation
+			// put there itself.
+			if (quiescedTargetRegistry.isPresent()) {
+				// A replace: the target is still there and still answers to this name, so its own registry goes
+				// back under it. Restored rather than merely resumed, because the pre-commit publication may have
+				// displaced it - and with `registerWithReplace` rather than `register` for the same reason, since
+				// the stricter call refuses a name occupied by a registry other than the one being restored, which
+				// on that path is exactly what it is.
+				//
+				// The registry may be one this operation installed rather than found, and it is put back either
+				// way: a drain can give up with sessions still inside it, and a registry that cannot be reached
+				// through the map is invisible to every later quiesce - replace, delete, engine shutdown - so those
+				// sessions would outlive the catalog they are bound to.
+				evita.registerWithReplaceCatalogSessionRegistry(catalogNameToBeReplaced, quiescedTargetRegistry.get());
 				// A replace quiesces its target with REJECT before touching anything, and a failure leaves that
 				// target standing - the operation changed nothing. Resuming it is therefore part of undoing, or
 				// the catalog that was *not* replaced spends the rest of the process answering
 				// `InstanceTerminatedException` to every session opened against it. Safe on the paths that failed
 				// before the drain ran, because `resumeOperations` lifts a suspension if one is standing and does
 				// nothing at all otherwise.
-				quiescedTargetRegistry.ifPresent(SessionRegistry::resumeOperations);
-			} else if (quiescedTargetRegistry.isPresent()) {
-				// A registry this operation owns without having found one: either it installed it, or a session
-				// that raced the obtain above did and this operation adopted it. The replace failed, so that
-				// catalog is still there and still answers to this name - which makes a resumed registry under
-				// it exactly what the first session would have left behind anyway.
-				//
-				// Resumed **in place**, never unpublished: the drain can give up with sessions still inside it,
-				// and a registry that cannot be reached through the map is invisible to every later quiesce -
-				// replace, delete, engine shutdown - so those sessions would outlive the catalog they are bound
-				// to. Unpublishing while suspended has the mirror-image cost, since a resume that follows the
-				// removal lets a racing `createSession` populate a registry nobody can reach any more.
 				quiescedTargetRegistry.get().resumeOperations();
 			} else {
-				// This name was never a catalog this operation could quiesce: a rename, whose target names
-				// nothing until the commit lands, or a replace onto a name that names no catalog. Nothing can
-				// have installed a registry under it in the meantime for the same reason - session creation
-				// refuses a name it cannot resolve to a catalog - so whatever answers to it now was put there by
-				// the registry swap on the success path, and goes back with the rest of it.
+				// A rename, whose target names nothing until the commit lands, or a replace onto a name that names
+				// no catalog. Nothing outside this operation can have installed a registry under such a name -
+				// session creation refuses a name it cannot resolve to a catalog - so whatever answers to it now is
+				// the registry the completion phase published, and it goes back with the rest of it. The surviving
+				// catalog keeps serving through the source name, whose registry stays published until the commit.
 				evita.removeCatalogSessionRegistryIfPresent(catalogNameToBeReplaced);
 			}
 			// and revert the suspension the operation opened with. Resuming used to happen on the success path
@@ -275,6 +274,47 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 				(theFuture, replacedCatalogs) -> {
 					final CatalogContract replacedCatalog = replacedCatalogs.iterator().next();
 
+					// The surviving catalog's registry is published under the target name *before* the commit, and
+					// stays suspended until after it. The commit is what makes that name resolve, and it does so
+					// synchronously - `updateEngineStateAfterEngineMutation` sets the next engine state under the
+					// engine-state lock and returns - so from the instant it returns the name is servable. Published
+					// after the commit, as it used to be, there is a window in which the name resolves to a live
+					// catalog that has no registry behind it: `createSessionInternal` builds a fresh and
+					// *unsuspended* one through `computeIfAbsent` and admits a session into it, the handoff below
+					// then displaces that registry, and the session inside it is reachable through no name at all -
+					// invisible to every later quiesce, and still bound to a catalog a subsequent rename, delete or
+					// shutdown will destroy underneath it.
+					//
+					// Publishing early is only safe because a registry built by `withDifferentCatalogSupplier`
+					// shares its active sessions, its suspension and its registration gate with the one it was
+					// derived from. What is published here is therefore already suspended, and a caller that
+					// resolves the target name inside the window waits out the POSTPONE and is then served by the
+					// very registry the catalog keeps afterwards, rather than by one about to be thrown away.
+					final SessionRegistry displacedRegistry = prevailingCatalogSessionRegistry
+						.map(
+							sessionRegistry -> evita.registerWithReplaceCatalogSessionRegistry(
+								catalogNameToBeReplaced,
+								sessionRegistry.withDifferentCatalogSupplier(
+									() -> (Catalog) evita.getCatalogInstanceOrThrowException(catalogNameToBeReplaced)
+								)
+							)
+						)
+						.orElse(null);
+					// Nothing else can be occupying the target name here: a rename's target names no catalog until
+					// the commit below lands and session creation refuses a name it cannot resolve, while a
+					// replace's target carries the registry this operation quiesced above. Asserted rather than
+					// cleaned up after, because the only available cleanup - draining a registry full of live
+					// sessions and giving up after five seconds - is the silent half-measure this whole ordering
+					// exists to remove. Throwing is safe at this point precisely because the commit has not run
+					// yet, so it reaches `undoOperations` like any other pre-commit failure.
+					Assert.isPremiseValid(
+						displacedRegistry == null || displacedRegistry == quiescedTargetRegistry.orElse(null),
+						() -> new GenericEvitaInternalError(
+							"Catalog `" + catalogNameToBeReplaced + "` gained a session registry while it was " +
+								"being renamed or replaced - the sessions it holds would be orphaned by the handoff!"
+						)
+					);
+
 					completionEngineStateUpdater.accept(
 						new AbstractEngineStateUpdater(transactionId, mutation) {
 							@Override
@@ -341,28 +381,23 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 					// The catalog survives under the target name in BOTH operations, so its session registry
 					// follows it there - it carries the active sessions, the FIFO queue and the consumed-version
 					// census that backups pin against, all of which belong to the catalog rather than to the name
-					// it happened to be reached by. This used to run for a replace only, and the rename branch
-					// resumed `removedCatalogSessionRegistry` - which for a rename is always empty, because the
-					// target name must not exist. The source name was therefore left holding a registry suspended
-					// for ever, answering `SessionBusyException` where it owed `CatalogNotFoundException`.
+					// it happened to be reached by. The registry is already published under the target name above;
+					// what is left here is retiring the name it used to answer to, and lifting the suspension.
 					prevailingCatalogSessionRegistry.ifPresentOrElse(
 						sessionRegistry -> {
+							// Dropped only now, never alongside the publication above: until the commit lands the
+							// source name still resolves to the live catalog, and a name left empty is a name the
+							// next `createSessionInternal` fills with a fresh, unsuspended registry - serving
+							// sessions against the very catalog this operation is renaming. Past the commit the
+							// name resolves to nothing, so the same call answers `CatalogNotFoundException`
+							// instead, which is what a renamed-away name owes its callers. This used to run for a
+							// replace only, and the rename branch resumed `removedCatalogSessionRegistry` - always
+							// empty for a rename, because the target name must not exist - so the source name was
+							// left holding a registry suspended for ever, answering `SessionBusyException`.
 							evita.removeCatalogSessionRegistryIfPresent(catalogNameToBeReplacedWith);
-							final SessionRegistry previous = evita.registerWithReplaceCatalogSessionRegistry(
-								catalogNameToBeReplaced,
-								sessionRegistry.withDifferentCatalogSupplier(
-									() -> (Catalog) evita.getCatalogInstanceOrThrowException(
-										catalogNameToBeReplaced))
-							);
-							// resumed before the straggler below is dealt with, so the name the clients want is
-							// serving again at the first possible moment rather than after a close that may wait
+							// One suspension is shared by both views of this registry, so this single call releases
+							// the callers waiting on either name, and it is the last thing the handoff owes them.
 							sessionRegistry.resumeOperations();
-							// compared against the registry this operation quiesced - which may be one it installed
-							// itself - rather than against whatever existed beforehand, or a registry we created
-							// and suspended would be mistaken for a straggler and closed a second time
-							retireStragglerRegistry(
-								previous, quiescedTargetRegistry.orElse(null), catalogNameToBeReplaced
-							);
 						},
 						// The surviving catalog has no registry to hand over. Reachable only if it stopped being a
 						// catalog between the `obtainCatalogSessionRegistry` that opens this method and here,
@@ -472,50 +507,6 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 			builder.withRetiredFolder(targetName, supersededFolderId);
 		}
 		return Optional.of(builder.build());
-	}
-
-	/**
-	 * Retires the session registry the swap above displaced, when it is not the one this operation suspended.
-	 *
-	 * A third registry can be there for one reason: the target name had none when the operation started — nothing
-	 * had opened a session on it since boot — so there was nothing to suspend, and the first session request that
-	 * arrived while the operation ran built one through `Evita#createSessionInternal`. Its sessions are bound to
-	 * the catalog this operation is about to terminate, and its catalog supplier resolves a name that no longer
-	 * names anything, so it cannot serve another request whatever we do here.
-	 *
-	 * Closing it with `REJECT` is therefore about *how* those clients find out: an `InstanceTerminatedException`
-	 * says the catalog they held is gone, which is true and actionable, where leaving it alone lets them discover
-	 * it through whatever the dangling supplier throws next. It also waits for a query still running on it before
-	 * the caller terminates the catalog underneath it.
-	 *
-	 * **Nothing here may propagate.** By this point the engine-state commit is durable and the replace has
-	 * succeeded — the target already serves the incoming data and the source name is already gone. Reporting a
-	 * failure would be wrong about what happened, and would do it on the rarest path, which is exactly what the
-	 * premise assert this replaced did: it turned a completed operation into a `GenericEvitaInternalError`. Both
-	 * known throws live inside the close, which waits up to five seconds for sessions to drain and then asserts
-	 * that they did.
-	 *
-	 * @param displaced   the registry the swap replaced, or null when the target name held none
-	 * @param suspended   the registry this operation suspended for the target name, or null when it had none
-	 * @param catalogName the target name, for the log record
-	 */
-	private static void retireStragglerRegistry(
-		@Nullable SessionRegistry displaced,
-		@Nullable SessionRegistry suspended,
-		@Nonnull String catalogName
-	) {
-		if (displaced == null || displaced == suspended) {
-			return;
-		}
-		try {
-			displaced.closeAllActiveSessionsAndSuspend(SuspendOperation.REJECT);
-		} catch (RuntimeException ex) {
-			log.warn(
-				"Sessions opened on catalog `{}` while it was being replaced could not be closed — they are " +
-					"bound to the superseded catalog and will fail on their next call.",
-				catalogName, ex
-			);
-		}
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/CatalogHandoverFailedException.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/CatalogHandoverFailedException.java
@@ -45,7 +45,12 @@ import java.io.Serial;
  * unusable catalog carrying this as its cause, so the failure is refused legibly until a restart rebuilds the
  * catalog from its folder - which it can, precisely because nothing was allowed to be written in between.
  *
- * Thrown only by the storage layer, which is the only layer that knows where that line falls.
+ * Raised where the line is known to have been crossed: by the storage layer, which owns the relabel itself, and
+ * by {@link io.evitadb.core.catalog.Catalog#replace} for the rebuild that follows it - the replacement catalog
+ * is assembled after the relabel and after the previous persistence service has been closed, so a failure there
+ * leaves the identical disagreement behind. It is **not** the only way a caller learns the line was crossed: a
+ * failure raised past the handover by code that has never heard of it carries no marker at all, and the operator
+ * recognises that case by having recorded the handover's completion rather than by inspecting the failure.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
@@ -55,15 +60,25 @@ public class CatalogHandoverFailedException extends EvitaInternalError {
 	/**
 	 * Reports a handover that failed once the folder had already been relabelled for it.
 	 *
-	 * @param catalogName name the catalog was being handed over to
-	 * @param cause       failure that interrupted the handover
+	 * Both names are carried because they are the two halves of what the reader needs: the catalog is refused
+	 * under the name it still answers to, while the folder on disk has been relabelled for the other one.
+	 * Naming only the target - as this once did - shows a user a catalog name that never existed for them.
+	 *
+	 * @param catalogName    name the catalog is still published under, and the one that will refuse sessions
+	 * @param newCatalogName name it was being handed over to, and the one its folder now carries
+	 * @param cause          failure that interrupted the handover
 	 */
-	public CatalogHandoverFailedException(@Nonnull String catalogName, @Nonnull Throwable cause) {
+	public CatalogHandoverFailedException(
+		@Nonnull String catalogName,
+		@Nonnull String newCatalogName,
+		@Nonnull Throwable cause
+	) {
 		super(
-			"Handover of catalog `" + catalogName + "` failed after its storage folder had been relabelled " +
-				"for it, so the folder no longer agrees with the engine state: " + cause.getMessage(),
-			"Catalog `" + catalogName + "` could not be renamed and cannot be used until the server is " +
-				"restarted, which restores it under the name it had before.",
+			"Handover of catalog `" + catalogName + "` to `" + newCatalogName + "` failed after its storage " +
+				"folder had been relabelled for it, so the folder no longer agrees with the engine state: " +
+				cause.getMessage(),
+			"Catalog `" + catalogName + "` could not be renamed to `" + newCatalogName + "` and cannot be used " +
+				"until the server is restarted, which restores it under the name it had before.",
 			cause
 		);
 	}

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/CatalogHandoverFailedException.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/CatalogHandoverFailedException.java
@@ -1,0 +1,71 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spi.store.catalog.persistence;
+
+import io.evitadb.exception.EvitaInternalError;
+
+import javax.annotation.Nonnull;
+import java.io.Serial;
+
+/**
+ * Reports that a catalog rename or replace failed **after the point of no return** - the moment the folder's
+ * stored identity became the incoming catalog's and stopped agreeing with engine state.
+ *
+ * This exception exists to be recognised, not merely reported. Everything a rename does is reversible right up
+ * to that moment: the writes are buffered, the engine-state commit has not run, the session registries can be
+ * put back, and the catalog is untouched. Past it the folder has been relabelled for a rename that will now
+ * never be committed, and a caller that resumes session admission regardless is serving a catalog whose next
+ * accepted transaction is appended to the write-ahead log and then replayed, at the following boot, against a
+ * name engine state has never heard of - at which point the catalog does not load at all. A failure past the
+ * close that follows carries the same marker for the further reason that no persistence service is left
+ * behind the catalog either.
+ *
+ * A caller that sees this must therefore stop compensating and start declaring: bind the surviving name to an
+ * unusable catalog carrying this as its cause, so the failure is refused legibly until a restart rebuilds the
+ * catalog from its folder - which it can, precisely because nothing was allowed to be written in between.
+ *
+ * Thrown only by the storage layer, which is the only layer that knows where that line falls.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+public class CatalogHandoverFailedException extends EvitaInternalError {
+	@Serial private static final long serialVersionUID = -7729061372554518891L;
+
+	/**
+	 * Reports a handover that failed once the folder had already been relabelled for it.
+	 *
+	 * @param catalogName name the catalog was being handed over to
+	 * @param cause       failure that interrupted the handover
+	 */
+	public CatalogHandoverFailedException(@Nonnull String catalogName, @Nonnull Throwable cause) {
+		super(
+			"Handover of catalog `" + catalogName + "` failed after its storage folder had been relabelled " +
+				"for it, so the folder no longer agrees with the engine state: " + cause.getMessage(),
+			"Catalog `" + catalogName + "` could not be renamed and cannot be used until the server is " +
+				"restarted, which restores it under the name it had before.",
+			cause
+		);
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/CatalogHandoverFailedException.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/CatalogHandoverFailedException.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2025
+ *   Copyright (c) 2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ import java.io.Serial;
  *
  * Thrown only by the storage layer, which is the only layer that knows where that line falls.
  *
- * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
 public class CatalogHandoverFailedException extends EvitaInternalError {
 	@Serial private static final long serialVersionUID = -7729061372554518891L;

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -80,6 +80,7 @@ import io.evitadb.spi.export.ExportService;
 import io.evitadb.spi.store.catalog.header.HeaderInfoSupplier;
 import io.evitadb.spi.store.catalog.header.model.CatalogHeader;
 import io.evitadb.spi.store.catalog.header.model.EntityCollectionHeader;
+import io.evitadb.spi.store.catalog.persistence.CatalogHandoverFailedException;
 import io.evitadb.spi.store.catalog.persistence.CatalogPersistenceService;
 import io.evitadb.spi.store.catalog.persistence.CatalogFragmentationSnapshot;
 import io.evitadb.spi.store.catalog.persistence.CatalogStorageFootprint;
@@ -2868,44 +2869,64 @@ public class DefaultCatalogPersistenceService
 			catalogHeader.lastEntityCollectionPrimaryKey()
 		);
 
-		// the bootstrap keeps being written under the prefix the folder's files already carry - the files are not
-		// renamed, so naming this record after the incoming catalog would address a `<newName>.boot` that does not
-		// exist and leave the real one holding a stale pointer
-		recordBootstrap(
-			newCatalogVersion,
-			this.storagePrefix,
-			this.bootstrapUsed.catalogFileIndex(),
-			dataStoreMemoryBuffer
-		);
+		// **Everything from here to the end of this method is past the operation's point of no return, and the
+		// wrapper is what tells the engine so.** The line falls here rather than at the `close()` further down,
+		// because what makes the rename irreversible is not losing the service - it is the folder's stored
+		// identity ceasing to agree with engine state. The writes above are buffered; this call is where they
+		// become durable, since `recordBootstrap` flushes the offset index and forces the pending syncs at its
+		// fence. A failure at or after this point can therefore leave the folder relabelled for a rename the
+		// engine-state commit will never make, and the damage that does is not theoretical: any transaction
+		// accepted afterwards is appended to the write-ahead log and replayed at the next boot against the
+		// name the folder now carries, which engine state has never heard of - the catalog then fails to
+		// load at all. A failure *before* this call has relabelled nothing and is fully compensable, which is
+		// why the span starts here and not at the top.
+		//
+		// Only this layer knows where that line falls, so only this layer can draw it; the engine's part is to
+		// stop compensating when it sees the marker and declare the catalog unusable until a restart.
+		try {
+			// the bootstrap keeps being written under the prefix the folder's files already carry - the files are not
+			// renamed, so naming this record after the incoming catalog would address a `<newName>.boot` that does not
+			// exist and leave the real one holding a stale pointer
+			recordBootstrap(
+				newCatalogVersion,
+				this.storagePrefix,
+				this.bootstrapUsed.catalogFileIndex(),
+				dataStoreMemoryBuffer
+			);
 
-		// A checkpoint owed by an earlier round still holds a prepared record addressing the root as it was BEFORE
-		// the header written above, and `close` below publishes whatever is owed. The bootstrap file is read back
-		// by position - `getLastCatalogBootstrapWithAutomaticUpgrade` takes the last record in the file, whatever
-		// version it names - so that older pointer would land after the one just written and the service reopened
-		// at the end of this method would load the catalog under the name it had before the rename. Discarding it
-		// is right on the merits rather than merely expedient: the record written above already did everything the
-		// owed checkpoint would have, since `recordBootstrap` flushes the offset index and forces the pending syncs
-		// at the fence inside `writeCatalogBootstrap` - which is also where the time travel size guard is scheduled,
-		// so the history this record reveals is still accounted for and the discard drops a duplicate
-		// publication rather than the bookkeeping that rides along with it. The field is only ever set together
-		// with the coordinator's own debt, so it is the exact condition, and settling it keeps the cadence gauge
-		// honest - reporting a completion when nothing was owed would fill it with samples no checkpoint produced.
-		if (this.deferredCheckpointBootstrap != null) {
-			this.deferredCheckpointBootstrap = null;
-			Objects.requireNonNull(this.checkpointCoordinator).noteCheckpointCompleted();
+			// A checkpoint owed by an earlier round still holds a prepared record addressing the root as it was BEFORE
+			// the header written above, and `close` below publishes whatever is owed. The bootstrap file is read back
+			// by position - `getLastCatalogBootstrapWithAutomaticUpgrade` takes the last record in the file, whatever
+			// version it names - so that older pointer would land after the one just written and the service reopened
+			// at the end of this method would load the catalog under the name it had before the rename. Discarding it
+			// is right on the merits rather than merely expedient: the record written above already did everything the
+			// owed checkpoint would have, since `recordBootstrap` flushes the offset index and forces the pending syncs
+			// at the fence inside `writeCatalogBootstrap` - which is also where the time travel size guard is
+			// scheduled, so the history this record reveals is still accounted for and the discard drops a duplicate
+			// publication rather than the bookkeeping that rides along with it. The field is only ever set together
+			// with the coordinator's own debt, so it is the exact condition, and settling it keeps the cadence gauge
+			// honest - reporting a completion when nothing was owed would fill it with samples no checkpoint produced.
+			if (this.deferredCheckpointBootstrap != null) {
+				this.deferredCheckpointBootstrap = null;
+				Objects.requireNonNull(this.checkpointCoordinator).noteCheckpointCompleted();
+			}
+
+			// The operation is a fixed amount of work now that nothing is copied or moved, so there is no meaningful
+			// intermediate progress to report - but the terminal tick still has to arrive, or a client tracking
+			// progress waits forever on an operation that has already finished.
+			progressObserver.accept(1, 1);
+
+			// close the catalog and reopen it under its new name, in the very same folder. Past this close there
+			// is additionally no service behind the catalog at all, and this method cannot make one, having just
+			// failed to - so a caller resuming session admission would be admitting sessions against a catalog
+			// with no persistence layer. The span already covers it.
+			this.close();
+			return new DefaultCatalogPersistenceService(
+				catalogNameToBeReplaced, this.catalogStoragePath, this
+			);
+		} catch (RuntimeException ex) {
+			throw new CatalogHandoverFailedException(catalogNameToBeReplaced, ex);
 		}
-
-		// The operation is a fixed amount of work now that nothing is copied or moved, so there is no meaningful
-		// intermediate progress to report - but the terminal tick still has to arrive, or a client tracking
-		// progress waits forever on an operation that has already finished.
-		progressObserver.accept(1, 1);
-
-		// close the catalog and reopen it under its new name, in the very same folder
-		this.close();
-
-		return new DefaultCatalogPersistenceService(
-			catalogNameToBeReplaced, this.catalogStoragePath, this
-		);
 	}
 
 	@Override

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -2942,7 +2942,7 @@ public class DefaultCatalogPersistenceService
 			// `Throwable`, not `RuntimeException`: an `Error` raised past the relabel leaves exactly the same
 			// disagreement behind, and letting it through unmarked would send the engine down the compensating
 			// path for the one class of failure least likely to be survivable.
-			throw new CatalogHandoverFailedException(catalogNameToBeReplaced, ex);
+			throw new CatalogHandoverFailedException(this.catalogName, catalogNameToBeReplaced, ex);
 		}
 	}
 

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -2857,36 +2857,50 @@ public class DefaultCatalogPersistenceService
 			}
 		);
 
-		storagePartPersistenceService.writeCatalogHeader(
-			STORAGE_PROTOCOL_VERSION,
-			newCatalogVersion,
-			this.catalogStoragePath,
-			catalogHeader.walFileReference(),
-			catalogHeader.collectionFileIndex(),
-			catalogHeader.catalogId(),
-			catalogNameToBeReplaced,
-			catalogHeader.catalogState(),
-			catalogHeader.lastEntityCollectionPrimaryKey()
-		);
-
 		// **Everything from here to the end of this method is past the operation's point of no return, and the
-		// wrapper is what tells the engine so.** The line falls here rather than at the `close()` further down,
-		// because what makes the rename irreversible is not losing the service - it is the folder's stored
-		// identity ceasing to agree with engine state. The writes above are buffered; this call is where they
-		// become durable, since `recordBootstrap` flushes the offset index and forces the pending syncs at its
-		// fence. A failure at or after this point can therefore leave the folder relabelled for a rename the
-		// engine-state commit will never make, and the damage that does is not theoretical: any transaction
-		// accepted afterwards is appended to the write-ahead log and replayed at the next boot against the
-		// name the folder now carries, which engine state has never heard of - the catalog then fails to
-		// load at all. A failure *before* this call has relabelled nothing and is fully compensable, which is
-		// why the span starts here and not at the top.
+		// wrapper is what tells the engine so.** The line falls here - not at the `close()` further down, and
+		// not at the top of the method - because what makes the rename irreversible is neither losing the
+		// service nor starting the work: it is the folder's stored identity ceasing to agree with engine state.
+		//
+		// The schema part written just above is what first commits that identity to the folder. It is not yet
+		// on disk - `recordBootstrap` below flushes the offset index and forces the pending syncs at its fence
+		// - but it does not need to be, because the offset index keeps it as a non-flushed value that the very
+		// next transaction or checkpoint will publish on our behalf. So from the moment that put *returns*,
+		// the relabel is going to reach disk whether this operation finishes or not, and a failure after it
+		// leaves the folder claiming a rename the engine-state commit will never make. What that costs is not
+		// theoretical: any transaction accepted afterwards is appended to the write-ahead log and replayed at
+		// the next boot against a name engine state has never heard of, and the catalog then fails to load.
+		//
+		// Nor can the engine take the queued value back once it exists. `reconcileStoredCatalogIdentity` repairs
+		// a divergent schema part only when the *header* name diverges too, so a published new-name schema part
+		// sitting under an old-name header is not something a restart notices - which is precisely why
+		// compensating past this point had to be abandoned rather than made to work.
+		//
+		// A failure *inside* that put is a different thing and stays compensable, which is why the span starts
+		// after it rather than before: the put streams the record before it registers the queued value
+		// (`OffsetIndex#doPut` -> `StorageRecord` -> `volatileValues.putValue`), and nothing between the
+		// registration and this line performs IO, so a write that fails has queued nothing and left the folder
+		// untouched. Declaring such a catalog unusable would take a perfectly healthy one offline, and
+		// `CatalogRenameFailurePathTest` holds this boundary from both sides.
 		//
 		// Only this layer knows where that line falls, so only this layer can draw it; the engine's part is to
 		// stop compensating when it sees the marker and declare the catalog unusable until a restart.
 		try {
-			// the bootstrap keeps being written under the prefix the folder's files already carry - the files are not
-			// renamed, so naming this record after the incoming catalog would address a `<newName>.boot` that does not
-			// exist and leave the real one holding a stale pointer
+			storagePartPersistenceService.writeCatalogHeader(
+				STORAGE_PROTOCOL_VERSION,
+				newCatalogVersion,
+				this.catalogStoragePath,
+				catalogHeader.walFileReference(),
+				catalogHeader.collectionFileIndex(),
+				catalogHeader.catalogId(),
+				catalogNameToBeReplaced,
+				catalogHeader.catalogState(),
+				catalogHeader.lastEntityCollectionPrimaryKey()
+			);
+
+			// the bootstrap keeps being written under the prefix the folder's files already carry - the files are
+			// not renamed, so naming this record after the incoming catalog would address a `<newName>.boot` that
+			// does not exist and leave the real one holding a stale pointer
 			recordBootstrap(
 				newCatalogVersion,
 				this.storagePrefix,
@@ -2924,7 +2938,10 @@ public class DefaultCatalogPersistenceService
 			return new DefaultCatalogPersistenceService(
 				catalogNameToBeReplaced, this.catalogStoragePath, this
 			);
-		} catch (RuntimeException ex) {
+		} catch (Throwable ex) {
+			// `Throwable`, not `RuntimeException`: an `Error` raised past the relabel leaves exactly the same
+			// disagreement behind, and letting it through unmarked would send the engine down the compensating
+			// path for the one class of failure least likely to be survivable.
 			throw new CatalogHandoverFailedException(catalogNameToBeReplaced, ex);
 		}
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameFailurePathTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameFailurePathTest.java
@@ -1,0 +1,360 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.SessionTraits;
+import io.evitadb.api.SessionTraits.SessionFlags;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Collections;
+import java.util.Set;
+
+import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
+
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static io.evitadb.test.TestTags.SESSION;
+import static io.evitadb.test.TestTags.STORAGE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Covers what a **failed** rename leaves behind, which issue #1414 reported as its second symptom and which no
+ * test reaches: every other rename test asserts about the success path.
+ *
+ * The issue reported three consequences of a rename that threw after the point of no return - sessions on the
+ * former name suspended for ever (surfacing as `SessionBusyException`), a catalog reachable under neither name,
+ * and an engine that could not release its folder lock, so the next boot in the same JVM failed with
+ * `FolderAlreadyUsedException` *after* `close()` had returned. The folder decoupling is expected to have removed
+ * all three - the lock now sits once on the storage root rather than per catalog, and a rename commits nothing
+ * until the storage work has succeeded - but "expected to" is what this test exists to replace.
+ *
+ * **Both tests found live defects, and both are calibrated against the fixes that closed them.** Drop
+ * `prevailingCatalogSessionRegistry.ifPresent(SessionRegistry::resumeOperations)` from `undoOperations` in
+ * `ModifyCatalogSchemaNameMutationOperator#doReplaceCatalogInternal` and the rename test fails reading the
+ * catalog back, with `SessionBusyException`. Drop the `quiescedTargetRegistry` resume beside it and the replace
+ * test fails the same way with `InstanceTerminatedException`, thrown out of
+ * `SessionRegistry#awaitResumeOrRefuse` - the catalog that was *not* replaced refusing every session it is
+ * offered. Both suspensions used to be lifted on the success path only.
+ *
+ * **How the failure is injected, and why here.** No production seam is used and no timing is raced. `replaceWith`
+ * writes the header and the bootstrap record through handles opened at boot, which file permissions cannot fail;
+ * it then closes the former persistence service and constructs a new one, and *that* constructor opens the
+ * folder's data file afresh. Revoking read permission on that file before the rename therefore fails the
+ * operation at exactly the point the issue's second shape failed at - after the old service is gone - and does so
+ * deterministically. POSIX permissions are also why the test is confined to Linux and macOS, and why it skips
+ * itself when the revocation does not bite, which is what happens when the suite runs as root.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Slf4j
+@DisplayName("A rename that fails after the persistence service has been handed over")
+@Tag(STORAGE)
+@Tag(MANAGEMENT)
+@Tag(SESSION)
+@EnabledOnOs({OS.LINUX, OS.MAC})
+class CatalogRenameFailurePathTest implements EvitaTestSupport {
+	private static final String ATTRIBUTE_PAYLOAD = "payload";
+	private static final String RENAMED_CATALOG = "renamedCatalog";
+	private static final String REPLACED_CATALOG = "replacedCatalog";
+	private static final String COMMITTED_VALUE = "committed before the failed rename";
+	private static final String TARGET_VALUE = "committed into the catalog being replaced away";
+	private static final String CATALOG_FILE_SUFFIX = ".catalog";
+
+	private TestPaths paths;
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		this.paths = createTestPaths(CatalogRenameFailurePathTest.class.getSimpleName());
+		Files.createDirectories(this.paths.storage());
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.waitUntilFullyInitialized();
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (this.evita != null && this.evita.isActive()) {
+			this.evita.close();
+		}
+		cleanupTestPaths(this.paths);
+	}
+
+	@Test
+	@DisplayName("Leaves the catalog usable under its former name and the engine able to restart")
+	void shouldLeaveCatalogUsableWhenRenameFailsAfterTheServiceHandover() throws Exception {
+		defineCatalogAndGoLive(TEST_CATALOG);
+		commitProduct(TEST_CATALOG, 1, COMMITTED_VALUE);
+
+		final Path dataFile = soleCatalogDataFile(catalogFolder(TEST_CATALOG));
+		final Set<PosixFilePermission> originalPermissions = Files.getPosixFilePermissions(dataFile);
+
+		try {
+			Files.setPosixFilePermissions(dataFile, Collections.emptySet());
+			assumeTrue(
+				isUnreadable(dataFile),
+				"Revoking read permission did not bite - the suite is running as a user that ignores it."
+			);
+
+			// the rename has to fail, and it has to fail *inside* the handover rather than in validation: the
+			// header and the bootstrap record are already written at this point, and the former service closed
+			assertThrows(
+				RuntimeException.class,
+				() -> this.evita.renameCatalog(TEST_CATALOG, RENAMED_CATALOG),
+				"The rename must report the failure rather than swallow it!"
+			);
+		} finally {
+			// restored before anything else touches the catalog - a wedged fixture would otherwise be
+			// indistinguishable from the defect under test, and would take the cleanup down with it
+			Files.setPosixFilePermissions(dataFile, originalPermissions);
+		}
+
+		// the catalog must answer under the name it still has. The issue reported the opposite: sessions on the
+		// former name stayed suspended because the operator resumed them only on the success path, so the name
+		// answered `SessionBusyException` where it owed either data or `CatalogNotFoundException`.
+		assertTrue(
+			this.evita.getCatalogNames().contains(TEST_CATALOG),
+			"A failed rename must leave the catalog under the name it started with!"
+		);
+		assertEquals(
+			COMMITTED_VALUE, readPayload(TEST_CATALOG, 1),
+			"A failed rename must leave the data readable through a fresh session!"
+		);
+
+		// the reported symptom: `close()` returned, yet the lock was still held and the next boot in the same
+		// JVM refused to start
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.waitUntilFullyInitialized();
+
+		assertTrue(
+			this.evita.getCatalogNames().contains(TEST_CATALOG),
+			"The catalog must come back from the restart that follows a failed rename!"
+		);
+		assertEquals(
+			COMMITTED_VALUE, readPayload(TEST_CATALOG, 1),
+			"The transaction committed before the failed rename must survive the restart!"
+		);
+	}
+
+	@Test
+	@DisplayName("Leaves both catalogs of a failed replace usable")
+	void shouldLeaveBothCatalogsUsableWhenReplaceFailsAfterTheServiceHandover() throws Exception {
+		defineCatalogAndGoLive(TEST_CATALOG);
+		commitProduct(TEST_CATALOG, 1, COMMITTED_VALUE);
+		defineCatalogAndGoLive(REPLACED_CATALOG);
+		commitProduct(REPLACED_CATALOG, 2, TARGET_VALUE);
+
+		// the target's registry must already exist when the replace starts, or the operation installs one purely
+		// to quiesce it and the undo path takes a different branch than the one under test here
+		assertEquals(TARGET_VALUE, readPayload(REPLACED_CATALOG, 2));
+
+		// the *source* is the catalog that survives a replace, so failing its handover fails the operation at
+		// the same point the rename case does
+		final Path dataFile = soleCatalogDataFile(catalogFolder(TEST_CATALOG));
+		final Set<PosixFilePermission> originalPermissions = Files.getPosixFilePermissions(dataFile);
+
+		try {
+			Files.setPosixFilePermissions(dataFile, Collections.emptySet());
+			assumeTrue(
+				isUnreadable(dataFile),
+				"Revoking read permission did not bite - the suite is running as a user that ignores it."
+			);
+
+			assertThrows(
+				RuntimeException.class,
+				() -> this.evita.replaceCatalog(TEST_CATALOG, REPLACED_CATALOG),
+				"The replace must report the failure rather than swallow it!"
+			);
+		} finally {
+			Files.setPosixFilePermissions(dataFile, originalPermissions);
+		}
+
+		// a failed replace changes nothing, so both catalogs have to answer exactly as they did before it - the
+		// source under its own name, and the target, whose sessions the operation quiesced with REJECT
+		assertEquals(
+			COMMITTED_VALUE, readPayload(TEST_CATALOG, 1),
+			"A failed replace must leave the source catalog readable!"
+		);
+		assertEquals(
+			TARGET_VALUE, readPayload(REPLACED_CATALOG, 2),
+			"A failed replace must leave the target catalog readable rather than rejecting sessions!"
+		);
+
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.waitUntilFullyInitialized();
+
+		assertEquals(
+			COMMITTED_VALUE, readPayload(TEST_CATALOG, 1),
+			"The source catalog must survive the restart that follows a failed replace!"
+		);
+		assertEquals(
+			TARGET_VALUE, readPayload(REPLACED_CATALOG, 2),
+			"The target catalog must survive the restart that follows a failed replace!"
+		);
+	}
+
+	/**
+	 * Returns the single catalog data file of the passed folder - the file the reopen constructor opens afresh,
+	 * and therefore the one whose permissions decide whether the handover succeeds.
+	 *
+	 * @param catalogDirectory folder to inspect
+	 * @return path of the data file, never null
+	 */
+	@Nonnull
+	private static Path soleCatalogDataFile(@Nonnull Path catalogDirectory) {
+		final File[] dataFiles = catalogDirectory.toFile().listFiles(
+			(dir, name) -> name.endsWith(CATALOG_FILE_SUFFIX)
+		);
+		assertNotNull(dataFiles, "The catalog folder must be listable!");
+		assertEquals(
+			1, dataFiles.length,
+			() -> "Exactly one catalog data file is expected in a freshly written catalog!"
+		);
+		return dataFiles[0].toPath();
+	}
+
+	/**
+	 * Tells whether the passed file genuinely cannot be opened for reading, which permission bits alone do not
+	 * settle - a superuser ignores them entirely.
+	 *
+	 * @param file file to probe
+	 * @return true when opening the file for reading fails
+	 */
+	private static boolean isUnreadable(@Nonnull Path file) {
+		try (final InputStream stream = Files.newInputStream(file)) {
+			assertNotNull(stream);
+			return false;
+		} catch (IOException ex) {
+			return true;
+		}
+	}
+
+	/**
+	 * Resolves the folder the passed catalog is bound to - an opaque token, not the catalog's name.
+	 *
+	 * @param catalogName the catalog whose folder to resolve
+	 * @return the folder path, never null
+	 */
+	@Nonnull
+	private Path catalogFolder(@Nonnull String catalogName) {
+		return this.paths.storage()
+			.resolve(this.evita.getCatalogFolderContext().folderIdFor(catalogName).id());
+	}
+
+	/**
+	 * Commits a single product in its own transaction and waits until the change is visible.
+	 *
+	 * @param catalogName    catalog to write into
+	 * @param primaryKey     primary key of the product
+	 * @param attributeValue value stored in the payload attribute
+	 */
+	private void commitProduct(@Nonnull String catalogName, int primaryKey, @Nonnull String attributeValue) {
+		final EvitaSessionContract session = this.evita.createSession(
+			new SessionTraits(catalogName, SessionFlags.READ_WRITE));
+		session.upsertEntity(
+			session.createNewEntity(Entities.PRODUCT, primaryKey)
+			       .setAttribute(ATTRIBUTE_PAYLOAD, attributeValue)
+		);
+		assertNotNull(session.closeNowWithProgress().onChangesVisible().toCompletableFuture().join());
+	}
+
+	/**
+	 * Reads a single product's payload attribute back through a fresh session.
+	 *
+	 * @param catalogName catalog to read from
+	 * @param primaryKey  primary key of the product
+	 * @return the stored payload
+	 */
+	@Nonnull
+	private String readPayload(@Nonnull String catalogName, int primaryKey) {
+		return this.evita.queryCatalog(
+			catalogName,
+			session -> {
+				return session.getEntity(Entities.PRODUCT, primaryKey, attributeContentAll())
+					.orElseThrow(() -> new AssertionError("The product must be present!"))
+					.getAttribute(ATTRIBUTE_PAYLOAD, String.class);
+			}
+		);
+	}
+
+	/**
+	 * Defines the passed catalog with a single product schema and takes it live.
+	 *
+	 * @param catalogName name of the catalog to define
+	 */
+	private void defineCatalogAndGoLive(@Nonnull String catalogName) {
+		this.evita.defineCatalog(catalogName);
+		this.evita.updateCatalog(
+			catalogName,
+			session -> {
+				session.defineEntitySchema(Entities.PRODUCT)
+				       .withoutGeneratedPrimaryKey()
+				       .withAttribute(ATTRIBUTE_PAYLOAD, String.class)
+				       .updateVia(session);
+				session.goLiveAndClose();
+			}
+		);
+	}
+
+	/**
+	 * Stock storage options - nothing here depends on the log or on time travel.
+	 *
+	 * @return the configuration, never null
+	 */
+	@Nonnull
+	private EvitaConfiguration getEvitaConfiguration() {
+		return newTestEvitaConfigurationBuilder(this.paths)
+			.storage(
+				StorageOptions.builder()
+					.storageDirectory(this.paths.storage())
+					.workDirectory(this.paths.work())
+					.build()
+			)
+			.build();
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameFailurePathTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameFailurePathTest.java
@@ -138,6 +138,9 @@ class CatalogRenameFailurePathTest implements EvitaTestSupport {
 	private static final String COMMITTED_VALUE = "committed before the failed rename";
 	private static final String TARGET_VALUE = "committed into the catalog being replaced away";
 	private static final String CATALOG_FILE_SUFFIX = ".catalog";
+	private static final String COLLECTION_FILE_SUFFIX = ".collection";
+	/** Mirrors `ModifyCatalogSchemaNameMutationOperator#MAX_INSPECTED_CAUSE_DEPTH`. */
+	private static final int MAX_INSPECTED_CAUSE_DEPTH = 32;
 
 	private TestPaths paths;
 	private Evita evita;
@@ -427,6 +430,85 @@ class CatalogRenameFailurePathTest implements EvitaTestSupport {
 		);
 	}
 
+	@Test
+	@DisplayName("Declares the catalog unusable when the rebuild after a successful relabel fails")
+	void shouldDeclareTheCatalogUnusableWhenTheRebuildAfterTheRelabelFails() throws Exception {
+		defineCatalogAndGoLive(TEST_CATALOG);
+		commitProduct(TEST_CATALOG, 1, COMMITTED_VALUE);
+		// Restarted so the offset index carries nothing that needs flushing. Without this the relabel's own
+		// flush forces pending syncs across every open handle - the collection file's included - and the
+		// failure lands back inside `replaceWith`, where the sibling tests already put it. On a cold index
+		// there is nothing to force, so the flush passes and the rebuild below is genuinely the first thing
+		// to touch this file.
+		restartEngine();
+
+		// **Revoking the collection file rather than the catalog's own moves the failure past everything the
+		// storage layer does.** The relabel writes the schema part, the header and the bootstrap record into
+		// the `.catalog` and `.boot` files, which stay readable throughout, so `replaceWith` succeeds all the
+		// way to closing the former service and opening its replacement. Only the rebuild that follows - one
+		// `EntityCollection` per collection, opened against that replacement - touches this file. That window
+		// belongs to `Catalog#replace` rather than to `replaceWith`, and until it was marked, a failure in it
+		// took the compensating path: session admission resumed against a catalog whose service had already
+		// been closed underneath it and whose folder already carried the other name.
+		final Path collectionFile = soleCollectionFile(catalogFolder(TEST_CATALOG));
+		final Set<PosixFilePermission> originalPermissions = Files.getPosixFilePermissions(collectionFile);
+
+		try {
+			Files.setPosixFilePermissions(collectionFile, Collections.emptySet());
+			assumeTrue(
+				isUnreadable(collectionFile),
+				"Revoking read permission did not bite - the suite is running as a user that ignores it."
+			);
+			assertThrows(
+				RuntimeException.class,
+				() -> this.evita.renameCatalog(TEST_CATALOG, RENAMED_CATALOG),
+				"The rename must report the failure rather than swallow it!"
+			);
+		} finally {
+			Files.setPosixFilePermissions(collectionFile, originalPermissions);
+		}
+
+		final CatalogCorruptedException refusal = assertThrows(
+			CatalogCorruptedException.class,
+			() -> readPayload(TEST_CATALOG, 1),
+			"A rebuild that failed after the relabel must leave the catalog refusing sessions, not serving " +
+				"them through a persistence service the handover already closed!"
+		);
+		assertTrue(
+			carriesHandoverFailure(refusal),
+			"The refusal must name the failed handover in its cause chain!"
+		);
+
+		// and the restart still repairs it, which is what makes refusing the honest answer rather than a
+		// permanent outage
+		restartEngine();
+
+		assertEquals(
+			COMMITTED_VALUE, readPayload(TEST_CATALOG, 1),
+			"The catalog must come back whole from the restart that follows a failed rebuild!"
+		);
+	}
+
+	/**
+	 * Locates the sole entity-collection data file in a catalog folder, which the tests use to fail the
+	 * rebuild that follows a successful relabel without disturbing the relabel itself.
+	 *
+	 * @param catalogDirectory folder holding the catalog's files
+	 * @return the collection data file
+	 */
+	@Nonnull
+	private static Path soleCollectionFile(@Nonnull Path catalogDirectory) {
+		final File[] collectionFiles = catalogDirectory.toFile().listFiles(
+			(dir, name) -> name.endsWith(COLLECTION_FILE_SUFFIX)
+		);
+		assertNotNull(collectionFiles, "The catalog folder must be listable!");
+		assertEquals(
+			1, collectionFiles.length,
+			() -> "Exactly one collection data file is expected for a catalog holding one collection!"
+		);
+		return collectionFiles[0].toPath();
+	}
+
 	/**
 	 * Tells whether a failure carries the storage layer's point-of-no-return marker anywhere in its cause
 	 * chain - the signal that the folder had already been relabelled when the handover failed.
@@ -436,11 +518,14 @@ class CatalogRenameFailurePathTest implements EvitaTestSupport {
 	 */
 	private static boolean carriesHandoverFailure(@Nonnull Throwable failure) {
 		Throwable current = failure;
-		while (current != null && current != current.getCause()) {
+		// bounded exactly like the production walk in `ModifyCatalogSchemaNameMutationOperator`, so the test
+		// cannot pass on a chain the engine itself would give up on
+		for (int depth = 0; current != null && depth < MAX_INSPECTED_CAUSE_DEPTH; depth++) {
 			if (current instanceof CatalogHandoverFailedException) {
 				return true;
 			}
-			current = current.getCause();
+			final Throwable cause = current.getCause();
+			current = cause == current ? null : cause;
 		}
 		return false;
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameFailurePathTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameFailurePathTest.java
@@ -28,6 +28,9 @@ import io.evitadb.api.SessionTraits;
 import io.evitadb.api.SessionTraits.SessionFlags;
 import io.evitadb.api.configuration.EvitaConfiguration;
 import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.core.exception.CatalogCorruptedException;
+import io.evitadb.exception.EvitaError;
+import io.evitadb.spi.store.catalog.persistence.CatalogHandoverFailedException;
 import io.evitadb.test.Entities;
 import io.evitadb.test.EvitaTestSupport;
 import lombok.extern.slf4j.Slf4j;
@@ -48,6 +51,12 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
 import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
 
@@ -55,6 +64,7 @@ import static io.evitadb.test.TestTags.MANAGEMENT;
 import static io.evitadb.test.TestTags.SESSION;
 import static io.evitadb.test.TestTags.STORAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -85,18 +95,38 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * `resumeOperations` call from that branch - the target then answers `InstanceTerminatedException` for the rest
  * of the process.
  *
- * **How the failure is injected, and why here.** No production seam is used and no timing is raced. `replaceWith`
- * writes the header and the bootstrap record through handles opened at boot, which file permissions cannot fail;
- * it then closes the former persistence service and constructs a new one, and *that* constructor opens the
- * folder's data file afresh. Revoking read permission on that file before the rename therefore fails the
- * operation at exactly the point the issue's second shape failed at - after the old service is gone - and does so
- * deterministically. POSIX permissions are also why the test is confined to Linux and macOS, and why it skips
- * itself when the revocation does not bite, which is what happens when the suite runs as root.
+ * The last two pin the invariants that made the declaration necessary, and both were written red against the
+ * behaviour they now forbid: a session served under the surviving name observed the *target's* schema name, and a
+ * single retried write was appended durably to the write-ahead log before the commit pipeline died on that
+ * poisoned name (`ExpandedEngineState#replaceCatalogReference` found no such catalog) - after which the next boot
+ * failed replaying it, which is issue #1414's headline symptom re-created by the branch that fixes it. They are
+ * written against the invariant rather than against the fix, so they stay green whether the window is closed
+ * (prepare-then-commit in the store) or declared, as it is today.
+ *
+ * **How the failure is injected, and where it actually lands.** No production seam is used and no timing is raced.
+ * Revoking read permission on the folder's data file before the rename fails `replaceWith` deterministically, and
+ * the cause chain says exactly where: `SyncFailedException` wrapping an `AccessDeniedException`, raised by the
+ * offset-index flush inside `recordBootstrap`. That is **before** the former persistence service is closed, not
+ * after - an earlier version of this comment claimed the failure landed in the takeover constructor, and it does
+ * not. The distinction is worth the words, because it is the whole reason the catalog is unusable afterwards: the
+ * header naming the incoming catalog has already been written, so the folder's stored identity disagrees with
+ * engine state, while the service that could still write to it is very much alive. That is the point of no return
+ * (`CatalogHandoverFailedException`), and it is reached here without any service ever being lost.
+ *
+ * **The same revocation lands on either side of that line, depending on how warm the engine is**, and the suite
+ * covers both deliberately. Warm, the offset index has writes buffered and the failure comes at the flush, past
+ * the relabel. Freshly booted, it has none, so `replaceWith` fails opening the file before writing anything and
+ * the catalog is untouched - `shouldLeaveTheTargetServingWhenTheFailedReplaceInstalledItsRegistry` asserts that
+ * this one is *not* reported as a handover failure. Without that pairing nothing stops the marker widening until
+ * every failed rename takes a healthy catalog offline.
+ *
+ * POSIX permissions are also why the test is confined to Linux and macOS, and why it skips itself when the
+ * revocation does not bite, which is what happens when the suite runs as root.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
 @Slf4j
-@DisplayName("A rename that fails after the persistence service has been handed over")
+@DisplayName("A rename or replace that fails partway through its storage handover")
 @Tag(STORAGE)
 @Tag(MANAGEMENT)
 @Tag(SESSION)
@@ -129,51 +159,44 @@ class CatalogRenameFailurePathTest implements EvitaTestSupport {
 	}
 
 	@Test
-	@DisplayName("Leaves the catalog usable under its former name and the engine able to restart")
-	void shouldLeaveCatalogUsableWhenRenameFailsAfterTheServiceHandover() throws Exception {
+	@DisplayName("Refuses sessions legibly under its former name, and recovers on restart")
+	void shouldRefuseSessionsLegiblyWhenRenameFailsPastTheFolderRelabel() throws Exception {
 		defineCatalogAndGoLive(TEST_CATALOG);
 		commitProduct(TEST_CATALOG, 1, COMMITTED_VALUE);
 
-		final Path dataFile = soleCatalogDataFile(catalogFolder(TEST_CATALOG));
-		final Set<PosixFilePermission> originalPermissions = Files.getPosixFilePermissions(dataFile);
+		failRenamePastTheFolderRelabel();
 
-		try {
-			Files.setPosixFilePermissions(dataFile, Collections.emptySet());
-			assumeTrue(
-				isUnreadable(dataFile),
-				"Revoking read permission did not bite - the suite is running as a user that ignores it."
-			);
-
-			// the rename has to fail, and it has to fail *inside* the handover rather than in validation: the
-			// header and the bootstrap record are already written at this point, and the former service closed
-			assertThrows(
-				RuntimeException.class,
-				() -> this.evita.renameCatalog(TEST_CATALOG, RENAMED_CATALOG),
-				"The rename must report the failure rather than swallow it!"
-			);
-		} finally {
-			// restored before anything else touches the catalog - a wedged fixture would otherwise be
-			// indistinguishable from the defect under test, and would take the cleanup down with it
-			Files.setPosixFilePermissions(dataFile, originalPermissions);
-		}
-
-		// the catalog must answer under the name it still has. The issue reported the opposite: sessions on the
-		// former name stayed suspended because the operator resumed them only on the success path, so the name
-		// answered `SessionBusyException` where it owed either data or `CatalogNotFoundException`.
+		// The name stays listed, and must: the commit never ran, so engine state still binds it to its folder.
+		// What changed is the *instance* behind the name. What must never happen is the symptom the issue is
+		// named after - the name answering `SessionBusyException` for the life of the process, because the
+		// operator resumed its sessions only on the success path.
 		assertTrue(
 			this.evita.getCatalogNames().contains(TEST_CATALOG),
 			"A failed rename must leave the catalog under the name it started with!"
 		);
-		assertEquals(
-			COMMITTED_VALUE, readPayload(TEST_CATALOG, 1),
-			"A failed rename must leave the data readable through a fresh session!"
+
+		// **This test asserted the opposite until the write path was measured.** The catalog was left serving,
+		// and reads did work - out of memory. Behind them the persistence service was closed, and a single
+		// write accepted afterwards was appended to the write-ahead log and then wedged the next boot
+		// replaying it. Serving a catalog whose persistence layer is gone is not availability, it is a trap
+		// that converts "recoverable by restart" into "unloadable at boot", so the honest answer past the
+		// handover is a refusal that says exactly what happened and leaves the restart able to repair it.
+		final CatalogCorruptedException refusal = assertThrows(
+			CatalogCorruptedException.class,
+			() -> readPayload(TEST_CATALOG, 1),
+			"A rename that failed past its point of no return must refuse sessions legibly!"
+		);
+		// walked rather than read off `getCause()` directly: the failure travels out of a nested future and
+		// arrives wrapped, and it is the marker's presence that matters, not its depth
+		assertTrue(
+			carriesHandoverFailure(refusal),
+			"The refusal must name the failed handover in its cause chain, not merely report corruption!"
 		);
 
 		// the reported symptom: `close()` returned, yet the lock was still held and the next boot in the same
-		// JVM refused to start
-		this.evita.close();
-		this.evita = new Evita(getEvitaConfiguration());
-		this.evita.waitUntilFullyInitialized();
+		// JVM refused to start. The restart is also what *lifts* the refusal above - the folder is reconciled
+		// against the name engine state binds it to, so the catalog comes back whole and under its own name.
+		restartEngine();
 
 		assertTrue(
 			this.evita.getCatalogNames().contains(TEST_CATALOG),
@@ -186,8 +209,8 @@ class CatalogRenameFailurePathTest implements EvitaTestSupport {
 	}
 
 	@Test
-	@DisplayName("Leaves both catalogs of a failed replace usable")
-	void shouldLeaveBothCatalogsUsableWhenReplaceFailsAfterTheServiceHandover() throws Exception {
+	@DisplayName("Refuses only the source of a failed replace, and leaves its target serving")
+	void shouldRefuseOnlyTheSourceWhenReplaceFailsPastTheFolderRelabel() throws Exception {
 		defineCatalogAndGoLive(TEST_CATALOG);
 		commitProduct(TEST_CATALOG, 1, COMMITTED_VALUE);
 		defineCatalogAndGoLive(REPLACED_CATALOG);
@@ -218,20 +241,23 @@ class CatalogRenameFailurePathTest implements EvitaTestSupport {
 			Files.setPosixFilePermissions(dataFile, originalPermissions);
 		}
 
-		// a failed replace changes nothing, so both catalogs have to answer exactly as they did before it - the
-		// source under its own name, and the target, whose sessions the operation quiesced with REJECT
-		assertEquals(
-			COMMITTED_VALUE, readPayload(TEST_CATALOG, 1),
-			"A failed replace must leave the source catalog readable!"
+		// The source is the catalog whose handover failed, so it - and only it - is refused past that point,
+		// for the reason spelled out in the rename test above.
+		assertThrows(
+			CatalogCorruptedException.class,
+			() -> readPayload(TEST_CATALOG, 1),
+			"A replace that failed past its point of no return must refuse sessions on the source legibly!"
 		);
+		// The target is the half of a replace that the handover never touches: its folder, its service and its
+		// data are exactly as they were, and the operation owes it nothing but the lifting of the REJECT
+		// suspension it opened with. Refusing it too would be the failure the branch already fixed, dressed
+		// up as caution - so the blast radius of the declaration above has to stop here, and this asserts it.
 		assertEquals(
 			TARGET_VALUE, readPayload(REPLACED_CATALOG, 2),
 			"A failed replace must leave the target catalog readable rather than rejecting sessions!"
 		);
 
-		this.evita.close();
-		this.evita = new Evita(getEvitaConfiguration());
-		this.evita.waitUntilFullyInitialized();
+		restartEngine();
 
 		assertEquals(
 			COMMITTED_VALUE, readPayload(TEST_CATALOG, 1),
@@ -269,10 +295,23 @@ class CatalogRenameFailurePathTest implements EvitaTestSupport {
 				"Revoking read permission did not bite - the suite is running as a user that ignores it."
 			);
 
-			assertThrows(
+			// **This injection lands on the other side of the point of no return from its siblings, and that is
+			// the point of the test.** On a freshly booted engine the offset index has nothing buffered, so the
+			// first thing `replaceWith` does is *open* the data file - which fails outright
+			// (`UnexpectedIOException` wrapping `FileNotFoundException`) before a single byte of the relabel is
+			// written. The sibling tests keep the engine warm, so the same revocation instead survives as far as
+			// the flush inside `recordBootstrap` and leaves the header already naming the incoming catalog.
+			// Same fault, same file, opposite verdicts - and the assertions below are what hold the engine to
+			// telling them apart.
+			final RuntimeException reported = assertThrows(
 				RuntimeException.class,
 				() -> this.evita.replaceCatalog(TEST_CATALOG, REPLACED_CATALOG),
 				"The replace must report the failure rather than swallow it!"
+			);
+			assertFalse(
+				carriesHandoverFailure(reported),
+				"A replace that failed before it relabelled anything must not be reported as a handover " +
+					"failure - declaring this one unusable would take a healthy catalog offline!"
 			);
 		} finally {
 			Files.setPosixFilePermissions(dataFile, originalPermissions);
@@ -290,10 +329,181 @@ class CatalogRenameFailurePathTest implements EvitaTestSupport {
 			TARGET_VALUE, readPayload(REPLACED_CATALOG, 2),
 			"A failed replace must leave an untouched target readable rather than rejecting sessions!"
 		);
+		// The source stays readable here, where its sibling above is refused, and the difference is not
+		// arbitrary: this failure never reached the relabel, so there is nothing about the catalog that a
+		// restart would need to repair and no reason to take it offline. Compensation is the right answer on
+		// this side of the line, and this asserts that the declaration does not creep across it.
 		assertEquals(
 			COMMITTED_VALUE, readPayload(TEST_CATALOG, 1),
-			"A failed replace must leave the source catalog readable!"
+			"A replace that failed before it relabelled anything must leave the source catalog readable!"
 		);
+
+		// **The only place the deferred schema exchange can be observed, and therefore the only place that
+		// holds it honest.** Past the relabel the catalog is refused outright, so a schema naming the wrong
+		// catalog would sit there unseen; here the catalog keeps serving, so an exchange performed ahead of
+		// the handover is visible through a plain session - and dangerous, because the commit pipeline looks
+		// a catalog up by the name its schema reports. A write accepted against a source still claiming the
+		// target's name is appended to the write-ahead log and wedges the next boot, which is the failure
+		// the sibling tests exist for, reached by a route the declaration deliberately does not guard.
+		assertEquals(
+			TEST_CATALOG,
+			this.evita.queryCatalog(
+				TEST_CATALOG,
+				(Function<EvitaSessionContract, String>) session -> session.getCatalogSchema().getName()
+			),
+			"A replace that failed before it relabelled anything must leave the source's schema naming the " +
+				"source - it is still serving, so a schema naming the replace's target poisons every write!"
+		);
+	}
+
+	@Test
+	@DisplayName("Never serves the target's schema name through a session after a failed rename")
+	void shouldNeverServeTargetSchemaNameWhenRenameFailsPastTheFolderRelabel() throws Exception {
+		defineCatalogAndGoLive(TEST_CATALOG);
+		commitProduct(TEST_CATALOG, 1, COMMITTED_VALUE);
+
+		failRenamePastTheFolderRelabel();
+
+		// Two outcomes honour the invariant, and the test deliberately accepts both so it survives either fix:
+		// a legible refusal (the catalog declares itself unusable past the point of no return), or a served
+		// session that tells the truth (the handover never destroyed anything, so there is nothing to hide).
+		// What must never happen is what happens today: a session is served, and it observes a catalog whose
+		// schema names the target of the rename that just FAILED - listed as `testCatalog`, answering
+		// `renamedCatalog`. Every consumer keying on the schema name - including the engine's own commit
+		// pipeline, see the sibling test - is lied to from that moment on.
+		try {
+			final String reportedName = this.evita.queryCatalog(
+				TEST_CATALOG,
+				(Function<EvitaSessionContract, String>) session -> session.getCatalogSchema().getName()
+			);
+			assertEquals(
+				TEST_CATALOG, reportedName,
+				"A session served after a failed rename must never observe the schema of the name the " +
+					"catalog does NOT answer to!"
+			);
+		} catch (RuntimeException refusal) {
+			// a refusal is the other acceptable outcome, but only a legible one: every deliberate evitaDB
+			// exception carries the `EvitaError` contract, and a bare NPE or wrapper leaking from a damaged
+			// internal state does not
+			assertTrue(
+				refusal instanceof EvitaError,
+				() -> "A refusal after a failed rename must be a legible evitaDB error, not " +
+					refusal.getClass().getName() + "!"
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("Survives the restart even when a client retried a write after the failed rename")
+	void shouldRecoverOnRestartWhenWriteWasAttemptedAfterTheFailedRename() throws Exception {
+		defineCatalogAndGoLive(TEST_CATALOG);
+		commitProduct(TEST_CATALOG, 1, COMMITTED_VALUE);
+
+		failRenamePastTheFolderRelabel();
+
+		// The retry a real client makes after seeing the rename fail. Its own outcome is deliberately not
+		// asserted - a legible refusal and a successful commit are both acceptable, depending on which fix
+		// lands - but it must not be allowed to hang the test, so it runs on a bounded daemon thread.
+		attemptWriteIgnoringOutcome(TEST_CATALOG, 7, "retried after the failed rename");
+
+		// The write above must not have poisoned the write-ahead log. Today it does: the commit pipeline
+		// appends the transaction durably and then dies looking the catalog up by its poisoned schema name
+		// (`ExpandedEngineState#replaceCatalogReference` finds no `renamedCatalog`), and the next boot dies
+		// replaying it - `processWriteAheadLog` stages a catalog named `renamedCatalog` that has no folder
+		// binding. One retried write converts "recoverable by restart" - which the sibling test proves holds
+		// when nothing touches the damaged catalog - into "unloadable at boot", which is issue #1414's
+		// headline symptom re-created. Whatever a fix does with the write itself, the boot must recover.
+		restartEngine();
+
+		assertTrue(
+			this.evita.getCatalogNames().contains(TEST_CATALOG),
+			"The catalog must come back from the restart even though a write was attempted after the " +
+				"failed rename!"
+		);
+		assertEquals(
+			COMMITTED_VALUE, readPayload(TEST_CATALOG, 1),
+			"The transaction committed before the failed rename must survive the restart even though a " +
+				"write was attempted after it!"
+		);
+	}
+
+	/**
+	 * Tells whether a failure carries the storage layer's point-of-no-return marker anywhere in its cause
+	 * chain - the signal that the folder had already been relabelled when the handover failed.
+	 *
+	 * @param failure failure reported to the caller
+	 * @return true when the handover marker is present
+	 */
+	private static boolean carriesHandoverFailure(@Nonnull Throwable failure) {
+		Throwable current = failure;
+		while (current != null && current != current.getCause()) {
+			if (current instanceof CatalogHandoverFailedException) {
+				return true;
+			}
+			current = current.getCause();
+		}
+		return false;
+	}
+
+	/**
+	 * Fails a rename of {@link #TEST_CATALOG} to {@link #RENAMED_CATALOG} deterministically inside the
+	 * persistence-service handover - after the former service is closed - by revoking read permission on the
+	 * catalog's data file for the duration of the operation. See the class javadoc for why this seam and no
+	 * other reaches the point the issue's second shape failed at.
+	 */
+	private void failRenamePastTheFolderRelabel() throws IOException {
+		final Path dataFile = soleCatalogDataFile(catalogFolder(TEST_CATALOG));
+		final Set<PosixFilePermission> originalPermissions = Files.getPosixFilePermissions(dataFile);
+		try {
+			Files.setPosixFilePermissions(dataFile, Collections.emptySet());
+			assumeTrue(
+				isUnreadable(dataFile),
+				"Revoking read permission did not bite - the suite is running as a user that ignores it."
+			);
+			assertThrows(
+				RuntimeException.class,
+				() -> this.evita.renameCatalog(TEST_CATALOG, RENAMED_CATALOG),
+				"The rename must report the failure rather than swallow it!"
+			);
+		} finally {
+			// restored before anything else touches the catalog - a wedged fixture would otherwise be
+			// indistinguishable from the defect under test, and would take the cleanup down with it
+			Files.setPosixFilePermissions(dataFile, originalPermissions);
+		}
+	}
+
+	/**
+	 * Commits a single product on a bounded daemon thread and swallows whatever the attempt produces -
+	 * success, refusal or timeout. Used where the *consequences* of an attempted write are under test rather
+	 * than the write itself, so its outcome must not decide the test and its potential hang must not stall it.
+	 *
+	 * @param catalogName    catalog to write into
+	 * @param primaryKey     primary key of the product
+	 * @param attributeValue value stored in the payload attribute
+	 */
+	private void attemptWriteIgnoringOutcome(
+		@Nonnull String catalogName,
+		int primaryKey,
+		@Nonnull String attributeValue
+	) {
+		final ExecutorService executor = Executors.newSingleThreadExecutor(
+			runnable -> {
+				final Thread thread = new Thread(runnable, "bounded-write-attempt");
+				thread.setDaemon(true);
+				return thread;
+			}
+		);
+		try {
+			executor
+				.submit(() -> commitProduct(catalogName, primaryKey, attributeValue))
+				.get(30, TimeUnit.SECONDS);
+		} catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+		} catch (ExecutionException | TimeoutException ex) {
+			// deliberately ignored - the attempt's outcome is not what this test asserts about
+		} finally {
+			executor.shutdownNow();
+		}
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameFailurePathTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameFailurePathTest.java
@@ -246,10 +246,18 @@ class CatalogRenameFailurePathTest implements EvitaTestSupport {
 
 		// The source is the catalog whose handover failed, so it - and only it - is refused past that point,
 		// for the reason spelled out in the rename test above.
-		assertThrows(
+		final CatalogCorruptedException refusal = assertThrows(
 			CatalogCorruptedException.class,
 			() -> readPayload(TEST_CATALOG, 1),
 			"A replace that failed past its point of no return must refuse sessions on the source legibly!"
+		);
+		// Asserted for the same reason as in the rename test: `CatalogCorruptedException` is what a catalog that
+		// failed to *open* reports too, so without this the test would still pass if the declaration were
+		// replaced by a catalog that simply cannot be loaded - a different failure wearing the same face.
+		assertTrue(
+			carriesHandoverFailure(refusal),
+			"The refusal must name the failed handover as its cause, or it is indistinguishable from a catalog " +
+				"that merely failed to open!"
 		);
 		// The target is the half of a replace that the handover never touches: its folder, its service and its
 		// data are exactly as they were, and the operation owes it nothing but the lifting of the REJECT

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameFailurePathTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameFailurePathTest.java
@@ -80,13 +80,10 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * offered. Both suspensions used to be lifted on the success path only.
  *
  * The third covers the *other* undo branch, which the second deliberately avoids: a target nobody has opened a
- * session on since boot has no registry, so the operation installs one purely to quiesce it and the undo has to
- * unpublish that registry rather than restore it. Calibrated by dropping the
- * `removeCatalogSessionRegistryIfPresent` call from that branch - the target then answers
- * `InstanceTerminatedException` for the rest of the process. What it cannot calibrate is the *ordering* within
- * that branch - unpublishing before resuming, so a racing `createSession` cannot land a live session in a
- * registry that is about to become unreachable - because reaching that window needs an interleaving no seam
- * exposes. The removal is asserted; the ordering is argued at the site.
+ * session on since boot has no registry, so the operation installs one purely to quiesce it, and the undo has to
+ * resume that registry **in place** rather than restore or unpublish it. Calibrated by dropping the
+ * `resumeOperations` call from that branch - the target then answers `InstanceTerminatedException` for the rest
+ * of the process.
  *
  * **How the failure is injected, and why here.** No production seam is used and no timing is raced. `replaceWith`
  * writes the header and the bootstrap record through handles opened at boot, which file permissions cannot fail;
@@ -247,8 +244,8 @@ class CatalogRenameFailurePathTest implements EvitaTestSupport {
 	}
 
 	@Test
-	@DisplayName("Leaves no registry behind when it installed one purely to quiesce the replace target")
-	void shouldLeaveNoRegistryBehindWhenReplaceFailsAgainstAnUntouchedTarget() throws Exception {
+	@DisplayName("Leaves the target serving when it installed a registry purely to quiesce it")
+	void shouldLeaveTheTargetServingWhenTheFailedReplaceInstalledItsRegistry() throws Exception {
 		defineCatalogAndGoLive(TEST_CATALOG);
 		commitProduct(TEST_CATALOG, 1, COMMITTED_VALUE);
 		defineCatalogAndGoLive(REPLACED_CATALOG);
@@ -281,14 +278,13 @@ class CatalogRenameFailurePathTest implements EvitaTestSupport {
 			Files.setPosixFilePermissions(dataFile, originalPermissions);
 		}
 
-		// asserted before anything opens a session, which would build a registry of its own and hide the leak.
-		// The registry the operation installed is suspended with REJECT, so leaving it published would make the
-		// target - a catalog that was never touched - answer `InstanceTerminatedException` for the rest of the
-		// process. Unpublishing it while it is still suspended is also what keeps a racing session request from
-		// landing in a registry that is about to become unreachable.
+		// Asserted before anything opens a session, so the registry can only be the one the operation installed
+		// to quiesce the target: it stays published and is resumed in place, which is exactly the state the
+		// first session would have left it in. The alternative - unpublishing it - orphans whatever sessions
+		// outlived a drain that gave up, since every later quiesce walks the registry map.
 		assertTrue(
-			this.evita.getCatalogSessionRegistry(REPLACED_CATALOG).isEmpty(),
-			"A failed replace must unpublish the registry it installed purely to quiesce the target!"
+			this.evita.getCatalogSessionRegistry(REPLACED_CATALOG).isPresent(),
+			"The failed replace must keep the registry it installed, rather than unpublishing it!"
 		);
 		assertEquals(
 			TARGET_VALUE, readPayload(REPLACED_CATALOG, 2),

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameFailurePathTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameFailurePathTest.java
@@ -71,13 +71,22 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * all three - the lock now sits once on the storage root rather than per catalog, and a rename commits nothing
  * until the storage work has succeeded - but "expected to" is what this test exists to replace.
  *
- * **Both tests found live defects, and both are calibrated against the fixes that closed them.** Drop
+ * **The first two tests found live defects, and both are calibrated against the fixes that closed them.** Drop
  * `prevailingCatalogSessionRegistry.ifPresent(SessionRegistry::resumeOperations)` from `undoOperations` in
  * `ModifyCatalogSchemaNameMutationOperator#doReplaceCatalogInternal` and the rename test fails reading the
  * catalog back, with `SessionBusyException`. Drop the `quiescedTargetRegistry` resume beside it and the replace
  * test fails the same way with `InstanceTerminatedException`, thrown out of
  * `SessionRegistry#awaitResumeOrRefuse` - the catalog that was *not* replaced refusing every session it is
  * offered. Both suspensions used to be lifted on the success path only.
+ *
+ * The third covers the *other* undo branch, which the second deliberately avoids: a target nobody has opened a
+ * session on since boot has no registry, so the operation installs one purely to quiesce it and the undo has to
+ * unpublish that registry rather than restore it. Calibrated by dropping the
+ * `removeCatalogSessionRegistryIfPresent` call from that branch - the target then answers
+ * `InstanceTerminatedException` for the rest of the process. What it cannot calibrate is the *ordering* within
+ * that branch - unpublishing before resuming, so a racing `createSession` cannot land a live session in a
+ * registry that is about to become unreachable - because reaching that window needs an interleaving no seam
+ * exposes. The removal is asserted; the ordering is argued at the site.
  *
  * **How the failure is injected, and why here.** No production seam is used and no timing is raced. `replaceWith`
  * writes the header and the bootstrap record through handles opened at boot, which file permissions cannot fail;
@@ -235,6 +244,69 @@ class CatalogRenameFailurePathTest implements EvitaTestSupport {
 			TARGET_VALUE, readPayload(REPLACED_CATALOG, 2),
 			"The target catalog must survive the restart that follows a failed replace!"
 		);
+	}
+
+	@Test
+	@DisplayName("Leaves no registry behind when it installed one purely to quiesce the replace target")
+	void shouldLeaveNoRegistryBehindWhenReplaceFailsAgainstAnUntouchedTarget() throws Exception {
+		defineCatalogAndGoLive(TEST_CATALOG);
+		commitProduct(TEST_CATALOG, 1, COMMITTED_VALUE);
+		defineCatalogAndGoLive(REPLACED_CATALOG);
+		commitProduct(REPLACED_CATALOG, 2, TARGET_VALUE);
+
+		// session registries live in memory only, so a restart is what produces a catalog that has none - and
+		// that is the branch where the operation has to install one before it can quiesce the target at all
+		restartEngine();
+		assertTrue(
+			this.evita.getCatalogSessionRegistry(REPLACED_CATALOG).isEmpty(),
+			"The target must start with no session registry, or this test exercises the other undo branch!"
+		);
+
+		final Path dataFile = soleCatalogDataFile(catalogFolder(TEST_CATALOG));
+		final Set<PosixFilePermission> originalPermissions = Files.getPosixFilePermissions(dataFile);
+
+		try {
+			Files.setPosixFilePermissions(dataFile, Collections.emptySet());
+			assumeTrue(
+				isUnreadable(dataFile),
+				"Revoking read permission did not bite - the suite is running as a user that ignores it."
+			);
+
+			assertThrows(
+				RuntimeException.class,
+				() -> this.evita.replaceCatalog(TEST_CATALOG, REPLACED_CATALOG),
+				"The replace must report the failure rather than swallow it!"
+			);
+		} finally {
+			Files.setPosixFilePermissions(dataFile, originalPermissions);
+		}
+
+		// asserted before anything opens a session, which would build a registry of its own and hide the leak.
+		// The registry the operation installed is suspended with REJECT, so leaving it published would make the
+		// target - a catalog that was never touched - answer `InstanceTerminatedException` for the rest of the
+		// process. Unpublishing it while it is still suspended is also what keeps a racing session request from
+		// landing in a registry that is about to become unreachable.
+		assertTrue(
+			this.evita.getCatalogSessionRegistry(REPLACED_CATALOG).isEmpty(),
+			"A failed replace must unpublish the registry it installed purely to quiesce the target!"
+		);
+		assertEquals(
+			TARGET_VALUE, readPayload(REPLACED_CATALOG, 2),
+			"A failed replace must leave an untouched target readable rather than rejecting sessions!"
+		);
+		assertEquals(
+			COMMITTED_VALUE, readPayload(TEST_CATALOG, 1),
+			"A failed replace must leave the source catalog readable!"
+		);
+	}
+
+	/**
+	 * Closes the engine and boots a new one over the same storage folder.
+	 */
+	private void restartEngine() {
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.waitUntilFullyInitialized();
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameRotatedWalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameRotatedWalTest.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -53,12 +54,17 @@ import static io.evitadb.test.TestTags.STORAGE;
 import static io.evitadb.test.TestTags.TRANSACTION;
 import static io.evitadb.test.TestTags.WAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Covers renaming a live catalog whose write-ahead log has already **rotated and been purged**, which is the one
- * rename shape no other test reaches.
+ * Covers renaming — and replacing — a live catalog whose write-ahead log has already **rotated and been purged**,
+ * which is the one shape no other test of either operation reaches.
+ *
+ * Both halves are here because both go through `ModifyCatalogSchemaNameMutationOperator#doReplaceCatalogInternal`
+ * and through the same `replaceWith`: a rename is a replace whose source and target are the same catalog. Covering
+ * only the rename left the operator half-tested against a rotated log.
  *
  * A rename moves no file: the folder keeps the prefix its files were created under, and the new catalog name is
  * written into the header only. Every log lookup therefore has to go through the prefix discovered from the
@@ -75,8 +81,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * **Calibration** — reverting `DefaultCatalogPersistenceService` (the rename constructor, `walFileNameProvider`)
  * to build the provider from `catalogName` rather than from the inherited storage prefix fails this test on the
- * file-name assertion, with an 8-byte stub written under the new catalog name beside the two files it failed to
- * find: `[renamedCatalog_9.wal, testCatalog_8.wal, testCatalog_9.wal]`.
+ * file-name assertion, with an 8-byte stub written under the new catalog name beside the files it failed to
+ * find - `renamedCatalog_9.wal` appearing beside `testCatalog_8.wal` and `testCatalog_9.wal`.
  *
  * Be precise about what that calibrates. It reconstructs the naming-provider defect, which was introduced *and*
  * fixed inside the folder-decoupling work itself — not the rename loop of issue #1414, which renamed the
@@ -88,13 +94,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
 @Slf4j
-@DisplayName("Rename of a catalog whose write-ahead log has rotated")
+@DisplayName("Rename and replace of a catalog whose write-ahead log has rotated")
 @Tag(STORAGE)
 @Tag(WAL)
 @Tag(TRANSACTION)
 class CatalogRenameRotatedWalTest implements EvitaTestSupport {
 	private static final String ATTRIBUTE_PAYLOAD = "payload";
 	private static final String RENAMED_CATALOG = "renamedCatalog";
+	private static final String REPLACED_CATALOG = "replacedCatalog";
 	/**
 	 * Long enough that a handful of transactions overflow a log file, so the fixture rotates within a count that
 	 * still runs in the fast loop.
@@ -166,6 +173,40 @@ class CatalogRenameRotatedWalTest implements EvitaTestSupport {
 	}
 
 	/**
+	 * Asserts that the operation created no write-ahead log file, which is what the orphaning defect did - it
+	 * wrote a stub under the catalog's new name beside the files it had failed to find.
+	 *
+	 * Stated as "nothing appeared" rather than "nothing changed" on purpose. Retention runs on its own schedule
+	 * and may purge a file at any moment, including while the operation is in flight, so asserting the set is
+	 * unchanged fails on a loaded machine for a reason that has nothing to do with the defect - measured, on a
+	 * full-suite run that saw `[5, 6, 7, 8, 9]` become `[8, 9]` mid-replace.
+	 *
+	 * @param before      log file names captured before the operation
+	 * @param after       log file names present after it
+	 * @param newName     the catalog name the operation introduced, which no file may carry
+	 * @param description what the assertion is about, for the failure message
+	 */
+	private static void assertNoWalFileAppeared(
+		@Nonnull Set<String> before,
+		@Nonnull Set<String> after,
+		@Nonnull String newName,
+		@Nonnull String description
+	) {
+		assertFalse(after.isEmpty(), description + " - the log must not have vanished entirely!");
+		assertTrue(
+			before.containsAll(after),
+			() -> description + " - no write-ahead log file may appear, but " + after +
+				" holds something that " + before + " did not."
+		);
+		final String forbiddenPrefix = newName + "_";
+		assertTrue(
+			after.stream().noneMatch(fileName -> fileName.startsWith(forbiddenPrefix)),
+			() -> description + " - no write-ahead log file may be addressed by the catalog's new name, but " +
+				after + " carries the `" + forbiddenPrefix + "` prefix."
+		);
+	}
+
+	/**
 	 * Asserts the passed indexes form an unbroken ascending run - the premise the log asserts on when it opens,
 	 * and the one the orphaned files of issue #1414 broke.
 	 *
@@ -195,76 +236,143 @@ class CatalogRenameRotatedWalTest implements EvitaTestSupport {
 	@AfterEach
 	void tearDown() {
 		if (this.evita != null && this.evita.isActive()) {
-			this.evita.close();
+			evita().close();
 		}
 		cleanupTestPaths(this.paths);
 	}
 
-	@Test
-	@DisplayName("Keeps the rotated log addressable, and opens again after a restart")
-	void shouldOpenRenamedCatalogWhoseWriteAheadLogHasRotated() throws Exception {
-		defineCatalogAndGoLive();
+	@Nested
+	@DisplayName("Rename")
+	class Rename {
 
-		final String payload = "x".repeat(PAYLOAD_LENGTH);
-		for (int i = 1; i <= TRANSACTION_COUNT; i++) {
-			commitProduct(TEST_CATALOG, i, payload + i);
+		@Test
+		@DisplayName("Keeps the rotated log addressable, and opens again after a restart")
+		void shouldOpenRenamedCatalogWhoseWriteAheadLogHasRotated() throws Exception {
+			defineCatalogAndGoLive();
+
+			final String payload = "x".repeat(PAYLOAD_LENGTH);
+			for (int i = 1; i <= TRANSACTION_COUNT; i++) {
+				commitProduct(TEST_CATALOG, i, payload + i);
+			}
+
+			// the fixture is only meaningful once the retention has purged the oldest files - that is what moves the
+			// surviving run above zero and makes a name-derived lookup observably differ from a prefix-derived one
+			final Path folder = catalogFolder(TEST_CATALOG);
+			awaitWalRotationAndPurge(folder);
+
+			final Set<String> walFilesBeforeRename = walFileNames(folder);
+			final int[] indexesBeforeRename = walIndexes(folder);
+			assertTrue(
+				indexesBeforeRename.length > 1 && indexesBeforeRename[0] > 0,
+				() -> "The fixture must rotate AND purge the log before the rename - it is what this test is for - " +
+					"but the surviving indexes were " + Arrays.toString(indexesBeforeRename) +
+					". Raise TRANSACTION_COUNT or lower WAL_FILE_SIZE_BYTES if the write path got cheaper."
+			);
+
+			evita().renameCatalog(TEST_CATALOG, RENAMED_CATALOG);
+
+			// a rename relabels the catalog and moves nothing, so the folder must hold exactly the files it held
+			// before - neither renamed onto the new name, nor joined by a stub created under it
+			final Path folderAfterRename = catalogFolder(RENAMED_CATALOG);
+			assertEquals(
+				folder, folderAfterRename,
+				"A rename must repoint the name, never move the data!"
+			);
+			assertNoWalFileAppeared(
+				walFilesBeforeRename, walFileNames(folderAfterRename), RENAMED_CATALOG, "After the rename"
+			);
+			assertContiguous(walIndexes(folderAfterRename), "After the rename");
+
+			// the write path has to stay anchored to the same prefix too: a transaction committed after the rename
+			// must extend the run the folder already carries rather than start a second one under the new name
+			commitProduct(RENAMED_CATALOG, TRANSACTION_COUNT + 1, "committed after the rename");
+			assertContiguous(walIndexes(folderAfterRename), "After a commit that follows the rename");
+
+			// the last transaction stops at WAL persistence rather than at visibility, so the log may still hold an
+			// unincorporated record when the engine goes down - which is what puts the restart on the replay path
+			// instead of merely on the addressing one. It is deliberately not asserted that replay *did* run: trunk
+			// incorporation is free to have caught up first, and a test that demanded it lose that race would be
+			// flaky. Either way the entity has to be there afterwards, and only one of the two paths can deliver it.
+			commitProductAwaitingWalOnly(RENAMED_CATALOG, TRANSACTION_COUNT + 2, "committed into the log only");
+
+			// the reported failure was a boot that threw out of the log's constructor, so the restart is the assertion
+			restartEngine();
+
+			assertTrue(
+				evita().getCatalogNames().contains(RENAMED_CATALOG),
+				"The renamed catalog must come back from the restart!"
+			);
+			assertEquals(
+				TRANSACTION_COUNT + 2, productCount(RENAMED_CATALOG),
+				"Every transaction committed around the rename must survive the restart!"
+			);
+			assertContiguous(walIndexes(catalogFolder(RENAMED_CATALOG)), "After the restart");
 		}
 
-		// the fixture is only meaningful once the retention has purged the oldest files - that is what moves the
-		// surviving run above zero and makes a name-derived lookup observably differ from a prefix-derived one
-		final Path folder = catalogFolder(TEST_CATALOG);
-		awaitWalRotationAndPurge(folder);
+	}
 
-		final Set<String> walFilesBeforeRename = walFileNames(folder);
-		final int[] indexesBeforeRename = walIndexes(folder);
-		assertTrue(
-			indexesBeforeRename.length > 1 && indexesBeforeRename[0] > 0,
-			() -> "The fixture must rotate AND purge the log before the rename - it is what this test is for - " +
-				"but the surviving indexes were " + Arrays.toString(indexesBeforeRename) +
-				". Raise TRANSACTION_COUNT or lower WAL_FILE_SIZE_BYTES if the write path got cheaper."
-		);
+	@Nested
+	@DisplayName("Replace")
+	class Replace {
 
-		this.evita.renameCatalog(TEST_CATALOG, RENAMED_CATALOG);
+		@Test
+		@DisplayName("Keeps the surviving catalog's rotated log addressable, and opens again after a restart")
+		void shouldOpenReplacedCatalogWhoseWriteAheadLogHasRotated() throws Exception {
+			defineCatalogAndGoLive();
 
-		// a rename relabels the catalog and moves nothing, so the folder must hold exactly the files it held
-		// before - neither renamed onto the new name, nor joined by a stub created under it
-		final Path folderAfterRename = catalogFolder(RENAMED_CATALOG);
-		assertEquals(
-			folder, folderAfterRename,
-			"A rename must repoint the name, never move the data!"
-		);
-		assertEquals(
-			walFilesBeforeRename, walFileNames(folderAfterRename),
-			"The rename must leave every write-ahead log file exactly as it found it!"
-		);
-		assertContiguous(walIndexes(folderAfterRename), "After the rename");
+			// the catalog being replaced *away* only has to exist - a replace purges it entirely, so the surviving
+			// data, and the log this test is about, are the source's
+			evita().defineCatalog(REPLACED_CATALOG);
 
-		// the write path has to stay anchored to the same prefix too: a transaction committed after the rename
-		// must extend the run the folder already carries rather than start a second one under the new name
-		commitProduct(RENAMED_CATALOG, TRANSACTION_COUNT + 1, "committed after the rename");
-		assertContiguous(walIndexes(folderAfterRename), "After a commit that follows the rename");
+			final String payload = "x".repeat(PAYLOAD_LENGTH);
+			for (int i = 1; i <= TRANSACTION_COUNT; i++) {
+				commitProduct(TEST_CATALOG, i, payload + i);
+			}
 
-		// the last transaction stops at WAL persistence rather than at visibility, so the log may still hold an
-		// unincorporated record when the engine goes down - which is what puts the restart on the replay path
-		// instead of merely on the addressing one. It is deliberately not asserted that replay *did* run: trunk
-		// incorporation is free to have caught up first, and a test that demanded it lose that race would be
-		// flaky. Either way the entity has to be there afterwards, and only one of the two paths can deliver it.
-		commitProductAwaitingWalOnly(RENAMED_CATALOG, TRANSACTION_COUNT + 2, "committed into the log only");
+			final Path survivingFolder = catalogFolder(TEST_CATALOG);
+			awaitWalRotationAndPurge(survivingFolder);
 
-		// the reported failure was a boot that threw out of the log's constructor, so the restart is the assertion
-		this.evita.close();
-		this.evita = new Evita(getEvitaConfiguration());
-		this.evita.waitUntilFullyInitialized();
+			final Set<String> walFilesBeforeReplace = walFileNames(survivingFolder);
+			final int[] indexesBeforeReplace = walIndexes(survivingFolder);
+			assertTrue(
+				indexesBeforeReplace.length > 1 && indexesBeforeReplace[0] > 0,
+				() -> "The fixture must rotate AND purge the log before the replace - it is what this test is " +
+					"for - but the surviving indexes were " + Arrays.toString(indexesBeforeReplace) +
+					". Raise TRANSACTION_COUNT or lower WAL_FILE_SIZE_BYTES if the write path got cheaper."
+			);
 
-		assertTrue(
-			this.evita.getCatalogNames().contains(RENAMED_CATALOG),
-			"The renamed catalog must come back from the restart!"
-		);
-		assertEquals(
-			TRANSACTION_COUNT + 2, productCount(RENAMED_CATALOG),
-			"Every transaction committed around the rename must survive the restart!"
-		);
-		assertContiguous(walIndexes(catalogFolder(RENAMED_CATALOG)), "After the restart");
+			evita().replaceCatalog(TEST_CATALOG, REPLACED_CATALOG);
+
+			// a replace repoints the target's name at the source's folder and tombstones the folder the target
+			// occupied. The source folder - the one that survives - must be as untouched as it is by a rename:
+			// the two operations run through the same operator, and only the rename half was ever covered here.
+			final Path folderAfterReplace = catalogFolder(REPLACED_CATALOG);
+			assertEquals(
+				survivingFolder, folderAfterReplace,
+				"A replace must repoint the name at the surviving folder, never move the data!"
+			);
+			assertNoWalFileAppeared(
+				walFilesBeforeReplace, walFileNames(folderAfterReplace), REPLACED_CATALOG, "After the replace"
+			);
+			assertContiguous(walIndexes(folderAfterReplace), "After the replace");
+
+			commitProduct(REPLACED_CATALOG, TRANSACTION_COUNT + 1, "committed after the replace");
+			assertContiguous(walIndexes(folderAfterReplace), "After a commit that follows the replace");
+			commitProductAwaitingWalOnly(REPLACED_CATALOG, TRANSACTION_COUNT + 2, "committed into the log only");
+
+			restartEngine();
+
+			assertTrue(
+				evita().getCatalogNames().contains(REPLACED_CATALOG),
+				"The catalog must come back from the restart under the name it was replaced into!"
+			);
+			assertEquals(
+				TRANSACTION_COUNT + 2, productCount(REPLACED_CATALOG),
+				"Every transaction committed around the replace must survive the restart!"
+			);
+			assertContiguous(walIndexes(catalogFolder(REPLACED_CATALOG)), "After the restart");
+		}
+
 	}
 
 	/**
@@ -285,6 +393,28 @@ class CatalogRenameRotatedWalTest implements EvitaTestSupport {
 		}
 		// deliberately silent - the caller asserts the precondition, so a timeout surfaces as the assertion
 		// naming what was actually on disk rather than as a bare timeout
+	}
+
+	/**
+	 * Returns the engine the nested tests run against. They cannot reach the field directly, and the qualified
+	 * form of the reference is unreadable at every call site.
+	 *
+	 * @return the running engine, never null
+	 */
+	@Nonnull
+	private Evita evita() {
+		return this.evita;
+	}
+
+	/**
+	 * Shuts the engine down and boots a fresh one over the same directories, in the same JVM - which is what puts
+	 * the next catalog load on the path issue #1414 died on, and what would surface a folder lock the previous
+	 * instance failed to release.
+	 */
+	private void restartEngine() {
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.waitUntilFullyInitialized();
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameRotatedWalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameRotatedWalTest.java
@@ -110,8 +110,6 @@ class CatalogRenameRotatedWalTest implements EvitaTestSupport {
 	private static final int TRANSACTION_COUNT = 30;
 	private static final long WAL_FILE_SIZE_BYTES = 16_384L;
 	private static final int WAL_FILE_COUNT_KEPT = 2;
-	private static final long WAIT_TIMEOUT_MILLIS = 60_000L;
-	private static final long POLL_INTERVAL_MILLIS = 100L;
 
 	private TestPaths paths;
 	private Evita evita;
@@ -257,9 +255,9 @@ class CatalogRenameRotatedWalTest implements EvitaTestSupport {
 
 			// the fixture is only meaningful once the retention has purged the oldest files - that is what moves the
 			// surviving run above zero and makes a name-derived lookup observably differ from a prefix-derived one
-			final Path folder = catalogFolder(TEST_CATALOG);
-			awaitWalRotationAndPurge(folder);
+			purgeRotatedWalFiles();
 
+			final Path folder = catalogFolder(TEST_CATALOG);
 			final Set<String> walFilesBeforeRename = walFileNames(folder);
 			final int[] indexesBeforeRename = walIndexes(folder);
 			assertTrue(
@@ -329,9 +327,9 @@ class CatalogRenameRotatedWalTest implements EvitaTestSupport {
 				commitProduct(TEST_CATALOG, i, payload + i);
 			}
 
-			final Path survivingFolder = catalogFolder(TEST_CATALOG);
-			awaitWalRotationAndPurge(survivingFolder);
+			purgeRotatedWalFiles();
 
+			final Path survivingFolder = catalogFolder(TEST_CATALOG);
 			final Set<String> walFilesBeforeReplace = walFileNames(survivingFolder);
 			final int[] indexesBeforeReplace = walIndexes(survivingFolder);
 			assertTrue(
@@ -376,23 +374,20 @@ class CatalogRenameRotatedWalTest implements EvitaTestSupport {
 	}
 
 	/**
-	 * Waits until the log has rotated far enough for the retention to have purged the oldest files, which is what
-	 * moves the first surviving index off zero.
+	 * Purges the WAL files the commits above rotated away, which is what moves the first surviving index off zero
+	 * and makes a name-derived lookup observably differ from a prefix-derived one.
 	 *
-	 * @param catalogDirectory folder to watch
+	 * **Done by shutting the engine down rather than by waiting for it to happen.** Rotation only queues a file
+	 * for removal; the deletion itself runs on `AbstractMutationLog`'s scheduled "WAL file remover" task, so no
+	 * commit completion implies it and there is nothing in the write path to latch on. `AbstractMutationLog#close`
+	 * drains those pending removals **synchronously**, so a restart is not a wait for the purge - it *is* the
+	 * purge, and the state on disk afterwards is the same whether the machine is idle or saturated.
+	 *
+	 * The alternative, polling the folder until the indexes move, is what this replaced: a positive wait paid on
+	 * every run, and one that reports a fixture that never converged as a failure of whatever ran next.
 	 */
-	private static void awaitWalRotationAndPurge(@Nonnull Path catalogDirectory) throws InterruptedException {
-		final long deadline = System.currentTimeMillis() + WAIT_TIMEOUT_MILLIS;
-		while (System.currentTimeMillis() < deadline) {
-			final int[] indexes = walIndexes(catalogDirectory);
-			if (indexes.length > 1 && indexes[0] > 0) {
-				return;
-			}
-			//noinspection BusyWait
-			Thread.sleep(POLL_INTERVAL_MILLIS);
-		}
-		// deliberately silent - the caller asserts the precondition, so a timeout surfaces as the assertion
-		// naming what was actually on disk rather than as a bare timeout
+	private void purgeRotatedWalFiles() {
+		restartEngine();
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameRotatedWalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameRotatedWalTest.java
@@ -1,0 +1,397 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.SessionTraits;
+import io.evitadb.api.SessionTraits.SessionFlags;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.configuration.TransactionOptions;
+import io.evitadb.spi.store.catalog.persistence.PersistenceService;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.evitadb.test.TestTags.STORAGE;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static io.evitadb.test.TestTags.WAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers renaming a live catalog whose write-ahead log has already **rotated and been purged**, which is the one
+ * rename shape no other test reaches.
+ *
+ * A rename moves no file: the folder keeps the prefix its files were created under, and the new catalog name is
+ * written into the header only. Every log lookup therefore has to go through the prefix discovered from the
+ * folder, never through the catalog name the header now carries. Derived from the name instead, the lookup
+ * addresses a file that does not exist, reports the log empty and creates a fresh one beside the files it failed
+ * to find — and the next boot then sees indexes that are not consecutive and refuses to open the catalog at all
+ * (`AbstractMutationLog#getFirstAndLastWalFileIndex` asserts the run is unbroken).
+ *
+ * The sibling case in `EvitaTest#shouldKeepWriteAheadLogAddressableAfterRename` commits a single transaction, so
+ * its log never leaves index 0 — with one file, a name-derived lookup and a prefix-derived one differ only in the
+ * file they create, and both leave a consecutive run behind. Rotation is what makes the two observably diverge,
+ * and it is why this fixture writes enough transactions to rotate the log **and** waits for the retention to
+ * purge the oldest files, so the surviving run starts above zero.
+ *
+ * **Calibration** — reverting `DefaultCatalogPersistenceService` (the rename constructor, `walFileNameProvider`)
+ * to build the provider from `catalogName` rather than from the inherited storage prefix fails this test on the
+ * file-name assertion, with an 8-byte stub written under the new catalog name beside the two files it failed to
+ * find: `[renamedCatalog_9.wal, testCatalog_8.wal, testCatalog_9.wal]`.
+ *
+ * Be precise about what that calibrates. It reconstructs the naming-provider defect, which was introduced *and*
+ * fixed inside the folder-decoupling work itself — not the rename loop of issue #1414, which renamed the
+ * bootstrap and the current data file and moved the directory. That code no longer exists to be reverted, so no
+ * one-line edit can reconstruct it; what the two have in common is the on-disk result, an orphaned log under the
+ * former name beside a stub under the new one, which is what this test detects. The argument that the original
+ * mechanism is gone is architectural and belongs in the ADR, not in a calibration.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Slf4j
+@DisplayName("Rename of a catalog whose write-ahead log has rotated")
+@Tag(STORAGE)
+@Tag(WAL)
+@Tag(TRANSACTION)
+class CatalogRenameRotatedWalTest implements EvitaTestSupport {
+	private static final String ATTRIBUTE_PAYLOAD = "payload";
+	private static final String RENAMED_CATALOG = "renamedCatalog";
+	/**
+	 * Long enough that a handful of transactions overflow a log file, so the fixture rotates within a count that
+	 * still runs in the fast loop.
+	 */
+	private static final int PAYLOAD_LENGTH = 4_096;
+	private static final int TRANSACTION_COUNT = 30;
+	private static final long WAL_FILE_SIZE_BYTES = 16_384L;
+	private static final int WAL_FILE_COUNT_KEPT = 2;
+	private static final long WAIT_TIMEOUT_MILLIS = 60_000L;
+	private static final long POLL_INTERVAL_MILLIS = 100L;
+
+	private TestPaths paths;
+	private Evita evita;
+
+	/**
+	 * Lists the write-ahead log files present in the passed folder.
+	 *
+	 * @param catalogDirectory folder to list
+	 * @return the log files found, never null
+	 */
+	@Nonnull
+	private static File[] listWalFiles(@Nonnull Path catalogDirectory) {
+		final File[] walFiles = catalogDirectory.toFile().listFiles(
+			(dir, name) -> name.endsWith(PersistenceService.WAL_FILE_SUFFIX)
+		);
+		return walFiles == null ? new File[0] : walFiles;
+	}
+
+	/**
+	 * Returns the names of the write-ahead log files present in the passed folder, in ascending index order.
+	 *
+	 * @param catalogDirectory folder to inspect
+	 * @return the file names, never null
+	 */
+	@Nonnull
+	private static Set<String> walFileNames(@Nonnull Path catalogDirectory) {
+		return Arrays.stream(listWalFiles(catalogDirectory))
+			.map(File::getName)
+			.sorted()
+			.collect(Collectors.toCollection(LinkedHashSet::new));
+	}
+
+	/**
+	 * Parses the index out of a write-ahead log file name locally, so the assertions depend on the file naming
+	 * convention itself rather than on the storage module's own parser.
+	 *
+	 * @param walFileName the file name to parse
+	 * @return the index the file carries
+	 */
+	private static int walIndex(@Nonnull String walFileName) {
+		final String withoutSuffix = walFileName.substring(
+			0, walFileName.length() - PersistenceService.WAL_FILE_SUFFIX.length()
+		);
+		return Integer.parseInt(withoutSuffix.substring(withoutSuffix.lastIndexOf('_') + 1));
+	}
+
+	/**
+	 * Returns the sorted write-ahead log indexes present in the passed folder.
+	 *
+	 * @param catalogDirectory folder to inspect
+	 * @return sorted indexes, never null
+	 */
+	@Nonnull
+	private static int[] walIndexes(@Nonnull Path catalogDirectory) {
+		return Arrays.stream(listWalFiles(catalogDirectory))
+			.mapToInt(file -> walIndex(file.getName()))
+			.sorted()
+			.toArray();
+	}
+
+	/**
+	 * Asserts the passed indexes form an unbroken ascending run - the premise the log asserts on when it opens,
+	 * and the one the orphaned files of issue #1414 broke.
+	 *
+	 * @param indexes sorted indexes to check
+	 * @param message what the run is being asserted about
+	 */
+	private static void assertContiguous(@Nonnull int[] indexes, @Nonnull String message) {
+		assertTrue(indexes.length > 0, message + " - at least one write-ahead log file must exist!");
+		for (int i = 1; i < indexes.length; i++) {
+			final int position = i;
+			assertEquals(
+				indexes[i - 1] + 1, indexes[i],
+				() -> message + " - the indexes must be consecutive, but " + Arrays.toString(indexes) +
+					" jumps at position " + position
+			);
+		}
+	}
+
+	@BeforeEach
+	void setUp() throws IOException {
+		this.paths = createTestPaths(CatalogRenameRotatedWalTest.class.getSimpleName());
+		Files.createDirectories(this.paths.storage());
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.waitUntilFullyInitialized();
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (this.evita != null && this.evita.isActive()) {
+			this.evita.close();
+		}
+		cleanupTestPaths(this.paths);
+	}
+
+	@Test
+	@DisplayName("Keeps the rotated log addressable, and opens again after a restart")
+	void shouldOpenRenamedCatalogWhoseWriteAheadLogHasRotated() throws Exception {
+		defineCatalogAndGoLive();
+
+		final String payload = "x".repeat(PAYLOAD_LENGTH);
+		for (int i = 1; i <= TRANSACTION_COUNT; i++) {
+			commitProduct(TEST_CATALOG, i, payload + i);
+		}
+
+		// the fixture is only meaningful once the retention has purged the oldest files - that is what moves the
+		// surviving run above zero and makes a name-derived lookup observably differ from a prefix-derived one
+		final Path folder = catalogFolder(TEST_CATALOG);
+		awaitWalRotationAndPurge(folder);
+
+		final Set<String> walFilesBeforeRename = walFileNames(folder);
+		final int[] indexesBeforeRename = walIndexes(folder);
+		assertTrue(
+			indexesBeforeRename.length > 1 && indexesBeforeRename[0] > 0,
+			() -> "The fixture must rotate AND purge the log before the rename - it is what this test is for - " +
+				"but the surviving indexes were " + Arrays.toString(indexesBeforeRename) +
+				". Raise TRANSACTION_COUNT or lower WAL_FILE_SIZE_BYTES if the write path got cheaper."
+		);
+
+		this.evita.renameCatalog(TEST_CATALOG, RENAMED_CATALOG);
+
+		// a rename relabels the catalog and moves nothing, so the folder must hold exactly the files it held
+		// before - neither renamed onto the new name, nor joined by a stub created under it
+		final Path folderAfterRename = catalogFolder(RENAMED_CATALOG);
+		assertEquals(
+			folder, folderAfterRename,
+			"A rename must repoint the name, never move the data!"
+		);
+		assertEquals(
+			walFilesBeforeRename, walFileNames(folderAfterRename),
+			"The rename must leave every write-ahead log file exactly as it found it!"
+		);
+		assertContiguous(walIndexes(folderAfterRename), "After the rename");
+
+		// the write path has to stay anchored to the same prefix too: a transaction committed after the rename
+		// must extend the run the folder already carries rather than start a second one under the new name
+		commitProduct(RENAMED_CATALOG, TRANSACTION_COUNT + 1, "committed after the rename");
+		assertContiguous(walIndexes(folderAfterRename), "After a commit that follows the rename");
+
+		// the last transaction stops at WAL persistence rather than at visibility, so the log may still hold an
+		// unincorporated record when the engine goes down - which is what puts the restart on the replay path
+		// instead of merely on the addressing one. It is deliberately not asserted that replay *did* run: trunk
+		// incorporation is free to have caught up first, and a test that demanded it lose that race would be
+		// flaky. Either way the entity has to be there afterwards, and only one of the two paths can deliver it.
+		commitProductAwaitingWalOnly(RENAMED_CATALOG, TRANSACTION_COUNT + 2, "committed into the log only");
+
+		// the reported failure was a boot that threw out of the log's constructor, so the restart is the assertion
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.waitUntilFullyInitialized();
+
+		assertTrue(
+			this.evita.getCatalogNames().contains(RENAMED_CATALOG),
+			"The renamed catalog must come back from the restart!"
+		);
+		assertEquals(
+			TRANSACTION_COUNT + 2, productCount(RENAMED_CATALOG),
+			"Every transaction committed around the rename must survive the restart!"
+		);
+		assertContiguous(walIndexes(catalogFolder(RENAMED_CATALOG)), "After the restart");
+	}
+
+	/**
+	 * Waits until the log has rotated far enough for the retention to have purged the oldest files, which is what
+	 * moves the first surviving index off zero.
+	 *
+	 * @param catalogDirectory folder to watch
+	 */
+	private static void awaitWalRotationAndPurge(@Nonnull Path catalogDirectory) throws InterruptedException {
+		final long deadline = System.currentTimeMillis() + WAIT_TIMEOUT_MILLIS;
+		while (System.currentTimeMillis() < deadline) {
+			final int[] indexes = walIndexes(catalogDirectory);
+			if (indexes.length > 1 && indexes[0] > 0) {
+				return;
+			}
+			//noinspection BusyWait
+			Thread.sleep(POLL_INTERVAL_MILLIS);
+		}
+		// deliberately silent - the caller asserts the precondition, so a timeout surfaces as the assertion
+		// naming what was actually on disk rather than as a bare timeout
+	}
+
+	/**
+	 * Resolves the folder the passed catalog is bound to - an opaque token, not the catalog's name.
+	 *
+	 * @param catalogName the catalog whose folder to resolve
+	 * @return the folder path, never null
+	 */
+	@Nonnull
+	private Path catalogFolder(@Nonnull String catalogName) {
+		return this.paths.storage()
+			.resolve(this.evita.getCatalogFolderContext().folderIdFor(catalogName).id());
+	}
+
+	/**
+	 * Commits a single product in its own transaction and waits until the change is visible.
+	 *
+	 * @param catalogName    catalog to write into
+	 * @param primaryKey     primary key of the product
+	 * @param attributeValue value stored in the payload attribute
+	 */
+	private void commitProduct(@Nonnull String catalogName, int primaryKey, @Nonnull String attributeValue) {
+		final EvitaSessionContract session = this.evita.createSession(
+			new SessionTraits(catalogName, SessionFlags.READ_WRITE));
+		session.upsertEntity(
+			session.createNewEntity(Entities.PRODUCT, primaryKey)
+			       .setAttribute(ATTRIBUTE_PAYLOAD, attributeValue)
+		);
+		assertNotNull(session.closeNowWithProgress().onChangesVisible().toCompletableFuture().join());
+	}
+
+	/**
+	 * Commits a single product and waits only until its record is persisted in the log, leaving the trunk
+	 * incorporation to run - or not run - before the engine goes down.
+	 *
+	 * @param catalogName    catalog to write into
+	 * @param primaryKey     primary key of the product
+	 * @param attributeValue value stored in the payload attribute
+	 */
+	private void commitProductAwaitingWalOnly(
+		@Nonnull String catalogName,
+		int primaryKey,
+		@Nonnull String attributeValue
+	) {
+		final EvitaSessionContract session = this.evita.createSession(
+			new SessionTraits(catalogName, SessionFlags.READ_WRITE));
+		session.upsertEntity(
+			session.createNewEntity(Entities.PRODUCT, primaryKey)
+			       .setAttribute(ATTRIBUTE_PAYLOAD, attributeValue)
+		);
+		assertNotNull(session.closeNowWithProgress().onWalAppended().toCompletableFuture().join());
+	}
+
+	/**
+	 * Counts the products stored in the passed catalog.
+	 *
+	 * @param catalogName catalog to read
+	 * @return number of products found
+	 */
+	private int productCount(@Nonnull String catalogName) {
+		return this.evita.queryCatalog(
+			catalogName,
+			session -> {
+				return session.getEntityCollectionSize(Entities.PRODUCT);
+			}
+		);
+	}
+
+	/**
+	 * Defines the catalog with a single product schema and takes it live.
+	 */
+	private void defineCatalogAndGoLive() {
+		this.evita.defineCatalog(TEST_CATALOG);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.PRODUCT)
+				       .withoutGeneratedPrimaryKey()
+				       .withAttribute(ATTRIBUTE_PAYLOAD, String.class)
+				       .updateVia(session);
+				session.goLiveAndClose();
+			}
+		);
+	}
+
+	/**
+	 * Configuration with a narrow log and a shallow retention - which is what makes the log rotate and purge
+	 * within a transaction count that still belongs in the fast loop.
+	 *
+	 * @return the configuration, never null
+	 */
+	@Nonnull
+	private EvitaConfiguration getEvitaConfiguration() {
+		return newTestEvitaConfigurationBuilder(this.paths)
+			.storage(
+				StorageOptions.builder()
+					.storageDirectory(this.paths.storage())
+					.workDirectory(this.paths.work())
+					.build()
+			)
+			.transaction(
+				TransactionOptions.builder()
+					.walFileSizeBytes(WAL_FILE_SIZE_BYTES)
+					.walFileCountKept(WAL_FILE_COUNT_KEPT)
+					.build()
+			)
+			.build();
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameUnpublishedHeaderTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogRenameUnpublishedHeaderTest.java
@@ -1,0 +1,342 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.SessionTraits;
+import io.evitadb.api.SessionTraits.SessionFlags;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static io.evitadb.test.TestTags.STORAGE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers a crash **between the catalog header write and the bootstrap publish** inside
+ * `DefaultCatalogPersistenceService#replaceWith` - the one window of a rename that nothing exercised.
+ *
+ * `replaceWith` writes the renamed catalog's header into the offset index and only then publishes a bootstrap
+ * record pointing at it; the engine-state commit that repoints the *name* happens later still. A process killed
+ * between the first two therefore leaves a data file carrying a header no bootstrap record refers to, over an
+ * engine state and a bootstrap that both still describe the catalog under its former name. The decoupling ADR
+ * argues this is safe because nothing has been repointed yet. This test is that argument, executed.
+ *
+ * **The fixture is a real crash artefact, not a hand-written one.** Every byte here is engine output: the storage
+ * directory is snapshotted before the rename, the rename is then performed for real, and everything *except* the
+ * catalog data files is rewound. That is exactly what the window leaves behind - the data file is append-only, so
+ * the header the rename wrote survives in it as unreferenced tail, while the bootstrap, the engine state and the
+ * folder's `.catalogname` label are all still the pre-rename ones.
+ *
+ * **Why a partial rewind here, when `CatalogRenameCrashReplayTest` insists on restoring the whole directory.**
+ * That test rewinds a *completed* commit, so anything it left out would describe a world no crash could produce -
+ * a catalog bound to a folder a later step had already deleted. This window sits strictly before the commit:
+ * nothing has been deleted, nothing repointed, and the data file's extra tail is precisely the asymmetry a crash
+ * there produces. Rewinding the data file too would model a crash *before* the header write, which is a different
+ * and considerably less interesting window.
+ *
+ * **No defect-injection calibration, deliberately, and here is what to check instead.** The other tests in this
+ * area are calibrated by reverting the line they guard; this one has no such line, because what it asserts is
+ * structural - an offset index reads through the root descriptor its bootstrap record names, so bytes past that
+ * descriptor are invisible rather than tolerated. There is nothing to revert that would make the window unsafe
+ * without redesigning the write path. What this test would catch is a change that ends that property: a strict
+ * "the data file must be exactly as long as the descriptor says" check on load, a retry that trips over the dead
+ * header, or a reordering that publishes the bootstrap record before the header it points at. The fixture guards
+ * itself with `assertDataFileGrewSince`, so it fails rather than silently passing if the rename stops appending.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Slf4j
+@DisplayName("Crash between the catalog header write and the bootstrap publish")
+@Tag(STORAGE)
+@Tag(MANAGEMENT)
+class CatalogRenameUnpublishedHeaderTest implements EvitaTestSupport {
+	private static final String ATTRIBUTE_PAYLOAD = "payload";
+	private static final String RENAMED_CATALOG = "renamedCatalog";
+	private static final String COMMITTED_VALUE = "committed before the crashed rename";
+	private static final String CATALOG_FILE_SUFFIX = ".catalog";
+
+	private TestPaths paths;
+	private Evita evita;
+
+	/**
+	 * Managed by JUnit, and deliberately outside the directories the engine knows about, so nothing can mistake
+	 * the snapshot for a catalog.
+	 */
+	@TempDir
+	private Path snapshotRoot;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		this.paths = createTestPaths(CatalogRenameUnpublishedHeaderTest.class.getSimpleName());
+		Files.createDirectories(this.paths.storage());
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (this.evita != null && this.evita.isActive()) {
+			this.evita.close();
+		}
+		cleanupTestPaths(this.paths);
+	}
+
+	@Test
+	@DisplayName("Leaves the catalog under its former name, usable, and renameable afterwards")
+	void shouldIgnoreAHeaderNoBootstrapRecordPointsAt() {
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.waitUntilFullyInitialized();
+		defineCatalogAndGoLive();
+		commitProduct(TEST_CATALOG, 1, COMMITTED_VALUE);
+		this.evita.close();
+
+		// the world as it stands before the rename writes anything at all
+		final Path snapshot = captureStorage();
+
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.waitUntilFullyInitialized();
+		this.evita.renameCatalog(TEST_CATALOG, RENAMED_CATALOG);
+		this.evita.close();
+
+		// The whole fixture rests on the rename having appended something to the data file: if it wrote its
+		// header anywhere else, rewinding around that file models nothing and this test passes for no reason.
+		// Asserted rather than assumed, so a change to where the header goes fails here instead of quietly
+		// turning the crash into a no-op.
+		assertDataFileGrewSince(snapshot);
+
+		// rewind everything the crash would not have reached, and keep the data file the rename appended its
+		// header to - the header is in there, and no bootstrap record names it any more
+		rewindEverythingButTheCatalogData(snapshot);
+
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.waitUntilFullyInitialized();
+
+		// nothing was repointed before the crash, so the catalog has to answer to the name it had all along
+		assertTrue(
+			this.evita.getCatalogNames().contains(TEST_CATALOG),
+			"A crash before the bootstrap publish must leave the catalog under its former name!"
+		);
+		assertFalse(
+			this.evita.getCatalogNames().contains(RENAMED_CATALOG),
+			"The rename never became durable, so its name must not be known to the engine!"
+		);
+		assertEquals(
+			COMMITTED_VALUE, readPayload(TEST_CATALOG, 1),
+			"The unpublished header must not cost the catalog its data!"
+		);
+
+		// and the failed attempt must not poison the next one - the dead header sits in the same file the retry
+		// appends to
+		this.evita.renameCatalog(TEST_CATALOG, RENAMED_CATALOG);
+		assertEquals(
+			COMMITTED_VALUE, readPayload(RENAMED_CATALOG, 1),
+			"A rename retried after the crash must succeed and keep the data!"
+		);
+
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.waitUntilFullyInitialized();
+		assertEquals(
+			COMMITTED_VALUE, readPayload(RENAMED_CATALOG, 1),
+			"The retried rename must survive a restart of its own!"
+		);
+	}
+
+	/**
+	 * Asserts the rename appended to the catalog data file - the unreferenced header whose survival across the
+	 * rewind is the entire point of the fixture.
+	 *
+	 * @param snapshot the pre-rename snapshot to compare against
+	 */
+	private void assertDataFileGrewSince(@Nonnull Path snapshot) {
+		final long before = soleCatalogDataFileSize(snapshot);
+		final long after = soleCatalogDataFileSize(this.paths.storage());
+		assertTrue(
+			after > before,
+			() -> "The rename must have appended its header to the catalog data file, but the file went from " +
+				before + " B to " + after + " B - the fixture would model nothing."
+		);
+	}
+
+	/**
+	 * Returns the size of the single catalog data file found anywhere under the passed directory.
+	 *
+	 * @param root directory to search
+	 * @return size of the data file in bytes
+	 */
+	private static long soleCatalogDataFileSize(@Nonnull Path root) {
+		try (final Stream<Path> tree = Files.walk(root)) {
+			final List<Path> dataFiles = tree
+				.filter(path -> path.getFileName().toString().endsWith(CATALOG_FILE_SUFFIX))
+				.toList();
+			assertEquals(1, dataFiles.size(), () -> "Exactly one catalog data file is expected under " + root + "!");
+			return Files.size(dataFiles.get(0));
+		} catch (IOException ex) {
+			throw new IllegalStateException("Cannot measure the catalog data file under `" + root + "`!", ex);
+		}
+	}
+
+	/**
+	 * Copies the whole storage directory aside. The engine must be closed.
+	 *
+	 * @return the directory the snapshot was written to
+	 */
+	@Nonnull
+	private Path captureStorage() {
+		final Path snapshot = this.snapshotRoot.resolve("storage-" + UUID.randomUUID());
+		copyTree(this.paths.storage(), snapshot, false);
+		return snapshot;
+	}
+
+	/**
+	 * Puts the snapshot back over the live storage directory, leaving every catalog data file as the rename left
+	 * it. The engine must be closed.
+	 *
+	 * @param snapshot directory to rewind from
+	 */
+	private void rewindEverythingButTheCatalogData(@Nonnull Path snapshot) {
+		copyTree(snapshot, this.paths.storage(), true);
+	}
+
+	/**
+	 * Copies a directory tree over another, optionally leaving catalog data files in the target untouched.
+	 * Deliberately plain: the trees are a handful of small files, and a fixture that needs explaining is a
+	 * fixture that gets doubted.
+	 *
+	 * @param source        tree to copy from
+	 * @param target        tree to copy into
+	 * @param keepDataFiles when true, `*.catalog` files already present in the target are left alone
+	 */
+	private static void copyTree(@Nonnull Path source, @Nonnull Path target, boolean keepDataFiles) {
+		try {
+			final List<Path> entries;
+			try (final Stream<Path> tree = Files.walk(source)) {
+				entries = tree.toList();
+			}
+			for (final Path entry : entries) {
+				final Path destination = target.resolve(source.relativize(entry).toString());
+				if (Files.isDirectory(entry)) {
+					Files.createDirectories(destination);
+				} else if (!keepDataFiles || !entry.getFileName().toString().endsWith(CATALOG_FILE_SUFFIX)) {
+					Files.createDirectories(destination.getParent());
+					Files.copy(entry, destination, StandardCopyOption.REPLACE_EXISTING);
+				}
+			}
+		} catch (IOException ex) {
+			throw new IllegalStateException("Cannot copy `" + source + "` to `" + target + "`!", ex);
+		}
+	}
+
+	/**
+	 * Commits a single product in its own transaction and waits until the change is visible.
+	 *
+	 * @param catalogName    catalog to write into
+	 * @param primaryKey     primary key of the product
+	 * @param attributeValue value stored in the payload attribute
+	 */
+	private void commitProduct(@Nonnull String catalogName, int primaryKey, @Nonnull String attributeValue) {
+		final EvitaSessionContract session = this.evita.createSession(
+			new SessionTraits(catalogName, SessionFlags.READ_WRITE));
+		session.upsertEntity(
+			session.createNewEntity(Entities.PRODUCT, primaryKey)
+			       .setAttribute(ATTRIBUTE_PAYLOAD, attributeValue)
+		);
+		assertNotNull(session.closeNowWithProgress().onChangesVisible().toCompletableFuture().join());
+	}
+
+	/**
+	 * Reads a single product's payload attribute back through a fresh session.
+	 *
+	 * @param catalogName catalog to read from
+	 * @param primaryKey  primary key of the product
+	 * @return the stored payload
+	 */
+	@Nonnull
+	private String readPayload(@Nonnull String catalogName, int primaryKey) {
+		return this.evita.queryCatalog(
+			catalogName,
+			session -> {
+				return session.getEntity(Entities.PRODUCT, primaryKey, attributeContentAll())
+					.orElseThrow(() -> new AssertionError("The product must be present!"))
+					.getAttribute(ATTRIBUTE_PAYLOAD, String.class);
+			}
+		);
+	}
+
+	/**
+	 * Defines the catalog with a single product schema and takes it live.
+	 */
+	private void defineCatalogAndGoLive() {
+		this.evita.defineCatalog(TEST_CATALOG);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.PRODUCT)
+				       .withoutGeneratedPrimaryKey()
+				       .withAttribute(ATTRIBUTE_PAYLOAD, String.class)
+				       .updateVia(session);
+				session.goLiveAndClose();
+			}
+		);
+	}
+
+	/**
+	 * Stock storage options - nothing here depends on the log or on time travel.
+	 *
+	 * @return the configuration, never null
+	 */
+	@Nonnull
+	private EvitaConfiguration getEvitaConfiguration() {
+		return newTestEvitaConfigurationBuilder(this.paths)
+			.storage(
+				StorageOptions.builder()
+					.storageDirectory(this.paths.storage())
+					.workDirectory(this.paths.work())
+					.build()
+			)
+			.build();
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogSessionRegistryHandoverTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogSessionRegistryHandoverTest.java
@@ -28,6 +28,7 @@ import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.configuration.EvitaConfiguration;
 import io.evitadb.api.exception.CatalogNotFoundException;
 import io.evitadb.api.requestResponse.progress.Progress;
+import io.evitadb.core.session.SessionRegistry;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.test.Entities;
 import io.evitadb.test.EvitaTestSupport;
@@ -56,6 +57,7 @@ import static io.evitadb.test.TestTags.MANAGEMENT;
 import static io.evitadb.test.TestTags.SESSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -506,7 +508,7 @@ class CatalogSessionRegistryHandoverTest implements EvitaTestSupport {
 			} finally {
 				release.countDown();
 			}
-			awaitBlockedSession(blockedSession);
+			awaitCompletionQuietly(blockedSession);
 
 			// The rename changed nothing, so the source must answer under its own name. The suspension used to be
 			// published before the `try` that installs the undo path, so nothing lifted it and this read failed
@@ -539,7 +541,7 @@ class CatalogSessionRegistryHandoverTest implements EvitaTestSupport {
 			} finally {
 				release.countDown();
 			}
-			awaitBlockedSession(blockedSession);
+			awaitCompletionQuietly(blockedSession);
 
 			// The target's own drain is what failed, and it fails *inside* the call that hands the registry to the
 			// operation - so the ownership the undo path resumes has to be recorded before the drain, not after it.
@@ -552,6 +554,60 @@ class CatalogSessionRegistryHandoverTest implements EvitaTestSupport {
 			assertEquals(
 				BRANDS_IN_SOURCE,
 				brandCount(SOURCE_CATALOG),
+				"A replace that failed must leave its source serving too!"
+			);
+		}
+
+		@Test
+		@DisplayName("Owns the target's registry before the source's drain can fail")
+		void shouldOwnTheTargetRegistryBeforeTheSourceDrainCanFail() throws Exception {
+			createCatalogWithBrands(TARGET_CATALOG, BRANDS_IN_TARGET);
+			createCatalogWithBrands(SOURCE_CATALOG, BRANDS_IN_SOURCE);
+			// the target must start with no registry, or the undo takes the branch that restores a pre-existing
+			// one and the ownership this test is about is never exercised
+			restartEngine();
+			assertFalse(
+				CatalogSessionRegistryHandoverTest.this.evita.getCatalogSessionRegistry(TARGET_CATALOG).isPresent(),
+				"The fixture must leave the target without a registry, or the test proves nothing!"
+			);
+
+			final CountDownLatch release = new CountDownLatch(1);
+			final Future<?> blockedSession = holdSessionOpen(SOURCE_CATALOG, release);
+			try {
+				assertThrows(
+					RuntimeException.class,
+					() -> CatalogSessionRegistryHandoverTest.this.evita.replaceCatalog(SOURCE_CATALOG, TARGET_CATALOG),
+					"A replace whose source will not drain must report the failure rather than swallow it!"
+				);
+			} finally {
+				release.countDown();
+			}
+			awaitCompletionQuietly(blockedSession);
+
+			// The heart of it, and observable without racing anything: the operation reached its own first failure
+			// point - the source's five-second drain - with the target's registry already in hand, so a registry
+			// exists under that name even though no session was ever opened on it. Owned late instead, the
+			// operation would spend that whole drain with the target unclaimed, and the undo would take a
+			// registry a session installed in the meantime to be its own leftover and unpublish it - hiding that
+			// session from every later quiesce and splitting the catalog's bookkeeping in two when the next
+			// session built a second registry.
+			final SessionRegistry targetRegistry = CatalogSessionRegistryHandoverTest.this.evita
+				.getCatalogSessionRegistry(TARGET_CATALOG)
+				.orElseThrow(() -> new AssertionError(
+					"The replace must own the target's registry before its source drain can fail, and leave it " +
+						"published when that drain does fail!"
+				));
+			assertEquals(
+				BRANDS_IN_TARGET, brandCount(TARGET_CATALOG),
+				"A replace that failed while quiescing its source must leave the target serving!"
+			);
+			assertSame(
+				targetRegistry,
+				CatalogSessionRegistryHandoverTest.this.evita.getCatalogSessionRegistry(TARGET_CATALOG).orElse(null),
+				"A session opened after the failure must reuse that registry rather than build a second one!"
+			);
+			assertEquals(
+				BRANDS_IN_SOURCE, brandCount(SOURCE_CATALOG),
 				"A replace that failed must leave its source serving too!"
 			);
 		}
@@ -589,16 +645,17 @@ class CatalogSessionRegistryHandoverTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Waits out the held session once it has been released. Its own outcome is not asserted: the drain rolled
-		 * it back and closed it underneath us, so it may well report that, and what this class is about is the
-		 * state the *catalogs* are left in.
+		 * Waits out work submitted to the executor — a held session, or an operation expected to fail. Its outcome
+		 * is deliberately not asserted: the held session was rolled back and closed underneath us and may report
+		 * that, the operation is *supposed* to throw, and what this class is about is the state the **catalogs**
+		 * are left in afterwards.
 		 *
-		 * @param blockedSession handle returned by {@link #holdSessionOpen(String, CountDownLatch)}
+		 * @param work handle of the submitted work to wait out
 		 */
-		private void awaitBlockedSession(@Nonnull Future<?> blockedSession)
+		private void awaitCompletionQuietly(@Nonnull Future<?> work)
 			throws InterruptedException, TimeoutException {
 			try {
-				blockedSession.get(30, TimeUnit.SECONDS);
+				work.get(30, TimeUnit.SECONDS);
 			} catch (ExecutionException ex) {
 				// expected - see above
 			}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogSessionRegistryHandoverTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/CatalogSessionRegistryHandoverTest.java
@@ -42,7 +42,11 @@ import javax.annotation.Nonnull;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
@@ -129,6 +133,22 @@ class CatalogSessionRegistryHandoverTest implements EvitaTestSupport {
 			}
 		);
 		this.evita.updateCatalog(catalogName, EvitaSessionContract::goLiveAndClose);
+	}
+
+	/**
+	 * Counts the brands the named catalog serves through a fresh session — which is both the data assertion and
+	 * the proof that the name accepts sessions at all.
+	 *
+	 * The counter is held in an explicitly typed local because `queryCatalog` is overloaded on `Function` and
+	 * `Consumer`, and an inline lambda matches both.
+	 *
+	 * @param catalogName catalog to read
+	 * @return number of brand entities the catalog holds
+	 */
+	private int brandCount(@Nonnull String catalogName) {
+		final Function<EvitaSessionContract, Integer> brandCounter =
+			session -> session.getEntityCollectionSize(Entities.BRAND);
+		return this.evita.queryCatalog(catalogName, brandCounter);
 	}
 
 	/**
@@ -278,6 +298,39 @@ class CatalogSessionRegistryHandoverTest implements EvitaTestSupport {
 			);
 		}
 
+		@Test
+		@DisplayName("Quiesces and hands over a catalog that has no registry yet")
+		void shouldInstallAndHandOverTheRegistryOfANeverSessionedCatalog() {
+			createCatalogWithBrands(SOURCE_CATALOG, BRANDS_IN_SOURCE);
+			// Registries are built lazily by the first session, so after a restart the catalog has none - the
+			// state every catalog is in right after a boot. Suspending only what is already registered quiesces
+			// nothing at all here, and a session arriving while the rename runs binds to the catalog whose
+			// persistence service the operation is in the middle of handing over.
+			restartEngine();
+			assertFalse(
+				CatalogSessionRegistryHandoverTest.this.evita.getCatalogSessionRegistry(SOURCE_CATALOG).isPresent(),
+				"The fixture must leave the catalog without a registry, or the test proves nothing!"
+			);
+
+			CatalogSessionRegistryHandoverTest.this.evita.renameCatalog(SOURCE_CATALOG, TARGET_CATALOG);
+
+			// asserted before anything opens a session: a registry under the new name can only be there because
+			// the rename installed one to quiesce the source and carried that one across
+			assertTrue(
+				CatalogSessionRegistryHandoverTest.this.evita.getCatalogSessionRegistry(TARGET_CATALOG).isPresent(),
+				"A rename must quiesce its source even when that source has no registry, and carry it over!"
+			);
+			assertFalse(
+				CatalogSessionRegistryHandoverTest.this.evita.getCatalogSessionRegistry(SOURCE_CATALOG).isPresent(),
+				"A name that no longer names a catalog must not keep holding a session registry!"
+			);
+			assertEquals(
+				BRANDS_IN_SOURCE,
+				brandCount(TARGET_CATALOG),
+				"The renamed catalog must serve its data under the new name!"
+			);
+		}
+
 	}
 
 	@Nested
@@ -377,6 +430,178 @@ class CatalogSessionRegistryHandoverTest implements EvitaTestSupport {
 				CatalogSessionRegistryHandoverTest.this.evita.getCatalogNames().contains(SOURCE_CATALOG),
 				"The source name must stop naming anything once it has been replaced into the target!"
 			);
+		}
+
+		@Test
+		@DisplayName("Quiesces and hands over a source that has no registry yet")
+		void shouldInstallAndHandOverTheRegistryOfANeverSessionedSource() {
+			createCatalogWithBrands(TARGET_CATALOG, BRANDS_IN_TARGET);
+			createCatalogWithBrands(SOURCE_CATALOG, BRANDS_IN_SOURCE);
+			restartEngine();
+			assertFalse(
+				CatalogSessionRegistryHandoverTest.this.evita.getCatalogSessionRegistry(SOURCE_CATALOG).isPresent(),
+				"The fixture must leave the source without a registry, or the test proves nothing!"
+			);
+
+			CatalogSessionRegistryHandoverTest.this.evita.replaceCatalog(SOURCE_CATALOG, TARGET_CATALOG);
+
+			assertTrue(
+				CatalogSessionRegistryHandoverTest.this.evita.getCatalogSessionRegistry(TARGET_CATALOG).isPresent(),
+				"A replace must quiesce its source even when that source has no registry, and carry it over!"
+			);
+			assertEquals(
+				BRANDS_IN_SOURCE,
+				brandCount(TARGET_CATALOG),
+				"The target must serve the data of the catalog that replaced it!"
+			);
+		}
+
+	}
+
+	/**
+	 * Covers what the operation is left holding when the *quiescing itself* fails.
+	 *
+	 * `SessionRegistry#closeAllActiveSessionsAndSuspend` publishes the suspension first and only then waits for
+	 * the sessions to leave, giving up after five seconds and throwing. Both suspensions this operation takes can
+	 * therefore fail with the suspension standing, and both have to be lifted on the way out - the surviving
+	 * catalog would otherwise answer `SessionBusyException`, and a replace target `InstanceTerminatedException`,
+	 * for the rest of the process.
+	 *
+	 * The drain is made to fail deterministically rather than by racing it: a session parked inside
+	 * `updateCatalog`'s session-bound lambda is a session with a method running, which is precisely what
+	 * `executeWhenMethodIsNotRunning` refuses to close. It is held there until the operation has already failed,
+	 * so no wall-clock budget decides the outcome; the five seconds spent waiting are the production drain's own
+	 * bound, not a sleep this test chose.
+	 */
+	@Nested
+	@DisplayName("Drain failure")
+	class DrainFailure {
+		private final ExecutorService blockedSessionExecutor = Executors.newSingleThreadExecutor(
+			runnable -> {
+				final Thread thread = new Thread(runnable, "blocked-session");
+				// daemon, so a wedged fixture cannot keep the surefire JVM alive after the suite finishes
+				thread.setDaemon(true);
+				return thread;
+			}
+		);
+
+		@AfterEach
+		void shutDownExecutor() {
+			this.blockedSessionExecutor.shutdownNow();
+		}
+
+		@Test
+		@DisplayName("Leaves the source serving when its sessions refuse to drain")
+		void shouldResumeTheSourceWhenItsDrainGivesUp() throws Exception {
+			createCatalogWithBrands(SOURCE_CATALOG, BRANDS_IN_SOURCE);
+
+			final CountDownLatch release = new CountDownLatch(1);
+			final Future<?> blockedSession = holdSessionOpen(SOURCE_CATALOG, release);
+			try {
+				assertThrows(
+					RuntimeException.class,
+					() -> CatalogSessionRegistryHandoverTest.this.evita.renameCatalog(SOURCE_CATALOG, TARGET_CATALOG),
+					"A rename whose source will not drain must report the failure rather than swallow it!"
+				);
+			} finally {
+				release.countDown();
+			}
+			awaitBlockedSession(blockedSession);
+
+			// The rename changed nothing, so the source must answer under its own name. The suspension used to be
+			// published before the `try` that installs the undo path, so nothing lifted it and this read failed
+			// with `SessionBusyException` for the life of the process.
+			assertEquals(
+				BRANDS_IN_SOURCE,
+				brandCount(SOURCE_CATALOG),
+				"A rename that failed while quiescing must leave the source serving!"
+			);
+			assertFalse(
+				CatalogSessionRegistryHandoverTest.this.evita.getCatalogNames().contains(TARGET_CATALOG),
+				"A rename that never got past quiescing must not have created the target name!"
+			);
+		}
+
+		@Test
+		@DisplayName("Leaves both catalogs serving when the replace target refuses to drain")
+		void shouldResumeTheTargetWhenItsDrainGivesUp() throws Exception {
+			createCatalogWithBrands(TARGET_CATALOG, BRANDS_IN_TARGET);
+			createCatalogWithBrands(SOURCE_CATALOG, BRANDS_IN_SOURCE);
+
+			final CountDownLatch release = new CountDownLatch(1);
+			final Future<?> blockedSession = holdSessionOpen(TARGET_CATALOG, release);
+			try {
+				assertThrows(
+					RuntimeException.class,
+					() -> CatalogSessionRegistryHandoverTest.this.evita.replaceCatalog(SOURCE_CATALOG, TARGET_CATALOG),
+					"A replace whose target will not drain must report the failure rather than swallow it!"
+				);
+			} finally {
+				release.countDown();
+			}
+			awaitBlockedSession(blockedSession);
+
+			// The target's own drain is what failed, and it fails *inside* the call that hands the registry to the
+			// operation - so the ownership the undo path resumes has to be recorded before the drain, not after it.
+			// Recorded after, as it used to be, this read answered `InstanceTerminatedException` for ever.
+			assertEquals(
+				BRANDS_IN_TARGET,
+				brandCount(TARGET_CATALOG),
+				"A replace that failed while quiescing its target must leave that target serving!"
+			);
+			assertEquals(
+				BRANDS_IN_SOURCE,
+				brandCount(SOURCE_CATALOG),
+				"A replace that failed must leave its source serving too!"
+			);
+		}
+
+		/**
+		 * Parks a session inside the catalog's session-bound lambda and returns once it is genuinely in there, so
+		 * the operation that follows cannot start before the session it must fail to drain exists.
+		 *
+		 * @param catalogName catalog to hold a session on
+		 * @param release     released by the caller once the session may leave
+		 * @return handle of the held session, to be awaited after the release
+		 */
+		@Nonnull
+		private Future<?> holdSessionOpen(@Nonnull String catalogName, @Nonnull CountDownLatch release)
+			throws InterruptedException {
+			final CountDownLatch inside = new CountDownLatch(1);
+			final Future<?> blockedSession = this.blockedSessionExecutor.submit(
+				() -> CatalogSessionRegistryHandoverTest.this.evita.updateCatalog(
+					catalogName,
+					session -> {
+						inside.countDown();
+						try {
+							// generous on purpose: this is a positive wait, and the release below is what ends it
+							if (!release.await(30, TimeUnit.SECONDS)) {
+								throw new IllegalStateException("The session was never released!");
+							}
+						} catch (InterruptedException ex) {
+							Thread.currentThread().interrupt();
+						}
+					}
+				)
+			);
+			assertTrue(inside.await(30, TimeUnit.SECONDS), "The session to be held open never started!");
+			return blockedSession;
+		}
+
+		/**
+		 * Waits out the held session once it has been released. Its own outcome is not asserted: the drain rolled
+		 * it back and closed it underneath us, so it may well report that, and what this class is about is the
+		 * state the *catalogs* are left in.
+		 *
+		 * @param blockedSession handle returned by {@link #holdSessionOpen(String, CountDownLatch)}
+		 */
+		private void awaitBlockedSession(@Nonnull Future<?> blockedSession)
+			throws InterruptedException, TimeoutException {
+			try {
+				blockedSession.get(30, TimeUnit.SECONDS);
+			} catch (ExecutionException ex) {
+				// expected - see above
+			}
 		}
 
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/engine/EngineTransactionManagerCommitBoundaryTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/engine/EngineTransactionManagerCommitBoundaryTest.java
@@ -62,8 +62,10 @@ import static io.evitadb.test.TestTags.TRANSACTION;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -91,6 +93,13 @@ import static org.mockito.Mockito.when;
  * past the boundary is best-effort and logged, which is the same rule the operators apply to their own
  * post-commit work. See `ModifyCatalogSchemaNameMutationOperator`, whose failure path is only able to choose
  * between two answers because no committed operation can reach it.
+ *
+ * **Not reporting is not the same as not caring**, and the last two tests hold the line between the two failures
+ * that look alike from the caller's side. Losing the in-memory publish leaves the durable and live halves out of
+ * step for good, so it wedges the engine; losing the retention bookkeeping and the change-capture wake-up that
+ * follow it costs a version's worth of work the next commit performs again, so it is logged and nothing more.
+ * Collapsing the two - wedging on either - would stop the whole engine because a subscriber went away during a
+ * shutdown, which is precisely the failure `SystemChangeObserver` is built to produce.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
@@ -207,16 +216,8 @@ class EngineTransactionManagerCommitBoundaryTest implements EvitaTestSupport {
 				evita, changeObserver, executor, rawService
 			)
 		) {
-			// `ServerModifyCatalogSchemaMutation` is the one engine mutation that reaches the commit without an
-			// operator and without a live catalog - it only advances the engine version - which is exactly the
-			// bare commit this test is about.
 			assertDoesNotThrow(
-				() -> manager.applyMutation(
-					new ServerModifyCatalogSchemaMutation(
-						1L, 1, new ModifyCatalogSchemaMutation(CATALOG_NAME, UUID.randomUUID())
-					),
-					null
-				),
+				() -> manager.applyMutation(bareEngineMutation(), null),
 				"A mutation that is already durable must not be reported as failed because a change observer " +
 					"refused it. The caller would undo bookkeeping the durable state already records, or retry an " +
 					"operation that has already happened - and neither redelivers the capture that was lost."
@@ -245,6 +246,123 @@ class EngineTransactionManagerCommitBoundaryTest implements EvitaTestSupport {
 				"The mutation was durable before the observer refused it, so the next boot must find it."
 			);
 		}
+	}
+
+	@Test
+	@DisplayName("should keep accepting mutations when the bookkeeping after the publish fails")
+	void shouldNotWedgeTheEngineWhenPostPublishBookkeepingFails() {
+		final ExpandedEngineState initialState = wrapAsExpanded(this.persistenceService.getEngineState());
+		final long versionBefore = initialState.version();
+		final AtomicReference<ExpandedEngineState> lastSetState = new AtomicReference<>();
+		final Evita evita = mockEvita(this.paths.storage(), initialState, lastSetState);
+
+		// The realistic failure of the whole post-publish tail, and the reason it may not wedge: this call walks
+		// change-capture subscribers, and `SystemChangeObserver` refuses it outright once closed - the same
+		// `assertActive` throw the test above uses for `processMutation`. A shutdown racing an in-flight commit
+		// produces it, and by then the durable and live halves are perfectly in step.
+		final SystemChangeObserver changeObserver = mock(SystemChangeObserver.class);
+		doThrow(new GenericEvitaInternalError("The change observer has already closed!"))
+			.when(changeObserver).notifyVersionPresentInLiveView(anyLong());
+		final ObservableExecutorService executor = mock(ObservableExecutorService.class);
+
+		@SuppressWarnings({"rawtypes"}) final EnginePersistenceService rawService = this.persistenceService;
+
+		//noinspection unchecked
+		try (
+			EngineTransactionManager manager = new EngineTransactionManager(
+				evita, changeObserver, executor, rawService
+			)
+		) {
+			assertDoesNotThrow(
+				() -> manager.applyMutation(bareEngineMutation(), null),
+				"The mutation was durable and published before the notification failed, so nothing is owed to " +
+					"the caller."
+			);
+			assertEquals(
+				versionBefore + 1, lastSetState.get().version(),
+				"The publish itself succeeded - only the bookkeeping behind it failed."
+			);
+
+			// The assertion this test exists for. A wedge here would refuse every subsequent mutation across
+			// every catalog for the life of the process, to protect a version that is already durable, already
+			// live, and already consistent - the cost of losing a subscriber wake-up is that the subscriber wakes
+			// on the next commit instead.
+			assertDoesNotThrow(
+				() -> manager.applyMutation(bareEngineMutation(), null),
+				"Losing the post-publish bookkeeping must not wedge the engine: the durable and live halves are " +
+					"in step, and the next commit redoes every one of those steps from the state it publishes."
+			);
+			assertEquals(
+				versionBefore + 2, lastSetState.get().version(),
+				"The second mutation must have committed and published like any other."
+			);
+		} finally {
+			this.persistenceService.close();
+			this.persistenceService = null;
+		}
+	}
+
+	@Test
+	@DisplayName("should wedge the engine when a durable commit cannot be published in memory")
+	void shouldWedgeTheEngineWhenTheDurableCommitCannotBePublished() {
+		final ExpandedEngineState initialState = wrapAsExpanded(this.persistenceService.getEngineState());
+		final AtomicReference<ExpandedEngineState> lastSetState = new AtomicReference<>();
+		final Evita evita = mockEvita(this.paths.storage(), initialState, lastSetState);
+		// Overrides the sink `mockEvita` installed: the publish is refused outright, which is the one
+		// post-durability failure the engine cannot absorb. Its real trigger is `setNextEngineState`'s own
+		// version-continuity premise check, which is supposed to be unreachable - the point of the test is what
+		// happens if it ever is not, since the alternative to wedging is erasing a commit per mutation, silently.
+		doThrow(new GenericEvitaInternalError("The engine refused to publish the committed state!"))
+			.when(evita).setNextEngineState(any(ExpandedEngineState.class));
+
+		final SystemChangeObserver changeObserver = mock(SystemChangeObserver.class);
+		final ObservableExecutorService executor = mock(ObservableExecutorService.class);
+
+		@SuppressWarnings({"rawtypes"}) final EnginePersistenceService rawService = this.persistenceService;
+
+		//noinspection unchecked
+		try (
+			EngineTransactionManager manager = new EngineTransactionManager(
+				evita, changeObserver, executor, rawService
+			)
+		) {
+			assertDoesNotThrow(
+				() -> manager.applyMutation(bareEngineMutation(), null),
+				"Even this failure is not reported: the mutation is durable, and telling the caller otherwise " +
+					"invites a retry of something that has already happened."
+			);
+
+			// Silence is affordable for the caller precisely because it is not affordable for the engine. The
+			// version counter has moved and the live state has not, so the next commit would derive its snapshot
+			// from the pre-commit state and persist it at the advanced version - erasing this one.
+			final Throwable refusal = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> manager.applyMutation(bareEngineMutation(), null),
+				"A commit that went durable without becoming live must stop the engine, not be logged and left " +
+					"to repeat itself once per mutation."
+			);
+			assertTrue(
+				refusal.getMessage().contains("Engine is wedged"),
+				"The refusal must name the wedge, so an operator reads why the engine stopped rather than " +
+					"guessing: " + refusal.getMessage()
+			);
+		} finally {
+			this.persistenceService.close();
+			this.persistenceService = null;
+		}
+	}
+
+	/**
+	 * Builds the one engine mutation that reaches the commit without an operator and without a live catalog - it
+	 * advances the engine version and does nothing else, which is exactly the bare commit these tests are about.
+	 *
+	 * @return a mutation that commits by advancing the engine version alone
+	 */
+	@Nonnull
+	private static ServerModifyCatalogSchemaMutation bareEngineMutation() {
+		return new ServerModifyCatalogSchemaMutation(
+			1L, 1, new ModifyCatalogSchemaMutation(CATALOG_NAME, UUID.randomUUID())
+		);
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/engine/EngineTransactionManagerCommitBoundaryTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/engine/EngineTransactionManagerCommitBoundaryTest.java
@@ -1,0 +1,250 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.transaction.engine;
+
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.configuration.TransactionOptions;
+import io.evitadb.api.requestResponse.schema.mutation.engine.ModifyCatalogSchemaMutation;
+import io.evitadb.api.requestResponse.schema.mutation.engine.ServerModifyCatalogSchemaMutation;
+import io.evitadb.core.Evita;
+import io.evitadb.core.cdc.SystemChangeObserver;
+import io.evitadb.core.engine.ExpandedEngineState;
+import io.evitadb.core.engine.TestCatalogFolderContexts;
+import io.evitadb.core.executor.ImmediateScheduledThreadPoolExecutor;
+import io.evitadb.core.executor.ObservableExecutorService;
+import io.evitadb.core.executor.Scheduler;
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.spi.store.catalog.shared.model.LogRecordReference;
+import io.evitadb.spi.store.engine.EnginePersistenceService;
+import io.evitadb.spi.store.engine.model.EngineState;
+import io.evitadb.store.engine.DefaultEnginePersistenceService;
+import io.evitadb.test.EvitaTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests where the engine commit's **durability boundary** falls, and what a failure on either side of it is
+ * allowed to mean.
+ *
+ * `appendWalAndStoreState` is the boundary: it appends the write-ahead log record and rewrites the bootstrap in
+ * one critical section, and once it returns the mutation survives a restart whatever happens next. The work that
+ * follows it - notifying change-capture subscribers, discharging tombstones, retiring generation counters - can
+ * still fail, and two things must hold when it does.
+ *
+ * **The in-memory publish must not be lost.** `SystemChangeObserver#processMutation` throws when the observer has
+ * closed underneath an in-flight operation, and it runs before the publish. Left unguarded, that leaves durable
+ * state ahead of the state every reader resolves against - a split brain no caller can compensate for, and one
+ * that no restart reports, because the restart simply reads the durable half and looks fine. It also strands the
+ * version counter, so the next mutation would append at a version the log already holds.
+ *
+ * **The failure must not be reported.** A caller told "this failed" would be told something untrue and would act
+ * on it: an operator undoes bookkeeping the durable state already records, and a client retries an operation that
+ * has already happened. Reporting costs something and recovers nothing - the capture the observer refused is lost
+ * either way, because `processMutation` is what fills the buffer a subscriber would replay from. So everything
+ * past the boundary is best-effort and logged, which is the same rule the operators apply to their own
+ * post-commit work. See `ModifyCatalogSchemaNameMutationOperator`, whose failure path is only able to choose
+ * between two answers because no committed operation can reach it.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("The engine commit's durability boundary")
+@Tag(ENGINE)
+@Tag(TRANSACTION)
+class EngineTransactionManagerCommitBoundaryTest implements EvitaTestSupport {
+	private static final String CATALOG_NAME = "someCatalog";
+
+	private TestPaths paths;
+	private StorageOptions storageOptions;
+	private TransactionOptions transactionOptions;
+	private Scheduler scheduler;
+	@Nullable private DefaultEnginePersistenceService persistenceService;
+
+	/**
+	 * Wraps a persisted snapshot as the expanded state the transaction manager reads, with no live catalogs -
+	 * the mutation driven below touches nothing but the engine version.
+	 *
+	 * @param engineState persisted snapshot read from disk
+	 * @return an `ExpandedEngineState` wrapping it with an empty catalogs map
+	 */
+	@Nonnull
+	private static ExpandedEngineState wrapAsExpanded(@Nonnull EngineState<?> engineState) {
+		@SuppressWarnings({"rawtypes", "unchecked"})
+		final EngineState<LogRecordReference> typedState = (EngineState) engineState;
+		return ExpandedEngineState.create(typedState, Collections.emptyMap());
+	}
+
+	/**
+	 * Builds a mock `Evita` exposing only what the transaction manager reads, with `setNextEngineState` routed
+	 * into the supplied sink so the test can tell whether the in-memory publish happened.
+	 *
+	 * @param storageDirectory storage root of the backing persistence service
+	 * @param initialState     initial expanded engine state to answer `getEngineState()` with
+	 * @param lastSetState     sink updated by `setNextEngineState(...)`
+	 * @return a partial `Evita` mock sufficient to drive one engine mutation
+	 */
+	@Nonnull
+	private static Evita mockEvita(
+		@Nonnull Path storageDirectory,
+		@Nonnull ExpandedEngineState initialState,
+		@Nonnull AtomicReference<ExpandedEngineState> lastSetState
+	) {
+		lastSetState.set(initialState);
+		final StorageOptions storage = StorageOptions.builder().storageDirectory(storageDirectory).build();
+		final ServerOptions server = ServerOptions.builder().transactionTimeoutInMilliseconds(5_000L).build();
+		final EvitaConfiguration configuration = mock(EvitaConfiguration.class);
+		when(configuration.storage()).thenReturn(storage);
+		when(configuration.server()).thenReturn(server);
+		final Evita evita = mock(Evita.class);
+		// `ModifyCatalogSchemaMutation#verifyApplicability` refuses a catalog the engine does not list, and that
+		// check runs before the commit this test is about ever starts.
+		when(evita.getCatalogNames()).thenReturn(Set.of(CATALOG_NAME));
+		when(evita.getConfiguration()).thenReturn(configuration);
+		when(evita.getCatalogFolderContext()).thenReturn(TestCatalogFolderContexts.onDirectory(storageDirectory));
+		when(evita.getEngineState()).thenAnswer(invocation -> lastSetState.get());
+		doAnswer(invocation -> {
+			lastSetState.set(invocation.getArgument(0, ExpandedEngineState.class));
+			return null;
+		}).when(evita).setNextEngineState(any(ExpandedEngineState.class));
+		return evita;
+	}
+
+	@BeforeEach
+	void setUp() {
+		this.paths = createTestPaths(this.getClass().getSimpleName());
+		assertTrue(this.paths.storage().toFile().mkdirs(), "Cannot create test storage directory.");
+		assertTrue(this.paths.work().toFile().mkdirs(), "Cannot create test work directory.");
+		this.storageOptions = StorageOptions.builder()
+			.storageDirectory(this.paths.storage())
+			.workDirectory(this.paths.work())
+			.build();
+		this.transactionOptions = TransactionOptions.builder()
+			.transactionMemoryBufferLimitSizeBytes(1024 << 10)
+			.transactionMemoryRegionCount(4)
+			.build();
+		this.scheduler = new Scheduler(new ImmediateScheduledThreadPoolExecutor());
+		this.persistenceService = new DefaultEnginePersistenceService(
+			this.storageOptions, this.transactionOptions, this.scheduler
+		);
+	}
+
+	@AfterEach
+	void tearDown() throws IOException {
+		if (this.persistenceService != null && !this.persistenceService.isClosed()) {
+			this.persistenceService.close();
+		}
+		cleanupTestPaths(this.paths);
+	}
+
+	@Test
+	@DisplayName("should publish the committed state and not report failure when an observer refuses it")
+	void shouldPublishAndNotReportFailureWhenTheObserverRefusesACommittedMutation() {
+		final ExpandedEngineState initialState = wrapAsExpanded(this.persistenceService.getEngineState());
+		final long versionBefore = initialState.version();
+		final AtomicReference<ExpandedEngineState> lastSetState = new AtomicReference<>();
+		final Evita evita = mockEvita(this.paths.storage(), initialState, lastSetState);
+
+		// Stands in for the one failure this window really produces: the observer closing underneath an
+		// in-flight operation, which `assertActive` turns into a throw on purpose (issue #1151). It fires after
+		// the write-ahead log record has been appended and the bootstrap rewritten, so the mutation it refuses
+		// is one that has already happened.
+		final SystemChangeObserver changeObserver = mock(SystemChangeObserver.class);
+		doThrow(new GenericEvitaInternalError("The change observer has already closed!"))
+			.when(changeObserver).processMutation(any());
+		final ObservableExecutorService executor = mock(ObservableExecutorService.class);
+
+		@SuppressWarnings({"rawtypes"}) final EnginePersistenceService rawService = this.persistenceService;
+
+		//noinspection unchecked
+		try (
+			EngineTransactionManager manager = new EngineTransactionManager(
+				evita, changeObserver, executor, rawService
+			)
+		) {
+			// `ServerModifyCatalogSchemaMutation` is the one engine mutation that reaches the commit without an
+			// operator and without a live catalog - it only advances the engine version - which is exactly the
+			// bare commit this test is about.
+			assertDoesNotThrow(
+				() -> manager.applyMutation(
+					new ServerModifyCatalogSchemaMutation(
+						1L, 1, new ModifyCatalogSchemaMutation(CATALOG_NAME, UUID.randomUUID())
+					),
+					null
+				),
+				"A mutation that is already durable must not be reported as failed because a change observer " +
+					"refused it. The caller would undo bookkeeping the durable state already records, or retry an " +
+					"operation that has already happened - and neither redelivers the capture that was lost."
+			);
+
+			final ExpandedEngineState published = lastSetState.get();
+			assertNotNull(published, "The engine state must have been published in memory.");
+			assertEquals(
+				versionBefore + 1, published.version(),
+				"The in-memory publish must survive an observer that refused the mutation. Skipped, it leaves " +
+					"durable state ahead of the state every reader resolves against - and nothing reports that, " +
+					"because a restart reads the durable half and looks healthy."
+			);
+		} finally {
+			this.persistenceService.close();
+			this.persistenceService = null;
+		}
+
+		// Read back through a fresh service rather than the one that just ran: a live handle answers from its
+		// own counters, so it reports what the code intended rather than what the next process will find.
+		try (final DefaultEnginePersistenceService reopened = new DefaultEnginePersistenceService(
+			this.storageOptions, this.transactionOptions, this.scheduler
+		)) {
+			assertEquals(
+				versionBefore + 1, reopened.getEngineState().version(),
+				"The mutation was durable before the observer refused it, so the next boot must find it."
+			);
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperatorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperatorTest.java
@@ -251,9 +251,11 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 		@Nonnull ModifyCatalogSchemaNameMutation mutation,
 		@Nonnull Consumer<EngineStateUpdater> completionUpdater
 	) throws Exception {
-		// The surviving catalog keeps its folder across the rename, and the completion phase relabels it - so the
-		// folder has to be there, or the run is noisy with a relabel failure that has nothing to do with the test.
+		// The surviving catalog keeps its folder across the rename and the completion phase relabels it, while a
+		// replace retires the folder its target was living in - so both have to be there, or the run is noisy with
+		// failures that have nothing to do with the test.
 		Files.createDirectories(storageDirectory.resolve(SOURCE_CATALOG_NAME));
+		Files.createDirectories(storageDirectory.resolve(TARGET_CATALOG_NAME));
 
 		final CatalogFolderContext folderContext = TestCatalogFolderContexts.onDirectory(storageDirectory);
 		@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> transitionUpdater = mock(Consumer.class);
@@ -267,7 +269,7 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 	}
 
 	@Nested
-	@DisplayName("The target name carries a registry from before the commit that publishes it")
+	@DisplayName("Where the target name's registry comes from, and when")
 	class PublicationOrdering {
 
 		@Test
@@ -322,6 +324,70 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 			assertTrue(
 				isServing(sourceRegistry),
 				"The suspension the rename opened with must be lifted once it has committed."
+			);
+		}
+
+		@Test
+		@DisplayName("should leave a replace target holding its own registry until the commit has landed")
+		void shouldNotAliasTheNameOfAReplaceTargetThatCanStillBeRestored(@TempDir Path storageDirectory)
+			throws Exception {
+			// The mirror image of the test above, and the reason it is not simply "publish early, always". A
+			// target that already names a catalog has a registry of its own holding that name from the read-only
+			// phase to the handoff, so the window the early publication closes never opens here - while the
+			// publication itself would cost something real. A caller captures the published registry *before* it
+			// waits out a suspension, and neither `handleSuspension` nor `registerWhileNotSuspended` consults the
+			// map again afterwards. So an alias taken back by a failed commit would leave that caller holding an
+			// unpublished registry, resolving a target catalog the failure left standing, and registering into the
+			// source registry's session map - untracked by the name it asked for, and invisible to the next
+			// quiesce of it.
+			final Map<String, SessionRegistry> registries = new ConcurrentHashMap<>(4);
+			final SessionRegistry sourceRegistry = sessionRegistryFor(SOURCE_CATALOG_NAME);
+			final SessionRegistry targetRegistry = sessionRegistryFor(TARGET_CATALOG_NAME);
+			registries.put(SOURCE_CATALOG_NAME, sourceRegistry);
+			registries.put(TARGET_CATALOG_NAME, targetRegistry);
+
+			final Map<String, CatalogContract> catalogs = new HashMap<>(4);
+			catalogs.put(SOURCE_CATALOG_NAME, catalogYielding(catalogWithSchema()));
+			catalogs.put(TARGET_CATALOG_NAME, catalogWithSchema());
+
+			final AtomicReference<SessionRegistry> atCommitTime = new AtomicReference<>();
+			@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> completionUpdater = mock(Consumer.class);
+			doAnswer(
+				invocation -> {
+					atCommitTime.set(registries.get(TARGET_CATALOG_NAME));
+					return null;
+				}
+			).when(completionUpdater).accept(any());
+
+			applyAndAwait(
+				mockEngine(catalogs, registries),
+				storageDirectory,
+				new ModifyCatalogSchemaNameMutation(SOURCE_CATALOG_NAME, TARGET_CATALOG_NAME, true),
+				completionUpdater
+			);
+
+			assertSame(
+				targetRegistry, atCommitTime.get(),
+				"While the replace can still fail, its target must answer through the registry it already had - " +
+					"an alias installed here is one the undo has to take back, and a caller that captured it in " +
+					"the meantime is no longer reachable through the name it opened."
+			);
+			assertNotSame(
+				targetRegistry, registries.get(TARGET_CATALOG_NAME),
+				"Once the replace has committed the name belongs to the surviving catalog, so the swap must have " +
+					"happened by the time the operation returns."
+			);
+			assertNotSame(
+				sourceRegistry, registries.get(TARGET_CATALOG_NAME),
+				"The target must carry the derived view, whose catalog supplier resolves the target name."
+			);
+			assertNull(
+				registries.get(SOURCE_CATALOG_NAME),
+				"The consumed catalog's name stops naming anything, so it must stop carrying a registry."
+			);
+			assertTrue(
+				isServing(sourceRegistry),
+				"The suspension the replace opened with must be lifted once it has committed."
 			);
 		}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperatorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperatorTest.java
@@ -1,0 +1,584 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.transaction.engine.operators;
+
+import io.evitadb.api.CatalogContract;
+import io.evitadb.api.exception.CatalogNotFoundException;
+import io.evitadb.api.exception.InstanceTerminatedException;
+import io.evitadb.api.observability.trace.TracingContext;
+import io.evitadb.api.requestResponse.progress.ProgressingFuture;
+import io.evitadb.api.requestResponse.schema.SealedCatalogSchema;
+import io.evitadb.api.requestResponse.schema.mutation.engine.ModifyCatalogSchemaNameMutation;
+import io.evitadb.core.Evita;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.engine.CatalogFolderContext;
+import io.evitadb.core.engine.TestCatalogFolderContexts;
+import io.evitadb.core.exception.SessionBusyException;
+import io.evitadb.core.session.SessionRegistry;
+import io.evitadb.core.session.SuspendOperation;
+import io.evitadb.core.transaction.engine.EngineStateUpdater;
+import io.evitadb.exception.GenericEvitaInternalError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nonnull;
+import java.io.Serial;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.SCHEMA;
+import static io.evitadb.test.TestTags.SESSION;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static java.util.Optional.ofNullable;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests `ModifyCatalogSchemaNameMutationOperator` — the operator behind both `renameCatalog` and `replaceCatalog`.
+ *
+ * The subject here is **when** the surviving catalog's session registry appears under the name it is moving to,
+ * relative to the engine-state commit that makes that name resolve. The commit is what publishes the new name, and
+ * it does so synchronously; a registry published after it therefore leaves a window in which the name resolves to a
+ * live catalog that has no registry behind it, and `Evita#createSessionInternal` fills such a name with a fresh,
+ * *unsuspended* registry of its own. The handoff then displaces that registry, and any session inside it is
+ * reachable through no name at all — invisible to every later quiesce, and bound to a catalog the next rename,
+ * delete or shutdown terminates underneath it.
+ *
+ * That window is a few instructions wide, so no test can reliably race it. What a test *can* pin down is the
+ * ordering that removes it, and the operator's own contract is the seam for that: `applyMutation` takes the
+ * completion-phase engine-state updater as a parameter, so a test that supplies its own observes the registry map
+ * at exactly the instant the commit is requested — before any part of it has run.
+ *
+ * The engine is mocked, which is what makes the fixtures state outright which names start with a registry: the real
+ * `obtainCatalogSessionRegistry` installs one for a catalog that has none, whereas the map here is pre-populated by
+ * each test. Sibling operator tests are driven the same way — see `DuplicateCatalogMutationOperatorTest`.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("ModifyCatalogSchemaNameMutationOperator tests")
+@Tag(ENGINE)
+@Tag(TRANSACTION)
+@Tag(SCHEMA)
+@Tag(SESSION)
+class ModifyCatalogSchemaNameMutationOperatorTest {
+
+	private static final String SOURCE_CATALOG_NAME = "renameSource";
+	private static final String TARGET_CATALOG_NAME = "renameTarget";
+
+	/**
+	 * Thrown by the probe's session factory to prove it was reached — see {@link #isServing(SessionRegistry)}.
+	 */
+	private static final class SessionAdmitted extends RuntimeException {
+		@Serial private static final long serialVersionUID = 8724551364772915826L;
+	}
+
+	/**
+	 * Reports whether the registry admits session creation.
+	 *
+	 * `SessionRegistry#createSession` runs its factory only once the suspension check has let the caller through, so
+	 * reaching the sentinel is proof that no suspension is standing. A suspended registry answers with the exception
+	 * its suspend operation prescribes instead — `SessionBusyException` after the POSTPONE wait runs out, or
+	 * `InstanceTerminatedException` immediately for REJECT.
+	 *
+	 * @param registry registry to probe
+	 * @return true when the registry is serving, false when it is still suspended
+	 */
+	private static boolean isServing(@Nonnull SessionRegistry registry) {
+		try {
+			registry.createSession(
+				__ -> {
+					throw new SessionAdmitted();
+				}
+			);
+			throw new GenericEvitaInternalError("The sentinel session factory must have thrown!");
+		} catch (SessionAdmitted admitted) {
+			return true;
+		} catch (SessionBusyException | InstanceTerminatedException refused) {
+			return false;
+		}
+	}
+
+	/**
+	 * Builds a `SessionRegistry` that owns no catalog. Nothing in these tests creates a session through it — the
+	 * probe above throws before the factory can touch a catalog — so the supplier is never called.
+	 *
+	 * @param catalogName name the registry is created for, for readability of failures only
+	 * @return a fresh registry, not suspended
+	 */
+	@Nonnull
+	private static SessionRegistry sessionRegistryFor(@Nonnull String catalogName) {
+		return new SessionRegistry(
+			mock(TracingContext.class),
+			() -> {
+				throw new GenericEvitaInternalError(
+					"Registry of catalog `" + catalogName + "` must not resolve its catalog in this test!"
+				);
+			},
+			SessionRegistry.createDataStore()
+		);
+	}
+
+	/**
+	 * Builds a catalog stub carrying a schema, which is all the operator reads of a catalog it is not renaming.
+	 *
+	 * @return the stub, answering version 1
+	 */
+	@Nonnull
+	private static Catalog catalogWithSchema() {
+		final SealedCatalogSchema schema = mock(SealedCatalogSchema.class);
+		when(schema.version()).thenReturn(1);
+
+		final Catalog catalog = mock(Catalog.class);
+		when(catalog.getSchema()).thenReturn(schema);
+		return catalog;
+	}
+
+	/**
+	 * Builds the catalog under rename: it answers a schema for the mutation to rewrite, and a `replace` future that
+	 * completes immediately with the renamed instance.
+	 *
+	 * @param replacementResult the catalog the `replace` future completes with
+	 * @return the stub, with `replace` wired to an already-finished future
+	 */
+	@Nonnull
+	private static Catalog catalogYielding(@Nonnull Catalog replacementResult) {
+		final Catalog catalog = catalogWithSchema();
+		when(catalog.replace(any(), any()))
+			.thenAnswer(__ -> new ProgressingFuture<CatalogContract>(1, ___ -> replacementResult));
+		return catalog;
+	}
+
+	/**
+	 * Builds an engine whose catalog lookups and session-registry map are backed by the passed maps, so that the
+	 * operator's writes are observable and its reads answer consistently with them.
+	 *
+	 * @param catalogs   catalogs the engine knows about, by name
+	 * @param registries registry map the operator reads and writes; mutated in place
+	 * @return the mocked engine
+	 */
+	@Nonnull
+	private static Evita mockEngine(
+		@Nonnull Map<String, CatalogContract> catalogs,
+		@Nonnull Map<String, SessionRegistry> registries
+	) {
+		final Evita evita = mock(Evita.class);
+		when(evita.getCatalogNames()).thenReturn(catalogs.keySet());
+		when(evita.getCatalogInstance(anyString()))
+			.thenAnswer(invocation -> ofNullable(catalogs.get(invocation.<String>getArgument(0))));
+		when(evita.getCatalogInstanceOrThrowException(anyString()))
+			.thenAnswer(
+				invocation -> {
+					final String catalogName = invocation.getArgument(0);
+					final CatalogContract catalog = catalogs.get(catalogName);
+					if (catalog == null) {
+						throw new CatalogNotFoundException(catalogName);
+					}
+					return catalog;
+				}
+			);
+		// `obtain` differs from `get` in production only by installing a registry for a catalog that has none, and
+		// every test here pre-populates the map for the names it cares about - so the two answer alike.
+		when(evita.obtainCatalogSessionRegistry(anyString()))
+			.thenAnswer(invocation -> ofNullable(registries.get(invocation.<String>getArgument(0))));
+		when(evita.getCatalogSessionRegistry(anyString()))
+			.thenAnswer(invocation -> ofNullable(registries.get(invocation.<String>getArgument(0))));
+		when(evita.registerWithReplaceCatalogSessionRegistry(anyString(), any()))
+			.thenAnswer(invocation -> registries.put(invocation.getArgument(0), invocation.getArgument(1)));
+		doAnswer(invocation -> registries.remove(invocation.<String>getArgument(0)))
+			.when(evita).removeCatalogSessionRegistryIfPresent(anyString());
+		return evita;
+	}
+
+	/**
+	 * Drives one rename or replace to completion on the calling thread.
+	 *
+	 * A same-thread executor rather than a pool, so that every assertion below runs after the whole chain - the
+	 * completion phase and the undo alike - rather than racing it.
+	 *
+	 * @param evita              engine the operator acts on
+	 * @param storageDirectory   root the folder context is built over
+	 * @param mutation           the rename or replace to apply
+	 * @param completionUpdater  stands in for the engine-state commit
+	 * @throws ExecutionException when the operation fails, exactly as the engine would see it
+	 */
+	private static void applyAndAwait(
+		@Nonnull Evita evita,
+		@Nonnull Path storageDirectory,
+		@Nonnull ModifyCatalogSchemaNameMutation mutation,
+		@Nonnull Consumer<EngineStateUpdater> completionUpdater
+	) throws Exception {
+		// The surviving catalog keeps its folder across the rename, and the completion phase relabels it - so the
+		// folder has to be there, or the run is noisy with a relabel failure that has nothing to do with the test.
+		Files.createDirectories(storageDirectory.resolve(SOURCE_CATALOG_NAME));
+
+		final CatalogFolderContext folderContext = TestCatalogFolderContexts.onDirectory(storageDirectory);
+		@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> transitionUpdater = mock(Consumer.class);
+
+		final ProgressingFuture<?> future = new ModifyCatalogSchemaNameMutationOperator(folderContext)
+			.applyMutation(UUID.randomUUID(), mutation, evita, transitionUpdater, completionUpdater);
+		future.execute(Runnable::run);
+		// generous, because it can only expire on a genuine hang - the executor above has already run the
+		// whole chain to completion by the time this line is reached
+		future.get(30, TimeUnit.SECONDS);
+	}
+
+	@Nested
+	@DisplayName("The target name carries a registry from before the commit that publishes it")
+	class PublicationOrdering {
+
+		@Test
+		@DisplayName("should publish the renamed catalog's registry before the engine state is committed")
+		void shouldPublishTheTargetRegistryBeforeTheEngineStateCommit(@TempDir Path storageDirectory)
+			throws Exception {
+			final Map<String, SessionRegistry> registries = new ConcurrentHashMap<>(4);
+			final SessionRegistry sourceRegistry = sessionRegistryFor(SOURCE_CATALOG_NAME);
+			registries.put(SOURCE_CATALOG_NAME, sourceRegistry);
+
+			final Map<String, CatalogContract> catalogs = new HashMap<>(4);
+			final Catalog sourceCatalog = catalogYielding(catalogWithSchema());
+			catalogs.put(SOURCE_CATALOG_NAME, sourceCatalog);
+
+			// The instant the commit is requested is the last instant at which the target name is still
+			// unresolvable, so what the map holds for it here is what a session arriving a moment later finds.
+			final AtomicReference<SessionRegistry> atCommitTime = new AtomicReference<>();
+			@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> completionUpdater = mock(Consumer.class);
+			doAnswer(
+				invocation -> {
+					atCommitTime.set(registries.get(TARGET_CATALOG_NAME));
+					return null;
+				}
+			).when(completionUpdater).accept(any());
+
+			applyAndAwait(
+				mockEngine(catalogs, registries),
+				storageDirectory,
+				new ModifyCatalogSchemaNameMutation(SOURCE_CATALOG_NAME, TARGET_CATALOG_NAME, false),
+				completionUpdater
+			);
+
+			assertNotNull(
+				atCommitTime.get(),
+				"The target name must already carry a session registry when the commit that publishes it runs - " +
+					"otherwise the name resolves to a live catalog with nothing behind it, and the first session " +
+					"to arrive installs a registry the handoff then throws away."
+			);
+			assertSame(
+				atCommitTime.get(), registries.get(TARGET_CATALOG_NAME),
+				"The registry published before the commit must be the one the operation leaves behind - a second " +
+					"one installed afterwards would orphan every session admitted into the first."
+			);
+			assertNotSame(
+				sourceRegistry, atCommitTime.get(),
+				"The target must carry the derived view, whose catalog supplier resolves the new name."
+			);
+			assertNull(
+				registries.get(SOURCE_CATALOG_NAME),
+				"The source name stops naming a catalog once the commit lands, so it must stop carrying a registry."
+			);
+			assertTrue(
+				isServing(sourceRegistry),
+				"The suspension the rename opened with must be lifted once it has committed."
+			);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("The derived registry the target is published through shares its origin's suspension")
+	class DerivedRegistry {
+
+		@Test
+		@DisplayName("should refuse sessions through the derived view until the origin is resumed")
+		void shouldRefuseSessionsThroughTheDerivedViewUntilTheOriginResumes() {
+			// This is what makes publishing under the target name *before* the commit safe at all: the view the
+			// target is published through is already suspended, so a session that resolves the new name in the
+			// window between the commit and the resume waits rather than being admitted into a registry the
+			// handoff is about to displace. Give the derived view a suspension of its own - a plain field copy
+			// rather than the shared reference - and the early publication silently becomes the bug it fixes.
+			final SessionRegistry origin = sessionRegistryFor(SOURCE_CATALOG_NAME);
+			origin.closeAllActiveSessionsAndSuspend(SuspendOperation.REJECT);
+
+			final SessionRegistry derived = origin.withDifferentCatalogSupplier(() -> null);
+			assertFalse(
+				isServing(derived),
+				"A view derived from a suspended registry must be suspended too - it shares the suspension, the " +
+					"active sessions and the registration gate with the registry it came from."
+			);
+
+			origin.resumeOperations();
+			assertTrue(
+				isServing(derived),
+				"Resuming the origin must release the derived view as well, or the name the clients moved to " +
+					"stays shut after the operation that moved them has finished."
+			);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("A commit that fails takes the early publication back with it")
+	class CommitFailure {
+
+		@Test
+		@DisplayName("should unpublish the target's registry when a rename fails at the commit")
+		void shouldUnpublishTheTargetRegistryWhenTheRenameCommitFails(@TempDir Path storageDirectory) {
+			final Map<String, SessionRegistry> registries = new ConcurrentHashMap<>(4);
+			final SessionRegistry sourceRegistry = sessionRegistryFor(SOURCE_CATALOG_NAME);
+			registries.put(SOURCE_CATALOG_NAME, sourceRegistry);
+
+			final Map<String, CatalogContract> catalogs = new HashMap<>(4);
+			catalogs.put(SOURCE_CATALOG_NAME, catalogYielding(catalogWithSchema()));
+
+			@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> completionUpdater = mock(Consumer.class);
+			doAnswer(
+				invocation -> {
+					throw new GenericEvitaInternalError("The engine state refused the rename!");
+				}
+			).when(completionUpdater).accept(any());
+
+			assertThrows(
+				ExecutionException.class,
+				() -> applyAndAwait(
+					mockEngine(catalogs, registries),
+					storageDirectory,
+					new ModifyCatalogSchemaNameMutation(SOURCE_CATALOG_NAME, TARGET_CATALOG_NAME, false),
+					completionUpdater
+				)
+			);
+
+			assertNull(
+				registries.get(TARGET_CATALOG_NAME),
+				"A rename that failed names no catalog under the target, so a registry left published there would " +
+					"refuse or serve sessions for a name that does not exist."
+			);
+			assertSame(
+				sourceRegistry, registries.get(SOURCE_CATALOG_NAME),
+				"The catalog kept its name, so it must keep the registry that name is served through."
+			);
+			assertTrue(
+				isServing(sourceRegistry),
+				"A failed rename must lift the suspension it opened with, or the catalog it did not rename spends " +
+					"the rest of the process answering SessionBusyException."
+			);
+		}
+
+		@Test
+		@DisplayName("should restore the replace target's own registry when the commit fails")
+		void shouldRestoreTheTargetsOwnRegistryWhenTheReplaceCommitFails(@TempDir Path storageDirectory) {
+			final Map<String, SessionRegistry> registries = new ConcurrentHashMap<>(4);
+			final SessionRegistry sourceRegistry = sessionRegistryFor(SOURCE_CATALOG_NAME);
+			final SessionRegistry targetRegistry = sessionRegistryFor(TARGET_CATALOG_NAME);
+			registries.put(SOURCE_CATALOG_NAME, sourceRegistry);
+			registries.put(TARGET_CATALOG_NAME, targetRegistry);
+
+			final Map<String, CatalogContract> catalogs = new HashMap<>(4);
+			catalogs.put(SOURCE_CATALOG_NAME, catalogYielding(catalogWithSchema()));
+			catalogs.put(TARGET_CATALOG_NAME, catalogWithSchema());
+
+			@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> completionUpdater = mock(Consumer.class);
+			doAnswer(
+				invocation -> {
+					throw new GenericEvitaInternalError("The engine state refused the replace!");
+				}
+			).when(completionUpdater).accept(any());
+
+			assertThrows(
+				ExecutionException.class,
+				() -> applyAndAwait(
+					mockEngine(catalogs, registries),
+					storageDirectory,
+					new ModifyCatalogSchemaNameMutation(SOURCE_CATALOG_NAME, TARGET_CATALOG_NAME, true),
+					completionUpdater
+				)
+			);
+
+			assertSame(
+				targetRegistry, registries.get(TARGET_CATALOG_NAME),
+				"The replace changed nothing, so the target must answer through its own registry again - the " +
+					"derived view the completion phase published belongs to a catalog that never took its place."
+			);
+			assertTrue(
+				isServing(targetRegistry),
+				"The target was quiesced with REJECT before the replace began; a failure that leaves that " +
+					"suspension standing makes the catalog it did not replace answer InstanceTerminatedException " +
+					"for the life of the process."
+			);
+			assertSame(
+				sourceRegistry, registries.get(SOURCE_CATALOG_NAME),
+				"The source catalog was not consumed, so it keeps the name and the registry it had."
+			);
+			assertTrue(
+				isServing(sourceRegistry),
+				"A failed replace must lift the suspension it opened the surviving catalog with."
+			);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("A registry that appears under the target name is refused, not tidied away")
+	class ForeignRegistry {
+
+		@Test
+		@DisplayName("should refuse to commit when the target name gained a registry of its own")
+		void shouldRefuseToCommitWhenTheTargetGainedAForeignRegistry(@TempDir Path storageDirectory) {
+			// Unreachable in production - a rename's target names no catalog until the commit lands, and session
+			// creation refuses a name it cannot resolve - which is why it is asserted rather than cleaned up after.
+			// The only cleanup available after the commit is draining a registry full of live sessions and giving
+			// up on it after five seconds, and that is the silent half-measure the ordering exists to remove.
+			final Map<String, SessionRegistry> registries = new ConcurrentHashMap<>(4);
+			final SessionRegistry sourceRegistry = sessionRegistryFor(SOURCE_CATALOG_NAME);
+			final SessionRegistry foreignRegistry = sessionRegistryFor(TARGET_CATALOG_NAME);
+			registries.put(SOURCE_CATALOG_NAME, sourceRegistry);
+
+			final Map<String, CatalogContract> catalogs = new HashMap<>(4);
+			catalogs.put(SOURCE_CATALOG_NAME, catalogYielding(catalogWithSchema()));
+
+			final Evita evita = mockEngine(catalogs, registries);
+			// Slipped in after the operator's read-only phase, so that it is present at the publication and absent
+			// at every earlier lookup - the interleaving the assertion guards against. Re-stubbed through
+			// `doAnswer`, because the `when(mock.call(...))` form would run the answer already installed by
+			// `mockEngine` against Mockito's null placeholder arguments.
+			doAnswer(
+				invocation -> {
+					registries.put(invocation.getArgument(0), invocation.getArgument(1));
+					return foreignRegistry;
+				}
+			).when(evita).registerWithReplaceCatalogSessionRegistry(anyString(), any());
+
+			@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> completionUpdater = mock(Consumer.class);
+
+			assertThrows(
+				ExecutionException.class,
+				() -> applyAndAwait(
+					evita,
+					storageDirectory,
+					new ModifyCatalogSchemaNameMutation(SOURCE_CATALOG_NAME, TARGET_CATALOG_NAME, false),
+					completionUpdater
+				),
+				"A registry that appeared under the target name holds sessions the handoff would orphan, so the " +
+					"operation must fail while failing is still free - before the commit."
+			);
+
+			assertNull(
+				registries.get(TARGET_CATALOG_NAME),
+				"The rename never committed, so the target name must be left naming nothing at all."
+			);
+			assertTrue(
+				isServing(sourceRegistry),
+				"The refusal happens before the commit, so it is an ordinary failure and the suspension it opened " +
+					"with is lifted like any other."
+			);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Progress reporting")
+	class OperationName {
+
+		@Test
+		@DisplayName("should name the operation after the direction it moves the catalog in")
+		void shouldProduceDescriptiveOperationName(@TempDir Path storageDirectory) {
+			final ModifyCatalogSchemaNameMutationOperator operator =
+				new ModifyCatalogSchemaNameMutationOperator(TestCatalogFolderContexts.onDirectory(storageDirectory));
+
+			assertEquals(
+				"Renaming catalog `" + SOURCE_CATALOG_NAME + "` to `" + TARGET_CATALOG_NAME + "`",
+				operator.getOperationName(
+					new ModifyCatalogSchemaNameMutation(SOURCE_CATALOG_NAME, TARGET_CATALOG_NAME, false)
+				)
+			);
+			assertEquals(
+				"Replacing catalog `" + SOURCE_CATALOG_NAME + "` with `" + TARGET_CATALOG_NAME + "`",
+				operator.getOperationName(
+					new ModifyCatalogSchemaNameMutation(SOURCE_CATALOG_NAME, TARGET_CATALOG_NAME, true)
+				)
+			);
+		}
+
+	}
+
+	/**
+	 * Guards the assumption every test above rests on: a rename's target name must not already be a catalog, which
+	 * is what makes "nothing can have installed a registry under it" true in the first place.
+	 */
+	@Nested
+	@DisplayName("Preconditions")
+	class Preconditions {
+
+		@Test
+		@DisplayName("should refuse to rename onto a name that already names a catalog")
+		void shouldRefuseToRenameOntoAnExistingName(@TempDir Path storageDirectory) {
+			final Map<String, SessionRegistry> registries = new ConcurrentHashMap<>(4);
+			registries.put(SOURCE_CATALOG_NAME, sessionRegistryFor(SOURCE_CATALOG_NAME));
+
+			final Map<String, CatalogContract> catalogs = new HashMap<>(4);
+			catalogs.put(SOURCE_CATALOG_NAME, catalogYielding(catalogWithSchema()));
+			catalogs.put(TARGET_CATALOG_NAME, catalogWithSchema());
+
+			@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> completionUpdater = mock(Consumer.class);
+
+			assertThrows(
+				RuntimeException.class,
+				() -> applyAndAwait(
+					mockEngine(catalogs, registries),
+					storageDirectory,
+					new ModifyCatalogSchemaNameMutation(SOURCE_CATALOG_NAME, TARGET_CATALOG_NAME, false),
+					completionUpdater
+				)
+			);
+
+			assertFalse(
+				registries.containsKey(TARGET_CATALOG_NAME),
+				"A rename refused before it started must not have touched the target name's registry."
+			);
+		}
+
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperatorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperatorTest.java
@@ -426,7 +426,7 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 	}
 
 	@Nested
-	@DisplayName("A commit that fails takes the early publication back with it")
+	@DisplayName("A commit that fails leaves each name answering through the registry it started with")
 	class CommitFailure {
 
 		@Test
@@ -504,8 +504,9 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 
 			assertSame(
 				targetRegistry, registries.get(TARGET_CATALOG_NAME),
-				"The replace changed nothing, so the target must answer through its own registry again - the " +
-					"derived view the completion phase published belongs to a catalog that never took its place."
+				"The replace changed nothing, so the target must still answer through the registry it had - a " +
+					"replace onto an existing catalog never publishes the derived view ahead of the commit, so " +
+					"there is nothing here for the undo to restore and nothing that may have displaced it."
 			);
 			assertTrue(
 				isServing(targetRegistry),

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperatorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperatorTest.java
@@ -63,6 +63,7 @@ import static io.evitadb.test.TestTags.SCHEMA;
 import static io.evitadb.test.TestTags.SESSION;
 import static io.evitadb.test.TestTags.TRANSACTION;
 import static java.util.Optional.ofNullable;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -74,7 +75,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -251,6 +255,31 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 		@Nonnull ModifyCatalogSchemaNameMutation mutation,
 		@Nonnull Consumer<EngineStateUpdater> completionUpdater
 	) throws Exception {
+		@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> transitionUpdater = mock(Consumer.class);
+		applyAndAwait(evita, storageDirectory, mutation, completionUpdater, transitionUpdater);
+	}
+
+	/**
+	 * Drives one rename or replace to completion on the calling thread, against a caller-supplied transition
+	 * updater.
+	 *
+	 * The transition updater is how the operator declares a catalog unusable, so a test that cares whether a
+	 * declaration happened has to hold the mock it is declared through.
+	 *
+	 * @param evita             engine the operator acts on
+	 * @param storageDirectory  root the folder context is built over
+	 * @param mutation          the rename or replace to apply
+	 * @param completionUpdater stands in for the engine-state commit
+	 * @param transitionUpdater stands in for the engine-state transition the declaration is published through
+	 * @throws ExecutionException when the operation fails, exactly as the engine would see it
+	 */
+	private static void applyAndAwait(
+		@Nonnull Evita evita,
+		@Nonnull Path storageDirectory,
+		@Nonnull ModifyCatalogSchemaNameMutation mutation,
+		@Nonnull Consumer<EngineStateUpdater> completionUpdater,
+		@Nonnull Consumer<EngineStateUpdater> transitionUpdater
+	) throws Exception {
 		// The surviving catalog keeps its folder across the rename and the completion phase relabels it, while a
 		// replace retires the folder its target was living in - so both have to be there, or the run is noisy with
 		// failures that have nothing to do with the test.
@@ -258,7 +287,6 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 		Files.createDirectories(storageDirectory.resolve(TARGET_CATALOG_NAME));
 
 		final CatalogFolderContext folderContext = TestCatalogFolderContexts.onDirectory(storageDirectory);
-		@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> transitionUpdater = mock(Consumer.class);
 
 		final ProgressingFuture<?> future = new ModifyCatalogSchemaNameMutationOperator(folderContext)
 			.applyMutation(UUID.randomUUID(), mutation, evita, transitionUpdater, completionUpdater);
@@ -426,12 +454,12 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 	}
 
 	@Nested
-	@DisplayName("A commit that fails leaves each name answering through the registry it started with")
+	@DisplayName("A commit that fails is past the point of no return, and is declared rather than compensated")
 	class CommitFailure {
 
 		@Test
-		@DisplayName("should unpublish the target's registry when a rename fails at the commit")
-		void shouldUnpublishTheTargetRegistryWhenTheRenameCommitFails(@TempDir Path storageDirectory) {
+		@DisplayName("should declare the catalog unusable when a rename fails at the commit")
+		void shouldDeclareTheCatalogUnusableWhenTheRenameCommitFails(@TempDir Path storageDirectory) {
 			final Map<String, SessionRegistry> registries = new ConcurrentHashMap<>(4);
 			final SessionRegistry sourceRegistry = sessionRegistryFor(SOURCE_CATALOG_NAME);
 			registries.put(SOURCE_CATALOG_NAME, sourceRegistry);
@@ -445,6 +473,7 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 					throw new GenericEvitaInternalError("The engine state refused the rename!");
 				}
 			).when(completionUpdater).accept(any());
+			@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> transitionUpdater = mock(Consumer.class);
 
 			assertThrows(
 				ExecutionException.class,
@@ -452,10 +481,18 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 					mockEngine(catalogs, registries),
 					storageDirectory,
 					new ModifyCatalogSchemaNameMutation(SOURCE_CATALOG_NAME, TARGET_CATALOG_NAME, false),
-					completionUpdater
+					completionUpdater,
+					transitionUpdater
 				)
 			);
 
+			// The commit runs *after* the handover, so by the time it fails the folder has been relabelled, the
+			// previous persistence service closed and the catalog's schema exchanged for the target's. Nothing
+			// about that failure carries the storage layer's marker - it was never raised by the storage layer -
+			// so a failure path that routes on the marker alone compensates here, and hands its callers a
+			// catalog whose every read dies against a closed service. What decides it is the record the
+			// completion phase leaves that the handover ran at all.
+			verify(transitionUpdater).accept(any());
 			assertNull(
 				registries.get(TARGET_CATALOG_NAME),
 				"A rename that failed names no catalog under the target, so a registry left published there would " +
@@ -473,8 +510,8 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 		}
 
 		@Test
-		@DisplayName("should restore the replace target's own registry when the commit fails")
-		void shouldRestoreTheTargetsOwnRegistryWhenTheReplaceCommitFails(@TempDir Path storageDirectory) {
+		@DisplayName("should declare the surviving catalog unusable when a replace fails at the commit")
+		void shouldDeclareTheSurvivingCatalogUnusableWhenTheReplaceCommitFails(@TempDir Path storageDirectory) {
 			final Map<String, SessionRegistry> registries = new ConcurrentHashMap<>(4);
 			final SessionRegistry sourceRegistry = sessionRegistryFor(SOURCE_CATALOG_NAME);
 			final SessionRegistry targetRegistry = sessionRegistryFor(TARGET_CATALOG_NAME);
@@ -491,6 +528,7 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 					throw new GenericEvitaInternalError("The engine state refused the replace!");
 				}
 			).when(completionUpdater).accept(any());
+			@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> transitionUpdater = mock(Consumer.class);
 
 			assertThrows(
 				ExecutionException.class,
@@ -498,10 +536,15 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 					mockEngine(catalogs, registries),
 					storageDirectory,
 					new ModifyCatalogSchemaNameMutation(SOURCE_CATALOG_NAME, TARGET_CATALOG_NAME, true),
-					completionUpdater
+					completionUpdater,
+					transitionUpdater
 				)
 			);
 
+			// Declared for the same reason as the rename above - the handover ran before the commit did. Only
+			// the *surviving* catalog is declared; the catalog that was to be replaced was never touched, which
+			// is what the two assertions below hold the line on.
+			verify(transitionUpdater).accept(any());
 			assertSame(
 				targetRegistry, registries.get(TARGET_CATALOG_NAME),
 				"The replace changed nothing, so the target must still answer through the registry it had - a " +
@@ -521,6 +564,113 @@ class ModifyCatalogSchemaNameMutationOperatorTest {
 			assertTrue(
 				isServing(sourceRegistry),
 				"A failed replace must lift the suspension it opened the surviving catalog with."
+			);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Work that fails after the commit is logged, never reported and never undone")
+	class PostCommitFailure {
+
+		@Test
+		@DisplayName("should neither declare nor report when the work after the commit fails")
+		void shouldNeitherDeclareNorReportWhenTheWorkAfterTheCommitFails(@TempDir Path storageDirectory) {
+			final Map<String, SessionRegistry> registries = new ConcurrentHashMap<>(4);
+			final SessionRegistry sourceRegistry = sessionRegistryFor(SOURCE_CATALOG_NAME);
+			registries.put(SOURCE_CATALOG_NAME, sourceRegistry);
+
+			final Map<String, CatalogContract> catalogs = new HashMap<>(4);
+			catalogs.put(SOURCE_CATALOG_NAME, catalogYielding(catalogWithSchema()));
+
+			final Evita evita = mockEngine(catalogs, registries);
+			// Retiring the source name is the first thing the handoff does *after* the commit has landed. Made to
+			// throw, it stands in for anything in that block failing - a premise assert in the live-view handover,
+			// a resume that refuses. The commit itself is untouched and succeeds.
+			doAnswer(
+				invocation -> {
+					throw new GenericEvitaInternalError("The registry map refused the retirement!");
+				}
+			).when(evita).removeCatalogSessionRegistryIfPresent(anyString());
+
+			@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> completionUpdater = mock(Consumer.class);
+			@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> transitionUpdater = mock(Consumer.class);
+
+			assertDoesNotThrow(
+				() -> applyAndAwait(
+					evita,
+					storageDirectory,
+					new ModifyCatalogSchemaNameMutation(SOURCE_CATALOG_NAME, TARGET_CATALOG_NAME, false),
+					completionUpdater,
+					transitionUpdater
+				),
+				"The commit has landed, so the rename happened and survives a restart. Reporting it as failed " +
+					"tells the caller to act on an operation that is already recorded in durable state."
+			);
+
+			verify(transitionUpdater, never()).accept(any());
+			// The injected throw lands one statement before the resume, so swallowing the failure is exactly
+			// what would hide this: the operation reports success while both names answer SessionBusyException
+			// for the life of the process - this issue's own headline symptom, on the path that claims to have
+			// worked. The resume is therefore owed from a `finally`, not from the block that failed.
+			assertTrue(
+				isServing(sourceRegistry),
+				"A commit that landed must lift the suspension it opened with even when the work after it " +
+					"failed, or the operation reports success and leaves every session refused until restart!"
+			);
+		}
+
+		@Test
+		@DisplayName("should hand the replace target over even when publishing to the live view fails")
+		void shouldHandTheReplaceTargetOverWhenPublishingToTheLiveViewFails(@TempDir Path storageDirectory) {
+			final Map<String, SessionRegistry> registries = new ConcurrentHashMap<>(4);
+			final SessionRegistry sourceRegistry = sessionRegistryFor(SOURCE_CATALOG_NAME);
+			final SessionRegistry targetRegistry = sessionRegistryFor(TARGET_CATALOG_NAME);
+			registries.put(SOURCE_CATALOG_NAME, sourceRegistry);
+			registries.put(TARGET_CATALOG_NAME, targetRegistry);
+
+			// Publishing the replacement to its transaction manager is the last statement before the registry
+			// handover, and the two cannot be reordered - so a failure there must be contained at the site rather
+			// than allowed to skip what follows it. For a replace onto an existing catalog what follows is the swap
+			// that displaces the target's own registry; skipped, that registry stays in the map under the committed
+			// name, still REJECT-suspended from the quiesce this operation opened with, and answers
+			// `InstanceTerminatedException` to every session for the life of the process - beneath an operation
+			// that reported success. The resume in the wrap's `finally` cannot reach it and must not: once the swap
+			// has happened that registry answers to no name, and resuming it would admit sessions no later quiesce
+			// could ever find.
+			final Catalog replacementResult = catalogWithSchema();
+			doThrow(new GenericEvitaInternalError("The transaction manager refused the replacement!"))
+				.when(replacementResult).notifyCatalogPresentInLiveView();
+
+			final Map<String, CatalogContract> catalogs = new HashMap<>(4);
+			catalogs.put(SOURCE_CATALOG_NAME, catalogYielding(replacementResult));
+			catalogs.put(TARGET_CATALOG_NAME, catalogWithSchema());
+
+			@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> completionUpdater = mock(Consumer.class);
+			@SuppressWarnings("unchecked") final Consumer<EngineStateUpdater> transitionUpdater = mock(Consumer.class);
+
+			assertDoesNotThrow(
+				() -> applyAndAwait(
+					mockEngine(catalogs, registries),
+					storageDirectory,
+					new ModifyCatalogSchemaNameMutation(SOURCE_CATALOG_NAME, TARGET_CATALOG_NAME, true),
+					completionUpdater,
+					transitionUpdater
+				),
+				"The commit has landed, so the replace happened - a live-view publication that failed afterwards " +
+					"is not the caller's to act on."
+			);
+
+			verify(transitionUpdater, never()).accept(any());
+			assertNotSame(
+				targetRegistry, registries.get(TARGET_CATALOG_NAME),
+				"The surviving catalog's registry must reach the committed name. Left undone, the name keeps the " +
+					"registry this operation quiesced with REJECT and refuses every session until restart!"
+			);
+			assertTrue(
+				isServing(sourceRegistry),
+				"A committed replace must lift the suspension it opened the surviving catalog with, whatever " +
+					"failed after the commit!"
 			);
 		}
 


### PR DESCRIPTION
Closes #1414

Issue #1414 reported that renaming a live catalog orphans its write-ahead log and can leave the catalog unreachable. Probing it showed **two defects**, one already fixed and one not — and closing the second one exposed five more in review, all in the same quiescing logic. The last of those turned out to be live on `dev` too, unrelated to what the issue reported.

## The WAL half — already fixed, now covered

The folder decoupling (#649 / PR #1417) removed it: the storage prefix is discovered from the folder's `*.boot` file and never derived from the catalog name, so a rename no longer strands the log under the old prefix. Verified in both directions — green on `dev`, and red with the naming-provider defect reintroduced, reproducing the issue's own file listing (`[8, 9, 9]` plus an 8-byte `renamedCatalog_9.wal` stub).

No test reached the shape that broke, so `CatalogRenameRotatedWalTest` now covers rename **and** replace of a catalog whose log has rotated and been purged.

## The session half — live on `dev`, fixed here

`doReplaceCatalogInternal` suspends the surviving catalog's session registry and quiesces a replace target with `REJECT`, but `undoOperations` lifted neither — the resume happened on the success path only. Any failure therefore left the catalog listed but unusable for the life of the process: `SessionBusyException` on the prevailing registry (rename **and** replace), `InstanceTerminatedException` on the quiesced target (replace). The issue diagnosed this in a parenthetical; it outlived the folder decoupling that removed the operation's other failure modes.

`CatalogRenameFailurePathTest` covers it by revoking read permission on the sole `*.catalog` data file before the rename. Header and bootstrap writes go through handles opened at boot, which permissions cannot fail; the reopen constructor after `replaceWith` opens the data file afresh — so the operation fails at exactly the point the issue's second shape failed at, deterministically and with no production seam.

## What review found on top of that

Four rounds on the fix below, each finding something the previous one had not settled — three of them defects in this PR's own work. A fifth round found something older, which gets its own section after this one.

**1. Unpublish before resume.** The restored resume ran before the registry map was put back, so a racing `createSession` could land a live session in a registry the next line unpublished.

**2. A source catalog with no registry was never quiesced.** Registries are built lazily by the first session, so a catalog nobody has opened one on since boot has none — and suspending "whatever is registered" then suspends nothing at all. A session racing the operation could bind to the very catalog whose persistence service `replace` was closing. The operation now *obtains* the registry, installing one when the catalog has none, exactly as it already did for a replace target.

**3. A drain that gave up escaped the recovery.** `closeAllActiveSessionsAndSuspend` publishes the suspension before it waits, and throws when the sessions do not leave within five seconds — with that suspension standing. The source's drain ran before the `try`, so such a failure never reached `undoOperations`; the target's ownership was recorded only after `suspendCatalogSessions` returned, which is after the throw. `Evita#obtainCatalogSessionRegistry` splits the half that cannot fail out of `suspendCatalogSessions`, so the operator owns a registry before draining it, and both drains run inside the `try`.

**4. The undo could delete a registry it never installed** — introduced by fix 3, which put a five-second failure point ahead of the moment the target was claimed. Ownership of the target's registry now happens at the top, above everything that can fail, symmetrically with the surviving catalog's. That also deleted the `AtomicReference` fix 3 had introduced: ownership no longer has to be smuggled out of the `try`.

Together these forced one design change worth naming: the undo **resumes an operation-owned registry in place** rather than unpublishing it. Once a drain can fail with sessions still inside, a registry nobody can reach through the map is invisible to every later quiesce, and those sessions would outlive the catalog they are bound to. Not unpublishing also closes the window in finding 1 outright.

## A fifth defect, found by review and already live on `dev`

Adversarial review then found a race that is **not** what #1414 reported and **not** a regression from this work —
`dev` has the same ordering. It is fixed here rather than deferred, and [recorded on the
issue](https://github.com/FgForrest/evitaDB/issues/1414#issuecomment-5296992155) as a separate finding.

The engine-state commit is what makes the target name resolve, and it does so **synchronously**. Handing the
registry over afterwards left a window in which that name resolved to a live catalog with no registry behind it:
`createSessionInternal` filled it through `computeIfAbsent` with a fresh and *unsuspended* registry, admitted a
session, and the handoff displaced that registry a few instructions later. The session inside it was then reachable
through no name at all — invisible to every quiesce, which walks the registry map — while still bound to a catalog
the next rename, delete or shutdown terminates underneath it. `retireStragglerRegistry` drained such a registry for
five seconds and **swallowed** the failure when it did not empty.

The registry is now published under the target name **before** the commit and left suspended until after it. That
is only safe because `withDifferentCatalogSupplier` shares the active sessions, the suspension and the registration
gate *by reference*: what gets published is already suspended, so a caller that resolves the target name inside the
window waits out the POSTPONE and is then served by the very registry the catalog keeps. The source mapping still
goes only after the commit — dropping it earlier would let a racing session build an unsuspended registry on the
catalog being renamed.

**This applies only where the target name has no registry of its own** — a rename, or a replace onto a name that
names nothing. A sixth review round caught the first attempt doing it unconditionally, which was both unnecessary
and harmful for a replace onto an existing catalog: that catalog's own registry already holds the name from the
read-only phase through to the handoff, so the window never opens there, while an alias published early is one a
failed commit has to take back. A caller captures the published registry *before* it waits out a suspension, and
neither `handleSuspension` nor `registerWhileNotSuspended` consults the map again afterwards — so such a caller
would be released holding an unpublished alias, resolve the target catalog the failure left standing, and register
into the *source* registry's session map, untracked by the name it asked for. The two cases that do publish early
are immune, because a failure leaves their target naming no catalog at all and the waiter dies on
`CatalogNotFoundException` before it can reach `addSession`. The replace-onto-existing path therefore keeps the
post-commit swap it has on `dev`.

Three consequences worth naming:

- **`retireStragglerRegistry` is gone.** Nothing can occupy the target name any more, so the case becomes a premise
  assert at the publication site — which sits *before* the commit, where failing is still free. The only cleanup
  available after the commit was draining a registry full of live sessions and giving up on it, which is the silent
  half-measure the ordering exists to remove.
- **The undo collapsed to two branches** and restores through `registerWithReplaceCatalogSessionRegistry`. By the
  time an undo runs, the target name legitimately carries the derived registry, and the strict `register` refuses a
  name held by a different one.
- **`Evita#registerCatalogSessionRegistry` is deleted** — that undo branch was its only caller repo-wide, and its
  contract ("throws if another registry holds the name") is now wrong for this whole area.

### Testing it without a production hook

The window is a few instructions wide and nothing in production can hold it open, so racing it would be exactly the
flaky construct this project rules out. What a test *can* pin down is the ordering that removes the window — and
the operator's own contract is the seam: `applyMutation` takes the completion-phase engine-state updater as a
**parameter**, so a test that supplies its own observes the registry map at the instant the commit is requested,
before any part of it has run. Four sibling operator tests are already driven this way.

Ruled out on the way there: CDC (`SystemChangeObserver` dispatches through `cdcExecutor`, asynchronously, so a
subscriber cannot gate the window) and `CatalogFolderContext` (built inside `Evita`'s constructor from a
`ServiceLoader`-resolved persistence service, so not per-test injectable).

`ModifyCatalogSchemaNameMutationOperatorTest` adds eight tests. One of them covers something that had **no test
anywhere**: that `withDifferentCatalogSupplier` shares its origin's suspension — the property the whole early
publication rests on.

| Defect reintroduced | Goes red |
|---|---|
| never publish ahead of the commit | `shouldPublishTheTargetRegistryBeforeTheEngineStateCommit`, `shouldRefuseToCommitWhenTheTargetGainedAForeignRegistry` |
| publish ahead of the commit unconditionally | `shouldNotAliasTheNameOfAReplaceTargetThatCanStillBeRestored`, `shouldDeclareTheSurvivingCatalogUnusableWhenTheReplaceCommitFails` |
| undo forgets to take the pre-commit publication back | `shouldDeclareTheCatalogUnusableWhenTheRenameCommitFails`, `shouldRefuseToCommitWhenTheTargetGainedAForeignRegistry` |
| undo skips the replace target's resume | `shouldDeclareTheSurvivingCatalogUnusableWhenTheReplaceCommitFails` |
| the premise assert deleted | `shouldRefuseToCommitWhenTheTargetGainedAForeignRegistry` |
| derived registry given a suspension of its own | `shouldRefuseSessionsThroughTheDerivedViewUntilTheOriginResumes` |

These pin the *ordering*, not a session actually racing the window — worth stating plainly, since the ordering is
what makes the race impossible rather than merely unlikely.

## A sixth defect: a failed rename could still wedge the next boot

The fifth review round asked what a failed handover leaves behind, and the answer was measured rather than argued.
It is the one place on this branch where a fix *re-opened* the issue's headline symptom rather than closing it.

`replaceWith` relabels the folder — schema part, header, bootstrap — before it closes the former persistence
service. Once the flush inside `recordBootstrap` has made that durable, the folder's stored identity disagrees
with engine state, and the commit that would have settled the disagreement is never going to run. `undoOperations`
resumed session admission regardless, so the catalog carried on serving. Reads answered out of memory. A write was
accepted, appended durably to the write-ahead log, and replayed at the next boot against a name engine state has
never heard of — `Catalog `renamedCatalog` is being staged without a folder binding!` — at which point the catalog
did not load at all.

On `dev` this was invisible, because the bug this branch fixes was hiding it: a failed rename left the source
registry suspended for ever, so nothing could reach the damaged catalog to write to it. Resuming those sessions is
correct, and it is what made the layer underneath reachable.

**The line is the durable relabel, not the `close()`.** An earlier reading of this — and the test comment that
carried it — put the point of no return at the service close. The cause chain says otherwise: the injected failure
is a `SyncFailedException` from the offset-index flush, raised while the service is still very much alive. Where
that line falls is the storage layer's to know, so `replaceWith` marks failures past it with
`CatalogHandoverFailedException`, and the engine's part is to stop compensating when it sees one — binding the
surviving name to `UnusableCatalog(CORRUPTED)` **before** resuming the registries, so the callers that resume
releases meet a legible refusal rather than a catalog with nothing behind it. A restart still repairs it, precisely
because nothing was allowed to be written in between.

`Catalog#replace` also stops exchanging the live catalog's schema ahead of the handover. Past the relabel the
declaration hides a poisoned name, but a failure *before* it leaves the catalog serving — and a schema naming the
operation's target poisons every write through the same commit-pipeline lookup.

### Both sides of the line, deliberately

The same permission revocation lands on either side of it depending on how warm the engine is: buffered writes fail
at the flush (past the relabel — declared), a cold offset index fails on open (nothing written — compensated, and
the catalog keeps serving). The suite covers both, and the pre-relabel test asserts the catalog is **not** reported
as a handover failure. Without that pairing nothing stops the marker widening until every failed rename takes a
healthy catalog offline.

Three tests changed premise rather than assertion. "Leaves the catalog usable" was measured to be true only for
reads, and the reads were the trap — the client that gets data back is the one that then tries a write.

| Defect reintroduced | Goes red |
|---|---|
| storage stops marking failures past the relabel | both refusal tests, plus the boot wedge returns verbatim |
| engine sees the marker and compensates anyway | all three refusal tests, plus the boot wedge |
| schema exchanged ahead of the handover again | `shouldLeaveTheTargetServingWhenTheFailedReplaceInstalledItsRegistry` (`expected: <testCatalog> but was: <replacedCatalog>`) |
| the rebuild after `replaceWith` left unmarked | `shouldDeclareTheCatalogUnusableWhenTheRebuildAfterTheRelabelFails`, with `PersistenceServiceClosed` — a session served through a service the handover already closed |

The four sets are nested but distinct, which is what shows they guard different things: strip only the store's
marker and the rebuild test survives, because the rebuild raises its own.

### The gate was the wrong shape, and so was the first fix for it

Two independent reviews converged on the same defect at three successive frames. Each correction was **smaller**
than the one it replaced, and the final one deletes a class, two predicates, an outcome and an extraction that an
earlier round of this branch had added.

**The gate asked the wrong question.** `isHandoverFailure(failure)` asks *where a failure came from*; what decides
between compensating and declaring is *how far the operation got*. Those coincide only while the failure is raised
inside `replaceWith`. Past it, most throws come from code that has never heard of the relabel — the engine commit,
the premise check guarding the registry handoff, the bookkeeping either side — so marking each site kept leaking.
A latch, set as the first statement of the completion phase, answers the question once where the answer is known.

**Nothing after durability may report failure.** The first fix for the commit window marked post-durability
failures so the operator could recognise them, and that was wrong: an operator that unwinds past its own
post-commit work leaves engine state published while its transaction manager still points at the instance it
replaced — demonstrated on `MakeCatalogAliveMutationOperator`, which is not this operator at all. Once
`appendWalAndStoreState` returns, the operation *has happened*; a caller told otherwise retries, and the retry
answers `CatalogNotFoundException` for a catalog that now exists under another name. So the commit's tail and the
operator's tail are best-effort and logged, and the failure path is back to two answers because no committed
operation can reach it.

Two more followed from the same rule. The resume is owed from a `finally` — a throw before it left both names
answering `SessionBusyException` for the life of the process, beneath an operation that reported success, which is
this issue's own headline symptom on the path claiming to have worked. And publishing to the live view is
contained at its site, because it cannot be reordered past the handover (a session admitted first commits against
a pipeline still based on the old instance) and skipping the handover strands a replace's quiesced target under
the committed name, REJECT-suspended.

| Defect reintroduced | Goes red |
|---|---|
| the latch removed, gate on the marker alone | both declaration tests |
| the operator's post-commit tail left unwrapped | `shouldNeitherDeclareNorReportWhenTheWorkAfterTheCommitFails` — a committed rename reported failed |
| post-durability failures propagate again | `EngineTransactionManagerCommitBoundaryTest` — a durable mutation reported failed |
| the resume moved out of the `finally` | the same post-commit test — success reported, sessions refused until restart |
| the live-view publication left to the wrap | `shouldHandTheReplaceTargetOverWhenPublishingToTheLiveViewFails` — target left REJECT-suspended |

Each injection narrows exactly one construct — `Throwable` to `Error`, or the guard to `if (false)` — so every
guard is falsified by the precise edit that would remove it, and no two share a casualty.

A final review round raised three more, all outside the class this issue reports. One was taken because it was
a consequence of the swallow rather than a pre-existing defect: losing the **in-memory publish** after durability
is not like losing the bookkeeping beside it, because the version counter has already moved — the next mutation
would derive from the pre-commit snapshot and persist it at the advanced version, erasing a binding or a
tombstone, silently, once per commit. That now `wedge`s the engine, the same escalation forward replay already
uses. Its trigger is unreachable by construction, so nothing provokes it in a test; it is in because being wrong
about that would be silent and durable. The same commit corrects the operator's class javadoc, which claimed
forward replay is unimplemented — untrue since `b7e3dfc9b`, and directly misleading about what a failed rename
can become after a restart.

**Known limits, none of them closed here.**

- **This does not close the class engine-wide.** `MakeCatalogAliveMutationOperator` and
  `SetCatalogStateMutationOperator` can still report failure after durability from their *own* post-commit
  statements. The manager's swallow fixes the unwind-*through* case; only its tail and this operator's are wrapped.
- **A change-capture gap is now traceable only by log line.** It warrants a counter or health indicator so a missed
  capture is observable without log scraping — the legitimate residue of making dispatch failures non-fatal.
- **A sliver inside `appendWalAndStoreState`.** A failure after its write-ahead log fsync but before the bootstrap
  rewrite is durable by forward replay, is declared, and the restart then *completes* the rename rather than
  restoring the previous name — contradicting `CatalogHandoverFailedException`'s own public message for that case.
- **No injection lands between the schema put and `writeCatalogHeader`**, so no test distinguishes the span's start
  boundary from the old one. Whether a mid-write failure inside that put leaves partial record bytes at an advanced
  buffer position that a sequential walk would trip on is a separate, likely pre-existing question, still open.
- **An unproven write-ahead-log rollback is indeterminate.** If `appendWalAndStoreState` fails after appending and
  its rollback *also* fails, the record stays durable at `walV == stateV + 1`: the rename is reported failed and
  declared unusable in memory, and the next boot forward-replays it to completion. A compound I/O failure whose end
  state after restart is correct, but whose report is wrong while it lasts. Closing it means an explicit
  indeterminate-commit state owned by `evita_store` and the transaction manager together.

None of these is filed separately, deliberately: all are degraded-I/O or impossible-class, none is in the
unreachable-catalog class the issue reports, and the record here plus the commit messages is the trace.

## Also covered

- **Crash between the catalog header write and the bootstrap publish** — `CatalogRenameUnpublishedHeaderTest` builds its fixture from real engine bytes: it snapshots the storage folder, runs a real rename, then rewinds everything except the append-only `*.catalog` files, so the unreferenced header survives as tail. The catalog must return under its former name, and a retried rename must then succeed.
- **The folder-lock symptom** — verified gone: the lock is engine-wide on the storage root, not per catalog.

## Verification

Every test here is calibrated — it goes red against the exact defect it guards, and only that test moves:

| Defect reintroduced | Goes red |
|---|---|
| WAL prefix derived from the catalog name | both `CatalogRenameRotatedWalTest` tests, reproducing the issue's listing |
| suspensions lifted on the success path only | rename and replace failure-path tests (`SessionBusyException` / `InstanceTerminatedException`) |
| target registry unpublished instead of resumed | `shouldLeaveTheTargetServingWhenTheFailedReplaceInstalledItsRegistry` |
| source obtained → merely looked up | the two "never sessioned" handover tests |
| either drain moved out of the recovery | both `DrainFailure` tests |
| the operator as of `7ba9fb597` | `shouldOwnTheTargetRegistryBeforeTheSourceDrainCanFail` |

The calibrations for the publication-ordering and failure-path fixes are tabulated in their own sections above.

The drain-failure tests park a session inside `updateCatalog`'s session-bound lambda — one `executeWhenMethodIsNotRunning` refuses to close — so the five-second drain deterministically gives up; the latch releases only after the failure has already happened, so no wall-clock budget decides the outcome.

`CatalogRenameRotatedWalTest` no longer polls for the WAL purge. Rotation only queues a file for removal and the deletion runs on a scheduled task, so nothing in the write path could be awaited — but `AbstractMutationLog#close` drains those pending removals synchronously, so restarting the engine *is* the purge. The fixture is now load-independent and faster.

7,522 tests green across the `management | session | storage | engine | transaction | wal | cdc` tags — widened from the earlier `management | session | storage` because the commit-boundary change sits under every engine mutation, not just rename. That covers the other two `suspendCatalogSessions` callers — catalog delete and go-live — plus the gRPC client suite. The full fast loop shows only environmental failures on the dev box (Docker absent for `ExportS3ServiceTest`, and an `OutOfMemoryError` in the JUnit engine).

No ADR: the reasoning here is file-local and carried by the commit messages and the comments at the sites.



