### PR TITLE
Add the WARM_UP reindex + goLive benchmark as a repo skill

### DIFF
--- a/.claude/skills/warmup-reindex-benchmark/SKILL.md
+++ b/.claude/skills/warmup-reindex-benchmark/SKILL.md
@@ -65,6 +65,11 @@ with zipfile.ZipFile('<export>.zip') as z: z.extractall('/var/tmp/senesi-bench/p
 disposable working directory on every run and the embedded engine only ever opens that copy, so the
 snapshot is never mutated — but it is also never re-verified, so keep the zip as the source of truth.
 
+`WORK_DIR` is wiped twice per run — once before the copy, once at teardown — so the harness deletes it
+only after proving it is its own: absent, empty, or carrying the `.evita-warmup-workdir` marker file it
+drops there. Point `WORK_DIR` at a directory holding anything else and the run refuses to start instead
+of wiping it.
+
 Key system properties (full list in the class JavaDoc):
 
 | property | meaning |
@@ -86,7 +91,9 @@ RUN=my-label .claude/skills/warmup-reindex-benchmark/run-warmup-reindex.sh
 
 **Run it backgrounded and let the harness wake you** — a full production catalog takes tens of minutes.
 Never poll for completion with `ps`: a finished JVM lingers as a zombie and `ps` still sees it. Detect
-by content — the script prints `RUN_STATUS=MEASUREMENT-DONE-<run>` as its last line.
+by content — the script prints `RUN_STATUS=MEASUREMENT-DONE-<run>` once the report is out, then exits
+with the loader's own status. The marker says the run *finished*; the exit code says whether it
+finished *well* (§4).
 
 Smoke-test the whole chain first, it costs a minute:
 
@@ -112,6 +119,15 @@ the load and calling the sum a publishing time is wrong. This is not hypothetica
 issue #1388 produced, a 15.0 s "goLive" that was Armeria's response timeout expiring. Check the marker
 before quoting a TOTAL, and check the **server** log for `is now alive!` — the transition may have
 completed server-side regardless.
+
+**A count mismatch fails the run; a verification that could not run does not.** After the report the
+harness re-queries both catalogs and compares per-collection entity counts. Counts that genuinely
+differ mean a short load — a faster and meaningless number — so the process exits non-zero and
+`run-warmup-load.sh` propagates that status. Verification that never got its answer (target gone,
+session refused, catalog terminated by a client-side goLive timeout) is logged as `UNVERIFIED` and
+leaves the exit code alone, because the counts are then unknown rather than known-bad. When automating
+a comparison, gate on the exit status — `UNVERIFIED` is the one outcome that needs a human to read the
+log.
 
 ## 5. Comparing two builds
 

--- a/.claude/skills/warmup-reindex-benchmark/SKILL.md
+++ b/.claude/skills/warmup-reindex-benchmark/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: warmup-reindex-benchmark
+description: Measure how long a full catalog reindex-and-publish takes — re-upsert every entity of a real production catalog into a fresh catalog in WARM_UP mode through the gRPC driver, then transition it to ALIVE via goLive. Reports load wall-clock, per-collection and per-upsert latency distributions, and the goLive transition separately. Invoke when asked how long publishing a dataset takes, when verifying a full reindex still completes after write-path or driver changes, when comparing ingestion throughput between two builds, or when profiling the server-side write path under a realistic bulk load.
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash(mvn *), Bash(rtk *), Bash(java *), Bash(git *), Bash(rg *), Bash(awk *), Bash(sed *), Bash(ps *), Bash(uptime *), Bash(free *), Bash(kill *), Bash(pkill *), Bash(cd *), Bash(ls *), Bash(du *), Bash(df *), Bash(unzip *), Bash(python3 *), Bash(cp *), Bash(mkdir *), Bash(chmod *), Bash(grep *), Bash(tail *), Bash(head *), AskUserQuestion
+---
+
+# WARM_UP reindex + goLive benchmark
+
+Measures the operation an e-commerce operator calls **publishing**: rebuild a catalog from scratch in
+`WARM_UP` state, then flip it to `ALIVE`. The harness
+(`IsolatedWarmupLoadBenchmark` + `CatalogCopySupport`, package `io.evitadb.performance.warmupload`) is
+dataset-agnostic — the catalog name is a system property, not baked in — so it applies to any
+production export, not just the "senesi" one it was built for.
+
+Complements `wal-replay-profiling`: that one measures **transactional commit** cost against an ALIVE
+catalog, this one measures **bulk ingest** into a WARM_UP catalog. They exercise different write paths
+and their numbers are not interchangeable.
+
+## Why the two processes
+
+The reader and the writer must not share a JVM. In a single-process copy the same thread deserializes
+source entities and applies target mutations, so no thread filter separates them — read-path Kryo work
+lands in the same flame graph as index maintenance. Running the writer as its own server means a
+profiler attached to it sees the ingestion path and nothing else. It also halves the writer's live set:
+the server holds only the catalog being built.
+
+The trade-off is that client-observed upsert latency then includes protobuf serialization, the loopback
+round trip and server-side deframing — **end-to-end ingestion latency, not write-path latency**. For
+`Product` at milliseconds each the wire is noise; for cheap collections (`Tag`, `Stock`, `Voucher`) it
+dominates and those rows must not be read as write-path costs. `TARGET_MODE=embedded` gives the
+transport-free control; the difference between the two modes is what gRPC costs.
+
+## Bundled scripts
+
+All three take `ROOT=<checkout>` (default `/www/oss/evita/release_2026-2`).
+
+- **`run-warmup-reindex.sh`** — the entry point. Starts the server, waits for readiness, runs the load,
+  tears down, prints the report. One command, one number.
+- **`run-warmup-target-server.sh`** — the write side alone. Use when profiling: attach to **this**
+  process. Supports `PROFILE=jfr|alloc|cpu` with `AP_LIB`.
+- **`run-warmup-load.sh`** — the read side alone. Use to drive several loads against one server.
+
+## 1. Building
+
+```shell
+mvn clean install -P full -DskipTests
+```
+
+`-P full` is mandatory — `evita_test/evita_performance_tests` is not in the default reactor. To rebuild
+only the perf module afterwards: `mvn -o -P full package -pl evita_test/evita_performance_tests -DskipTests`.
+
+## 2. Reproducing the fixture
+
+The source is a catalog export zip. Unzip it once into a directory that will be treated as read-only:
+
+```shell
+mkdir -p /var/tmp/senesi-bench/pristine
+python3 -c "
+import zipfile
+with zipfile.ZipFile('<export>.zip') as z: z.extractall('/var/tmp/senesi-bench/pristine')
+"
+```
+
+`PRISTINE_DIR` must be the **parent** of the `<CATALOG>/` folder. The harness copies it into a
+disposable working directory on every run and the embedded engine only ever opens that copy, so the
+snapshot is never mutated — but it is also never re-verified, so keep the zip as the source of truth.
+
+Key system properties (full list in the class JavaDoc):
+
+| property | meaning |
+|---|---|
+| `evita.warmup.pristineDataDir` | **required** — parent of the `<catalogName>/` snapshot folder |
+| `evita.warmup.catalogName` | source catalog name |
+| `evita.warmup.targetMode` | `remote` (default, profileable) or `embedded` (transport-free control) |
+| `evita.warmup.targetCatalog` | catalog to create and populate |
+| `evita.warmup.maxPerCollection` | cap per collection, `0` = unlimited — use a small value to smoke-test |
+| `evita.warmup.collections` | comma-separated subset, for isolating one collection |
+| `evita.warmup.perEntityCsv` | one CSV row per upsert |
+| `evita.warmup.holdOpenSeconds` | keeps the JVM alive after the report so a profiler can dump |
+
+## 3. Running
+
+```shell
+RUN=my-label .claude/skills/warmup-reindex-benchmark/run-warmup-reindex.sh
+```
+
+**Run it backgrounded and let the harness wake you** — a full production catalog takes tens of minutes.
+Never poll for completion with `ps`: a finished JVM lingers as a zombie and `ps` still sees it. Detect
+by content — the script prints `RUN_STATUS=MEASUREMENT-DONE-<run>` as its last line.
+
+Smoke-test the whole chain first, it costs a minute:
+
+```shell
+MAX_PER_COLL=200 RUN=smoke .claude/skills/warmup-reindex-benchmark/run-warmup-reindex.sh
+```
+
+## 4. What the report separates, and why
+
+Four things that are routinely conflated:
+
+- **load wall-clock** — read + upsert + loop overhead: how long the rebuild actually takes.
+- **upsert (pure)** — the sum of the individual `upsertEntity` calls, with mean/median/p95/p99.
+- **source read** — every source fetch, reported so it can be subtracted rather than silently
+  inflating throughput.
+- **goLive → ALIVE** — measured separately, **never** folded into the per-upsert statistics.
+
+Schema reconstruction happens before the clock starts and is excluded deliberately.
+
+**A failed goLive still prints a duration.** When the transition throws client-side the report marks it
+`*** CLIENT-SIDE FAILURE ***` and the figure is *time to failure*, not transition time — adding it to
+the load and calling the sum a publishing time is wrong. This is not hypothetical: it is exactly what
+issue #1388 produced, a 15.0 s "goLive" that was Armeria's response timeout expiring. Check the marker
+before quoting a TOTAL, and check the **server** log for `is now alive!` — the transition may have
+completed server-side regardless.
+
+## 5. Comparing two builds
+
+- **Never compare runs taken at different heaps.** Heap size feeds the collation-key cache's
+  heap-derived default sizing, so it changes the code path, not just the GC pressure. Pin
+  `SERVER_XMX` and `READER_XMX` and state them next to any number.
+- **The GC share is reported for the reader JVM only.** In `remote` mode the writer's GC has to be read
+  from the server's own GC log (`<BENCH_DIR>/server/<run>/gc.log`); the script prints the young/full
+  counts at teardown.
+- **A single run resolves about ±9 %, no better.** Two runs of *identical* code differed by 8.5 % on the
+  dominant collection, while another same-code pair agreed to 0.2 % — so the spread is not a fixed
+  property of the harness, and **what causes it is not known**. Page-cache state on the multi-GB
+  pristine snapshot was the obvious suspect, but the `a808b4e46` run was taken eight minutes after a
+  fresh unzip and came out fastest of all, which does not fit. Until someone pins it down, treat any
+  single-run gap under ~9 % as unresolved rather than reaching for an explanation — and prefer two runs
+  per build when the answer actually matters.
+- Numbers are not comparable to the gRPC baseline in
+  `documentation/adr/2026-07-27-write-path-performance-tuning/`: that harness also *read* over gRPC.
+
+## 6. Reference measurements
+
+Senesi production export (386,369 entities; 118,772 `Product`, which dominates), writer 23g, reader
+14g/8g, all collections, `storage.compress=true`, traffic recording and cache off, loopback gRPC.
+
+Every cell below is a figure the harness printed. Where a run's total was not isolated from the logs
+the cell is empty rather than reconstructed — a table that mixes measured and derived numbers under
+one header is how a wrong baseline gets quoted with confidence.
+
+| build | Product load | total load | goLive | TOTAL |
+|---|---|---|---|---|
+| v2026.2.0 | 1,158.1 s | 1,239.5 s | 30.1 s | 1,269.6 s |
+| v2026.2.0 | 1,059.9 s | 1,142.9 s | 29.8 s | 1,173.3 s |
+| v2026.2.2 | 1,009.7 s | — | — | — |
+| v2026.2.2 | 1,007.7 s | 1,084.6 s | **failed @ 15.0 s** ¹ | — ¹ |
+| dev @ `a808b4e46` | 870.4 s | 978.7 s | 27.7 s | **1,006.4 s** |
+
+**Compare on Product**: it is the only column measured identically in all five runs, and at ~89 % of
+load time it is what moves the total anyway.
+
+¹ issue #1388 — the retry decorator froze Armeria's 15 s response timeout at call start, so goLive
+could not outlive it. Fixed in PR #1389; a goLive that *completes* is part of what this benchmark
+verifies, not just how long it takes.
+
+`a808b4e46` carries the PR #1395 write-path schema/cardinality optimizations on top of v2026.2.2:
+Product mean upsert 8,281.6 → 7,115.5 µs (−14.1 %), and the writer took **0 full GCs** across the
+whole load. Its goLive is the first in this table that both completed *and* was measured post-#1388.
+
+## 7. Two ways a run silently lies
+
+1. **`evitaDB treats every storage subdirectory as a catalog.`** Leftovers in `TARGET_DATA_DIR` from an
+   earlier run can be picked up as catalogs. `run-warmup-reindex.sh` passes `RESET_DATA=true`; the
+   standalone server script does not by default, and only wipes paths under `/var/tmp` or `/tmp`.
+2. **Both JVMs must fit the cgroup.** Writer 23g + reader 14g is 37 GiB of heap before overhead. Check
+   `/sys/fs/cgroup/memory.max` — the server script prints it in its header. An undersized heap turns
+   this workload GC-bound and you end up measuring the collector.

--- a/.claude/skills/warmup-reindex-benchmark/SKILL.md
+++ b/.claude/skills/warmup-reindex-benchmark/SKILL.md
@@ -120,14 +120,19 @@ issue #1388 produced, a 15.0 s "goLive" that was Armeria's response timeout expi
 before quoting a TOTAL, and check the **server** log for `is now alive!` — the transition may have
 completed server-side regardless.
 
-**A count mismatch fails the run; a verification that could not run does not.** After the report the
-harness re-queries both catalogs and compares per-collection entity counts. Counts that genuinely
-differ mean a short load — a faster and meaningless number — so the process exits non-zero and
-`run-warmup-load.sh` propagates that status. Verification that never got its answer (target gone,
-session refused, catalog terminated by a client-side goLive timeout) is logged as `UNVERIFIED` and
-leaves the exit code alone, because the counts are then unknown rather than known-bad. When automating
-a comparison, gate on the exit status — `UNVERIFIED` is the one outcome that needs a human to read the
-log.
+**Three exit codes, because there are three outcomes.** After the report the harness re-queries both
+catalogs and compares per-collection entity counts, and says what it found in its status:
+
+| exit | meaning |
+|---|---|
+| `0` | counts verified against the source — or verification switched off by `SKIP_VERIFY=true`, which is the operator declining it on purpose |
+| `2` | the load finished and its figures stand, but verification never got its answer (target gone, session refused, catalog terminated by a client-side goLive timeout). Counts **unknown**, not known-bad |
+| `1` | the run failed: counts compared and genuinely differ — a short load, which is both wrong and flatteringly fast — or something else aborted it |
+
+Both `run-warmup-load.sh` and `run-warmup-reindex.sh` propagate the loader's status, so automation can
+gate on the exit code alone: accept `0`, reject `1`, and treat `2` as *measurement present,
+completeness unproven* — never as either. An unverified load is exactly the kind of run that quietly
+becomes a baseline.
 
 ## 5. Comparing two builds
 

--- a/.claude/skills/warmup-reindex-benchmark/run-warmup-load.sh
+++ b/.claude/skills/warmup-reindex-benchmark/run-warmup-load.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# Runs io.evitadb.performance.warmupload.IsolatedWarmupLoadBenchmark - the READ side of the isolated
+# WARM_UP reindex benchmark. It boots an embedded evitaDB holding the original catalog snapshot and
+# re-upserts every entity into a freshly created catalog, single-threaded, through one long-lived
+# WARM_UP session, then transitions that catalog to ALIVE.
+#
+# In the default `remote` mode the target catalog lives on a SEPARATE server process, which must
+# already be running - start it with run-warmup-target-server.sh and attach your profiler to THAT
+# process, not this one. This process only reads.
+#
+# In `embedded` mode the target is a second catalog in this same JVM. That is useless for profiling
+# (reader and writer share every thread) but it gives a transport-free latency baseline: run both
+# modes and the difference is what gRPC costs you.
+#
+# The pristine snapshot directory is never written to - the harness copies it into a disposable
+# working directory on every run. PRISTINE_DIR must be the PARENT of the <CATALOG>/ folder.
+#
+#   ROOT           evitaDB checkout to take the jar from          (default /www/oss/evita/release_2026-2)
+#   PRISTINE_DIR   parent of the <CATALOG>/ snapshot folder       (default /var/tmp/senesi-bench/pristine)
+#   CATALOG        source catalog name                            (default senesi)
+#   TARGET_MODE    remote | embedded                              (default remote)
+#   TARGET         target catalog name        (default: <CATALOG> remote, <CATALOG>_warmup embedded)
+#   TARGET_HOST    target server host                             (default localhost)
+#   TARGET_PORT    target server gRPC port                        (default 5555)
+#   WORK_DIR       disposable working copy of the source          (default /var/tmp/senesi-bench/work)
+#   XMX            reader heap                                    (default 14g)
+#   XMS            reader initial heap                            (default 8g)
+#   MAX_PER_COLL   cap entities per collection, 0 = unlimited     (default 0)
+#   COLLECTIONS    comma-separated subset of collections          (default all)
+#   BATCH_SIZE     entities read from the source per fetch        (default 1000)
+#   PROGRESS       upserts between progress lines, 0 = off        (default 25000)
+#   HOLD_OPEN      seconds to keep THIS jvm alive after report    (default 0)
+#   PER_ENTITY_CSV path for a per-upsert CSV                      (default none)
+#   KEEP_WORK_DIR  keep the working dir after the run             (default false)
+#   SKIP_VERIFY    skip the post-load count verification          (default false)
+#   LOG_DIR        where the run log and GC log land
+#   JAVA_BIN       JVM to use                                     (default JDK 17)
+#
+# Heap size is NOT a neutral knob: it feeds the collation-key cache's heap-derived default sizing, and
+# an undersized heap turns this workload GC-bound. Never compare two runs taken at different heaps.
+
+set -euo pipefail
+
+ROOT="${ROOT:-/www/oss/evita/release_2026-2}"
+JAR="${ROOT}/evita_test/evita_performance_tests/target/benchmarks.jar"
+
+PRISTINE_DIR="${PRISTINE_DIR:-/var/tmp/senesi-bench/pristine}"
+CATALOG="${CATALOG:-senesi}"
+TARGET_MODE="${TARGET_MODE:-remote}"
+TARGET_HOST="${TARGET_HOST:-localhost}"
+TARGET_PORT="${TARGET_PORT:-5555}"
+WORK_DIR="${WORK_DIR:-/var/tmp/senesi-bench/work}"
+XMX="${XMX:-14g}"
+XMS="${XMS:-8g}"
+MAX_PER_COLL="${MAX_PER_COLL:-0}"
+COLLECTIONS="${COLLECTIONS:-}"
+BATCH_SIZE="${BATCH_SIZE:-1000}"
+PROGRESS="${PROGRESS:-25000}"
+HOLD_OPEN="${HOLD_OPEN:-0}"
+PER_ENTITY_CSV="${PER_ENTITY_CSV:-}"
+KEEP_WORK_DIR="${KEEP_WORK_DIR:-false}"
+SKIP_VERIFY="${SKIP_VERIFY:-false}"
+JAVA_BIN="${JAVA_BIN:-/usr/lib/jvm/java-17-openjdk-amd64/bin/java}"
+LOG_DIR="${LOG_DIR:-/var/tmp/senesi-bench/runs/$(date +%Y%m%d-%H%M%S)}"
+
+if [[ -z "${TARGET:-}" ]]; then
+	if [[ "${TARGET_MODE}" == "embedded" ]]; then
+		# embedded mode shares one engine, so the target must not collide with the source
+		TARGET="${CATALOG}_warmup"
+	else
+		TARGET="${CATALOG}"
+	fi
+fi
+
+if [[ ! -f "${JAR}" ]]; then
+	echo "ERROR: benchmarks jar not found at ${JAR}" >&2
+	echo "Build it first:  cd ${ROOT} && mvn clean install -P full -DskipTests" >&2
+	echo "(or point ROOT at the checkout you meant)" >&2
+	exit 1
+fi
+if [[ ! -d "${PRISTINE_DIR}/${CATALOG}" ]]; then
+	echo "ERROR: ${PRISTINE_DIR}/${CATALOG} does not exist." >&2
+	echo "PRISTINE_DIR must be the PARENT of the catalog folder." >&2
+	exit 1
+fi
+if [[ ! -x "${JAVA_BIN}" ]]; then
+	echo "ERROR: JAVA_BIN ${JAVA_BIN} is not executable - override JAVA_BIN." >&2
+	exit 1
+fi
+if [[ "${TARGET_MODE}" != "remote" && "${TARGET_MODE}" != "embedded" ]]; then
+	echo "ERROR: TARGET_MODE must be 'remote' or 'embedded', got '${TARGET_MODE}'." >&2
+	exit 1
+fi
+
+mkdir -p "${LOG_DIR}"
+
+# Byte Buddy generates classes reflectively at runtime and needs these packages opened on JDK 17+.
+# The jar's manifest carries them too, but a manifest Add-Opens applies to `java -jar` only - this
+# harness is launched with `-cp`, so they MUST be repeated here or booting Evita dies with
+# "Cannot define class using reflection".
+JVM_ARGS=(
+	"-Xmx${XMX}"
+	"-Xms${XMS}"
+	--add-opens java.base/java.lang=ALL-UNNAMED
+	--add-opens java.base/java.lang.invoke=ALL-UNNAMED
+	--add-opens java.base/java.math=ALL-UNNAMED
+	--add-opens java.base/java.util=ALL-UNNAMED
+	"-Xlog:gc*:file=${LOG_DIR}/reader-gc.log:time,uptime,level,tags:filecount=5,filesize=100M"
+	-XX:+HeapDumpOnOutOfMemoryError
+	"-XX:HeapDumpPath=${LOG_DIR}"
+)
+
+APP_PROPS=(
+	"-Devita.warmup.pristineDataDir=${PRISTINE_DIR}"
+	"-Devita.warmup.catalogName=${CATALOG}"
+	"-Devita.warmup.targetMode=${TARGET_MODE}"
+	"-Devita.warmup.targetCatalog=${TARGET}"
+	"-Devita.warmup.targetHost=${TARGET_HOST}"
+	"-Devita.warmup.targetPort=${TARGET_PORT}"
+	"-Devita.warmup.workDir=${WORK_DIR}"
+	"-Devita.warmup.maxPerCollection=${MAX_PER_COLL}"
+	"-Devita.warmup.batchSize=${BATCH_SIZE}"
+	"-Devita.warmup.progressInterval=${PROGRESS}"
+	"-Devita.warmup.holdOpenSeconds=${HOLD_OPEN}"
+	"-Devita.warmup.skipVerification=${SKIP_VERIFY}"
+	"-Devita.warmup.keepWorkDir=${KEEP_WORK_DIR}"
+)
+if [[ -n "${COLLECTIONS}" ]]; then
+	APP_PROPS+=("-Devita.warmup.collections=${COLLECTIONS}")
+fi
+if [[ -n "${PER_ENTITY_CSV}" ]]; then
+	APP_PROPS+=("-Devita.warmup.perEntityCsv=${PER_ENTITY_CSV}")
+fi
+
+RUN_LOG="${LOG_DIR}/run.log"
+{
+	echo "=== WARM_UP reindex - READER side (source is embedded here) ==="
+	echo "when          : $(date -Is)"
+	echo "jar           : ${JAR}"
+	echo "jar built     : $(date -Is -r "${JAR}")"
+	echo "git           : $(git -C "${ROOT}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+	echo "java          : $("${JAVA_BIN}" -version 2>&1 | head -1)"
+	echo "reader heap   : -Xmx${XMX} -Xms${XMS}"
+	echo "source catalog: ${CATALOG} (from ${PRISTINE_DIR})"
+	if [[ "${TARGET_MODE}" == "remote" ]]; then
+		echo "target        : ${TARGET} (remote ${TARGET_HOST}:${TARGET_PORT} over gRPC)"
+	else
+		echo "target        : ${TARGET} (embedded, same JVM - transport-free control)"
+	fi
+	echo "max per coll. : ${MAX_PER_COLL}"
+	echo "collections   : ${COLLECTIONS:-<all>}"
+	echo "log dir       : ${LOG_DIR}"
+	if [[ "${TARGET_MODE}" == "remote" ]]; then
+		echo "REMINDER      : attach the profiler to the SERVER process, not this one."
+	fi
+	echo "================================================================"
+} | tee "${RUN_LOG}"
+
+echo "Running (log: ${RUN_LOG})..."
+set +e
+"${JAVA_BIN}" "${JVM_ARGS[@]}" "${APP_PROPS[@]}" \
+	-cp "${JAR}" io.evitadb.performance.warmupload.IsolatedWarmupLoadBenchmark 2>&1 | tee -a "${RUN_LOG}"
+STATUS="${PIPESTATUS[0]}"
+set -e
+
+echo "exit status: ${STATUS}" | tee -a "${RUN_LOG}"
+echo "artifacts in ${LOG_DIR}:"
+ls -la "${LOG_DIR}"
+exit "${STATUS}"

--- a/.claude/skills/warmup-reindex-benchmark/run-warmup-load.sh
+++ b/.claude/skills/warmup-reindex-benchmark/run-warmup-load.sh
@@ -16,6 +16,10 @@
 # The pristine snapshot directory is never written to - the harness copies it into a disposable
 # working directory on every run. PRISTINE_DIR must be the PARENT of the <CATALOG>/ folder.
 #
+# WORK_DIR is wiped before the copy and again at teardown, so the harness deletes it only when it is
+# absent, empty, or carries the `.evita-warmup-workdir` marker it drops there - point WORK_DIR at a
+# directory holding anything else and the run refuses to start rather than wiping it.
+#
 #   ROOT           evitaDB checkout to take the jar from          (default /www/oss/evita/release_2026-2)
 #   PRISTINE_DIR   parent of the <CATALOG>/ snapshot folder       (default /var/tmp/senesi-bench/pristine)
 #   CATALOG        source catalog name                            (default senesi)

--- a/.claude/skills/warmup-reindex-benchmark/run-warmup-load.sh
+++ b/.claude/skills/warmup-reindex-benchmark/run-warmup-load.sh
@@ -20,6 +20,12 @@
 # absent, empty, or carries the `.evita-warmup-workdir` marker it drops there - point WORK_DIR at a
 # directory holding anything else and the run refuses to start rather than wiping it.
 #
+# This script exits with the loader's own status, which distinguishes three outcomes: 0 - entity counts
+# verified against the source (or SKIP_VERIFY=true); 2 - load finished and its figures stand, but the
+# counts could not be verified and are therefore unknown; 1 - the run failed, counts genuinely differ or
+# something else aborted it. Gate automation on that code: accept 0, reject 1, and never let a 2 pass as
+# either.
+#
 #   ROOT           evitaDB checkout to take the jar from          (default /www/oss/evita/release_2026-2)
 #   PRISTINE_DIR   parent of the <CATALOG>/ snapshot folder       (default /var/tmp/senesi-bench/pristine)
 #   CATALOG        source catalog name                            (default senesi)

--- a/.claude/skills/warmup-reindex-benchmark/run-warmup-reindex.sh
+++ b/.claude/skills/warmup-reindex-benchmark/run-warmup-reindex.sh
@@ -151,3 +151,10 @@ if [[ "${PROFILE}" == "alloc" || "${PROFILE}" == "cpu" ]]; then
 	echo "profile  : ${COLLAPSED} ($(stat -c %s "${COLLAPSED}" 2>/dev/null || echo 0) bytes)"
 	echo "           copy it out of the tree before the next 'mvn clean'"
 fi
+
+# The loader's status is carried out of here, but only at the very end: the server still has to be torn
+# down, the report still has to be printed and RUN_STATUS still has to be emitted, all of which happen
+# above regardless of how the load went. Falling off the end instead would return 0 for a load that
+# failed its post-copy count verification - and a caller gating on the exit code would read a short,
+# meaninglessly fast load as a good measurement.
+exit "${LOAD_EXIT}"

--- a/.claude/skills/warmup-reindex-benchmark/run-warmup-reindex.sh
+++ b/.claude/skills/warmup-reindex-benchmark/run-warmup-reindex.sh
@@ -156,5 +156,6 @@ fi
 # down, the report still has to be printed and RUN_STATUS still has to be emitted, all of which happen
 # above regardless of how the load went. Falling off the end instead would return 0 for a load that
 # failed its post-copy count verification - and a caller gating on the exit code would read a short,
-# meaninglessly fast load as a good measurement.
+# meaninglessly fast load as a good measurement. The loader distinguishes 0 (counts verified), 2 (load
+# stands but counts unverified) and 1 (run failed); all three are passed through unchanged.
 exit "${LOAD_EXIT}"

--- a/.claude/skills/warmup-reindex-benchmark/run-warmup-reindex.sh
+++ b/.claude/skills/warmup-reindex-benchmark/run-warmup-reindex.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# One full WARM_UP reindex + goLive, end to end: starts the target server, waits for it to be ready,
+# runs the load, tears the server down and summarises. This is the entry point for "how long does
+# publishing this catalog take" - the other two scripts exist for when you want the halves separately
+# (profiling the writer, or driving several loads against one server).
+#
+# Completion and readiness are detected by log CONTENT, never by process liveness: a finished JVM
+# lingers as a zombie and `ps` still sees it, so a liveness check hangs forever on a job that is
+# already done.
+#
+#   ROOT           evitaDB checkout to measure                (default /www/oss/evita/release_2026-2)
+#   RUN            run label, names the log directories       (default <git-short-sha>)
+#   CATALOG        source catalog name                        (default senesi)
+#   PRISTINE_DIR   parent of the <CATALOG>/ snapshot folder   (default /var/tmp/senesi-bench/pristine)
+#   BENCH_DIR      root for all run artifacts                 (default /var/tmp/senesi-bench)
+#   SERVER_XMX     writer heap                                (default 23g)
+#   READER_XMX     reader heap                                (default 14g)
+#   READER_XMS     reader initial heap                        (default 8g)
+#   MAX_PER_COLL   cap entities per collection, 0 = unlimited (default 0)
+#   COLLECTIONS    comma-separated subset of collections      (default all)
+#   READY_TIMEOUT  seconds to wait for the server             (default 180)
+#   PROFILE        none | jfr | alloc | cpu                   (default none)
+#   AP_LIB         libasyncProfiler.so, required for alloc/cpu
+#   PROFILE_DUMP_TIMEOUT  seconds to let the profiler flush   (default 120)
+#
+# Anything else the two underlying scripts accept can be exported and will be inherited.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${ROOT:-/www/oss/evita/release_2026-2}"
+CATALOG="${CATALOG:-senesi}"
+PRISTINE_DIR="${PRISTINE_DIR:-/var/tmp/senesi-bench/pristine}"
+BENCH_DIR="${BENCH_DIR:-/var/tmp/senesi-bench}"
+SERVER_XMX="${SERVER_XMX:-23g}"
+READER_XMX="${READER_XMX:-14g}"
+READER_XMS="${READER_XMS:-8g}"
+MAX_PER_COLL="${MAX_PER_COLL:-0}"
+COLLECTIONS="${COLLECTIONS:-}"
+READY_TIMEOUT="${READY_TIMEOUT:-180}"
+PROFILE="${PROFILE:-none}"
+AP_LIB="${AP_LIB:-}"
+PROFILE_DUMP_TIMEOUT="${PROFILE_DUMP_TIMEOUT:-120}"
+
+if [[ "${PROFILE}" == "alloc" || "${PROFILE}" == "cpu" ]] && [[ -z "${AP_LIB}" || ! -f "${AP_LIB}" ]]; then
+	echo "ERROR: PROFILE=${PROFILE} needs AP_LIB pointing at libasyncProfiler.so." >&2
+	exit 1
+fi
+RUN="${RUN:-$(git -C "${ROOT}" rev-parse --short HEAD 2>/dev/null || echo run)}"
+
+SRV_LOG_DIR="${BENCH_DIR}/server/${RUN}"
+RUN_LOG_DIR="${BENCH_DIR}/runs/${RUN}"
+SRV_OUT="${SRV_LOG_DIR}/stdout.log"
+TARGET_DATA_DIR="${TARGET_DATA_DIR:-${BENCH_DIR}/target-data}"
+
+mkdir -p "${SRV_LOG_DIR}" "${RUN_LOG_DIR}"
+
+stamp() { echo "[$(date +%H:%M:%S)] $*"; }
+
+stamp "checkout : ${ROOT}"
+GIT_SHA="$(git -C "${ROOT}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+GIT_BRANCH="$(git -C "${ROOT}" branch --show-current 2>/dev/null || echo detached)"
+stamp "git      : ${GIT_SHA} (${GIT_BRANCH})"
+stamp "catalog  : ${CATALOG} from ${PRISTINE_DIR}"
+stamp "heaps    : writer ${SERVER_XMX}, reader ${READER_XMX}/${READER_XMS}"
+
+# ---------------------------------------------------------------- writer -----
+stamp "starting target server${PROFILE:+ (PROFILE=${PROFILE})}"
+XMX="${SERVER_XMX}" XMS="${SERVER_XMX}" RESET_DATA=true \
+	ROOT="${ROOT}" TARGET_DATA_DIR="${TARGET_DATA_DIR}" LOG_DIR="${SRV_LOG_DIR}" \
+	PROFILE="${PROFILE:-none}" AP_LIB="${AP_LIB:-}" \
+	"${SCRIPT_DIR}/run-warmup-target-server.sh" > "${SRV_OUT}" 2>&1 &
+SRV_SHELL_PID=$!
+
+COLLAPSED="${SRV_LOG_DIR}/writer-${PROFILE:-none}.collapsed"
+
+# SIGTERM, then wait for the profiler to finish writing, and only then escalate. async-profiler flushes
+# its dump from a JVM shutdown hook, so a SIGKILL that arrives first leaves a ZERO-BYTE .collapsed while
+# every exit code still reports success. A 23g-heap JVM does not always shut down inside five seconds,
+# so the wait is on the file growing - content, not a fixed sleep.
+teardown() {
+	kill "${SRV_SHELL_PID}" 2>/dev/null
+	pkill -f "${ROOT}/evita_server/target/evita-server.jar" 2>/dev/null
+	if [[ "${PROFILE:-none}" == "alloc" || "${PROFILE:-none}" == "cpu" ]]; then
+		local waited=0
+		local size=0
+		local previous=-1
+		while (( waited < PROFILE_DUMP_TIMEOUT )); do
+			size="$(stat -c %s "${COLLAPSED}" 2>/dev/null || echo 0)"
+			# non-empty AND no longer growing => the dump is complete
+			if (( size > 0 && size == previous )); then break; fi
+			previous="${size}"
+			sleep 2
+			waited=$(( waited + 2 ))
+		done
+		stamp "profile dump: ${size} bytes after ${waited}s"
+		if (( size == 0 )); then
+			stamp "WARNING: ${COLLAPSED} is EMPTY - the profile was lost, do not trust this run"
+		fi
+	else
+		sleep 5
+	fi
+	pkill -9 -f "${ROOT}/evita_server/target/evita-server.jar" 2>/dev/null
+}
+
+READY=false
+for _ in $(seq 1 "${READY_TIMEOUT}"); do
+	if grep -q 'API .gRPC. listening' "${SRV_OUT}" 2>/dev/null; then READY=true; break; fi
+	if grep -qE 'BindException|FolderAlreadyUsed|Exception in thread "main"' "${SRV_OUT}" 2>/dev/null; then break; fi
+	sleep 1
+done
+
+if [[ "${READY}" != "true" ]]; then
+	stamp "SERVER DID NOT BECOME READY within ${READY_TIMEOUT}s - aborting"
+	tail -40 "${SRV_OUT}"
+	teardown
+	echo "RUN_STATUS=SERVER_NOT_READY"
+	exit 1
+fi
+stamp "target server ready"
+
+# ---------------------------------------------------------------- loader -----
+stamp "running reindex (${COLLECTIONS:-all collections}) - a full production catalog takes tens of minutes"
+ROOT="${ROOT}" CATALOG="${CATALOG}" PRISTINE_DIR="${PRISTINE_DIR}" \
+	XMX="${READER_XMX}" XMS="${READER_XMS}" MAX_PER_COLL="${MAX_PER_COLL}" \
+	COLLECTIONS="${COLLECTIONS}" \
+	WORK_DIR="${BENCH_DIR}/work" PER_ENTITY_CSV="${RUN_LOG_DIR}/per-entity.csv" \
+	LOG_DIR="${RUN_LOG_DIR}" \
+	"${SCRIPT_DIR}/run-warmup-load.sh" > "${RUN_LOG_DIR}/stdout.log" 2>&1
+LOAD_EXIT=$?
+stamp "load exit=${LOAD_EXIT}"
+
+# ------------------------------------------------------------- teardown ------
+stamp "on-disk target catalog: $(du -sh "${TARGET_DATA_DIR}" 2>/dev/null | cut -f1)"
+teardown
+YOUNG_GCS="$(grep -c 'Pause Young' "${SRV_LOG_DIR}/gc.log" 2>/dev/null)"
+FULL_GCS="$(grep -c 'Pause Full' "${SRV_LOG_DIR}/gc.log" 2>/dev/null)"
+stamp "writer GC: ${YOUNG_GCS:-0} young, ${FULL_GCS:-0} full"
+
+echo
+# The report is fenced by `===` rules on BOTH sides of its title, so a naive range ending at the first
+# rule prints the title and nothing else - stop at the second one instead.
+sed 's/\x1b\[[0-9;]*m//g' "${RUN_LOG_DIR}/stdout.log" |
+	awk '/SINGLE-THREADED WARM_UP BULK LOAD - RESULT/ { f = 1 } f { print; if (/^=+$/ && ++n == 2) exit }'
+echo
+echo "LOAD_EXIT=${LOAD_EXIT}"
+echo "RUN_STATUS=MEASUREMENT-DONE-${RUN}"
+echo "artifacts: ${RUN_LOG_DIR} (loader), ${SRV_LOG_DIR} (server + GC log)"
+if [[ "${PROFILE}" == "alloc" || "${PROFILE}" == "cpu" ]]; then
+	echo "profile  : ${COLLAPSED} ($(stat -c %s "${COLLAPSED}" 2>/dev/null || echo 0) bytes)"
+	echo "           copy it out of the tree before the next 'mvn clean'"
+fi

--- a/.claude/skills/warmup-reindex-benchmark/run-warmup-target-server.sh
+++ b/.claude/skills/warmup-reindex-benchmark/run-warmup-target-server.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#
+# Starts the evitaDB server that acts as the WRITE side of the isolated WARM_UP reindex benchmark.
+#
+# This is the process to attach a profiler to. It holds ONLY the catalog being built - the source
+# catalog lives in the loader process (embedded), so nothing a profiler samples here belongs to the
+# read path. Start this first, then run run-warmup-load.sh in another shell - or use
+# run-warmup-reindex.sh, which drives both and tears down afterwards.
+#
+# Derived from evita_server/run-server.sh, with three deliberate differences, each of which would
+# otherwise corrupt the measurement:
+#
+#   1. server.trafficRecording.enabled=false  - run-server.sh enables it with a 0 ms flush interval,
+#      which records and flushes every single mutation. That is write-path overhead landing straight
+#      in the profile you are trying to read.
+#   2. an explicit -Xmx                       - run-server.sh sets none, so the JVM would take 25% of
+#      the cgroup limit. Heap size also feeds the collation-key cache's heap-derived default sizing,
+#      so an unpinned heap silently changes the code path between runs.
+#   3. a dedicated, empty storage directory   - so the target catalog is built from nothing and the
+#      source snapshot is nowhere near this process.
+#
+# JDWP is off by default (run-server.sh has it on); a debug transport is not something to leave in a
+# measurement run. Set JDWP=true if you need it.
+#
+#   ROOT             evitaDB checkout to take the jar from   (default /www/oss/evita/release_2026-2)
+#   TARGET_DATA_DIR  storage dir for the catalog being built (default /var/tmp/senesi-bench/target-data)
+#   XMX / XMS        writer heap                             (default 23g / 23g)
+#   GRPC_PORT        gRPC port to listen on                  (default 5555)
+#   COMPRESS         storage.compress                        (default true, matches run-server.sh)
+#   PROFILE          none | jfr | alloc | cpu                (default none)
+#   AP_LIB           path to libasyncProfiler.so (alloc/cpu)
+#   JDWP             expose a debug transport on 8005        (default false)
+#   RESET_DATA       wipe TARGET_DATA_DIR before starting    (default false)
+#   LOG_DIR          where the server + GC log and profile go
+#   JAVA_BIN         JVM to use                              (default JDK 17)
+
+set -euo pipefail
+
+ROOT="${ROOT:-/www/oss/evita/release_2026-2}"
+SERVER_JAR="${ROOT}/evita_server/target/evita-server.jar"
+
+TARGET_DATA_DIR="${TARGET_DATA_DIR:-/var/tmp/senesi-bench/target-data}"
+XMX="${XMX:-23g}"
+XMS="${XMS:-23g}"
+GRPC_PORT="${GRPC_PORT:-5555}"
+COMPRESS="${COMPRESS:-true}"
+PROFILE="${PROFILE:-none}"
+AP_LIB="${AP_LIB:-}"
+JDWP="${JDWP:-false}"
+RESET_DATA="${RESET_DATA:-false}"
+JAVA_BIN="${JAVA_BIN:-/usr/lib/jvm/java-17-openjdk-amd64/bin/java}"
+LOG_DIR="${LOG_DIR:-/var/tmp/senesi-bench/server/$(date +%Y%m%d-%H%M%S)}"
+
+if [[ ! -f "${SERVER_JAR}" ]]; then
+	echo "ERROR: server jar not found at ${SERVER_JAR}" >&2
+	echo "Build it first:  cd ${ROOT} && mvn clean install -P full -DskipTests" >&2
+	echo "(or point ROOT at the checkout you meant)" >&2
+	exit 1
+fi
+if [[ ! -x "${JAVA_BIN}" ]]; then
+	echo "ERROR: JAVA_BIN ${JAVA_BIN} is not executable - override JAVA_BIN." >&2
+	exit 1
+fi
+
+# Guard the wipe: only ever touch a path that is clearly a dedicated scratch directory, never a data
+# directory someone might actually care about.
+if [[ "${RESET_DATA}" == "true" ]]; then
+	case "${TARGET_DATA_DIR}" in
+		/var/tmp/*|/tmp/*)
+			echo "RESET_DATA=true - wiping ${TARGET_DATA_DIR}"
+			rm -rf "${TARGET_DATA_DIR:?}"
+			;;
+		*)
+			echo "ERROR: refusing to wipe '${TARGET_DATA_DIR}' - RESET_DATA only wipes paths under /var/tmp or /tmp." >&2
+			echo "Delete it by hand if that is really what you want." >&2
+			exit 1
+			;;
+	esac
+fi
+
+mkdir -p "${TARGET_DATA_DIR}" "${LOG_DIR}"
+
+if [[ -n "$(ls -A "${TARGET_DATA_DIR}" 2>/dev/null)" ]]; then
+	echo "NOTE: ${TARGET_DATA_DIR} is not empty - leftovers from an earlier run."
+	echo "      The benchmark drops and recreates its target catalog, so this is usually harmless."
+	echo "      Pass RESET_DATA=true for a guaranteed-clean start."
+fi
+
+JVM_ARGS=(
+	"-Xmx${XMX}"
+	"-Xms${XMS}"
+	# improves profiler stack accuracy; negligible runtime cost, and standard for profiling runs
+	-XX:+UnlockDiagnosticVMOptions
+	-XX:+DebugNonSafepoints
+	--add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+	--add-opens java.base/java.lang=ALL-UNNAMED
+	--add-opens java.base/java.lang.invoke=ALL-UNNAMED
+	--add-opens java.base/java.math=ALL-UNNAMED
+	--add-opens java.base/java.util=ALL-UNNAMED
+	"-Xlog:gc*:file=${LOG_DIR}/gc.log:time,uptime,level,tags:filecount=5,filesize=100M"
+	-XX:+HeapDumpOnOutOfMemoryError
+	"-XX:HeapDumpPath=${LOG_DIR}"
+	"-javaagent:${SERVER_JAR}"
+)
+
+if [[ "${JDWP}" == "true" ]]; then
+	JVM_ARGS+=("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8005")
+fi
+
+case "${PROFILE}" in
+	none) ;;
+	jfr)
+		JVM_ARGS+=("-XX:StartFlightRecording=settings=profile,filename=${LOG_DIR}/writer.jfr,dumponexit=true")
+		;;
+	alloc|cpu)
+		if [[ -z "${AP_LIB}" || ! -f "${AP_LIB}" ]]; then
+			echo "ERROR: PROFILE=${PROFILE} needs AP_LIB pointing at libasyncProfiler.so." >&2
+			exit 1
+		fi
+		JVM_ARGS+=("-agentpath:${AP_LIB}=start,event=${PROFILE},collapsed,file=${LOG_DIR}/writer-${PROFILE}.collapsed")
+		;;
+	*)
+		echo "ERROR: unknown PROFILE '${PROFILE}' (expected none|jfr|alloc|cpu)." >&2
+		exit 1
+		;;
+esac
+
+# `closeSessionsAfterSecondsOfInactivity=0` disables the session reaper: the benchmark holds ONE
+# WARM_UP write session open for the entire load, which can run for tens of minutes.
+#
+# `export.fileSystem.directory` must also be pinned: it defaults to `./export` relative to the working
+# directory and evitaDB takes an exclusive folder lock on it, so two engines started from the same
+# project directory fight over it and the second dies with FolderAlreadyUsedException.
+APP_ARGS=(
+	"storage.storageDirectory=${TARGET_DATA_DIR}"
+	"export.fileSystem.directory=${TARGET_DATA_DIR}/export"
+	"storage.compress=${COMPRESS}"
+	"server.trafficRecording.enabled=false"
+	"server.closeSessionsAfterSecondsOfInactivity=0"
+	"cache.enabled=false"
+	"api.exposedOn=localhost"
+	"api.certificate.generateAndUseSelfSigned=true"
+	"api.endpoints.gRPC.host=:${GRPC_PORT}"
+	"api.endpoints.gRPC.tlsMode=RELAXED"
+	"api.endpoints.gRPC.mTLS.enabled=false"
+	"api.endpoints.system.tlsMode=RELAXED"
+)
+
+{
+	echo "=== WARM_UP reindex TARGET server (write side - attach the profiler HERE) ==="
+	echo "when          : $(date -Is)"
+	echo "server jar    : ${SERVER_JAR}"
+	echo "jar built     : $(date -Is -r "${SERVER_JAR}")"
+	echo "git           : $(git -C "${ROOT}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+	echo "java          : $("${JAVA_BIN}" -version 2>&1 | head -1)"
+	echo "writer heap   : -Xmx${XMX} -Xms${XMS}"
+	echo "data dir      : ${TARGET_DATA_DIR}"
+	echo "gRPC port     : ${GRPC_PORT}"
+	echo "compress      : ${COMPRESS}"
+	echo "traffic rec.  : DISABLED (measurement run)"
+	echo "profile       : ${PROFILE}"
+	echo "jdwp          : ${JDWP}"
+	echo "cgroup max    : $(awk '{printf "%.1f GiB", $1/1073741824}' /sys/fs/cgroup/memory.max 2>/dev/null || echo n/a)"
+	echo "log dir       : ${LOG_DIR}"
+	echo "=============================================================================="
+} | tee "${LOG_DIR}/server.log"
+
+exec "${JAVA_BIN}" "${JVM_ARGS[@]}" -jar "${SERVER_JAR}" "${APP_ARGS[@]}" 2>&1 | tee -a "${LOG_DIR}/server.log"

--- a/.editorconfig
+++ b/.editorconfig
@@ -1231,3 +1231,10 @@ max_line_length = off
 [documentation/**]
 trim_trailing_whitespace = false
 max_line_length = off
+
+# Skill definitions carry a YAML front matter block whose `description:` and `allowed-tools:` values
+# must each be ONE logical line -- that string is what the agent matches a task against, so wrapping
+# it is not a formatting choice, it changes the parsed value. Every SKILL.md in the tree already
+# exceeds 120 columns on those two lines; the limit is simply not expressible here.
+[.claude/skills/**/SKILL.md]
+max_line_length = off

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/warmupload/CatalogCopySupport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/warmupload/CatalogCopySupport.java
@@ -1,0 +1,559 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.performance.warmupload;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.query.require.EntityContentRequire;
+import io.evitadb.api.query.require.EntityFetch;
+import io.evitadb.api.requestResponse.schema.AssociatedDataSchemaContract;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
+import io.evitadb.api.requestResponse.schema.AttributeUniquenessType;
+import io.evitadb.api.requestResponse.schema.CatalogSchemaContract;
+import io.evitadb.api.requestResponse.schema.CatalogSchemaEditor.CatalogSchemaBuilder;
+import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.api.requestResponse.schema.EntitySchemaEditor.EntitySchemaBuilder;
+import io.evitadb.api.requestResponse.schema.EvolutionMode;
+import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
+import io.evitadb.api.requestResponse.schema.GlobalAttributeUniquenessType;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaEditor.ReferenceSchemaBuilder;
+import io.evitadb.api.requestResponse.schema.ReflectedReferenceSchemaContract;
+import io.evitadb.api.requestResponse.schema.ReflectedReferenceSchemaContract.AttributeInheritanceBehavior;
+import io.evitadb.api.requestResponse.schema.SortableAttributeCompoundSchemaContract;
+import io.evitadb.api.requestResponse.schema.SortableAttributeCompoundSchemaContract.AttributeElement;
+import io.evitadb.api.requestResponse.schema.builder.SortableAttributeCompoundSchemaBuilder;
+import io.evitadb.dataType.Scope;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Currency;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static io.evitadb.api.query.QueryConstraints.associatedDataContentAll;
+import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
+import static io.evitadb.api.query.QueryConstraints.dataInLocalesAll;
+import static io.evitadb.api.query.QueryConstraints.entityFetch;
+import static io.evitadb.api.query.QueryConstraints.entityFetchAll;
+import static io.evitadb.api.query.QueryConstraints.hierarchyContent;
+import static io.evitadb.api.query.QueryConstraints.priceContentAll;
+import static io.evitadb.api.query.QueryConstraints.referenceContentWithAttributes;
+
+/**
+ * Shared, transport-agnostic building blocks for copying one catalog into another: faithful schema
+ * reconstruction and the full-content fetch requirement used to read the entities being copied.
+ *
+ * Extracted so both target modes of {@link IsolatedWarmupLoadBenchmark} - `remote`, which drives a
+ * separate server over gRPC, and `embedded`, which drives an in-process engine - share exactly one
+ * implementation, and so the older all-in-one {@link io.evitadb.spike.WarmupCopyCatalogBenchmark} can
+ * adopt it without a second copy. The schema-replication rules encoded here are load-bearing and were
+ * arrived at empirically; every non-obvious one carries the reason it exists at its site (see
+ * {@link #replicateReflectedReferences} in particular). Duplicating them would mean rediscovering the
+ * same engine rejections.
+ *
+ * Everything here operates on an open {@link EvitaSessionContract}, so the caller owns session
+ * lifecycle and this class stays usable from both the embedded ({@code Evita}) and the remote
+ * ({@code EvitaClient}) side.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class CatalogCopySupport {
+
+	/**
+	 * Purely static helper - never instantiated.
+	 */
+	private CatalogCopySupport() {
+		throw new UnsupportedOperationException("CatalogCopySupport is a static helper and must not be instantiated.");
+	}
+
+	/**
+	 * Reconstructs the source schema on the target catalog through the supplied (read-write) session.
+	 * Global (catalog-level) attributes are created first, then entity schemas are created in three passes
+	 * so cross-collection references resolve: (1) everything except references, (2) plain references, (3)
+	 * reflected references (which need the plain reference they reflect to already exist on the target
+	 * entity).
+	 *
+	 * @param session             open read-write session of the target catalog (in WARM_UP)
+	 * @param sourceCatalogSchema the source catalog schema (for global attributes)
+	 * @param sourceEntitySchemas the source entity schemas to reproduce
+	 */
+	public static void replicateSchema(
+		@Nonnull final EvitaSessionContract session,
+		@Nonnull final CatalogSchemaContract sourceCatalogSchema,
+		@Nonnull final Collection<EntitySchemaContract> sourceEntitySchemas
+	) {
+		replicateGlobalAttributes(sourceCatalogSchema, session);
+		// pass 1 - entity bodies without references
+		for (final EntitySchemaContract source : sourceEntitySchemas) {
+			final EntitySchemaBuilder builder = session.defineEntitySchema(source.getName());
+			replicateEntityBase(source, builder);
+			builder.updateVia(session);
+		}
+		// pass 2 - plain references
+		for (final EntitySchemaContract source : sourceEntitySchemas) {
+			final EntitySchemaBuilder builder = session.defineEntitySchema(source.getName());
+			replicatePlainReferences(source, builder);
+			builder.updateVia(session);
+		}
+		// pass 3 - reflected references
+		for (final EntitySchemaContract source : sourceEntitySchemas) {
+			final EntitySchemaBuilder builder = session.defineEntitySchema(source.getName());
+			replicateReflectedReferences(source, builder);
+			builder.updateVia(session);
+		}
+	}
+
+	/**
+	 * Builds the full-content fetch requirement for a collection. When the collection has no reflected
+	 * references, {@link io.evitadb.api.query.QueryConstraints#entityFetchAll() entityFetchAll()} is used
+	 * (guaranteed complete and future-proof). When it does, an equivalent fetch is assembled that pulls all
+	 * attributes, associated data, prices, locales, hierarchy and only the plain (non-reflected) references
+	 * with their attributes - so the read-only reflected projections are never transferred nor copied.
+	 *
+	 * @param schema the source schema of the collection
+	 * @return the content requirement to use when fetching entities for copying
+	 */
+	@Nonnull
+	public static EntityFetch buildContentRequirement(@Nonnull final EntitySchemaContract schema) {
+		boolean hasReflectedReference = false;
+		for (final ReferenceSchemaContract reference : schema.getReferences().values()) {
+			if (reference instanceof ReflectedReferenceSchemaContract) {
+				hasReflectedReference = true;
+				break;
+			}
+		}
+		if (!hasReflectedReference) {
+			return entityFetchAll();
+		}
+		final List<EntityContentRequire> requirements = new ArrayList<>();
+		requirements.add(attributeContentAll());
+		requirements.add(associatedDataContentAll());
+		requirements.add(dataInLocalesAll());
+		if (schema.isWithPrice()) {
+			requirements.add(priceContentAll());
+		}
+		if (schema.isWithHierarchy()) {
+			requirements.add(hierarchyContent());
+		}
+		for (final ReferenceSchemaContract reference : schema.getReferences().values()) {
+			if (reference instanceof ReflectedReferenceSchemaContract) {
+				continue;
+			}
+			requirements.add(referenceContentWithAttributes(reference.getName()));
+		}
+		return entityFetch(requirements.toArray(new EntityContentRequire[0]));
+	}
+
+	/**
+	 * Copies every catalog-level global attribute (including its global-uniqueness settings) onto the
+	 * target catalog schema.
+	 *
+	 * @param sourceCatalogSchema the source catalog schema
+	 * @param session             open WARM_UP session of the target catalog
+	 */
+	private static void replicateGlobalAttributes(
+		@Nonnull final CatalogSchemaContract sourceCatalogSchema,
+		@Nonnull final EvitaSessionContract session
+	) {
+		if (sourceCatalogSchema.getAttributes().isEmpty()) {
+			return;
+		}
+		final CatalogSchemaBuilder builder = session.getCatalogSchema().openForWrite();
+		for (final GlobalAttributeSchemaContract attribute : sourceCatalogSchema.getAttributes().values()) {
+			builder.withAttribute(
+				attribute.getName(),
+				attribute.getType(),
+				editor -> {
+					applyAttribute(attribute, editor);
+					final List<Scope> uniqueGlobally = new ArrayList<>(2);
+					final List<Scope> uniqueGloballyWithinLocale = new ArrayList<>(2);
+					for (final Scope scope : Scope.values()) {
+						final GlobalAttributeUniquenessType type = attribute.getGlobalUniquenessType(scope);
+						if (type == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG) {
+							uniqueGlobally.add(scope);
+						} else if (type == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE) {
+							uniqueGloballyWithinLocale.add(scope);
+						}
+					}
+					if (!uniqueGlobally.isEmpty()) {
+						editor.uniqueGloballyInScope(uniqueGlobally.toArray(new Scope[0]));
+					}
+					if (!uniqueGloballyWithinLocale.isEmpty()) {
+						editor.uniqueGloballyWithinLocaleInScope(uniqueGloballyWithinLocale.toArray(new Scope[0]));
+					}
+				}
+			);
+		}
+		builder.updateVia(session);
+	}
+
+	/**
+	 * Reproduces the primary-key strategy, hierarchy, price handling, locales, evolution mode, attributes,
+	 * associated data and (entity-level) sortable attribute compounds of the source entity schema - but no
+	 * references.
+	 *
+	 * @param source  the source entity schema
+	 * @param builder the target entity schema builder
+	 */
+	private static void replicateEntityBase(
+		@Nonnull final EntitySchemaContract source,
+		@Nonnull final EntitySchemaBuilder builder
+	) {
+		final Set<EvolutionMode> evolutionModes = source.getEvolutionMode();
+		if (evolutionModes.isEmpty()) {
+			builder.verifySchemaStrictly();
+		} else {
+			builder.verifySchemaButAllow(evolutionModes.toArray(new EvolutionMode[0]));
+		}
+
+		if (source.isWithGeneratedPrimaryKey()) {
+			builder.withGeneratedPrimaryKey();
+		} else {
+			builder.withoutGeneratedPrimaryKey();
+		}
+
+		if (source.isWithHierarchy()) {
+			final Scope[] hierarchyScopes = scopesWhere(source::isHierarchyIndexedInScope);
+			if (hierarchyScopes.length > 0) {
+				builder.withHierarchyIndexedInScope(hierarchyScopes);
+			} else {
+				builder.withHierarchy();
+			}
+		}
+
+		if (source.isWithPrice()) {
+			final Scope[] priceScopes = scopesWhere(source::isPriceIndexedInScope);
+			final Scope[] effectivePriceScopes = priceScopes.length > 0 ?
+				priceScopes : new Scope[]{Scope.DEFAULT_SCOPE};
+			final int indexedPricePlaces = source.getIndexedPricePlaces();
+			final Currency[] currencies = source.getCurrencies().toArray(new Currency[0]);
+			if (currencies.length > 0) {
+				builder.withPriceInCurrencyIndexedInScope(indexedPricePlaces, currencies, effectivePriceScopes);
+			} else {
+				builder.withPriceIndexedInScope(indexedPricePlaces, effectivePriceScopes);
+			}
+		}
+
+		if (!source.getLocales().isEmpty()) {
+			builder.withLocale(source.getLocales().toArray(new Locale[0]));
+		}
+
+		for (final AttributeSchemaContract attribute : source.getAttributes().values()) {
+			if (attribute instanceof GlobalAttributeSchemaContract) {
+				// global attributes are defined at catalog level - just reference them here
+				builder.withGlobalAttribute(attribute.getName());
+			} else {
+				builder.withAttribute(
+					attribute.getName(),
+					attribute.getType(),
+					editor -> applyAttribute(attribute, editor)
+				);
+			}
+		}
+
+		for (final AssociatedDataSchemaContract associatedData : source.getAssociatedData().values()) {
+			builder.withAssociatedData(
+				associatedData.getName(),
+				associatedData.getType(),
+				editor -> {
+					if (associatedData.isLocalized()) {
+						editor.localized();
+					}
+					if (associatedData.isNullable()) {
+						editor.nullable();
+					}
+				}
+			);
+		}
+
+		for (final SortableAttributeCompoundSchemaContract compound : source.getSortableAttributeCompounds().values()) {
+			applySortableAttributeCompound(compound, builder::withSortableAttributeCompound);
+		}
+	}
+
+	/**
+	 * Adds the plain (non-reflected) references of the source entity schema to the target builder,
+	 * reproducing cardinality, group type, per-scope index type, faceting, reference attributes and
+	 * reference-level sortable attribute compounds.
+	 *
+	 * @param source  the source entity schema
+	 * @param builder the target entity schema builder
+	 */
+	private static void replicatePlainReferences(
+		@Nonnull final EntitySchemaContract source,
+		@Nonnull final EntitySchemaBuilder builder
+	) {
+		for (final ReferenceSchemaContract reference : source.getReferences().values()) {
+			if (reference instanceof ReflectedReferenceSchemaContract) {
+				continue;
+			}
+			if (reference.isReferencedEntityTypeManaged()) {
+				builder.withReferenceToEntity(
+					reference.getName(),
+					reference.getReferencedEntityType(),
+					reference.getCardinality(),
+					editor -> applyReference(reference, editor)
+				);
+			} else {
+				builder.withReferenceTo(
+					reference.getName(),
+					reference.getReferencedEntityType(),
+					reference.getCardinality(),
+					editor -> applyReference(reference, editor)
+				);
+			}
+		}
+	}
+
+	/**
+	 * Adds the reflected references of the source entity schema to the target builder, reproducing the
+	 * reflected reference name, cardinality, faceting and attribute-inheritance behaviour.
+	 *
+	 * @param source  the source entity schema
+	 * @param builder the target entity schema builder
+	 */
+	private static void replicateReflectedReferences(
+		@Nonnull final EntitySchemaContract source,
+		@Nonnull final EntitySchemaBuilder builder
+	) {
+		for (final ReferenceSchemaContract reference : source.getReferences().values()) {
+			if (!(reference instanceof ReflectedReferenceSchemaContract reflected)) {
+				continue;
+			}
+			builder.withReflectedReferenceToEntity(
+				reflected.getName(),
+				reflected.getReferencedEntityType(),
+				reflected.getReflectedReferenceName(),
+				editor -> {
+					// Only override what the reflected reference does NOT inherit from its target reference.
+					// Re-declaring an inherited property (cardinality, faceting) or an inherited attribute is
+					// rejected by the engine ("... is inherited ... but it is already defined!"). A freshly
+					// created reflected reference already defaults to inherited cardinality, so we set it only
+					// when it is explicitly overridden - calling withCardinalityInherited() here would emit a
+					// ModifyReferenceSchemaCardinalityMutation(null) that the WAL serializer cannot write.
+					if (!reflected.isCardinalityInherited()) {
+						editor.withCardinality(reflected.getCardinality());
+					}
+					// attribute-inheritance behaviour governs which target-reference attributes are inherited;
+					// the inherited attributes themselves must NOT be re-declared here
+					final AttributeInheritanceBehavior behavior = reflected.getAttributesInheritanceBehavior();
+					final String[] inheritanceFilter = reflected.getAttributeInheritanceFilter();
+					if (behavior == AttributeInheritanceBehavior.INHERIT_ONLY_SPECIFIED) {
+						editor.withAttributesInherited(inheritanceFilter);
+					} else {
+						editor.withAttributesInheritedExcept(inheritanceFilter);
+					}
+					if (!reflected.isFacetedInherited()) {
+						final Scope[] facetedScopes = scopesWhere(reflected::isFacetedInScope);
+						if (facetedScopes.length > 0) {
+							editor.facetedInScope(facetedScopes);
+						}
+					}
+				}
+			);
+		}
+	}
+
+	/**
+	 * Applies the group type, per-scope index type, faceting, attributes and sortable attribute compounds
+	 * of a plain reference onto its target reference builder.
+	 *
+	 * @param reference the source reference schema
+	 * @param editor    the target reference builder
+	 */
+	private static void applyReference(
+		@Nonnull final ReferenceSchemaContract reference,
+		@Nonnull final ReferenceSchemaBuilder editor
+	) {
+		if (reference.getReferencedGroupType() != null) {
+			if (reference.isReferencedGroupTypeManaged()) {
+				editor.withGroupTypeRelatedToEntity(reference.getReferencedGroupType());
+			} else {
+				editor.withGroupType(reference.getReferencedGroupType());
+			}
+		}
+
+		final List<Scope> forFiltering = new ArrayList<>(2);
+		final List<Scope> forFilteringAndPartitioning = new ArrayList<>(2);
+		for (final Scope scope : Scope.values()) {
+			switch (reference.getReferenceIndexType(scope)) {
+				case FOR_FILTERING -> forFiltering.add(scope);
+				case FOR_FILTERING_AND_PARTITIONING -> forFilteringAndPartitioning.add(scope);
+				case NONE -> {
+					// not indexed in this scope - nothing to do
+				}
+			}
+		}
+		if (!forFiltering.isEmpty()) {
+			editor.indexedForFilteringInScope(forFiltering.toArray(new Scope[0]));
+		}
+		if (!forFilteringAndPartitioning.isEmpty()) {
+			editor.indexedForFilteringAndPartitioningInScope(forFilteringAndPartitioning.toArray(new Scope[0]));
+		}
+
+		final Scope[] facetedScopes = scopesWhere(reference::isFacetedInScope);
+		if (facetedScopes.length > 0) {
+			editor.facetedInScope(facetedScopes);
+		}
+
+		for (final AttributeSchemaContract attribute : reference.getAttributes().values()) {
+			editor.withAttribute(
+				attribute.getName(),
+				attribute.getType(),
+				attributeEditor -> applyAttribute(attribute, attributeEditor)
+			);
+		}
+
+		for (final SortableAttributeCompoundSchemaContract compound :
+			reference.getSortableAttributeCompounds().values()) {
+			applySortableAttributeCompound(compound, editor::withSortableAttributeCompound);
+		}
+	}
+
+	/**
+	 * Copies all common attribute flags (localized, nullable, representative, default value, indexed
+	 * decimal places, per-scope filterable/sortable and per-scope collection-level uniqueness) from the
+	 * source attribute onto the given editor. Works for entity, reference and global attribute editors
+	 * alike.
+	 *
+	 * @param attribute the source attribute schema
+	 * @param editor    the target attribute editor
+	 */
+	private static void applyAttribute(
+		@Nonnull final AttributeSchemaContract attribute,
+		@Nonnull final AttributeSchemaEditor<?> editor
+	) {
+		if (attribute.isLocalized()) {
+			editor.localized();
+		}
+		if (attribute.isNullable()) {
+			editor.nullable();
+		}
+		if (attribute.isRepresentative()) {
+			editor.representative();
+		}
+		if (attribute.getDefaultValue() != null) {
+			editor.withDefaultValue(attribute.getDefaultValue());
+		}
+		if (attribute.getIndexedDecimalPlaces() > 0) {
+			editor.indexDecimalPlaces(attribute.getIndexedDecimalPlaces());
+		}
+
+		final Scope[] filterableScopes = scopesWhere(attribute::isFilterableInScope);
+		if (filterableScopes.length > 0) {
+			editor.filterableInScope(filterableScopes);
+		}
+		final Scope[] sortableScopes = scopesWhere(attribute::isSortableInScope);
+		if (sortableScopes.length > 0) {
+			editor.sortableInScope(sortableScopes);
+		}
+
+		final List<Scope> unique = new ArrayList<>(2);
+		final List<Scope> uniqueWithinLocale = new ArrayList<>(2);
+		for (final Scope scope : Scope.values()) {
+			final AttributeUniquenessType type = attribute.getUniquenessType(scope);
+			if (type == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION) {
+				unique.add(scope);
+			} else if (type == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE) {
+				uniqueWithinLocale.add(scope);
+			}
+		}
+		if (!unique.isEmpty()) {
+			editor.uniqueInScope(unique.toArray(new Scope[0]));
+		}
+		if (!uniqueWithinLocale.isEmpty()) {
+			editor.uniqueWithinLocaleInScope(uniqueWithinLocale.toArray(new Scope[0]));
+		}
+	}
+
+	/**
+	 * Recreates a sortable attribute compound (its ordered attribute elements and per-scope indexing)
+	 * through the supplied factory - which is either the entity or the reference builder's
+	 * {@code withSortableAttributeCompound} method.
+	 *
+	 * @param compound the source sortable attribute compound
+	 * @param factory  builder method that registers the compound
+	 */
+	private static void applySortableAttributeCompound(
+		@Nonnull final SortableAttributeCompoundSchemaContract compound,
+		@Nonnull final SortableAttributeCompoundFactory factory
+	) {
+		final List<AttributeElement> elements = compound.getAttributeElements();
+		factory.create(
+			compound.getName(),
+			elements.toArray(new AttributeElement[0]),
+			editor -> {
+				final Scope[] indexedScopes = scopesWhere(compound::isIndexedInScope);
+				if (indexedScopes.length > 0) {
+					editor.indexedInScope(indexedScopes);
+				}
+			}
+		);
+	}
+
+	/**
+	 * Returns the scopes for which the supplied predicate holds.
+	 *
+	 * @param predicate scope test
+	 * @return matching scopes (never null, possibly empty)
+	 */
+	@Nonnull
+	private static Scope[] scopesWhere(@Nonnull final Predicate<Scope> predicate) {
+		final List<Scope> matching = new ArrayList<>(Scope.values().length);
+		for (final Scope scope : Scope.values()) {
+			if (predicate.test(scope)) {
+				matching.add(scope);
+			}
+		}
+		return matching.toArray(new Scope[0]);
+	}
+
+	/**
+	 * Narrow functional bridge for the two {@code withSortableAttributeCompound(name, elements, whichIs)}
+	 * builder methods (entity-level and reference-level), which share an identical signature but live on
+	 * unrelated editor interfaces.
+	 */
+	@FunctionalInterface
+	private interface SortableAttributeCompoundFactory {
+
+		/**
+		 * Registers a sortable attribute compound.
+		 *
+		 * @param name     compound name
+		 * @param elements ordered attribute elements
+		 * @param whichIs  compound configuration callback
+		 */
+		void create(
+			@Nonnull String name,
+			@Nonnull AttributeElement[] elements,
+			@Nonnull Consumer<SortableAttributeCompoundSchemaBuilder> whichIs
+		);
+	}
+
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/warmupload/IsolatedWarmupLoadBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/warmupload/IsolatedWarmupLoadBenchmark.java
@@ -32,7 +32,6 @@ import io.evitadb.api.configuration.EvitaConfiguration;
 import io.evitadb.api.configuration.ExportOptions;
 import io.evitadb.api.configuration.ServerOptions;
 import io.evitadb.api.configuration.StorageOptions;
-import io.evitadb.export.file.configuration.FileSystemExportOptions;
 import io.evitadb.api.query.Query;
 import io.evitadb.api.query.require.EntityFetch;
 import io.evitadb.api.requestResponse.data.EntityReferenceContract;
@@ -45,6 +44,7 @@ import io.evitadb.driver.config.ClientTimeoutOptions;
 import io.evitadb.driver.config.ClientTlsOptions;
 import io.evitadb.driver.config.EvitaClientConfiguration;
 import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.export.file.configuration.FileSystemExportOptions;
 import io.evitadb.test.builder.CopyExistingEntityBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
@@ -52,9 +52,11 @@ import org.apache.commons.io.FileUtils;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.io.Serial;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -165,7 +167,8 @@ public class IsolatedWarmupLoadBenchmark {
 	public static final String TARGET_PORT_PROPERTY = "evita.warmup.targetPort";
 	/**
 	 * System property overriding the working directory the pristine snapshot is copied into. Defaults to a
-	 * fresh temp directory.
+	 * fresh temp directory. The harness wipes this directory before the copy and again on teardown, so it
+	 * only ever accepts one it can prove is disposable - see {@link #WORK_DIR_MARKER_FILE}.
 	 */
 	public static final String WORK_DIR_PROPERTY = "evita.warmup.workDir";
 	/**
@@ -210,6 +213,19 @@ public class IsolatedWarmupLoadBenchmark {
 	public static final String KEEP_WORK_DIR_PROPERTY = "evita.warmup.keepWorkDir";
 
 	/**
+	 * Name of the file dropped into the working directory to mark it as this harness's disposable scratch
+	 * space. Both deletions of that directory - the one before the copy and the one on teardown - refuse to
+	 * run unless the directory is empty or carries this marker, because {@value #WORK_DIR_PROPERTY} is an
+	 * operator-supplied path and a mistyped one would otherwise be wiped without warning.
+	 *
+	 * A marker rather than a `/tmp` prefix whitelist: a working copy of a production-sized catalog is tens of
+	 * gigabytes and legitimately belongs on whichever volume has the room, so a path check would reject valid
+	 * setups while still permitting a fat-fingered path that happens to sit under `/tmp`. The file lands at
+	 * the storage-directory root next to the engine's own lock file, where catalog discovery cannot see it -
+	 * `CatalogFolderClassifier` only ever enumerates directories.
+	 */
+	private static final String WORK_DIR_MARKER_FILE = ".evita-warmup-workdir";
+	/**
 	 * Default number of entities read from the source per fetch.
 	 */
 	private static final int DEFAULT_BATCH_SIZE = 1_000;
@@ -252,9 +268,11 @@ public class IsolatedWarmupLoadBenchmark {
 	 * constants for configuration.
 	 *
 	 * @param args ignored - the harness is configured entirely through system properties
-	 * @throws Exception when the working copy cannot be prepared, the target is unreachable, or either
-	 *                   engine fails to close - all of which must abort the run loudly rather than yield
-	 *                   a partial measurement
+	 * @throws Exception when the working copy cannot be prepared, the target is unreachable, the loaded
+	 *                   entity counts do not match the source, or either engine fails to close - all of
+	 *                   which must abort the run loudly rather than yield a partial measurement. Nothing is
+	 *                   caught here on purpose: the resulting non-zero exit code is the only failure signal
+	 *                   an automated caller gets.
 	 */
 	public static void main(@Nonnull final String[] args) throws Exception {
 		new IsolatedWarmupLoadBenchmark().run();
@@ -264,8 +282,9 @@ public class IsolatedWarmupLoadBenchmark {
 	 * Prepares the working copy, boots the embedded source engine, connects (or falls back) to the target,
 	 * runs the measured rebuild and prints the report.
 	 *
-	 * @throws Exception when the working copy cannot be prepared, the target is unreachable, or either
-	 *                   engine fails to close
+	 * @throws LoadVerificationFailedException when the target does not hold what the source does
+	 * @throws Exception                       when the working copy cannot be prepared, the target is
+	 *                                         unreachable, or either engine fails to close
 	 */
 	private void run() throws Exception {
 		final Path pristineDataDir = Path.of(requiredProperty(PRISTINE_DATA_DIR_PROPERTY));
@@ -303,7 +322,7 @@ public class IsolatedWarmupLoadBenchmark {
 		// ---- prepare a disposable working copy - the pristine snapshot is never written to -----
 		log.info("Copying pristine snapshot `{}` -> working directory `{}`...", pristineDataDir, workDataDir);
 		final long prepareStart = System.nanoTime();
-		FileUtils.deleteDirectory(workDataDir.toFile());
+		prepareWorkingDirectory(workDataDir);
 		FileUtils.copyDirectory(
 			pristineDataDir.resolve(sourceCatalog).toFile(),
 			workDataDir.resolve(sourceCatalog).toFile()
@@ -311,7 +330,10 @@ public class IsolatedWarmupLoadBenchmark {
 		log.info("Working copy ready in {} ms.", (System.nanoTime() - prepareStart) / 1_000_000);
 
 		final Evita source = bootSourceEngine(workDataDir);
-		try {
+		// `try (source)` rather than a plain close in the finally: when the measured block and the close both
+		// fail, try-with-resources attaches the close failure as suppressed instead of letting it replace the
+		// original one - and a verification mismatch is precisely the failure that must survive teardown.
+		try (source) {
 			awaitCatalogAlive(source, sourceCatalog);
 			final EvitaContract target = targetMode == TargetMode.REMOTE ?
 				connectToTargetServer(targetHost, targetPort) : source;
@@ -334,10 +356,19 @@ public class IsolatedWarmupLoadBenchmark {
 				} else {
 					try {
 						verifyCopy(source, target, sourceCatalog, targetCatalog, maxPerCollection, result);
+					} catch (LoadVerificationFailedException ex) {
+						// verification RAN and the counts genuinely differ: the load was short, so the number
+						// printed above is both wrong and flatteringly fast. Rethrowing is what makes the JVM
+						// exit non-zero - an automated caller checking the exit code has nothing else to read.
+						throw ex;
 					} catch (Exception ex) {
+						// anything else means verification never got its answer (target unreachable, session
+						// refused, catalog terminated by a client-side goLive timeout) - the counts are unknown
+						// rather than known-bad, which is not grounds for discarding a completed measurement
 						log.error(
 							"Post-copy verification could not run - the load figures above stand, but the " +
-								"target entity counts are UNVERIFIED for this run.", ex
+								"target entity counts are UNVERIFIED for this run. This is not a count " +
+								"mismatch: a mismatch fails the run instead.", ex
 						);
 					}
 				}
@@ -349,12 +380,87 @@ public class IsolatedWarmupLoadBenchmark {
 				}
 			}
 		} finally {
-			source.close();
 			if (keepWorkDir) {
 				log.info("Working directory `{}` kept on disk by configuration.", workDataDir);
 			} else {
-				FileUtils.deleteDirectory(workDataDir.toFile());
+				try {
+					deleteWorkingDirectory(workDataDir);
+				} catch (Exception ex) {
+					// a teardown that cannot finish is a nuisance, not the reason the run failed - throwing here
+					// would overwrite whatever the measured block reported with a message about a directory
+					log.error(
+						"Working directory `{}` could not be removed - remove it by hand before the next run.",
+						workDataDir, ex
+					);
+				}
 			}
+		}
+	}
+
+	/**
+	 * Empties the working directory and lays a freshly marked one in its place, ready for the pristine
+	 * snapshot to be copied in. The marker is what licenses every later deletion of this directory - see
+	 * {@link #deleteWorkingDirectory(Path)}.
+	 *
+	 * @param workDataDir the directory the working copy is built in
+	 * @throws IOException when the directory cannot be emptied, created or marked
+	 */
+	private static void prepareWorkingDirectory(@Nonnull final Path workDataDir) throws IOException {
+		deleteWorkingDirectory(workDataDir);
+		Files.createDirectories(workDataDir);
+		Files.writeString(
+			workDataDir.resolve(WORK_DIR_MARKER_FILE),
+			"Disposable working copy of a catalog snapshot, created by " +
+				IsolatedWarmupLoadBenchmark.class.getName() + "." + System.lineSeparator() +
+				"Every run of that benchmark wipes this directory. Do not keep anything here." +
+				System.lineSeparator(),
+			StandardCharsets.UTF_8
+		);
+	}
+
+	/**
+	 * Deletes the working directory, but only after establishing that it is this harness's to delete: it
+	 * must be absent, empty, or carry the {@link #WORK_DIR_MARKER_FILE} marker left by
+	 * {@link #prepareWorkingDirectory(Path)}. {@value #WORK_DIR_PROPERTY} is an operator-supplied path that
+	 * gets wiped twice per run, and a mistyped or copy-pasted one must fail loudly rather than quietly.
+	 *
+	 * @param workDataDir the directory to delete
+	 * @throws IOException                when the directory cannot be inspected or deleted
+	 * @throws GenericEvitaInternalError  when it holds something this harness did not put there
+	 */
+	private static void deleteWorkingDirectory(@Nonnull final Path workDataDir) throws IOException {
+		if (!Files.exists(workDataDir)) {
+			return;
+		}
+		if (!Files.isDirectory(workDataDir)) {
+			throw new GenericEvitaInternalError(
+				"Refusing to delete `" + workDataDir + "` - it is not a directory. Point `" + WORK_DIR_PROPERTY +
+					"` at a disposable directory.",
+				"Configured working directory is not a directory."
+			);
+		}
+		if (!Files.exists(workDataDir.resolve(WORK_DIR_MARKER_FILE)) && !isEmptyDirectory(workDataDir)) {
+			throw new GenericEvitaInternalError(
+				"Refusing to delete `" + workDataDir + "` - it is not empty and carries no `" +
+					WORK_DIR_MARKER_FILE + "` marker, so this harness did not create it. Point `" +
+					WORK_DIR_PROPERTY + "` at a disposable directory, or empty this one by hand if it really " +
+					"is scratch space.",
+				"Refusing to delete a working directory this harness did not create."
+			);
+		}
+		FileUtils.deleteDirectory(workDataDir.toFile());
+	}
+
+	/**
+	 * Tells whether the given directory holds no entries at all.
+	 *
+	 * @param directory the directory to inspect
+	 * @return true when the directory has no entries
+	 * @throws IOException when the directory cannot be listed
+	 */
+	private static boolean isEmptyDirectory(@Nonnull final Path directory) throws IOException {
+		try (final DirectoryStream<Path> entries = Files.newDirectoryStream(directory)) {
+			return !entries.iterator().hasNext();
 		}
 	}
 
@@ -743,6 +849,9 @@ public class IsolatedWarmupLoadBenchmark {
 	 * @param targetCatalog    name of the freshly built catalog
 	 * @param maxPerCollection the per-collection cap that was applied (0 == uncapped)
 	 * @param result           the measurement, holding the per-collection copied counts
+	 * @throws LoadVerificationFailedException when the counts were compared and differ - the one failure this
+	 *                                        method reports as a verdict rather than as an inability to reach
+	 *                                        the target, and the one the caller must not downgrade to a log
 	 */
 	private static void verifyCopy(
 		@Nonnull final Evita source,
@@ -778,7 +887,9 @@ public class IsolatedWarmupLoadBenchmark {
 		}
 		System.out.print(table);
 		if (mismatches.length() > 0) {
-			throw new IllegalStateException("Load verification FAILED - entity counts differ:" + mismatches);
+			throw new LoadVerificationFailedException(
+				"Load verification FAILED - entity counts differ:" + mismatches
+			);
 		}
 		System.out.println(
 			maxPerCollection > 0 ?
@@ -1018,6 +1129,22 @@ public class IsolatedWarmupLoadBenchmark {
 	@Nonnull
 	private static String padRight(@Nonnull final String value, final int width) {
 		return value.length() >= width ? value : value + " ".repeat(width - value.length());
+	}
+
+	/**
+	 * Raised when the post-copy verification ran to completion and the target does **not** hold what the
+	 * source does. It exists to be distinguishable from every other way verification can fail - an
+	 * unreachable target, a refused session, a catalog terminated client-side by a goLive timeout - because
+	 * those leave the counts merely *unknown*, while this one is a measured verdict that the load was short.
+	 * The distinction is the whole point: a short load yields a faster and entirely meaningless number, so
+	 * only this failure is allowed to take the run down with it.
+	 */
+	private static class LoadVerificationFailedException extends GenericEvitaInternalError {
+		@Serial private static final long serialVersionUID = -2871894423915203164L;
+
+		LoadVerificationFailedException(@Nonnull final String message) {
+			super(message);
+		}
 	}
 
 	/**

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/warmupload/IsolatedWarmupLoadBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/warmupload/IsolatedWarmupLoadBenchmark.java
@@ -1,0 +1,1328 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.performance.warmupload;
+
+import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
+import io.evitadb.api.CatalogState;
+import io.evitadb.api.EvitaContract;
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.configuration.CacheOptions;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ExportOptions;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.export.file.configuration.FileSystemExportOptions;
+import io.evitadb.api.query.Query;
+import io.evitadb.api.query.require.EntityFetch;
+import io.evitadb.api.requestResponse.data.EntityReferenceContract;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.schema.CatalogSchemaContract;
+import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.core.Evita;
+import io.evitadb.driver.EvitaClient;
+import io.evitadb.driver.config.ClientTimeoutOptions;
+import io.evitadb.driver.config.ClientTlsOptions;
+import io.evitadb.driver.config.EvitaClientConfiguration;
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.test.builder.CopyExistingEntityBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.entityPrimaryKeyInSet;
+import static io.evitadb.api.query.QueryConstraints.filterBy;
+import static io.evitadb.api.query.QueryConstraints.page;
+import static io.evitadb.api.query.QueryConstraints.require;
+
+/**
+ * Single-threaded WARM_UP bulk-load benchmark that reads from an **embedded** source catalog and writes
+ * into a **separate, independently profileable** target.
+ *
+ * The whole point of the split: the reader and the writer must not share a JVM. In a single-process copy
+ * the very same thread deserializes source entities and applies target mutations, so no thread filter or
+ * sampling trick can separate them - read-path Kryo work lands in the same flame graph as index
+ * maintenance. Running the writer as its own server process means a profiler attached to it sees the
+ * ingestion path and nothing else.
+ *
+ * A second, less obvious benefit: it halves the writer's live set. The older all-in-one-server harness
+ * ({@link io.evitadb.spike.WarmupCopyCatalogBenchmark}) kept *both* catalogs in the server heap, which is
+ * the configuration the write-path ADR found death-spiralling in G1. Here the server holds only the
+ * catalog being built.
+ *
+ * **Two target modes**, selected by {@value #TARGET_MODE_PROPERTY}:
+ *
+ * - **`remote`** (default) - the target is a separate evitaDB server reached over gRPC, started
+ *   beforehand (see `.claude/skills/warmup-reindex-benchmark/run-warmup-target-server.sh`, or let
+ *   `run-warmup-reindex.sh` drive both sides). This is the mode to profile: attach to the *server*
+ *   process. The trade-off is that client-observed upsert latency then includes protobuf
+ *   serialization, the loopback round trip and server-side deframing - it is **end-to-end ingestion
+ *   latency, not write-path latency**.
+ * - **`embedded`** - the target is a second catalog inside this same JVM, i.e. no transport at all. Useless
+ *   for profiling (see above) but it yields a transport-free latency baseline. **Running both modes and
+ *   differencing them is how the gRPC overhead in the `remote` numbers gets quantified** rather than
+ *   guessed at.
+ *
+ * **What is measured.** The clock starts after schema reconstruction (excluded) and the report separates
+ * four things that are routinely conflated:
+ *
+ * - **pure upsert time** - the sum of every individual {@link EvitaSessionContract#upsertEntity} call,
+ *   with its full mean/median/p95/p99 distribution.
+ * - **source read time** - every source fetch, reported so it can be seen and subtracted rather than
+ *   silently inflating throughput.
+ * - **copy wall-clock** - read + upsert + loop overhead, i.e. how long the rebuild actually takes.
+ * - **goLive transition** - measured separately, never folded into the per-upsert statistics.
+ *
+ * **Caveats that must travel with any number this prints:**
+ *
+ * - In `remote` mode one upsert is one gRPC round trip (~50-200 us on loopback). Against `Product` at
+ *   milliseconds each that is noise, but for cheap collections (tag, stock, voucher) the wire dominates
+ *   and those rows must not be read as write-path costs.
+ * - Heap size is not a neutral knob: it feeds the collation-key cache's heap-derived default sizing, and
+ *   an undersized heap turns this workload GC-bound. **Never compare runs taken at different heaps.** The
+ *   GC share of the measured window is always reported; treat anything materially above ~15 % as a
+ *   measurement of the collector rather than of evitaDB. Note the reported GC figure covers **this**
+ *   (reader) JVM - in `remote` mode the writer's GC must be read from the server's own GC log.
+ * - Numbers here are not comparable to the 2 020 s / 16.1 ms-per-`Product` gRPC baseline in
+ *   `documentation/adr/2026-07-27-write-path-performance-tuning/`: that harness also *read* over gRPC.
+ *
+ * The source archive is never touched - the pristine snapshot directory is copied into a disposable
+ * working directory on every run and the embedded engine only ever opens that copy.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Slf4j
+public class IsolatedWarmupLoadBenchmark {
+
+	/**
+	 * System property pointing to the directory holding a `&lt;catalogName&gt;/` subfolder with the
+	 * pristine source snapshot. Copied fresh into the working directory on every run, never written to.
+	 * Mandatory.
+	 */
+	public static final String PRISTINE_DATA_DIR_PROPERTY = "evita.warmup.pristineDataDir";
+	/**
+	 * System property naming the source catalog; the pristine data directory must contain a subfolder with
+	 * exactly this name.
+	 */
+	public static final String CATALOG_NAME_PROPERTY = "evita.warmup.catalogName";
+	/**
+	 * System property naming the target catalog to create and populate. In `remote` mode this lives on the
+	 * separate server, so it may safely carry the same name as the source.
+	 */
+	public static final String TARGET_CATALOG_PROPERTY = "evita.warmup.targetCatalog";
+	/**
+	 * System property selecting where the target catalog lives: `remote` (a separate server over gRPC, the
+	 * profileable mode) or `embedded` (this JVM, the transport-free control).
+	 */
+	public static final String TARGET_MODE_PROPERTY = "evita.warmup.targetMode";
+	/**
+	 * System property naming the target server host (`remote` mode only).
+	 */
+	public static final String TARGET_HOST_PROPERTY = "evita.warmup.targetHost";
+	/**
+	 * System property naming the target server gRPC port (`remote` mode only).
+	 */
+	public static final String TARGET_PORT_PROPERTY = "evita.warmup.targetPort";
+	/**
+	 * System property overriding the working directory the pristine snapshot is copied into. Defaults to a
+	 * fresh temp directory.
+	 */
+	public static final String WORK_DIR_PROPERTY = "evita.warmup.workDir";
+	/**
+	 * System property capping the entities copied per collection (`0` = unlimited). A small positive value
+	 * gives a fast end-to-end smoke test; leave it `0` for a real measurement.
+	 */
+	public static final String MAX_PER_COLLECTION_PROPERTY = "evita.warmup.maxPerCollection";
+	/**
+	 * System property restricting the run to a comma-separated subset of collections (empty = all). Useful
+	 * when profiling, since one collection typically dominates the whole copy.
+	 */
+	public static final String COLLECTIONS_PROPERTY = "evita.warmup.collections";
+	/**
+	 * System property overriding how many entities are read from the source per fetch. Reads are keyed by an
+	 * explicit primary-key set, so each fetch is an indexed lookup rather than a deep-pagination scan.
+	 */
+	public static final String BATCH_SIZE_PROPERTY = "evita.warmup.batchSize";
+	/**
+	 * System property setting how many upserts pass between two intra-collection progress lines (`0` = only
+	 * per-collection summaries). A full run takes tens of minutes, so this is what makes it observable.
+	 */
+	public static final String PROGRESS_INTERVAL_PROPERTY = "evita.warmup.progressInterval";
+	/**
+	 * System property keeping this JVM alive for the given number of seconds after the report is printed.
+	 * Mostly useful in `embedded` mode; when profiling the *server* in `remote` mode it is the server that
+	 * has to be kept alive, which its own launcher handles.
+	 */
+	public static final String HOLD_OPEN_SECONDS_PROPERTY = "evita.warmup.holdOpenSeconds";
+	/**
+	 * System property naming a CSV file to receive one row per upserted entity (collection, primary key,
+	 * upsert duration). Unset (default) records nothing.
+	 */
+	public static final String PER_ENTITY_CSV_PROPERTY = "evita.warmup.perEntityCsv";
+	/**
+	 * System property skipping the post-copy count verification. Verification re-queries both catalogs and
+	 * costs a little time, but it is the only guard against a silently short copy - skip only deliberately.
+	 */
+	public static final String SKIP_VERIFICATION_PROPERTY = "evita.warmup.skipVerification";
+	/**
+	 * System property keeping the working directory on disk after the run instead of deleting it.
+	 */
+	public static final String KEEP_WORK_DIR_PROPERTY = "evita.warmup.keepWorkDir";
+
+	/**
+	 * Default number of entities read from the source per fetch.
+	 */
+	private static final int DEFAULT_BATCH_SIZE = 1_000;
+	/**
+	 * Default number of upserts between two intra-collection progress lines.
+	 */
+	private static final int DEFAULT_PROGRESS_INTERVAL = 25_000;
+	/**
+	 * GC share of the measured window above which the run is called out as GC-bound in the report.
+	 */
+	private static final double GC_BOUND_WARNING_THRESHOLD = 15.0;
+	/**
+	 * Upper bound for a single gRPC message accepted by the client. Armeria's default is 10 MB; a rich
+	 * entity (senesi `Product` with prices and references) plus schema payloads can approach it, and the
+	 * deframer aborts the whole run with `RESOURCE_EXHAUSTED` rather than degrading. 256 MB is ample
+	 * headroom while still guarding against a runaway message.
+	 */
+	private static final int MAX_GRPC_MESSAGE_SIZE = 256 * 1024 * 1024;
+	/**
+	 * How long to wait for the target server to accept connections before giving up (`remote` mode).
+	 */
+	private static final Duration SERVER_WAIT_TIMEOUT = Duration.ofMinutes(10);
+
+	/**
+	 * Where the target catalog lives.
+	 */
+	private enum TargetMode {
+		/**
+		 * A separate evitaDB server reached over gRPC - the mode to profile.
+		 */
+		REMOTE,
+		/**
+		 * A second catalog inside this JVM - the transport-free control.
+		 */
+		EMBEDDED
+	}
+
+	/**
+	 * Program entry point. See the class-level documentation for what is measured and the `*_PROPERTY`
+	 * constants for configuration.
+	 *
+	 * @param args ignored - the harness is configured entirely through system properties
+	 * @throws Exception when the working copy cannot be prepared, the target is unreachable, or either
+	 *                   engine fails to close - all of which must abort the run loudly rather than yield
+	 *                   a partial measurement
+	 */
+	public static void main(@Nonnull final String[] args) throws Exception {
+		new IsolatedWarmupLoadBenchmark().run();
+	}
+
+	/**
+	 * Prepares the working copy, boots the embedded source engine, connects (or falls back) to the target,
+	 * runs the measured rebuild and prints the report.
+	 *
+	 * @throws Exception when the working copy cannot be prepared, the target is unreachable, or either
+	 *                   engine fails to close
+	 */
+	private void run() throws Exception {
+		final Path pristineDataDir = Path.of(requiredProperty(PRISTINE_DATA_DIR_PROPERTY));
+		final String sourceCatalog = System.getProperty(CATALOG_NAME_PROPERTY, "senesi");
+		final TargetMode targetMode = TargetMode.valueOf(
+			System.getProperty(TARGET_MODE_PROPERTY, "remote").trim().toUpperCase()
+		);
+		final String targetCatalog = System.getProperty(
+			TARGET_CATALOG_PROPERTY, targetMode == TargetMode.REMOTE ? sourceCatalog : sourceCatalog + "_warmup"
+		);
+		final String targetHost = System.getProperty(TARGET_HOST_PROPERTY, "localhost");
+		final int targetPort = Integer.parseInt(System.getProperty(TARGET_PORT_PROPERTY, "5555"));
+		final int maxPerCollection = Integer.parseInt(System.getProperty(MAX_PER_COLLECTION_PROPERTY, "0"));
+		final int batchSize = Integer.parseInt(
+			System.getProperty(BATCH_SIZE_PROPERTY, String.valueOf(DEFAULT_BATCH_SIZE))
+		);
+		final int progressInterval = Integer.parseInt(
+			System.getProperty(PROGRESS_INTERVAL_PROPERTY, String.valueOf(DEFAULT_PROGRESS_INTERVAL))
+		);
+		final int holdOpenSeconds = Integer.parseInt(System.getProperty(HOLD_OPEN_SECONDS_PROPERTY, "0"));
+		final boolean skipVerification = Boolean.parseBoolean(System.getProperty(SKIP_VERIFICATION_PROPERTY, "false"));
+		final boolean keepWorkDir = Boolean.parseBoolean(System.getProperty(KEEP_WORK_DIR_PROPERTY, "false"));
+		final Path perEntityCsv = System.getProperty(PER_ENTITY_CSV_PROPERTY) == null ?
+			null : Path.of(System.getProperty(PER_ENTITY_CSV_PROPERTY));
+		final Set<String> requestedCollections = parseCollections(System.getProperty(COLLECTIONS_PROPERTY));
+		final Path workDataDir = System.getProperty(WORK_DIR_PROPERTY) == null ?
+			Files.createTempDirectory("evita-warmup-source") : Path.of(System.getProperty(WORK_DIR_PROPERTY));
+
+		if (batchSize < 1) {
+			throw new GenericEvitaInternalError(
+				"Batch size must be positive, got " + batchSize + ".", "Batch size must be positive."
+			);
+		}
+
+		// ---- prepare a disposable working copy - the pristine snapshot is never written to -----
+		log.info("Copying pristine snapshot `{}` -> working directory `{}`...", pristineDataDir, workDataDir);
+		final long prepareStart = System.nanoTime();
+		FileUtils.deleteDirectory(workDataDir.toFile());
+		FileUtils.copyDirectory(
+			pristineDataDir.resolve(sourceCatalog).toFile(),
+			workDataDir.resolve(sourceCatalog).toFile()
+		);
+		log.info("Working copy ready in {} ms.", (System.nanoTime() - prepareStart) / 1_000_000);
+
+		final Evita source = bootSourceEngine(workDataDir);
+		try {
+			awaitCatalogAlive(source, sourceCatalog);
+			final EvitaContract target = targetMode == TargetMode.REMOTE ?
+				connectToTargetServer(targetHost, targetPort) : source;
+			try {
+				final CopyResult result = copyCatalog(
+					source, target, targetMode, sourceCatalog, targetCatalog, requestedCollections,
+					maxPerCollection, batchSize, progressInterval, perEntityCsv
+				);
+				// The report is rendered BEFORE verification. Verification has to talk to the target, and a
+				// goLive that failed client-side leaves the catalog terminated from this client's point of
+				// view - so a verification that cannot even run must not take the measurement down with it.
+				System.out.println(
+					result.format(sourceCatalog, targetCatalog, targetMode, targetHost, targetPort, batchSize)
+				);
+				if (perEntityCsv != null) {
+					log.info("Per-entity upsert CSV written to `{}`.", perEntityCsv);
+				}
+				if (skipVerification) {
+					log.info("Post-copy verification skipped by configuration.");
+				} else {
+					try {
+						verifyCopy(source, target, sourceCatalog, targetCatalog, maxPerCollection, result);
+					} catch (Exception ex) {
+						log.error(
+							"Post-copy verification could not run - the load figures above stand, but the " +
+								"target entity counts are UNVERIFIED for this run.", ex
+						);
+					}
+				}
+				holdOpen(holdOpenSeconds);
+			} finally {
+				// in embedded mode the target IS the source engine - closing it here would be premature
+				if (target != source) {
+					target.close();
+				}
+			}
+		} finally {
+			source.close();
+			if (keepWorkDir) {
+				log.info("Working directory `{}` kept on disk by configuration.", workDataDir);
+			} else {
+				FileUtils.deleteDirectory(workDataDir.toFile());
+			}
+		}
+	}
+
+	/**
+	 * Boots the embedded engine that serves as the **read** side. Session inactivity timeouts are
+	 * effectively disabled because one source read session is held open for the entire run.
+	 *
+	 * @param workDataDir storage directory holding the working copy of the source catalog
+	 * @return the booted instance
+	 */
+	@Nonnull
+	private static Evita bootSourceEngine(@Nonnull final Path workDataDir) {
+		log.info(
+			"Booting embedded source engine against `{}` (reader max heap {})...",
+			workDataDir, formatBytes(Runtime.getRuntime().maxMemory())
+		);
+		final long bootStart = System.nanoTime();
+		final Evita evita = new Evita(
+			EvitaConfiguration.builder()
+				.server(
+					ServerOptions.builder()
+						.queryTimeoutInMilliseconds(3_600_000)
+						.transactionTimeoutInMilliseconds(3_600_000)
+						.closeSessionsAfterSecondsOfInactivity(Integer.MAX_VALUE)
+						.build()
+				)
+				.storage(StorageOptions.builder().storageDirectory(workDataDir).build())
+				.cache(CacheOptions.builder().build())
+				// The export directory defaults to `./export` RELATIVE TO THE WORKING DIRECTORY, and evitaDB
+				// takes an exclusive folder lock on it. The target server is normally launched from the same
+				// project directory, so leaving this at its default makes the second engine to start die with
+				// `FolderAlreadyUsedException`. Keeping it inside the disposable work dir both avoids the
+				// clash and gets it cleaned up with everything else.
+				.export(
+					new FileSystemExportOptions(
+						true,
+						ExportOptions.DEFAULT_SIZE_LIMIT_BYTES,
+						ExportOptions.DEFAULT_HISTORY_EXPIRATION_SECONDS,
+						workDataDir.resolve("export")
+					)
+				)
+				.build()
+		);
+		log.info("Source engine boot returned in {} ms.", (System.nanoTime() - bootStart) / 1_000_000);
+		return evita;
+	}
+
+	/**
+	 * Connects to the separate target server and blocks until it answers. The server is expected to run with
+	 * `tlsMode=RELAXED` and mTLS disabled (as `run-server.sh` configures it); timeouts are deliberately
+	 * generous because a bulk load of a multi-GB catalog runs for a long time.
+	 *
+	 * @param host target server host
+	 * @param port target server gRPC (and system API) port
+	 * @return the connected client
+	 */
+	@Nonnull
+	private static EvitaClient connectToTargetServer(@Nonnull final String host, final int port) {
+		final EvitaClientConfiguration configuration = EvitaClientConfiguration.builder()
+			.host(host)
+			.port(port)
+			.systemApiPort(port)
+			.tls(ClientTlsOptions.builder().tlsEnabled(false).mtlsEnabled(false).build())
+			.timeouts(
+				ClientTimeoutOptions.builder()
+					.timeout(1, TimeUnit.HOURS)
+					.streamingTimeout(1, TimeUnit.HOURS)
+					.build()
+			)
+			.build();
+		final Consumer<GrpcClientBuilder> grpcConfigurator = grpcClientBuilder -> grpcClientBuilder
+			.maxResponseMessageLength(MAX_GRPC_MESSAGE_SIZE)
+			.maxResponseLength(MAX_GRPC_MESSAGE_SIZE);
+
+		log.info("Connecting to target server at {}:{}...", host, port);
+		final EvitaClient client = new EvitaClient(configuration, grpcConfigurator);
+		final long deadline = System.nanoTime() + SERVER_WAIT_TIMEOUT.toNanos();
+		while (true) {
+			try {
+				client.getCatalogNames();
+				log.info("Target server at {}:{} is answering.", host, port);
+				return client;
+			} catch (final RuntimeException ex) {
+				if (System.nanoTime() > deadline) {
+					client.close();
+					throw new GenericEvitaInternalError(
+						"Target server at " + host + ":" + port + " did not become available within " +
+							SERVER_WAIT_TIMEOUT.toMinutes() + " minutes - is it started, and is its gRPC port " +
+							port + " with tlsMode=RELAXED? Last error: " + ex.getMessage(),
+						"Target server did not become available in time.", ex
+					);
+				}
+				sleepQuietly(1_000L);
+			}
+		}
+	}
+
+	/**
+	 * Runs the measured rebuild: reads the source schema, reconstructs it on a freshly created target
+	 * catalog (untimed), then copies every entity of every selected collection on a single thread through
+	 * one long-lived WARM_UP session, and finally switches the target to ALIVE.
+	 *
+	 * @param source               the embedded engine holding the source catalog
+	 * @param target               where the target catalog lives (a client, or the same engine)
+	 * @param targetMode           which of the two the target is
+	 * @param sourceCatalog        name of the catalog to read
+	 * @param targetCatalog        name of the catalog to create and populate
+	 * @param requestedCollections collections to copy, or empty for all
+	 * @param maxPerCollection     maximum entities per collection (0 == unlimited)
+	 * @param batchSize            entities read from the source per fetch
+	 * @param progressInterval     upserts between intra-collection progress lines (0 == none)
+	 * @param perEntityCsv         optional CSV destination for one row per upsert
+	 * @return the collected measurement
+	 * @throws IOException when the per-entity CSV cannot be written
+	 */
+	@Nonnull
+	private static CopyResult copyCatalog(
+		@Nonnull final Evita source,
+		@Nonnull final EvitaContract target,
+		@Nonnull final TargetMode targetMode,
+		@Nonnull final String sourceCatalog,
+		@Nonnull final String targetCatalog,
+		@Nonnull final Set<String> requestedCollections,
+		final int maxPerCollection,
+		final int batchSize,
+		final int progressInterval,
+		@Nullable final Path perEntityCsv
+	) throws IOException {
+		// ---- read the source schema (not timed) ----------------------------------------------
+		final CatalogSchemaContract sourceCatalogSchema;
+		final List<String> entityTypes;
+		final Map<String, EntitySchemaContract> sourceEntitySchemas = new LinkedHashMap<>();
+		try (final EvitaSessionContract schemaSession = source.createReadOnlySession(sourceCatalog)) {
+			sourceCatalogSchema = schemaSession.getCatalogSchema();
+			entityTypes = new ArrayList<>(new TreeSet<>(schemaSession.getAllEntityTypes()));
+			for (final String entityType : entityTypes) {
+				sourceEntitySchemas.put(entityType, schemaSession.getEntitySchemaOrThrowException(entityType));
+			}
+		}
+		log.info("Source catalog `{}` has {} collections: {}", sourceCatalog, entityTypes.size(), entityTypes);
+
+		final List<String> selectedTypes = selectCollections(entityTypes, requestedCollections);
+		if (selectedTypes.size() != entityTypes.size()) {
+			log.info("Restricted to {} collection(s): {}", selectedTypes.size(), selectedTypes);
+		}
+
+		// ---- create + reconstruct the target schema (not timed) ------------------------------
+		if (targetMode == TargetMode.EMBEDDED && targetCatalog.equals(sourceCatalog)) {
+			throw new GenericEvitaInternalError(
+				"In embedded target mode the target catalog must differ from the source catalog - both live " +
+					"in the same engine. Set `" + TARGET_CATALOG_PROPERTY + "`.",
+				"In embedded target mode the target catalog must differ from the source catalog."
+			);
+		}
+		target.deleteCatalogIfExists(targetCatalog);
+		target.defineCatalog(targetCatalog);
+		final long schemaStart = System.nanoTime();
+		target.updateCatalog(
+			targetCatalog,
+			session -> {
+				CatalogCopySupport.replicateSchema(session, sourceCatalogSchema, sourceEntitySchemas.values());
+			}
+		);
+		log.info(
+			"Target catalog `{}` created and schema reconstructed in {} ms - starting single-threaded WARM_UP load.",
+			targetCatalog, (System.nanoTime() - schemaStart) / 1_000_000
+		);
+
+		final Map<String, CollectionResult> byCollection = new LinkedHashMap<>();
+		final LatencySamples overallUpsert = new LatencySamples(1 << 16);
+		final List<String> perEntityRows = perEntityCsv == null ? null : new ArrayList<>(1 << 16);
+		final GcSnapshot gcBefore = GcSnapshot.capture();
+		final long copyWallStart;
+		final long copyWallNanos;
+		final long goLiveNanos;
+		final String goLiveError;
+
+		// one long-lived read session on the source and one long-lived WARM_UP write session on the target,
+		// both held open for the entire run - the source session is the outer resource
+		try (final EvitaSessionContract sourceSession = source.createReadOnlySession(sourceCatalog)) {
+			final EvitaSessionContract targetSession = target.createReadWriteSession(targetCatalog);
+			try {
+				copyWallStart = System.nanoTime();
+				for (final String entityType : selectedTypes) {
+					final CollectionResult collectionResult = copyCollection(
+						sourceSession, targetSession, sourceEntitySchemas.get(entityType),
+						maxPerCollection, batchSize, progressInterval, overallUpsert, perEntityRows
+					);
+					byCollection.put(entityType, collectionResult);
+					log.info(
+						"  loaded {} {} in {} - upsert mean {}, median {} | cumulative {} entities, {}",
+						String.format("%,10d", collectionResult.entities()), padRight(entityType, 20),
+						formatDuration(collectionResult.wallNanos()),
+						formatMicros(collectionResult.upsertLatency().mean()),
+						formatMicros(collectionResult.upsertLatency().median()),
+						String.format("%,d", overallUpsert.count()),
+						formatDuration(System.nanoTime() - copyWallStart)
+					);
+				}
+				copyWallNanos = System.nanoTime() - copyWallStart;
+
+				// Written BEFORE the ALIVE transition, deliberately. goLive can fail client-side and it
+				// closes the session on its way out either way, so anything deferred past this point risks
+				// losing the raw samples of a half-hour run to a failure that happened after the measurement
+				// was already complete.
+				if (perEntityRows != null) {
+					writePerEntityCsv(perEntityCsv, perEntityRows);
+				}
+
+				final long goLiveStart = System.nanoTime();
+				String goLiveFailure = null;
+				try {
+					// switches the target catalog from WARM_UP to ALIVE (this also closes the session)
+					targetSession.goLiveAndClose();
+				} catch (Exception ex) {
+					// A failed transition must NOT discard a completed load - the load IS the measurement,
+					// and the transition may well have succeeded on the server regardless. Observed on
+					// 2026.2.2 over gRPC: the client aborts with a spurious DEADLINE_EXCEEDED (reporting an
+					// hour-long deadline) ~12 s in, while the server logs `is now alive!` ~11 s later. Without
+					// this catch the exception escapes before the report is rendered and the per-entity CSV is
+					// written, throwing away a 27-minute run over a post-load failure.
+					goLiveFailure = ex.getClass().getSimpleName() + ": " + ex.getMessage();
+					log.error("goLiveAndClose() failed - load completed, so results are still reported.", ex);
+				}
+				goLiveNanos = System.nanoTime() - goLiveStart;
+				goLiveError = goLiveFailure;
+			} finally {
+				// goLiveAndClose() already closed it on the happy path; this only matters when the load threw
+				if (targetSession.isActive()) {
+					targetSession.close();
+				}
+			}
+		}
+		final GcSnapshot gcAfter = GcSnapshot.capture();
+
+		return new CopyResult(
+			byCollection, overallUpsert.summarize(), copyWallNanos, goLiveNanos, goLiveError,
+			gcAfter.minus(gcBefore), Runtime.getRuntime().maxMemory(),
+			Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+		);
+	}
+
+	/**
+	 * Copies every entity of a single collection from the source session into the (WARM_UP) target session.
+	 * Primary keys are gathered once via a cheap reference-only query, then entities are fetched with full
+	 * content in primary-key batches so each read is an indexed lookup rather than a deep-pagination scan.
+	 *
+	 * Each {@link EvitaSessionContract#upsertEntity} call is timed individually; the surrounding read is
+	 * timed as a separate aggregate. Anything else in this loop is deliberately trivial so the two together
+	 * account for essentially all of the collection's wall clock.
+	 *
+	 * @param sourceSession    long-lived read session on the source catalog
+	 * @param targetSession    long-lived WARM_UP write session on the target catalog
+	 * @param schema           the source schema of the collection to copy
+	 * @param maxPerCollection maximum entities to copy (0 == unlimited)
+	 * @param batchSize        entities read per fetch
+	 * @param progressInterval upserts between progress lines (0 == none)
+	 * @param overallUpsert    accumulator collecting every upsert sample across all collections
+	 * @param perEntityRows    optional collector of per-entity CSV rows
+	 * @return the collection's measurement
+	 */
+	@Nonnull
+	private static CollectionResult copyCollection(
+		@Nonnull final EvitaSessionContract sourceSession,
+		@Nonnull final EvitaSessionContract targetSession,
+		@Nonnull final EntitySchemaContract schema,
+		final int maxPerCollection,
+		final int batchSize,
+		final int progressInterval,
+		@Nonnull final LatencySamples overallUpsert,
+		@Nullable final List<String> perEntityRows
+	) {
+		final String entityType = schema.getName();
+		// reflected references are read-only projections auto-maintained from the owning (plain) reference on
+		// the other entity; they must not be fetched or written here - copying the plain reference rebuilds them
+		final EntityFetch contentRequirement = CatalogCopySupport.buildContentRequirement(schema);
+		int[] primaryKeys = fetchAllPrimaryKeys(sourceSession, entityType);
+		if (maxPerCollection > 0 && primaryKeys.length > maxPerCollection) {
+			primaryKeys = Arrays.copyOf(primaryKeys, maxPerCollection);
+		}
+
+		final LatencySamples upsertSamples = new LatencySamples(Math.max(1024, primaryKeys.length));
+		final long collectionStart = System.nanoTime();
+		long readNanos = 0L;
+		long copied = 0L;
+		long nextProgressAt = progressInterval > 0 ? progressInterval : Long.MAX_VALUE;
+
+		for (int offset = 0; offset < primaryKeys.length; offset += batchSize) {
+			final int limit = Math.min(batchSize, primaryKeys.length - offset);
+			final Integer[] batch = new Integer[limit];
+			for (int i = 0; i < limit; i++) {
+				batch[i] = primaryKeys[offset + i];
+			}
+
+			final long readStart = System.nanoTime();
+			final List<SealedEntity> entities = sourceSession.queryListOfSealedEntities(
+				Query.query(
+					collection(entityType),
+					filterBy(entityPrimaryKeyInSet(batch)),
+					require(page(1, limit), contentRequirement)
+				)
+			);
+			readNanos += System.nanoTime() - readStart;
+
+			for (int i = 0; i < entities.size(); i++) {
+				final SealedEntity entity = entities.get(i);
+				final CopyExistingEntityBuilder builder = new CopyExistingEntityBuilder(entity);
+				final long upsertStart = System.nanoTime();
+				targetSession.upsertEntity(builder);
+				final long upsertNanos = System.nanoTime() - upsertStart;
+				upsertSamples.add(upsertNanos);
+				overallUpsert.add(upsertNanos);
+				if (perEntityRows != null) {
+					perEntityRows.add(entityType + ',' + entity.getPrimaryKey() + ',' + upsertNanos);
+				}
+			}
+			copied += entities.size();
+
+			if (copied >= nextProgressAt) {
+				final long elapsed = System.nanoTime() - collectionStart;
+				log.info(
+					"    {} ... {} / {} entities, {} elapsed, {} entities/s (wall)",
+					entityType, String.format("%,d", copied), String.format("%,d", primaryKeys.length),
+					formatDuration(elapsed), String.format("%,.0f", copied * 1_000_000_000.0 / elapsed)
+				);
+				nextProgressAt = copied + progressInterval;
+			}
+		}
+
+		final long wallNanos = System.nanoTime() - collectionStart;
+		return new CollectionResult(copied, wallNanos, readNanos, upsertSamples.summarize());
+	}
+
+	/**
+	 * Returns the complete set of primary keys of the given collection in a single reference-only query
+	 * (no entity bodies fetched), so subsequent full-content reads can be batched by primary key.
+	 *
+	 * @param sourceSession read session on the source catalog
+	 * @param entityType    the collection whose primary keys are requested
+	 * @return array of all primary keys of the collection
+	 */
+	@Nonnull
+	private static int[] fetchAllPrimaryKeys(
+		@Nonnull final EvitaSessionContract sourceSession,
+		@Nonnull final String entityType
+	) {
+		final int total = countEntities(sourceSession, entityType);
+		if (total == 0) {
+			return new int[0];
+		}
+		final List<EntityReferenceContract> references = sourceSession.queryListOfEntityReferences(
+			Query.query(collection(entityType), require(page(1, total)))
+		);
+		final int[] primaryKeys = new int[references.size()];
+		for (int i = 0; i < references.size(); i++) {
+			primaryKeys[i] = references.get(i).getPrimaryKey();
+		}
+		return primaryKeys;
+	}
+
+	/**
+	 * Returns the total number of entities of the given collection via a cheap reference-only count query.
+	 *
+	 * @param session    an open session on the catalog to count in
+	 * @param entityType the collection to count
+	 * @return total entity count of the collection
+	 */
+	private static int countEntities(
+		@Nonnull final EvitaSessionContract session,
+		@Nonnull final String entityType
+	) {
+		return session.queryEntityReference(
+			Query.query(collection(entityType), require(page(1, 1)))
+		).getTotalRecordCount();
+	}
+
+	/**
+	 * Verifies the load is complete by comparing, per collection, the entity count in the (now ALIVE) target
+	 * catalog against the authoritative count re-queried from the source - independently of the copy loop, so
+	 * a silently short read is caught rather than masked. Any discrepancy fails the benchmark loudly, because
+	 * a short load produces a *faster* and entirely meaningless number.
+	 *
+	 * @param source           the embedded engine holding the source catalog
+	 * @param target           where the target catalog lives
+	 * @param sourceCatalog    name of the catalog that was read
+	 * @param targetCatalog    name of the freshly built catalog
+	 * @param maxPerCollection the per-collection cap that was applied (0 == uncapped)
+	 * @param result           the measurement, holding the per-collection copied counts
+	 */
+	private static void verifyCopy(
+		@Nonnull final Evita source,
+		@Nonnull final EvitaContract target,
+		@Nonnull final String sourceCatalog,
+		@Nonnull final String targetCatalog,
+		final int maxPerCollection,
+		@Nonnull final CopyResult result
+	) {
+		final StringBuilder mismatches = new StringBuilder(128);
+		final StringBuilder table = new StringBuilder(512);
+		table.append(String.format("%-22s %12s %12s %12s%n", "collection", "source", "target", "loaded"));
+		try (
+			final EvitaSessionContract sourceSession = source.createReadOnlySession(sourceCatalog);
+			final EvitaSessionContract targetSession = target.createReadOnlySession(targetCatalog)
+		) {
+			for (final Map.Entry<String, CollectionResult> entry : result.byCollection().entrySet()) {
+				final String entityType = entry.getKey();
+				final int sourceCount = countEntities(sourceSession, entityType);
+				final int targetCount = countEntities(targetSession, entityType);
+				final long loaded = entry.getValue().entities();
+				final long expected = maxPerCollection > 0 ? Math.min(sourceCount, maxPerCollection) : sourceCount;
+				table.append(String.format("%-22s %12d %12d %12d%n", entityType, sourceCount, targetCount, loaded));
+				if (targetCount != expected || loaded != expected) {
+					mismatches.append(System.lineSeparator())
+						.append("  ").append(entityType)
+						.append(": expected ").append(expected)
+						.append(" (source=").append(sourceCount)
+						.append("), target=").append(targetCount)
+						.append(", loaded=").append(loaded);
+				}
+			}
+		}
+		System.out.print(table);
+		if (mismatches.length() > 0) {
+			throw new IllegalStateException("Load verification FAILED - entity counts differ:" + mismatches);
+		}
+		System.out.println(
+			maxPerCollection > 0 ?
+				"Load verified: target matches min(source, cap) for every loaded collection." :
+				"Load verified: target entity counts match the source exactly for every loaded collection."
+		);
+	}
+
+	/**
+	 * Blocks until the given catalog reaches {@link CatalogState#ALIVE}. Boot-time WAL catch-up runs on a
+	 * background thread and the {@link Evita} constructor returns while the catalog is still in the
+	 * transitional {@link CatalogState#BEING_ACTIVATED} state; querying it before that settles throws.
+	 *
+	 * @param evita       the booted engine
+	 * @param catalogName the catalog to wait for
+	 */
+	private static void awaitCatalogAlive(@Nonnull final Evita evita, @Nonnull final String catalogName) {
+		final long start = System.nanoTime();
+		final long deadlineNanos = start + Duration.ofMinutes(60).toNanos();
+		while (true) {
+			final CatalogState state = evita.getCatalogState(catalogName)
+				.orElseThrow(() -> new GenericEvitaInternalError(
+					"Catalog `" + catalogName + "` not found in the freshly booted Evita instance.",
+					"Catalog not found in the freshly booted Evita instance."
+				));
+			if (state == CatalogState.ALIVE) {
+				log.info(
+					"Source catalog `{}` fully activated in {}.",
+					catalogName, formatDuration(System.nanoTime() - start)
+				);
+				return;
+			} else if (!state.isTransitional()) {
+				throw new GenericEvitaInternalError(
+					"Catalog `" + catalogName + "` ended up in unexpected non-transitional state `" + state +
+						"` after boot instead of `ALIVE`.",
+					"Catalog ended up in an unexpected non-transitional state after boot."
+				);
+			} else if (System.nanoTime() > deadlineNanos) {
+				throw new GenericEvitaInternalError(
+					"Timed out waiting for catalog `" + catalogName + "` to become `ALIVE` (still `" + state + "`).",
+					"Timed out waiting for catalog to become `ALIVE`."
+				);
+			}
+			sleepQuietly(200L);
+		}
+	}
+
+	/**
+	 * Keeps this JVM alive for the configured number of seconds so an attached profiler can stop and dump
+	 * its recording before the process exits.
+	 *
+	 * @param holdOpenSeconds seconds to wait (non-positive returns immediately)
+	 */
+	private static void holdOpen(final int holdOpenSeconds) {
+		if (holdOpenSeconds <= 0) {
+			return;
+		}
+		log.info("Holding this JVM open for {} s so an attached profiler can dump...", holdOpenSeconds);
+		sleepQuietly(holdOpenSeconds * 1_000L);
+	}
+
+	/**
+	 * Sleeps for the given number of milliseconds, restoring the interrupt flag and failing loudly when
+	 * interrupted - a silently swallowed interrupt here would truncate a measurement without saying so.
+	 *
+	 * @param millis milliseconds to sleep
+	 */
+	private static void sleepQuietly(final long millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (final InterruptedException interrupted) {
+			Thread.currentThread().interrupt();
+			throw new GenericEvitaInternalError(
+				"Interrupted while waiting.", "Interrupted while waiting.", interrupted
+			);
+		}
+	}
+
+	/**
+	 * Writes one CSV row per upserted entity.
+	 *
+	 * @param perEntityCsv destination file
+	 * @param rows         pre-rendered rows, without the header
+	 * @throws IOException when the file cannot be written
+	 */
+	private static void writePerEntityCsv(@Nonnull final Path perEntityCsv, @Nonnull final List<String> rows)
+		throws IOException {
+		final StringBuilder csv = new StringBuilder(rows.size() * 40 + 64);
+		csv.append("collection,primaryKey,upsert_nanos\n");
+		for (int i = 0; i < rows.size(); i++) {
+			csv.append(rows.get(i)).append('\n');
+		}
+		Files.write(perEntityCsv, csv.toString().getBytes(StandardCharsets.UTF_8));
+	}
+
+	/**
+	 * Parses the comma-separated collection filter.
+	 *
+	 * @param raw the raw property value (may be null or blank)
+	 * @return the requested collection names, empty when everything is to be copied
+	 */
+	@Nonnull
+	private static Set<String> parseCollections(@Nullable final String raw) {
+		final Set<String> result = new LinkedHashSet<>(8);
+		if (raw == null || raw.isBlank()) {
+			return result;
+		}
+		for (final String part : raw.split(",")) {
+			final String trimmed = part.trim();
+			if (!trimmed.isEmpty()) {
+				result.add(trimmed);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Intersects the source's collections with the requested subset, preserving source order and failing on
+	 * a name that does not exist - a typo must not silently shrink the measured workload.
+	 *
+	 * @param entityTypes          all collections present in the source
+	 * @param requestedCollections the requested subset (empty selects everything)
+	 * @return the collections to copy
+	 */
+	@Nonnull
+	private static List<String> selectCollections(
+		@Nonnull final List<String> entityTypes,
+		@Nonnull final Set<String> requestedCollections
+	) {
+		if (requestedCollections.isEmpty()) {
+			return entityTypes;
+		}
+		final List<String> unknown = new ArrayList<>(requestedCollections);
+		unknown.removeAll(entityTypes);
+		if (!unknown.isEmpty()) {
+			throw new GenericEvitaInternalError(
+				"Requested collection(s) " + unknown +
+					" do not exist in the source catalog - available: " + entityTypes,
+				"Requested collection(s) do not exist in the source catalog."
+			);
+		}
+		final List<String> selected = new ArrayList<>(requestedCollections.size());
+		for (final String entityType : entityTypes) {
+			if (requestedCollections.contains(entityType)) {
+				selected.add(entityType);
+			}
+		}
+		return selected;
+	}
+
+	/**
+	 * Reads a mandatory system property.
+	 *
+	 * @param propertyName the property to read
+	 * @return its value
+	 */
+	@Nonnull
+	private static String requiredProperty(@Nonnull final String propertyName) {
+		final String value = System.getProperty(propertyName);
+		if (value == null || value.isBlank()) {
+			throw new GenericEvitaInternalError(
+				"Required system property `" + propertyName + "` is not set - see " +
+					IsolatedWarmupLoadBenchmark.class.getSimpleName() + " JavaDoc.",
+				"Required system property `" + propertyName + "` is not set."
+			);
+		}
+		return value;
+	}
+
+	/**
+	 * Formats a nanosecond duration for reading. Sub-minute durations stay in seconds - rounding a 0.4 s
+	 * collection to `0:00:00` would throw away everything it had to say - while anything longer renders
+	 * as `H:mm:ss`, because a full bulk load runs for twenty minutes and nobody reads `1,209.4 s` without
+	 * reaching for a calculator.
+	 *
+	 * @param nanos the duration
+	 * @return e.g. `12.4 s` for short durations, `0:20:09` for long ones
+	 */
+	@Nonnull
+	private static String formatDuration(final long nanos) {
+		final double seconds = nanos / 1_000_000_000.0;
+		if (seconds < 60.0) {
+			return String.format("%,.1f s", seconds);
+		}
+		final long totalSeconds = Math.round(seconds);
+		return String.format(
+			"%d:%02d:%02d", totalSeconds / 3_600, (totalSeconds % 3_600) / 60, totalSeconds % 60
+		);
+	}
+
+	/**
+	 * Formats a nanosecond duration as `H:mm:ss` followed by the raw seconds in parentheses. Used for the
+	 * headline report figures, where the clock form is what gets read but the seconds are what gets
+	 * compared against an earlier run.
+	 *
+	 * @param nanos the duration
+	 * @return e.g. `0:20:09  (1,209.4 s)`
+	 */
+	@Nonnull
+	private static String formatDurationWithSeconds(final long nanos) {
+		final long totalSeconds = Math.round(nanos / 1_000_000_000.0);
+		return String.format(
+			"%d:%02d:%02d  (%,.1f s)",
+			totalSeconds / 3_600, (totalSeconds % 3_600) / 60, totalSeconds % 60, nanos / 1_000_000_000.0
+		);
+	}
+
+	/**
+	 * Formats a nanosecond duration as microseconds.
+	 *
+	 * @param nanos the duration
+	 * @return e.g. `1,234.5 us`
+	 */
+	@Nonnull
+	private static String formatMicros(final long nanos) {
+		return String.format("%,.1f us", nanos / 1_000.0);
+	}
+
+	/**
+	 * Formats a byte count in gibibytes.
+	 *
+	 * @param bytes the byte count
+	 * @return e.g. `14.0 GiB`
+	 */
+	@Nonnull
+	private static String formatBytes(final long bytes) {
+		return String.format("%.1f GiB", bytes / 1024.0 / 1024.0 / 1024.0);
+	}
+
+	/**
+	 * Right-pads a string to the requested width (used for log alignment).
+	 *
+	 * @param value the string to pad
+	 * @param width target width
+	 * @return the padded string
+	 */
+	@Nonnull
+	private static String padRight(@Nonnull final String value, final int width) {
+		return value.length() >= width ? value : value + " ".repeat(width - value.length());
+	}
+
+	/**
+	 * Growable, allocation-frugal collector of nanosecond latency samples. Single-threaded by construction -
+	 * every sample is added by the one copying thread - so nothing here synchronizes.
+	 */
+	private static final class LatencySamples {
+		private long[] samples;
+		private int count;
+
+		/**
+		 * @param initialCapacity capacity to pre-size the backing array to
+		 */
+		LatencySamples(final int initialCapacity) {
+			this.samples = new long[initialCapacity];
+		}
+
+		/**
+		 * Records a single latency sample.
+		 *
+		 * @param nanos the measured duration in nanoseconds
+		 */
+		void add(final long nanos) {
+			if (this.count == this.samples.length) {
+				this.samples = Arrays.copyOf(this.samples, this.samples.length << 1);
+			}
+			this.samples[this.count++] = nanos;
+		}
+
+		/**
+		 * @return number of samples collected so far
+		 */
+		int count() {
+			return this.count;
+		}
+
+		/**
+		 * Sorts a copy of the collected samples and derives the summary statistics from them.
+		 *
+		 * @return immutable summary of everything recorded
+		 */
+		@Nonnull
+		LatencySummary summarize() {
+			if (this.count == 0) {
+				return new LatencySummary(0, 0, 0, 0, 0, 0, 0, 0);
+			}
+			final long[] sorted = Arrays.copyOf(this.samples, this.count);
+			Arrays.sort(sorted);
+			long sum = 0;
+			for (int i = 0; i < sorted.length; i++) {
+				sum += sorted[i];
+			}
+			return new LatencySummary(
+				sorted.length, sorted[0], sum / sorted.length, percentile(sorted, 50),
+				percentile(sorted, 95), percentile(sorted, 99), sorted[sorted.length - 1], sum
+			);
+		}
+
+		/**
+		 * @param sorted     ascending array of samples
+		 * @param percentile the requested percentile (1-100)
+		 * @return the sample at the requested percentile
+		 */
+		private static long percentile(@Nonnull final long[] sorted, final int percentile) {
+			final int index = (int) Math.min(sorted.length - 1L, (percentile * (long) sorted.length) / 100L);
+			return sorted[index];
+		}
+	}
+
+	/**
+	 * Summary statistics of one latency series, all durations in nanoseconds.
+	 *
+	 * @param count  number of samples
+	 * @param min    smallest sample
+	 * @param mean   arithmetic mean
+	 * @param median 50th percentile
+	 * @param p95    95th percentile
+	 * @param p99    99th percentile
+	 * @param max    largest sample
+	 * @param sum    sum of all samples
+	 */
+	private record LatencySummary(
+		int count, long min, long mean, long median, long p95, long p99, long max, long sum
+	) {
+	}
+
+	/**
+	 * Cumulative garbage-collection counters sampled from the platform MX beans of **this** JVM.
+	 *
+	 * @param collections total collections across all collectors
+	 * @param millis      total time spent collecting, in milliseconds
+	 */
+	private record GcSnapshot(long collections, long millis) {
+
+		/**
+		 * @return the current cumulative GC counters of this JVM
+		 */
+		@Nonnull
+		static GcSnapshot capture() {
+			long collections = 0L;
+			long millis = 0L;
+			final List<GarbageCollectorMXBean> beans = ManagementFactory.getGarbageCollectorMXBeans();
+			for (int i = 0; i < beans.size(); i++) {
+				final GarbageCollectorMXBean bean = beans.get(i);
+				final long count = bean.getCollectionCount();
+				final long time = bean.getCollectionTime();
+				// a bean reports -1 when the counter is unavailable; ignore rather than corrupt the sum
+				if (count > 0) {
+					collections += count;
+				}
+				if (time > 0) {
+					millis += time;
+				}
+			}
+			return new GcSnapshot(collections, millis);
+		}
+
+		/**
+		 * @param earlier the snapshot taken before the measured window
+		 * @return the delta accumulated during the window
+		 */
+		@Nonnull
+		GcSnapshot minus(@Nonnull final GcSnapshot earlier) {
+			return new GcSnapshot(this.collections - earlier.collections, this.millis - earlier.millis);
+		}
+	}
+
+	/**
+	 * One collection's measurement.
+	 *
+	 * @param entities      entities upserted
+	 * @param wallNanos     wall-clock of the whole collection loop (read + upsert + overhead)
+	 * @param readNanos     time spent reading the entities out of the source catalog
+	 * @param upsertLatency distribution of the individual upsert calls
+	 */
+	private record CollectionResult(
+		long entities, long wallNanos, long readNanos, @Nonnull LatencySummary upsertLatency
+	) {
+	}
+
+	/**
+	 * The whole run's measurement, and the renderer of the final report.
+	 *
+	 * @param byCollection  per-collection measurements, in load order
+	 * @param overallUpsert distribution of every upsert call across all collections
+	 * @param copyWallNanos wall-clock of the whole load loop
+	 * @param goLiveNanos   wall-clock of the WARM_UP to ALIVE transition (time-to-failure if it threw)
+	 * @param goLiveError   {@code null} when the transition succeeded, otherwise the client-side failure
+	 * @param gcDuringCopy  GC activity of THIS (reader) JVM during the measured window
+	 * @param maxHeapBytes  this JVM's maximum heap
+	 * @param usedHeapBytes this JVM's heap in use once the load finished
+	 */
+	private record CopyResult(
+		@Nonnull Map<String, CollectionResult> byCollection,
+		@Nonnull LatencySummary overallUpsert,
+		long copyWallNanos,
+		long goLiveNanos,
+		@Nullable String goLiveError,
+		@Nonnull GcSnapshot gcDuringCopy,
+		long maxHeapBytes,
+		long usedHeapBytes
+	) {
+
+		/**
+		 * Renders the whole result as a human-readable report block.
+		 *
+		 * @param sourceCatalog name of the catalog that was read
+		 * @param targetCatalog name of the catalog that was built
+		 * @param targetMode    where the target lived
+		 * @param targetHost    target server host (`remote` mode)
+		 * @param targetPort    target server port (`remote` mode)
+		 * @param batchSize     entities read per fetch
+		 * @return the formatted report
+		 */
+		@Nonnull
+		String format(
+			@Nonnull final String sourceCatalog,
+			@Nonnull final String targetCatalog,
+			@Nonnull final TargetMode targetMode,
+			@Nonnull final String targetHost,
+			final int targetPort,
+			final int batchSize
+		) {
+			long readNanos = 0L;
+			for (final CollectionResult collectionResult : this.byCollection.values()) {
+				readNanos += collectionResult.readNanos();
+			}
+			final long entities = this.overallUpsert.count();
+			final long upsertNanos = this.overallUpsert.sum();
+			final double copySeconds = this.copyWallNanos / 1_000_000_000.0;
+			final double upsertSeconds = upsertNanos / 1_000_000_000.0;
+			final double gcSeconds = this.gcDuringCopy.millis() / 1_000.0;
+			final double gcShare = this.copyWallNanos == 0 ? 0.0 : 100.0 * gcSeconds / copySeconds;
+
+			final StringBuilder report = new StringBuilder(4096);
+			report.append("========================================================================\n");
+			report.append("     SINGLE-THREADED WARM_UP BULK LOAD - RESULT\n");
+			report.append("========================================================================\n");
+			report.append(String.format("source catalog          : %s (embedded, this JVM)%n", sourceCatalog));
+			report.append(String.format(
+				"target catalog          : %s (%s)%n", targetCatalog,
+				targetMode == TargetMode.REMOTE ?
+					"remote server " + targetHost + ":" + targetPort + " over gRPC" : "embedded, this JVM"
+			));
+			report.append(String.format("entities upserted       : %,d%n", entities));
+			report.append(String.format("read batch size         : %,d%n", batchSize));
+			report.append(String.format(
+				"reader JVM heap         : max %.1f GiB, used after load %.1f GiB%n",
+				this.maxHeapBytes / 1024.0 / 1024.0 / 1024.0, this.usedHeapBytes / 1024.0 / 1024.0 / 1024.0
+			));
+			report.append("------------------------------------------------------------------------\n");
+			report.append(String.format(
+				"load wall-clock         : %s%n", formatDurationWithSeconds(this.copyWallNanos)
+			));
+			report.append(String.format(
+				"  upsert (pure)         : %s  %.1f%% of wall%n",
+				formatDurationWithSeconds(upsertNanos),
+				copySeconds == 0 ? 0.0 : 100.0 * upsertSeconds / copySeconds
+			));
+			report.append(String.format(
+				"  source read           : %s  %.1f%% of wall%n",
+				formatDurationWithSeconds(readNanos),
+				this.copyWallNanos == 0 ? 0.0 : 100.0 * readNanos / this.copyWallNanos
+			));
+			report.append(String.format(
+				"goLive -> ALIVE         : %s%s%n",
+				formatDurationWithSeconds(this.goLiveNanos),
+				this.goLiveError == null ? "" : "   *** CLIENT-SIDE FAILURE (see below) ***"
+			));
+			report.append(String.format(
+				"TOTAL (load + goLive)   : %s%n",
+				formatDurationWithSeconds(this.copyWallNanos + this.goLiveNanos)
+			));
+			if (this.goLiveError != null) {
+				report.append("  !! goLive failed CLIENT-side: ").append(this.goLiveError).append('\n');
+				report.append("  !! the load figures above are unaffected; check the SERVER log for\n");
+				report.append("  !! `is now alive!` - the transition may have completed regardless.\n");
+			}
+			report.append("------------------------------------------------------------------------\n");
+			report.append(String.format(
+				"throughput (pure upsert): %,10.1f upserts/s%n",
+				upsertNanos == 0 ? 0.0 : entities * 1_000_000_000.0 / upsertNanos
+			));
+			report.append(String.format(
+				"throughput (wall-clock) : %,10.1f entities/s%n",
+				this.copyWallNanos == 0 ? 0.0 : entities * 1_000_000_000.0 / this.copyWallNanos
+			));
+			report.append("------------------------------------------------------------------------\n");
+			report.append("per-upsert latency (microseconds)\n");
+			report.append(String.format(
+				"  %10s %10s %10s %10s %10s %10s%n", "mean", "median", "p95", "p99", "min", "max"
+			));
+			report.append(String.format(
+				"  %10.1f %10.1f %10.1f %10.1f %10.1f %10.1f%n",
+				this.overallUpsert.mean() / 1_000.0, this.overallUpsert.median() / 1_000.0,
+				this.overallUpsert.p95() / 1_000.0, this.overallUpsert.p99() / 1_000.0,
+				this.overallUpsert.min() / 1_000.0, this.overallUpsert.max() / 1_000.0
+			));
+			if (targetMode == TargetMode.REMOTE) {
+				report.append(
+					"  NOTE: remote mode - these include protobuf serialization, the loopback round trip and\n" +
+						"  server-side deframing. This is end-to-end ingestion latency, NOT write-path latency.\n" +
+						"  Run the same load with -Devita.warmup.targetMode=embedded to quantify the difference.\n"
+				);
+			}
+			report.append("------------------------------------------------------------------------\n");
+			report.append(String.format(
+				"reader JVM GC           : %,d collections, %,.1f s (%.1f%% of load wall-clock)%n",
+				this.gcDuringCopy.collections(), gcSeconds, gcShare
+			));
+			if (targetMode == TargetMode.REMOTE) {
+				report.append("  (the WRITER's GC is what matters - read it from the server's own GC log)\n");
+			} else if (gcShare > GC_BOUND_WARNING_THRESHOLD) {
+				report.append(String.format(
+					"  !! WARNING: GC consumed %.1f%% of the measured window. This run describes the%n" +
+						"  !! collector more than it describes the write path - raise -Xmx and re-measure%n" +
+						"  !! before drawing any conclusion from the numbers above.%n",
+					gcShare
+				));
+			}
+			report.append("------------------------------------------------------------------------\n");
+			report.append("per-collection breakdown (slowest first)\n");
+			report.append(String.format(
+				"%-22s %12s %9s %9s %9s %10s %10s %10s %7s%n",
+				"collection", "entities", "wall s", "read s", "upsert s",
+				"mean us", "med us", "p99 us", "%wall"
+			));
+			final List<Map.Entry<String, CollectionResult>> sorted = new ArrayList<>(this.byCollection.entrySet());
+			sorted.sort((a, b) -> Long.compare(b.getValue().wallNanos(), a.getValue().wallNanos()));
+			for (final Map.Entry<String, CollectionResult> entry : sorted) {
+				final CollectionResult value = entry.getValue();
+				final LatencySummary latency = value.upsertLatency();
+				report.append(String.format(
+					"%-22s %,12d %9.1f %9.1f %9.1f %10.1f %10.1f %10.1f %6.1f%%%n",
+					entry.getKey(), value.entities(),
+					value.wallNanos() / 1_000_000_000.0,
+					value.readNanos() / 1_000_000_000.0,
+					latency.sum() / 1_000_000_000.0,
+					latency.mean() / 1_000.0, latency.median() / 1_000.0, latency.p99() / 1_000.0,
+					this.copyWallNanos == 0 ? 0.0 : 100.0 * value.wallNanos() / this.copyWallNanos
+				));
+			}
+			report.append("========================================================================\n");
+			return report.toString();
+		}
+	}
+
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/warmupload/IsolatedWarmupLoadBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/warmupload/IsolatedWarmupLoadBenchmark.java
@@ -213,6 +213,15 @@ public class IsolatedWarmupLoadBenchmark {
 	public static final String KEEP_WORK_DIR_PROPERTY = "evita.warmup.keepWorkDir";
 
 	/**
+	 * Exit code for a run whose load completed and was reported, but whose entity counts could not be
+	 * verified - the target went away, a session was refused, a client-side goLive timeout terminated the
+	 * catalog from this client's point of view. The measurement itself stands, which is why this is not a
+	 * failure; but it has not been shown to describe a *complete* load either, which is why it is not a
+	 * success. A caller that only reads the exit code has to be able to tell the two apart, so the state
+	 * gets a code of its own rather than borrowing `0` from a verified run or `1` from a broken one.
+	 */
+	private static final int EXIT_CODE_UNVERIFIED = 2;
+	/**
 	 * Name of the file dropped into the working directory to mark it as this harness's disposable scratch
 	 * space. Both deletions of that directory - the one before the copy and the one on teardown - refuse to
 	 * run unless the directory is empty or carries this marker, because {@value #WORK_DIR_PROPERTY} is an
@@ -267,26 +276,34 @@ public class IsolatedWarmupLoadBenchmark {
 	 * Program entry point. See the class-level documentation for what is measured and the `*_PROPERTY`
 	 * constants for configuration.
 	 *
+	 * Exits `0` only when the load was verified (or verification was switched off deliberately),
+	 * {@link #EXIT_CODE_UNVERIFIED} when the measurement stands but could not be verified, and `1` - by
+	 * letting the exception out - when the run failed outright. That is the whole failure signal an
+	 * automated caller gets, so nothing is caught here on purpose.
+	 *
 	 * @param args ignored - the harness is configured entirely through system properties
 	 * @throws Exception when the working copy cannot be prepared, the target is unreachable, the loaded
 	 *                   entity counts do not match the source, or either engine fails to close - all of
-	 *                   which must abort the run loudly rather than yield a partial measurement. Nothing is
-	 *                   caught here on purpose: the resulting non-zero exit code is the only failure signal
-	 *                   an automated caller gets.
+	 *                   which must abort the run loudly rather than yield a partial measurement
 	 */
 	public static void main(@Nonnull final String[] args) throws Exception {
-		new IsolatedWarmupLoadBenchmark().run();
+		final int exitCode = new IsolatedWarmupLoadBenchmark().run();
+		if (exitCode != 0) {
+			System.exit(exitCode);
+		}
 	}
 
 	/**
 	 * Prepares the working copy, boots the embedded source engine, connects (or falls back) to the target,
 	 * runs the measured rebuild and prints the report.
 	 *
+	 * @return `0` when the load was verified or verification was switched off deliberately,
+	 *         {@link #EXIT_CODE_UNVERIFIED} when the measurement stands but verification never got its answer
 	 * @throws LoadVerificationFailedException when the target does not hold what the source does
 	 * @throws Exception                       when the working copy cannot be prepared, the target is
 	 *                                         unreachable, or either engine fails to close
 	 */
-	private void run() throws Exception {
+	private int run() throws Exception {
 		final Path pristineDataDir = Path.of(requiredProperty(PRISTINE_DATA_DIR_PROPERTY));
 		final String sourceCatalog = System.getProperty(CATALOG_NAME_PROPERTY, "senesi");
 		final TargetMode targetMode = TargetMode.valueOf(
@@ -329,6 +346,7 @@ public class IsolatedWarmupLoadBenchmark {
 		);
 		log.info("Working copy ready in {} ms.", (System.nanoTime() - prepareStart) / 1_000_000);
 
+		int exitCode = 0;
 		final Evita source = bootSourceEngine(workDataDir);
 		// `try (source)` rather than a plain close in the finally: when the measured block and the close both
 		// fail, try-with-resources attaches the close failure as suppressed instead of letting it replace the
@@ -364,11 +382,15 @@ public class IsolatedWarmupLoadBenchmark {
 					} catch (Exception ex) {
 						// anything else means verification never got its answer (target unreachable, session
 						// refused, catalog terminated by a client-side goLive timeout) - the counts are unknown
-						// rather than known-bad, which is not grounds for discarding a completed measurement
+						// rather than known-bad, which is not grounds for discarding a completed measurement.
+						// It is not grounds for calling the run a success either: an unverified load must not be
+						// accepted by automation that only looks at the exit code, so it gets its own one.
+						exitCode = EXIT_CODE_UNVERIFIED;
 						log.error(
 							"Post-copy verification could not run - the load figures above stand, but the " +
-								"target entity counts are UNVERIFIED for this run. This is not a count " +
-								"mismatch: a mismatch fails the run instead.", ex
+								"target entity counts are UNVERIFIED for this run (exit code " +
+								EXIT_CODE_UNVERIFIED + "). This is not a count mismatch: a mismatch fails the " +
+								"run instead.", ex
 						);
 					}
 				}
@@ -395,6 +417,7 @@ public class IsolatedWarmupLoadBenchmark {
 				}
 			}
 		}
+		return exitCode;
 	}
 
 	/**

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/WarmupCopyCatalogBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/WarmupCopyCatalogBenchmark.java
@@ -26,63 +26,34 @@ package io.evitadb.spike;
 import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
 import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.query.Query;
-import io.evitadb.api.query.require.EntityContentRequire;
 import io.evitadb.api.query.require.EntityFetch;
 import io.evitadb.api.requestResponse.data.EntityReferenceContract;
 import io.evitadb.api.requestResponse.data.SealedEntity;
-import io.evitadb.api.requestResponse.schema.AssociatedDataSchemaContract;
-import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
-import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
-import io.evitadb.api.requestResponse.schema.AttributeUniquenessType;
 import io.evitadb.api.requestResponse.schema.CatalogSchemaContract;
-import io.evitadb.api.requestResponse.schema.CatalogSchemaEditor.CatalogSchemaBuilder;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
-import io.evitadb.api.requestResponse.schema.EntitySchemaEditor.EntitySchemaBuilder;
-import io.evitadb.api.requestResponse.schema.EvolutionMode;
-import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
-import io.evitadb.api.requestResponse.schema.GlobalAttributeUniquenessType;
-import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
-import io.evitadb.api.requestResponse.schema.ReferenceSchemaEditor.ReferenceSchemaBuilder;
-import io.evitadb.api.requestResponse.schema.ReflectedReferenceSchemaContract;
-import io.evitadb.api.requestResponse.schema.ReflectedReferenceSchemaContract.AttributeInheritanceBehavior;
-import io.evitadb.api.requestResponse.schema.SortableAttributeCompoundSchemaContract;
-import io.evitadb.api.requestResponse.schema.SortableAttributeCompoundSchemaContract.AttributeElement;
-import io.evitadb.api.requestResponse.schema.builder.SortableAttributeCompoundSchemaBuilder;
-import io.evitadb.dataType.Scope;
 import io.evitadb.driver.EvitaClient;
 import io.evitadb.driver.config.ClientTlsOptions;
 import io.evitadb.driver.config.ClientTimeoutOptions;
 import io.evitadb.driver.config.EvitaClientConfiguration;
+import io.evitadb.performance.warmupload.CatalogCopySupport;
 import io.evitadb.test.builder.CopyExistingEntityBuilder;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Currency;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
-import static io.evitadb.api.query.QueryConstraints.associatedDataContentAll;
-import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
 import static io.evitadb.api.query.QueryConstraints.collection;
-import static io.evitadb.api.query.QueryConstraints.dataInLocalesAll;
-import static io.evitadb.api.query.QueryConstraints.entityFetch;
-import static io.evitadb.api.query.QueryConstraints.entityFetchAll;
 import static io.evitadb.api.query.QueryConstraints.entityPrimaryKeyInSet;
 import static io.evitadb.api.query.QueryConstraints.filterBy;
-import static io.evitadb.api.query.QueryConstraints.hierarchyContent;
 import static io.evitadb.api.query.QueryConstraints.page;
-import static io.evitadb.api.query.QueryConstraints.priceContentAll;
-import static io.evitadb.api.query.QueryConstraints.referenceContentWithAttributes;
 import static io.evitadb.api.query.QueryConstraints.require;
 
 /**
@@ -409,7 +380,7 @@ public class WarmupCopyCatalogBenchmark {
 		final String entityType = schema.getName();
 		// reflected references are read-only projections auto-maintained from the owning (plain) reference on
 		// the other entity; they must not be fetched or written here - copying the plain reference rebuilds them
-		final EntityFetch contentRequirement = buildContentRequirement(schema);
+		final EntityFetch contentRequirement = CatalogCopySupport.buildContentRequirement(schema);
 		int[] primaryKeys = fetchAllPrimaryKeys(client, sourceCatalog, entityType);
 		if (maxPerCollection > 0 && primaryKeys.length > maxPerCollection) {
 			final int[] capped = new int[maxPerCollection];
@@ -443,47 +414,6 @@ public class WarmupCopyCatalogBenchmark {
 			copied += entities.size();
 		}
 		return copied;
-	}
-
-	/**
-	 * Builds the full-content fetch requirement for a collection. When the collection has no reflected
-	 * references, {@link io.evitadb.api.query.QueryConstraints#entityFetchAll() entityFetchAll()} is used
-	 * (guaranteed complete and future-proof). When it does, an equivalent fetch is assembled that pulls all
-	 * attributes, associated data, prices, locales, hierarchy and only the plain (non-reflected) references
-	 * with their attributes - so the read-only reflected projections are never transferred nor copied.
-	 *
-	 * @param schema the source schema of the collection
-	 * @return the content requirement to use when fetching entities for copying
-	 */
-	@Nonnull
-	private static EntityFetch buildContentRequirement(@Nonnull final EntitySchemaContract schema) {
-		boolean hasReflectedReference = false;
-		for (final ReferenceSchemaContract reference : schema.getReferences().values()) {
-			if (reference instanceof ReflectedReferenceSchemaContract) {
-				hasReflectedReference = true;
-				break;
-			}
-		}
-		if (!hasReflectedReference) {
-			return entityFetchAll();
-		}
-		final List<EntityContentRequire> requirements = new ArrayList<>();
-		requirements.add(attributeContentAll());
-		requirements.add(associatedDataContentAll());
-		requirements.add(dataInLocalesAll());
-		if (schema.isWithPrice()) {
-			requirements.add(priceContentAll());
-		}
-		if (schema.isWithHierarchy()) {
-			requirements.add(hierarchyContent());
-		}
-		for (final ReferenceSchemaContract reference : schema.getReferences().values()) {
-			if (reference instanceof ReflectedReferenceSchemaContract) {
-				continue;
-			}
-			requirements.add(referenceContentWithAttributes(reference.getName()));
-		}
-		return entityFetch(requirements.toArray(new EntityContentRequire[0]));
 	}
 
 	/**
@@ -603,10 +533,11 @@ public class WarmupCopyCatalogBenchmark {
 	// ============================================================================================
 
 	/**
-	 * Reconstructs the source schema on the target catalog. Global (catalog-level) attributes are created
-	 * first, then entity schemas are created in three passes so cross-collection references resolve: (1)
-	 * everything except references, (2) plain references, (3) reflected references (which need the plain
-	 * reference they reflect to already exist on the target entity).
+	 * Reconstructs the source schema on the target catalog through a single `updateCatalog` call. The
+	 * replication rules themselves live in {@link CatalogCopySupport#replicateSchema} - they are shared
+	 * with {@link io.evitadb.performance.warmupload.IsolatedWarmupLoadBenchmark}, were arrived at
+	 * empirically, and must not be duplicated: a second copy silently stops receiving the fixes the
+	 * first one gets.
 	 *
 	 * @param client              the shared gRPC client
 	 * @param targetCatalog       name of the target catalog (already defined, in WARM_UP)
@@ -619,413 +550,15 @@ public class WarmupCopyCatalogBenchmark {
 		@Nonnull final CatalogSchemaContract sourceCatalogSchema,
 		@Nonnull final Collection<EntitySchemaContract> sourceEntitySchemas
 	) {
+		// the lambda must keep a block body: an expression-bodied implicitly-typed lambda is potentially
+		// compatible with BOTH the `Consumer` and the `Function` overload of `updateCatalog`, which the
+		// compiler rejects as ambiguous. A block that is void-compatible only resolves to the `Consumer`
+		// overload - the same reason `read` below funnels its query lambdas through an explicit `Function`.
 		client.updateCatalog(
 			targetCatalog,
 			session -> {
-				replicateGlobalAttributes(sourceCatalogSchema, session);
-				// pass 1 - entity bodies without references
-				for (final EntitySchemaContract source : sourceEntitySchemas) {
-					final EntitySchemaBuilder builder = session.defineEntitySchema(source.getName());
-					replicateEntityBase(source, builder);
-					builder.updateVia(session);
-				}
-				// pass 2 - plain references
-				for (final EntitySchemaContract source : sourceEntitySchemas) {
-					final EntitySchemaBuilder builder = session.defineEntitySchema(source.getName());
-					replicatePlainReferences(source, builder);
-					builder.updateVia(session);
-				}
-				// pass 3 - reflected references
-				for (final EntitySchemaContract source : sourceEntitySchemas) {
-					final EntitySchemaBuilder builder = session.defineEntitySchema(source.getName());
-					replicateReflectedReferences(source, builder);
-					builder.updateVia(session);
-				}
+				CatalogCopySupport.replicateSchema(session, sourceCatalogSchema, sourceEntitySchemas);
 			}
-		);
-	}
-
-	/**
-	 * Copies every catalog-level global attribute (including its global-uniqueness settings) onto the
-	 * target catalog schema.
-	 *
-	 * @param sourceCatalogSchema the source catalog schema
-	 * @param session             open WARM_UP session of the target catalog
-	 */
-	private static void replicateGlobalAttributes(
-		@Nonnull final CatalogSchemaContract sourceCatalogSchema,
-		@Nonnull final EvitaSessionContract session
-	) {
-		if (sourceCatalogSchema.getAttributes().isEmpty()) {
-			return;
-		}
-		final CatalogSchemaBuilder builder = session.getCatalogSchema().openForWrite();
-		for (final GlobalAttributeSchemaContract attribute : sourceCatalogSchema.getAttributes().values()) {
-			builder.withAttribute(
-				attribute.getName(),
-				attribute.getType(),
-				editor -> {
-					applyAttribute(attribute, editor);
-					final List<Scope> uniqueGlobally = new ArrayList<>(2);
-					final List<Scope> uniqueGloballyWithinLocale = new ArrayList<>(2);
-					for (final Scope scope : Scope.values()) {
-						final GlobalAttributeUniquenessType type = attribute.getGlobalUniquenessType(scope);
-						if (type == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG) {
-							uniqueGlobally.add(scope);
-						} else if (type == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE) {
-							uniqueGloballyWithinLocale.add(scope);
-						}
-					}
-					if (!uniqueGlobally.isEmpty()) {
-						editor.uniqueGloballyInScope(uniqueGlobally.toArray(new Scope[0]));
-					}
-					if (!uniqueGloballyWithinLocale.isEmpty()) {
-						editor.uniqueGloballyWithinLocaleInScope(uniqueGloballyWithinLocale.toArray(new Scope[0]));
-					}
-				}
-			);
-		}
-		builder.updateVia(session);
-	}
-
-	/**
-	 * Reproduces the primary-key strategy, hierarchy, price handling, locales, evolution mode, attributes,
-	 * associated data and (entity-level) sortable attribute compounds of the source entity schema - but no
-	 * references.
-	 *
-	 * @param source  the source entity schema
-	 * @param builder the target entity schema builder
-	 */
-	private static void replicateEntityBase(
-		@Nonnull final EntitySchemaContract source,
-		@Nonnull final EntitySchemaBuilder builder
-	) {
-		final Set<EvolutionMode> evolutionModes = source.getEvolutionMode();
-		if (evolutionModes.isEmpty()) {
-			builder.verifySchemaStrictly();
-		} else {
-			builder.verifySchemaButAllow(evolutionModes.toArray(new EvolutionMode[0]));
-		}
-
-		if (source.isWithGeneratedPrimaryKey()) {
-			builder.withGeneratedPrimaryKey();
-		} else {
-			builder.withoutGeneratedPrimaryKey();
-		}
-
-		if (source.isWithHierarchy()) {
-			final Scope[] hierarchyScopes = scopesWhere(source::isHierarchyIndexedInScope);
-			if (hierarchyScopes.length > 0) {
-				builder.withHierarchyIndexedInScope(hierarchyScopes);
-			} else {
-				builder.withHierarchy();
-			}
-		}
-
-		if (source.isWithPrice()) {
-			final Scope[] priceScopes = scopesWhere(source::isPriceIndexedInScope);
-			final Scope[] effectivePriceScopes = priceScopes.length > 0 ? priceScopes : new Scope[]{Scope.DEFAULT_SCOPE};
-			final int indexedPricePlaces = source.getIndexedPricePlaces();
-			final Currency[] currencies = source.getCurrencies().toArray(new Currency[0]);
-			if (currencies.length > 0) {
-				builder.withPriceInCurrencyIndexedInScope(indexedPricePlaces, currencies, effectivePriceScopes);
-			} else {
-				builder.withPriceIndexedInScope(indexedPricePlaces, effectivePriceScopes);
-			}
-		}
-
-		if (!source.getLocales().isEmpty()) {
-			builder.withLocale(source.getLocales().toArray(new Locale[0]));
-		}
-
-		for (final AttributeSchemaContract attribute : source.getAttributes().values()) {
-			if (attribute instanceof GlobalAttributeSchemaContract) {
-				// global attributes are defined at catalog level - just reference them here
-				builder.withGlobalAttribute(attribute.getName());
-			} else {
-				builder.withAttribute(
-					attribute.getName(),
-					attribute.getType(),
-					editor -> applyAttribute(attribute, editor)
-				);
-			}
-		}
-
-		for (final AssociatedDataSchemaContract associatedData : source.getAssociatedData().values()) {
-			builder.withAssociatedData(
-				associatedData.getName(),
-				associatedData.getType(),
-				editor -> {
-					if (associatedData.isLocalized()) {
-						editor.localized();
-					}
-					if (associatedData.isNullable()) {
-						editor.nullable();
-					}
-				}
-			);
-		}
-
-		for (final SortableAttributeCompoundSchemaContract compound : source.getSortableAttributeCompounds().values()) {
-			applySortableAttributeCompound(compound, builder::withSortableAttributeCompound);
-		}
-	}
-
-	/**
-	 * Adds the plain (non-reflected) references of the source entity schema to the target builder,
-	 * reproducing cardinality, group type, per-scope index type, faceting, reference attributes and
-	 * reference-level sortable attribute compounds.
-	 *
-	 * @param source  the source entity schema
-	 * @param builder the target entity schema builder
-	 */
-	private static void replicatePlainReferences(
-		@Nonnull final EntitySchemaContract source,
-		@Nonnull final EntitySchemaBuilder builder
-	) {
-		for (final ReferenceSchemaContract reference : source.getReferences().values()) {
-			if (reference instanceof ReflectedReferenceSchemaContract) {
-				continue;
-			}
-			if (reference.isReferencedEntityTypeManaged()) {
-				builder.withReferenceToEntity(
-					reference.getName(),
-					reference.getReferencedEntityType(),
-					reference.getCardinality(),
-					editor -> applyReference(reference, editor)
-				);
-			} else {
-				builder.withReferenceTo(
-					reference.getName(),
-					reference.getReferencedEntityType(),
-					reference.getCardinality(),
-					editor -> applyReference(reference, editor)
-				);
-			}
-		}
-	}
-
-	/**
-	 * Adds the reflected references of the source entity schema to the target builder, reproducing the
-	 * reflected reference name, cardinality, faceting and attribute-inheritance behaviour.
-	 *
-	 * @param source  the source entity schema
-	 * @param builder the target entity schema builder
-	 */
-	private static void replicateReflectedReferences(
-		@Nonnull final EntitySchemaContract source,
-		@Nonnull final EntitySchemaBuilder builder
-	) {
-		for (final ReferenceSchemaContract reference : source.getReferences().values()) {
-			if (!(reference instanceof ReflectedReferenceSchemaContract reflected)) {
-				continue;
-			}
-			builder.withReflectedReferenceToEntity(
-				reflected.getName(),
-				reflected.getReferencedEntityType(),
-				reflected.getReflectedReferenceName(),
-				editor -> {
-					// Only override what the reflected reference does NOT inherit from its target reference.
-					// Re-declaring an inherited property (cardinality, faceting) or an inherited attribute is
-					// rejected by the engine ("... is inherited ... but it is already defined!"). A freshly
-					// created reflected reference already defaults to inherited cardinality, so we set it only
-					// when it is explicitly overridden - calling withCardinalityInherited() here would emit a
-					// ModifyReferenceSchemaCardinalityMutation(null) that the WAL serializer cannot write.
-					if (!reflected.isCardinalityInherited()) {
-						editor.withCardinality(reflected.getCardinality());
-					}
-					// attribute-inheritance behaviour governs which target-reference attributes are inherited;
-					// the inherited attributes themselves must NOT be re-declared here
-					final AttributeInheritanceBehavior behavior = reflected.getAttributesInheritanceBehavior();
-					final String[] inheritanceFilter = reflected.getAttributeInheritanceFilter();
-					if (behavior == AttributeInheritanceBehavior.INHERIT_ONLY_SPECIFIED) {
-						editor.withAttributesInherited(inheritanceFilter);
-					} else {
-						editor.withAttributesInheritedExcept(inheritanceFilter);
-					}
-					if (!reflected.isFacetedInherited()) {
-						final Scope[] facetedScopes = scopesWhere(reflected::isFacetedInScope);
-						if (facetedScopes.length > 0) {
-							editor.facetedInScope(facetedScopes);
-						}
-					}
-				}
-			);
-		}
-	}
-
-	/**
-	 * Applies the group type, per-scope index type, faceting, attributes and sortable attribute compounds
-	 * of a plain reference onto its target reference builder.
-	 *
-	 * @param reference the source reference schema
-	 * @param editor    the target reference builder
-	 */
-	private static void applyReference(
-		@Nonnull final ReferenceSchemaContract reference,
-		@Nonnull final ReferenceSchemaBuilder editor
-	) {
-		if (reference.getReferencedGroupType() != null) {
-			if (reference.isReferencedGroupTypeManaged()) {
-				editor.withGroupTypeRelatedToEntity(reference.getReferencedGroupType());
-			} else {
-				editor.withGroupType(reference.getReferencedGroupType());
-			}
-		}
-
-		final List<Scope> forFiltering = new ArrayList<>(2);
-		final List<Scope> forFilteringAndPartitioning = new ArrayList<>(2);
-		for (final Scope scope : Scope.values()) {
-			switch (reference.getReferenceIndexType(scope)) {
-				case FOR_FILTERING -> forFiltering.add(scope);
-				case FOR_FILTERING_AND_PARTITIONING -> forFilteringAndPartitioning.add(scope);
-				case NONE -> {
-					// not indexed in this scope - nothing to do
-				}
-			}
-		}
-		if (!forFiltering.isEmpty()) {
-			editor.indexedForFilteringInScope(forFiltering.toArray(new Scope[0]));
-		}
-		if (!forFilteringAndPartitioning.isEmpty()) {
-			editor.indexedForFilteringAndPartitioningInScope(forFilteringAndPartitioning.toArray(new Scope[0]));
-		}
-
-		final Scope[] facetedScopes = scopesWhere(reference::isFacetedInScope);
-		if (facetedScopes.length > 0) {
-			editor.facetedInScope(facetedScopes);
-		}
-
-		for (final AttributeSchemaContract attribute : reference.getAttributes().values()) {
-			editor.withAttribute(
-				attribute.getName(),
-				attribute.getType(),
-				attributeEditor -> applyAttribute(attribute, attributeEditor)
-			);
-		}
-
-		for (final SortableAttributeCompoundSchemaContract compound : reference.getSortableAttributeCompounds().values()) {
-			applySortableAttributeCompound(compound, editor::withSortableAttributeCompound);
-		}
-	}
-
-	/**
-	 * Copies all common attribute flags (localized, nullable, representative, default value, indexed
-	 * decimal places, per-scope filterable/sortable and per-scope collection-level uniqueness) from the
-	 * source attribute onto the given editor. Works for entity, reference and global attribute editors
-	 * alike.
-	 *
-	 * @param attribute the source attribute schema
-	 * @param editor    the target attribute editor
-	 */
-	private static void applyAttribute(
-		@Nonnull final AttributeSchemaContract attribute,
-		@Nonnull final AttributeSchemaEditor<?> editor
-	) {
-		if (attribute.isLocalized()) {
-			editor.localized();
-		}
-		if (attribute.isNullable()) {
-			editor.nullable();
-		}
-		if (attribute.isRepresentative()) {
-			editor.representative();
-		}
-		if (attribute.getDefaultValue() != null) {
-			editor.withDefaultValue(attribute.getDefaultValue());
-		}
-		if (attribute.getIndexedDecimalPlaces() > 0) {
-			editor.indexDecimalPlaces(attribute.getIndexedDecimalPlaces());
-		}
-
-		final Scope[] filterableScopes = scopesWhere(attribute::isFilterableInScope);
-		if (filterableScopes.length > 0) {
-			editor.filterableInScope(filterableScopes);
-		}
-		final Scope[] sortableScopes = scopesWhere(attribute::isSortableInScope);
-		if (sortableScopes.length > 0) {
-			editor.sortableInScope(sortableScopes);
-		}
-
-		final List<Scope> unique = new ArrayList<>(2);
-		final List<Scope> uniqueWithinLocale = new ArrayList<>(2);
-		for (final Scope scope : Scope.values()) {
-			final AttributeUniquenessType type = attribute.getUniquenessType(scope);
-			if (type == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION) {
-				unique.add(scope);
-			} else if (type == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE) {
-				uniqueWithinLocale.add(scope);
-			}
-		}
-		if (!unique.isEmpty()) {
-			editor.uniqueInScope(unique.toArray(new Scope[0]));
-		}
-		if (!uniqueWithinLocale.isEmpty()) {
-			editor.uniqueWithinLocaleInScope(uniqueWithinLocale.toArray(new Scope[0]));
-		}
-	}
-
-	/**
-	 * Recreates a sortable attribute compound (its ordered attribute elements and per-scope indexing)
-	 * through the supplied factory - which is either the entity or the reference builder's
-	 * {@code withSortableAttributeCompound} method.
-	 *
-	 * @param compound the source sortable attribute compound
-	 * @param factory  builder method that registers the compound
-	 */
-	private static void applySortableAttributeCompound(
-		@Nonnull final SortableAttributeCompoundSchemaContract compound,
-		@Nonnull final SortableAttributeCompoundFactory factory
-	) {
-		final List<AttributeElement> elements = compound.getAttributeElements();
-		factory.create(
-			compound.getName(),
-			elements.toArray(new AttributeElement[0]),
-			editor -> {
-				final Scope[] indexedScopes = scopesWhere(compound::isIndexedInScope);
-				if (indexedScopes.length > 0) {
-					editor.indexedInScope(indexedScopes);
-				}
-			}
-		);
-	}
-
-	/**
-	 * Returns the scopes for which the supplied predicate holds.
-	 *
-	 * @param predicate scope test
-	 * @return matching scopes (never null, possibly empty)
-	 */
-	@Nonnull
-	private static Scope[] scopesWhere(@Nonnull final Predicate<Scope> predicate) {
-		final List<Scope> matching = new ArrayList<>(Scope.values().length);
-		for (final Scope scope : Scope.values()) {
-			if (predicate.test(scope)) {
-				matching.add(scope);
-			}
-		}
-		return matching.toArray(new Scope[0]);
-	}
-
-	/**
-	 * Narrow functional bridge for the two {@code withSortableAttributeCompound(name, elements, whichIs)}
-	 * builder methods (entity-level and reference-level), which share an identical signature but live on
-	 * unrelated editor interfaces.
-	 */
-	@FunctionalInterface
-	private interface SortableAttributeCompoundFactory {
-
-		/**
-		 * Registers a sortable attribute compound.
-		 *
-		 * @param name     compound name
-		 * @param elements ordered attribute elements
-		 * @param whichIs  compound configuration callback
-		 */
-		void create(
-			@Nonnull String name,
-			@Nonnull AttributeElement[] elements,
-			@Nonnull Consumer<SortableAttributeCompoundSchemaBuilder> whichIs
 		);
 	}
 


### PR DESCRIPTION
Adds the harness that measures what an operator calls **publishing**: rebuild a catalog from scratch in `WARM_UP` state through the gRPC driver, then flip it to `ALIVE`. It complements `wal-replay-profiling`, which measures transactional commit cost against an `ALIVE` catalog — different write paths, non-interchangeable numbers.

The harness itself is not new: it produced the before/after figures quoted in `2026-08-05-schema-handling-write-path-optimizations`, and it is what caught #1388 (a "goLive" that was really Armeria's 15 s response timeout expiring). It has been living untracked in a working tree, and was lost once already when a bench worktree was pruned. This commits it.

## What is here

**1. `test:` the skill and the harness** — `.claude/skills/warmup-reindex-benchmark/` (SKILL.md plus three runner scripts) and `io.evitadb.performance.warmupload` (`IsolatedWarmupLoadBenchmark`, `CatalogCopySupport`) in `evita_test/evita_performance_tests`.

The reader and the writer run as separate JVMs deliberately. In a single-process copy the same thread deserializes source entities and applies target mutations, so no thread filter separates read-path Kryo from index maintenance and the write path cannot be profiled at all. Isolating the writer also halves its live set — the server holds only the catalog being built, which is the configuration the write-path ADR found death-spiralling in G1. The cost is that client-observed upsert latency then includes protobuf serialization and the loopback round trip; `targetMode=embedded` is the transport-free control, and the difference between the two modes is what gRPC costs.

The `.editorconfig` entry exempts `SKILL.md` from the 120-column limit: a skill's YAML front matter must keep `description:` and `allowed-tools:` on one logical line each, because that string is what a task is matched against — wrapping it changes the parsed value rather than merely reformatting it.

**2. `refactor:` de-duplicate the older spike** — `io.evitadb.spike.WarmupCopyCatalogBenchmark` carried its own copy of the nine schema-replication helpers `CatalogCopySupport` was extracted to hold. Eight were byte-identical and `buildContentRequirement` differed only in visibility. Those rules were arrived at empirically against engine rejections (a reflected reference must not re-declare what it inherits; `withCardinalityInherited()` emits a mutation the WAL serializer cannot write), which is exactly the knowledge that rots when a second copy stops receiving the first one's fixes. 1052 → 588 lines, 30 imports dropped. `replicateSchema` survives as a four-line wrapper because the spike drives a client and needs the `updateCatalog` call, while the shared implementation takes an already-open session so both target modes can use it.

## Verification

`mvn clean install -P full -DskipTests` against the dev reactor, then `mvn -o -P full package -pl evita_test/evita_performance_tests` — BUILD SUCCESS, with `CatalogCopySupport.class`, the `IsolatedWarmupLoadBenchmark` classes and the rewritten `WarmupCopyCatalogBenchmark.class` all produced. The first attempt failed on `reference to updateCatalog is ambiguous`: an expression-bodied implicitly-typed lambda is potentially compatible with both the `Consumer` and the `Function` overload. The wrapper now keeps a block body, with a comment saying why — the same hazard the file's `read()` helper already documents.

No ADR: `.claude/rules/adr.md` lists benchmark-harness tooling under "never a record", so the reasoning is in the commit messages.

## Two things worth a reviewer's eye

- `SKILL.md` defaults `ROOT=/www/oss/evita/release_2026-2`. It is env-overridable and every script takes `ROOT=<checkout>`, but it is a release-branch path in a document landing on `dev`.
- The reference-measurement table is five 2026.2-lineage runs (v2026.2.0 through `dev@a808b4e46`). Honest as history and each row names its build, but it is not a `dev` baseline. Cells that could not be isolated from the run logs are left empty rather than reconstructed, and the table states that a single run resolves only ±9 % — with the cause of that spread explicitly recorded as unknown.