### PR TITLE
Decide price histogram granularity per accessor, not per query

### DIFF
--- a/documentation/adr/2026-08-24-price-histogram-per-accessor-granularity.md
+++ b/documentation/adr/2026-08-24-price-histogram-per-accessor-granularity.md
@@ -1,11 +1,11 @@
 ---
 title: Price histogram granularity is decided per accessor, not all-or-nothing across the query
 date: 2026-08-24
-updated: 2026-08-24 13:10
-status: proposed
+updated: 2026-08-24 13:45
+status: accepted
 kind: fix
 issues: [1433]
-prs: []
+prs: [1435, 1436]
 areas: [evita_engine/src/main/java/io/evitadb/core/query/algebra/price, evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram]
 supersedes: []
 superseded-by: []
@@ -214,5 +214,8 @@ list would get simpler.
 - **2026-05-18** — #1159 fix merged (PR #1165); per-inner-record path introduced behind the
   all-or-nothing capability gate
 - **2026-08-24** — mixed-pool defect reported as #1433, reproduced, fixed; record written with the
-  implementation, `status: proposed` until the PR merges (flip to `accepted` and fill `prs:` then —
-  `date:` stays as written)
+  implementation and accepted. The fix ships through two pull requests rather than one: PR #1435 into
+  `release_2026-2`, where the defect was reported, and PR #1436 into `dev`. `release_2026-2` holds ten
+  commits `dev` does not, so #1436 is a cherry-pick onto a branch cut from `dev` rather than a
+  retarget — a retarget would have dragged those ten unrelated commits into the diff. Both were
+  verified independently against their own base, `dev` being 257 commits ahead at the time.

--- a/documentation/adr/2026-08-24-price-histogram-per-accessor-granularity.md
+++ b/documentation/adr/2026-08-24-price-histogram-per-accessor-granularity.md
@@ -1,0 +1,218 @@
+---
+title: Price histogram granularity is decided per accessor, not all-or-nothing across the query
+date: 2026-08-24
+updated: 2026-08-24 13:10
+status: proposed
+kind: fix
+issues: [1433]
+prs: []
+areas: [evita_engine/src/main/java/io/evitadb/core/query/algebra/price, evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram]
+supersedes: []
+superseded-by: []
+relates: []
+---
+
+# Price histogram granularity is decided per accessor, not all-or-nothing across the query
+
+The per-inner-record price histogram shipped in #1159 only engaged when *every*
+`FilteredPriceRecordAccessor` in the query exposed the per-inner-record side-output. Because a
+`filterBy` builds one price branch per `PriceInnerRecordHandling` present in the catalog, and only
+the `LOWEST_PRICE` branch has per-inner-record data points to give, that rule could never be
+satisfied by a candidate pool mixing handling modes — the histogram silently fell back to
+per-entity granularity, which is exactly the symptom #1159 was opened to remove. The capability
+probe is now read per accessor: exposing accessors contribute their per-inner-record records, and
+the unchanged per-entity collector tops up every entity those records did not cover.
+
+## Why
+
+A category listing that contains both simple products (`NONE`) and master/variant products
+(`LOWEST_PRICE`) is the ordinary shape of an e-commerce catalog, not an edge case. In such a pool
+the shipped code capped the histogram's upper bound at the highest *price for sale*, hiding every
+non-cheapest variant price above it — reported on a live 2026.2 deployment as a histogram maximum
+of 5 000 CZK for a pool containing an 8 000 CZK variant.
+
+The constraint that made this non-obvious is that the two halves of the answer are produced by
+completely different machinery. The `LOWEST_PRICE` half arrives as an eagerly-collected array from
+`LowestPriceTerminationFormula`'s side-output; the `NONE`/`SUM` half is produced by an
+entity-driven collector that walks the filter result and asks each accessor for the prices of one
+entity at a time. There is no single call that yields both, so "just merge the accessors" is not
+available as a one-liner.
+
+### Previous state
+
+`FilteredPriceRecords.allAccessorsExposePerInnerRecordHistogram` returned `true` only when the
+collection was non-empty and every member exposed the side-output; `PriceHistogramComputer` used it
+to choose between two whole-query paths. Two independent causes closed that gate on a mixed pool:
+
+- the `SHALLOW` accessor scan descends through `PlainPriceTerminationFormula` (which is not a
+  `FilteredPriceRecordAccessor`) and surfaces the inner `PriceIdToEntityIdTranslateFormula`, which
+  inherits the interface default of `false`;
+- `SelectionFormula` implements the accessor interface unconditionally, so a wrapper the planner
+  inserted above a price-free sub-tree was gathered into the histogram's accessor list and reported
+  `false` on its own.
+
+Either was sufficient. Neither was visible in tests, because the per-inner-record fixtures added in
+#1165 used a homogeneous `LOWEST_PRICE` pool, and the shared assertion helper *dispatched on the
+composition of the pool* — asserting per-entity counts the moment one entity was not
+`LOWEST_PRICE`. The assertion adapted to the engine, so it could not detect the engine getting
+coarser.
+
+## Options considered
+
+### Option A — partition the accessor set, top up the remainder (chosen)
+
+Read `exposesPerInnerRecordHistogramRecords()` per accessor. Merge the exposing accessors'
+side-output, narrow it to the entities the whole filter matched, then run the existing
+`FilteredPriceRecordsCollector` over `baseline \ covered` and concatenate. `SelectionFormula`'s
+probe becomes "any inner accessor exposes" and its histogram records become "only the exposing
+inners' contribution".
+
+- **Pros:** each half keeps running through the code path that already has passing assertions
+  behind it; double counting is impossible by construction rather than by argument, which is what
+  makes it hold on the prefetch plan too (there a `SelectionFormula`'s per-entity alternative would
+  happily answer for a `LOWEST_PRICE` entity, but it is never asked — that entity is not in the
+  remainder); no accessor is asked for a shape it does not have.
+- **Cons:** the histogram now computes the relaxed baseline bitmap on the per-inner-record path,
+  which it previously skipped; one extra `contains` per per-inner-record price.
+
+### Option B — stop the `SHALLOW` scan at the termination formula (declined)
+
+The issue's own prescription: fix the accessor collection so each handling branch contributes its
+*termination* formula rather than the raw translate formula underneath it — by making
+`PlainPriceTerminationFormula` a `FilteredPriceRecordAccessor`.
+
+- **Pros:** attacks the surfaced-wrong-node problem at its origin; the accessor list would then read
+  as one entry per handling branch, which is easier to reason about.
+- **Rejected because:** `PlainPriceTerminationFormula` owns no price records at all — it is the
+  no-price-filter variant that deliberately postpones resolving the entity price, and it delegates
+  straight to `getDelegate().compute()`. Stopping the scan there yields *zero* contribution from the
+  `NONE` branch, so those entities would vanish from the histogram entirely — worse than the bug.
+  Making it a real accessor means giving it a record store and a resolution step it exists to avoid.
+  Revisit if `PlainPriceTerminationFormula` ever has to resolve entity prices for another reason.
+
+### Option C — give `PriceIdToEntityIdTranslateFormula` the capability (declined)
+
+Let the node the `SHALLOW` scan actually surfaces answer `true`, so the merge covers every branch.
+
+- **Pros:** a one-line change at the exact node the scan returns; no partitioning logic anywhere.
+- **Rejected because:** it returns one raw record per translated price id (`SortingForm.NOT_SORTED`),
+  not per-entity winners. Merging those inflates the buckets — an entity present in two queried
+  price lists would contribute twice. The per-entity view for that branch only exists after the
+  entity-driven collector has picked the winner, which is precisely what Option A keeps doing.
+
+## Decision
+
+**Chosen: Option A.** The driver is that the two halves are genuinely different computations and
+the correct answer is their union, not a choice between them. Options B and C both try to make one
+mechanism serve both, and each breaks on the same fact: the `NONE` branch's per-entity winner is not
+materialised anywhere until the collector selects it.
+
+Option B becomes worth revisiting only if `PlainPriceTerminationFormula` gains eager price
+resolution for an unrelated reason — at that point it could contribute directly and the accessor
+list would get simpler.
+
+## Key technical details
+
+- **Entry point:** `PriceHistogramComputer.getPriceRecords()` partitions via
+  `FilteredPriceRecords.collectPerInnerRecordHistogramAccessors(...)`; the two-pass assembly lives
+  in `collectPerInnerRecordHistogramRecords(List)`.
+- **Invariant — the probe is per accessor.** `exposesPerInnerRecordHistogramRecords()` returning
+  `false` forfeits *that accessor's* contribution and nothing else. Any future reader that ANDs the
+  probe across a collection reintroduces this bug. `SelectionFormula` follows the same rule with
+  "any inner exposes".
+- **The `SHALLOW` scan still surfaces `PriceIdToEntityIdTranslateFormula`, and that is now inert —
+  not a leftover.** It keeps answering `false`, but a `false` no longer closes the gate for anyone
+  else, and the branch it stands for is picked up by the entity-driven remainder pass. Nothing needs
+  to change at the scan; see Option B for why stopping it earlier would be a regression.
+- **The side-output is not narrowed at its source.** `LowestPriceTerminationFormula` fills its
+  funnel from its own delegate — the price sub-tree — so it covers entities that the non-price parts
+  of the query (`entityPrimaryKeyInSet`, attribute filters, hierarchy constraints) exclude. The
+  computer narrows it to the baseline; removing that narrowing turns a 10-data-point histogram into a
+  108-data-point one on the fixture named below. This latent over-count predates this change and was
+  simply unreachable while the whole path was gated off for anything but price-only queries.
+- **The remainder pass must not reuse `priceRecordsLookupResult`.** That result comes from
+  `FilteredPricesSorter`, built over the full accessor set and the full filter result, so it already
+  contains a per-entity record for every `LOWEST_PRICE` entity that pass 1 expanded.
+- **`covered` is built with incremental `PersistentRoaringBitmap.add`, not
+  `RoaringBitmapBackedBitmap.buildWriter()`.** The constant-memory writer materialises a container
+  when the high bits change and so assumes ascending input; concatenating several accessors'
+  side-outputs restarts at each accessor's lowest entity primary key.
+
+## Verification
+
+- `CombinedPriceEntityByPriceFilteringFunctionalTest` (mixed `NONE`/`LOWEST_PRICE`/`SUM` pool) — the
+  four `shouldReturnPriceHistogram*` tests are the reproduction. Restoring the all-or-nothing gate on
+  the fixed code reproduces every one of them: `expected 78 but was 70` (twice), `58/52`, and `8/6` on
+  the prefetch variant. After the fix all four pass.
+- **The prefetch variant needs *both* halves of the gate restored to reproduce.** Reverting only
+  `PriceHistogramComputer` leaves it green, because on a prefetched plan the single top-level accessor
+  is the `SelectionFormula` wrapper — the all-or-nothing decision was being taken *inside* it, by its
+  own all-true probe over the inners. That is what makes the wrapper change load-bearing rather than
+  cosmetic, and it is worth knowing before concluding a future gate change is covered.
+- `FindFirstPriceEntityByPriceFilteringFunctionalTest`, new test
+  `shouldLimitPerInnerRecordHistogramToEntitiesMatchedByNonPriceConstraint` — pins the narrowing with
+  an `entityPrimaryKeyInSet` handle over a pure `LOWEST_PRICE` fixture. Counterfactual check: with the
+  narrowing removed it reports `expected 10 but was 108`, and the mixed prefetch test `expected 8 but
+  was 39`.
+- `SelectionFormulaHistogramCapabilityTest` — the capability probe now asserts "any", plus a new
+  *Accessor set partitioning* group covering the price-free wrapper and the surfaced translate
+  formula.
+- **Both named reproductions are covered, and the coverage is asserted rather than measured.** The
+  `CombinedPrice...` fixture carries all three handlings in every pool the histogram tests query, so
+  the `LOWEST_PRICE + SUM` mix the issue names is exercised and not merely assumed.
+  `assertPoolMixesInnerRecordHandling` pins that for the index-plan pools, and the prefetch test pins
+  two properties of the six entities it selects: that they span every handling the dataset offers, and
+  — wherever the dataset has `LOWEST_PRICE` — that at least one of them is a *multi*-inner-record
+  master. **The second guard is not redundant with the first.** An intermediate version of the picker
+  produced a perfectly balanced `{NONE=2, LOWEST_PRICE=2, SUM=2}` pool whose masters all happened to
+  carry a single variant; per-entity and per-inner-record granularity return identical numbers for
+  such a pool, and the deliberately regressed engine passed against it. Handling diversity is not
+  granularity diversity, and only the latter can detect this bug.
+- **Cross-plan and cached-payload agreement.** `VERIFY_ALTERNATIVE_INDEX_RESULTS` and
+  `VERIFY_POSSIBLE_CACHING_TREES` are now enabled on the per-inner-record tests; they had been
+  omitted since #1159 because the old all-or-nothing gate could flip between rebuilt plans and the
+  verifier raised `InconsistentResultsException`. The caching verifier substitutes
+  `FlattenedFormulaWithFilteredPricesForHistogram` for the flagged LP, which is what gives the cached
+  form of the hybrid path its coverage.
+- Full sweep `-Dgroups="price | histogram | cache"`: 1609 tests, 0 failures, 4 skipped (1607 before
+  the two prefetch overrides were enabled).
+
+## Consequences & open follow-ups
+
+- The shared assertion helper `EntityByPriceFilteringFunctionalTest.assertHistogramIntegrity` no
+  longer dispatches on the pool's composition — it derives the expectation from each entity's own
+  handling, so a future regression to coarser granularity fails the test instead of changing which
+  branch it takes. `assertHistogramIntegrityPerEntity` was deleted; the per-inner-record helper
+  remains for the pure-`LOWEST_PRICE` call sites.
+- **The prefetch histogram test's fixture is now derived, not hard-coded.**
+  `shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch` used to pick its six
+  entities with per-price-list `getPriceForSale` comparisons and assert a literal
+  `assertEquals(3, result.getTotalRecordCount())`. That only models `NONE` handling, which is why the
+  `FindFirst` and `Sum` overrides had silently been left without `@Test` — enabling them failed on the
+  fixture's own precondition, not on anything the test was written to check. Selection now goes
+  through `PricesContract.hasPriceInInterval`, the model's own per-handling reading of `priceBetween`,
+  and the expected count is the size of the group it selected. Both overrides now carry `@Test` and
+  pass. The lesson generalises: a fixture predicate that hand-rolls price semantics per price list is
+  only valid for the `NONE` dataset, and the suite has a subclass per handling mode.
+  **What changed is the predicate, not the constants.** The `[50, 150]` band and the two
+  `assertEquals(3, ...)` group sizes are still hard-coded in the base method and inherited by all four
+  datasets; they hold on every one of them today, but a data-generator change that shifts the price
+  distribution can still starve a group. The difference is the failure mode: it would now be an honest
+  "this dataset cannot supply six suitable entities", not a precondition that was wrong by
+  construction for three datasets out of four. Deriving the band from the dataset is the next step if
+  that ever bites.
+- `shouldReturnProductsHavingPriceInCurrencyAndPriceListInIntervalWithTaxOrderByPriceAscendingWithoutExplicitAnd`
+  is the one remaining `@Test`-less override in the price hierarchy (in both the `FindFirst` and `Sum`
+  subclasses). It is an ordering test, not a histogram one, so it is out of scope here — but it is the
+  same class of gap and worth the same treatment.
+- `SUM` still contributes one data point per entity, per the #1159 specification table. Nothing in
+  this change makes that assumption load-bearing anywhere new — a future `SUM` per-inner-record
+  requirement only has to flip its termination formula's probe to `true`.
+
+## Timeline
+
+- **2026-05-18** — #1159 fix merged (PR #1165); per-inner-record path introduced behind the
+  all-or-nothing capability gate
+- **2026-08-24** — mixed-pool defect reported as #1433, reproduced, fixed; record written with the
+  implementation, `status: proposed` until the PR merges (flip to `accepted` and fill `prs:` then —
+  `date:` stays as written)

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | proposed | #1433 |
+| 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | accepted | #1433, PR #1435, PR #1436 |
 | 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | proposed | #1433 |
 | 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |

--- a/documentation/user/en/query/requirements/histogram.md
+++ b/documentation/user/en/query/requirements/histogram.md
@@ -318,6 +318,11 @@ handles inner records (`PriceInnerRecordHandling`), because that determines what
 | `SUM`                 | One — the cumulated price of all inner records |
 | `LOWEST_PRICE`        | **One per inner-record id** — the winning price of each variant |
 
+The rule is applied **per entity**, using that entity's own handling. A candidate pool that mixes handling
+modes — a category listing containing both simple products and master/variant products, for instance —
+therefore contributes the union of both rules: every `LOWEST_PRICE` master still expands into one data point
+per variant, while its `NONE` and `SUM` neighbours contribute a single price for sale each.
+
 To demonstrate the use of the histogram, we will use the following example:
 
 <SourceCodeTabs requires="evita_test/evita_documentation_tests/src/test/resources/META-INF/documentation/evitaql-init.java" langSpecificTabOnly>

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/SelectionFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/SelectionFormula.java
@@ -258,18 +258,26 @@ public class SelectionFormula extends AbstractFormula implements ChildrenDepende
 
 	/**
 	 * Propagates the histogram side-output capability from inner accessors so {@link PriceHistogramComputer}'s
-	 * bypass continues to fire even when prefetch wiring (`PriceInPriceListsTranslator`) inserts a
-	 * {@link SelectionFormula} between the histogram and the histogram-aware
+	 * per-inner-record path continues to fire even when prefetch wiring (`PriceInPriceListsTranslator`) inserts
+	 * a {@link SelectionFormula} between the histogram and the histogram-aware
 	 * `io.evitadb.core.query.algebra.price.termination.LowestPriceTerminationFormula`. A naive
-	 * top-level-only probe would miss wrapped LPs and incorrectly disable the bypass.
+	 * top-level-only probe would miss wrapped LPs and incorrectly disable the per-inner-record granularity.
 	 *
-	 * Semantics are "all-true": this wrapper exposes the side-output only if **every** inner accessor
-	 * does. The histogram producer collects the accessor list from a `withoutUserFilter` view of the
-	 * filtering tree, so wrappers above un-flagged inner LPs (e.g. price-between LPs under
-	 * `UserFilterFormula`) never end up in the histogram accessor list in the first place.
+	 * Semantics are "any-true": this wrapper exposes the side-output when **at least one** inner accessor
+	 * does. A single `SelectionFormula` is inserted above the whole price filter container, so in a catalog
+	 * mixing {@link io.evitadb.api.requestResponse.data.PriceInnerRecordHandling} values its inner accessor
+	 * set legitimately contains both the flagged `LOWEST_PRICE` termination formula and the non-exposing
+	 * `NONE`/`SUM` branches. Under the previous "all-true" rule that mix silently dropped the histogram back
+	 * to per-entity granularity (issue #1433). {@link #getFilteredPriceRecordsForHistogram} therefore returns
+	 * only the *exposing* inners' contribution, and the histogram producer routes every entity not covered by
+	 * it through the per-entity collector.
 	 *
 	 * **Prefetch parity**: the probe ignores `isPrefetchExecution()` — both alternative plans (index and
-	 * prefetch) must return the same histogram or `VERIFY_ALTERNATIVE_INDEX_RESULTS` fails. The cost of
+	 * prefetch) must return the same histogram. `QueryPlanner.verifyConsistentResultsInAllPlans` executes
+	 * the query under the bitmap-favouring *and* the prefetch-favouring policy and compares the whole
+	 * `EvitaResponse`, extra results included, so a divergence raises `InconsistentResultsException` — but
+	 * only when a query enables `VERIFY_ALTERNATIVE_INDEX_RESULTS` **and** `PREFER_PREFETCHING` together.
+	 * The cost of
 	 * running the inner LP's `computeInternal()` on the prefetch path to populate the side-output is
 	 * accepted because histogram queries are inherently expensive; the alternative is silently wrong
 	 * histograms whenever prefetch is enabled.
@@ -284,22 +292,26 @@ public class SelectionFormula extends AbstractFormula implements ChildrenDepende
 
 	/**
 	 * One-shot computation backing {@link #exposesPerInnerRecordHistogramRecords()}. Delegates to the
-	 * shared {@link FilteredPriceRecords#allAccessorsExposePerInnerRecordHistogram(Collection)} probe
-	 * so the "all-or-nothing" rule cannot drift between the wrapper and the histogram producer. An
-	 * empty inner-accessor set returns `false` because there is no histogram-aware LP to forward to.
+	 * shared {@link FilteredPriceRecords#anyAccessorExposesPerInnerRecordHistogram(Collection)} probe
+	 * so the rule cannot drift between the wrapper and the histogram producer. An empty inner-accessor
+	 * set returns `false` because there is no histogram-aware LP to forward to — notably, a wrapper
+	 * inserted above a price-free sub-tree must not claim a capability it has no records for.
 	 *
-	 * @return `true` iff every inner {@link FilteredPriceRecordAccessor} exposes the per-inner-record
-	 *         histogram side-output
+	 * @return `true` iff at least one inner {@link FilteredPriceRecordAccessor} exposes the
+	 *         per-inner-record histogram side-output
 	 */
 	private boolean computeExposesPerInnerRecordHistogramRecords() {
-		return FilteredPriceRecords.allAccessorsExposePerInnerRecordHistogram(findInnerAccessors());
+		return FilteredPriceRecords.anyAccessorExposesPerInnerRecordHistogram(findInnerAccessors());
 	}
 
 	/**
-	 * Walks the delegate's inner accessors and merges their per-inner-record histogram records into a
-	 * single flat array. Called by {@link PriceHistogramComputer} only when
-	 * {@link #exposesPerInnerRecordHistogramRecords()} returned `true`, so every inner accessor is
-	 * guaranteed to populate its side-output without throwing.
+	 * Merges the per-inner-record histogram records of the delegate's **histogram-exposing** inner
+	 * accessors into a single flat array. Non-exposing inner accessors (the `NONE` and `SUM` handling
+	 * branches, which have no per-inner-record data points to contribute) are deliberately skipped: the
+	 * entities they cover are picked up by `PriceHistogramComputer`'s per-entity collector pass over
+	 * whatever the returned records did not cover. Calling
+	 * {@link FilteredPriceRecordAccessor#getFilteredPriceRecordsForHistogram} on them here would either
+	 * trip a flag-off LP's guard or contribute raw per-price-id records that inflate the buckets.
 	 *
 	 * Always delegates to the inner accessors — even on the prefetch path — so both alternative plans
 	 * produce the same histogram (see the JavaDoc on
@@ -309,57 +321,28 @@ public class SelectionFormula extends AbstractFormula implements ChildrenDepende
 	 *
 	 * Behaviour matrix:
 	 *
-	 * - no inner accessors → fall back to {@link #getFilteredPriceRecords(QueryExecutionContext)};
-	 * - any inner accessor missing the capability → fall back to per-entity records (the wrapper
-	 *   honours the default interface contract for non-histogram-aware accessors rather than tripping
-	 *   the merge guard mid-loop on a flag-off LP);
-	 * - single histogram-aware inner accessor → size-1 fast path returns its records directly without
-	 *   the intermediate array and `System.arraycopy` round-trip;
-	 * - two or more histogram-aware inner accessors → the actual concatenation is delegated to
+	 * - no exposing inner accessor → fall back to {@link #getFilteredPriceRecords(QueryExecutionContext)},
+	 *   honouring the default interface contract for non-histogram-aware accessors. Defensive only: the
+	 *   caller probes {@link #exposesPerInnerRecordHistogramRecords()} first;
+	 * - exactly one exposing inner accessor → fast path returns its records directly, without the
+	 *   intermediate array and `System.arraycopy` round-trip;
+	 * - two or more exposing inner accessors → the concatenation is delegated to
 	 *   {@link FilteredPriceRecords#mergePerInnerRecordHistogramRecords(Collection, QueryExecutionContext)}
 	 *   so the algorithm stays in one place.
-	 *
-	 * The capability-mismatch fallbacks differ intentionally between size-1 and size≥2:
-	 *
-	 * - size-1 falls back to the *inner* accessor's per-entity records because the wrapper's view
-	 *   over a single delegate is, by construction, that single delegate's view — there is nothing to
-	 *   merge and routing through the wrapper would just add a no-op `createFromFormulas` round-trip;
-	 * - size≥2 falls back to the *wrapper's* per-entity records because per-inner-record arrays from
-	 *   multiple accessors can overlap on the same entity primary key, and only the wrapper's own
-	 *   `getFilteredPriceRecords` knows how to reduce them (via `createFromFormulas`) into a single
-	 *   coherent per-entity view.
-	 *
-	 * Today both fallbacks are dead in production because the caller (`PriceHistogramComputer`)
-	 * always probes `exposesPerInnerRecordHistogramRecords()` first; the asymmetry is kept as a
-	 * defensive safety net in case that contract ever loosens.
 	 */
 	@Nonnull
 	@Override
 	public FilteredPriceRecords getFilteredPriceRecordsForHistogram(@Nonnull QueryExecutionContext context) {
-		final Collection<FilteredPriceRecordAccessor> innerAccessors = findInnerAccessors();
-		if (innerAccessors.isEmpty()) {
+		final List<FilteredPriceRecordAccessor> exposingAccessors =
+			FilteredPriceRecords.collectPerInnerRecordHistogramAccessors(findInnerAccessors());
+		if (exposingAccessors.isEmpty()) {
 			return getFilteredPriceRecords(context);
 		}
-		if (innerAccessors.size() == 1) {
-			// size-1 fast path — common case where the delegate wraps a single histogram-aware LP; avoids the
-			// intermediate array and `System.arraycopy` round-trip below. Mirror the default interface
-			// contract: when the inner accessor is not histogram-aware, fall back to its per-entity records
-			// rather than trip the LP's histogram-collection guard.
-			final FilteredPriceRecordAccessor inner = innerAccessors.iterator().next();
-			if (!inner.exposesPerInnerRecordHistogramRecords()) {
-				return inner.getFilteredPriceRecords(context);
-			}
-			return inner.getFilteredPriceRecordsForHistogram(context);
-		}
-		if (!exposesPerInnerRecordHistogramRecords()) {
-			// size>=2 capability mismatch — at least one inner accessor lacks the side-output, so entering
-			// the merge loop would trip the flag-off LP's guard. Defer to the wrapper's per-entity output
-			// (which the production planner always initialises with a non-null context) instead. Mirrors
-			// the default interface contract for non-histogram-aware accessors.
-			return getFilteredPriceRecords(context);
+		if (exposingAccessors.size() == 1) {
+			return exposingAccessors.get(0).getFilteredPriceRecordsForHistogram(context);
 		}
 		final PriceRecordContract[] merged = FilteredPriceRecords.mergePerInnerRecordHistogramRecords(
-			innerAccessors, context
+			exposingAccessors, context
 		);
 		if (merged.length == 0) {
 			return FilteredPriceRecords.EMPTY;

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/FilteredPriceRecordAccessor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/FilteredPriceRecordAccessor.java
@@ -87,8 +87,9 @@ public interface FilteredPriceRecordAccessor {
 	}
 
 	/**
-	 * Capability probe used by `PriceHistogramComputer` to decide whether it may bypass the per-entity
-	 * `FilteredPriceRecordsCollector` and read the per-inner-record records directly from each accessor.
+	 * Capability probe used by `PriceHistogramComputer` to partition the accessor set: accessors that
+	 * answer `true` contribute their per-inner-record records directly, everything else is served by the
+	 * per-entity `FilteredPriceRecordsCollector`.
 	 *
 	 * Returns `true` only when {@link #getFilteredPriceRecordsForHistogram(QueryExecutionContext)} is
 	 * guaranteed to expose the per-inner-record histogram side-output for this accessor's scope:
@@ -102,8 +103,15 @@ public interface FilteredPriceRecordAccessor {
 	 * - `FlattenedFormulaWithFilteredPricesForHistogram` (the cached form of the above) always returns
 	 *   `true`.
 	 * - Wrapper accessors (e.g. `SelectionFormula`) propagate the capability from their inner
-	 *   accessors so the histogram bypass continues to fire even when prefetch wiring inserts a
-	 *   wrapper between the histogram and the histogram-aware termination formula.
+	 *   accessors so the per-inner-record granularity survives prefetch wiring inserting a wrapper
+	 *   between the histogram and the histogram-aware termination formula.
+	 *
+	 * **A `false` answer only forfeits this accessor's own contribution.** It must never be read as
+	 * "the whole histogram falls back to per-entity granularity" — the accessors of a single query
+	 * routinely mix answers, because a `filterBy` builds one price branch per
+	 * {@link PriceInnerRecordHandling} present in the catalog and only the `LOWEST_PRICE` branch has
+	 * per-inner-record data points to give. Treating the probe as all-or-nothing is what made the
+	 * histogram silently revert to per-entity granularity for mixed pools (issue #1433).
 	 *
 	 * Implementations that override this method must keep its evaluation allocation-free — the probe
 	 * is called once per accessor during histogram planning, but cumulatively across multi-tenant

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/filteredPriceRecords/FilteredPriceRecords.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/filteredPriceRecords/FilteredPriceRecords.java
@@ -49,6 +49,7 @@ import io.evitadb.roaringbitmap.RoaringBitmapWriter;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -78,27 +79,60 @@ public interface FilteredPriceRecords extends Serializable {
 	FilteredPriceRecords EMPTY = new ResolvedFilteredPriceRecords();
 
 	/**
-	 * Returns `true` when every accessor in the supplied collection exposes the per-inner-record
+	 * Returns `true` when **at least one** accessor in the supplied collection exposes the per-inner-record
 	 * histogram side-output (see {@link FilteredPriceRecordAccessor#exposesPerInnerRecordHistogramRecords()}).
-	 * An empty collection returns `false` because there is no histogram-aware contributor — the
-	 * caller must fall back to its non-histogram path.
+	 * An empty collection returns `false` because there is no histogram-aware contributor at all.
+	 *
+	 * The probe is deliberately *any*, not *all*. A single `filterBy` produces one price branch per
+	 * {@link io.evitadb.api.requestResponse.data.PriceInnerRecordHandling} present in the catalog, and only
+	 * the `LOWEST_PRICE` branch has per-inner-record data points to contribute — `NONE` and `SUM` correctly
+	 * contribute one price for sale per entity. An all-or-nothing rule therefore discarded the whole
+	 * per-inner-record contribution as soon as the candidate pool mixed handling modes (issue #1433);
+	 * callers now merge the exposing accessors' side-output and route the remaining entities through the
+	 * per-entity collector.
 	 *
 	 * Centralises the capability probe so the histogram producer and wrapper formulas like
-	 * `SelectionFormula` cannot drift on the "all-or-nothing" rule.
+	 * `SelectionFormula` cannot drift apart on the rule.
 	 *
 	 * @param accessors accessors to probe
-	 * @return `true` iff the collection is non-empty and every accessor exposes the side-output
+	 * @return `true` iff at least one accessor exposes the side-output
 	 */
-	static boolean allAccessorsExposePerInnerRecordHistogram(@Nonnull Collection<FilteredPriceRecordAccessor> accessors) {
-		if (accessors.isEmpty()) {
-			return false;
-		}
+	static boolean anyAccessorExposesPerInnerRecordHistogram(
+		@Nonnull Collection<FilteredPriceRecordAccessor> accessors
+	) {
 		for (final FilteredPriceRecordAccessor accessor : accessors) {
-			if (!accessor.exposesPerInnerRecordHistogramRecords()) {
-				return false;
+			if (accessor.exposesPerInnerRecordHistogramRecords()) {
+				return true;
 			}
 		}
-		return true;
+		return false;
+	}
+
+	/**
+	 * Returns the subset of `accessors` that expose the per-inner-record histogram side-output, preserving
+	 * the input order. Only these accessors may be passed to
+	 * {@link #mergePerInnerRecordHistogramRecords(Collection, QueryExecutionContext)} — calling the merge on
+	 * a non-exposing accessor would either trip its histogram-collection guard or silently contribute
+	 * per-entity records a second time.
+	 *
+	 * @param accessors accessors to partition
+	 * @return the exposing accessors; an empty list when none of them expose the side-output
+	 */
+	@Nonnull
+	static List<FilteredPriceRecordAccessor> collectPerInnerRecordHistogramAccessors(
+		@Nonnull Collection<FilteredPriceRecordAccessor> accessors
+	) {
+		List<FilteredPriceRecordAccessor> exposing = null;
+		for (final FilteredPriceRecordAccessor accessor : accessors) {
+			if (accessor.exposesPerInnerRecordHistogramRecords()) {
+				// lazily allocated — the common non-histogram query never reaches this branch at all
+				if (exposing == null) {
+					exposing = new ArrayList<>(accessors.size());
+				}
+				exposing.add(accessor);
+			}
+		}
+		return exposing == null ? List.of() : exposing;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/PriceHistogramComputer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/PriceHistogramComputer.java
@@ -44,6 +44,7 @@ import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
 import io.evitadb.index.price.model.priceRecord.PriceRecord;
 import io.evitadb.index.price.model.priceRecord.PriceRecordContract;
+import io.evitadb.roaringbitmap.PersistentRoaringBitmap;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
 import net.openhft.hashing.LongHashFunction;
@@ -54,6 +55,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.ToIntFunction;
@@ -72,11 +74,15 @@ import static java.util.Optional.ofNullable;
  *   histogram cruncher via the existing {@link FilteredPriceRecordsCollector} path.
  * - **`LOWEST_PRICE`**: the filter planner constructs every outer {@link LowestPriceTerminationFormula} in
  *   the filtering tree with its `collectPerInnerRecordPrices` flag enabled, so {@code computeInternal()}
- *   populates a per-inner-record side-output funnel alongside the regular per-entity result. When every
- *   {@link FilteredPriceRecordAccessor} in {@link #filteredPriceRecordAccessors} exposes that side-output
- *   (checked by {@link #allAccessorsExposePerInnerRecordHistogram()}), the
- *   {@link FilteredPriceRecordsCollector} is bypassed and the per-inner-record records are merged directly.
- *   This ensures the histogram reports one bucket data point per inner-record-id rather than one per entity.
+ *   populates a per-inner-record side-output funnel alongside the regular per-entity result. Every
+ *   {@link FilteredPriceRecordAccessor} in {@link #filteredPriceRecordAccessors} that exposes that
+ *   side-output contributes one bucket data point per inner-record-id rather than one per entity.
+ *
+ * The two rules compose rather than exclude each other: a `filterBy` produces one price branch per
+ * handling value present in the catalog, so a candidate pool mixing simple products with master/variant
+ * products is the common case, not an exception. The per-inner-record records are collected first and the
+ * per-entity collector then tops up exactly the entities they did not cover — see
+ * {@link #collectPerInnerRecordHistogramRecords(List)}.
  *
  * The computed result is memoized in {@link #memoizedResult}; the intermediate price records array is memoized in
  * {@link #memoizedPriceRecords}. Both fields are `null` until {@link #compute()} is first invoked.
@@ -442,56 +448,123 @@ public class PriceHistogramComputer implements CacheableEvitaResponseExtraResult
 	 *
 	 * Branching:
 	 *
-	 * - When every accessor in {@link #filteredPriceRecordAccessors} exposes the per-inner-record
+	 * - When **at least one** accessor in {@link #filteredPriceRecordAccessors} exposes the per-inner-record
 	 *   side-output prepared at construction time by {@link LowestPriceTerminationFormula} (or its
-	 *   flattened cache sibling {@link FlattenedFormulaWithFilteredPricesForHistogram}), the
-	 *   {@link FilteredPriceRecordsCollector} is bypassed entirely so the histogram reports one bucket
-	 *   data point per inner record id, not per entity. The {@code PriceHistogramTranslator} collects
+	 *   flattened cache sibling {@link FlattenedFormulaWithFilteredPricesForHistogram}), those accessors
+	 *   contribute one bucket data point per inner record id and every entity they do not cover is topped
+	 *   up from the {@link FilteredPriceRecordsCollector} — see
+	 *   {@link #collectPerInnerRecordHistogramRecords(List)}. The {@code PriceHistogramTranslator} collects
 	 *   this accessor list from a {@code withoutUserFilter} view of the filtering tree so the inner
 	 *   {@link LowestPriceTerminationFormula} produced by {@code priceBetween} (which would otherwise
 	 *   double-count the same entities) does not show up here.
-	 * - Otherwise (`NONE`/`SUM` handling, mixed catalog, or no LOWEST_PRICE LP at all) the existing
-	 *   collector path runs unchanged.
+	 * - Otherwise (pure `NONE`/`SUM` handling, or no LOWEST_PRICE LP at all) the existing collector path
+	 *   runs unchanged.
 	 */
 	private PriceRecordContract[] getPriceRecords() {
 		if (this.memoizedPriceRecords == null) {
-			if (allAccessorsExposePerInnerRecordHistogram()) {
-				this.memoizedPriceRecords = collectPerInnerRecordHistogramRecords();
-			} else {
-				this.memoizedPriceRecords = collectViaPriceRecordsCollector();
-			}
+			final List<FilteredPriceRecordAccessor> histogramAccessors =
+				FilteredPriceRecords.collectPerInnerRecordHistogramAccessors(this.filteredPriceRecordAccessors);
+			this.memoizedPriceRecords = histogramAccessors.isEmpty() ?
+				collectViaPriceRecordsCollector() :
+				collectPerInnerRecordHistogramRecords(histogramAccessors);
 		}
 		return this.memoizedPriceRecords;
 	}
 
 	/**
-	 * Returns `true` when every accessor in {@link #filteredPriceRecordAccessors} exposes a per-inner-record
-	 * histogram side-output (see {@link FilteredPriceRecordAccessor#exposesPerInnerRecordHistogramRecords()}).
+	 * Assembles the histogram baseline from a candidate pool that may mix
+	 * {@link io.evitadb.api.requestResponse.data.PriceInnerRecordHandling} values, in two passes:
 	 *
-	 * The capability probe is virtual rather than `instanceof`-based so wrapper accessors — currently
-	 * `io.evitadb.core.query.algebra.prefetch.SelectionFormula` inserted by `PriceInPriceListsTranslator`
-	 * for prefetch-eligible queries — can propagate the capability from their inner histogram-aware
-	 * `LowestPriceTerminationFormula` without the histogram producer having to know about them.
+	 * 1. the per-inner-record side-output of `histogramAccessors` (the `LOWEST_PRICE` branches) —
+	 *    **narrowed to the entities the query actually matched**. A termination formula's side-output
+	 *    covers everything its own price sub-tree matched and is not intersected with the non-price parts
+	 *    of the query (an `entityPrimaryKeyInSet`, an attribute filter, a hierarchy constraint), so
+	 *    without this narrowing the histogram would describe entities the query excluded;
+	 * 2. the per-entity price for sale of every remaining entity, collected through the unchanged
+	 *    {@link FilteredPriceRecordsCollector}. This covers the `NONE` and `SUM` branches, for which one
+	 *    data point per entity is the correct contribution.
 	 *
-	 * Delegates to {@link FilteredPriceRecords#allAccessorsExposePerInnerRecordHistogram(Collection)}
-	 * so the "all-or-nothing" rule stays in one place.
+	 * The second pass runs over `baseline \ covered` rather than over the whole baseline, which is what
+	 * makes double counting impossible by construction — including on the prefetch plan, where a
+	 * `SelectionFormula`'s per-entity alternative would happily answer for a `LOWEST_PRICE` entity that
+	 * pass 1 already expanded. For the same reason {@link #priceRecordsLookupResult} (computed by
+	 * {@link io.evitadb.core.query.sort.price.FilteredPricesSorter} over the *full* accessor set and the
+	 * *full* result) must not be reused here.
+	 *
+	 * @param histogramAccessors accessors exposing the per-inner-record side-output; never empty
+	 * @return every price record the histogram should bucket
 	 */
-	private boolean allAccessorsExposePerInnerRecordHistogram() {
-		return FilteredPriceRecords.allAccessorsExposePerInnerRecordHistogram(this.filteredPriceRecordAccessors);
+	@Nonnull
+	private PriceRecordContract[] collectPerInnerRecordHistogramRecords(
+		@Nonnull List<FilteredPriceRecordAccessor> histogramAccessors
+	) {
+		final PersistentRoaringBitmap baseline = computeHistogramBaseline();
+		final PriceRecordContract[] perInnerRecordPrices = FilteredPriceRecords.mergePerInnerRecordHistogramRecords(
+			histogramAccessors, this.context
+		);
+
+		// pass 1 — keep only the per-inner-record prices of entities that survived the whole filter, and
+		// remember which entities they already account for. `covered` is built by incremental `add` rather
+		// than through `RoaringBitmapBackedBitmap.buildWriter()`: the constant-memory writer materializes a
+		// container as soon as the high bits change and therefore assumes ascending input, which the
+		// concatenation of several accessors' side-outputs does not provide (each restarts at its own
+		// lowest entity primary key)
+		final PersistentRoaringBitmap covered = new PersistentRoaringBitmap();
+		final PriceRecordContract[] narrowedPrices = new PriceRecordContract[perInnerRecordPrices.length];
+		int narrowedCount = 0;
+		for (final PriceRecordContract priceRecord : perInnerRecordPrices) {
+			final int entityPrimaryKey = priceRecord.entityPrimaryKey();
+			if (baseline.contains(entityPrimaryKey)) {
+				narrowedPrices[narrowedCount++] = priceRecord;
+				covered.add(entityPrimaryKey);
+			}
+		}
+
+		// pass 2 — top up with the per-entity price for sale of everything pass 1 left uncovered
+		final PersistentRoaringBitmap remainder = PersistentRoaringBitmap.andNot(baseline, covered);
+		if (remainder.isEmpty()) {
+			return narrowedCount == narrowedPrices.length ?
+				narrowedPrices : Arrays.copyOf(narrowedPrices, narrowedCount);
+		}
+		final PriceRecordContract[] perEntityPrices = FilteredPriceRecords
+			.collectFilteredPriceRecordsFromPriceRecordAccessors(
+				this.filteredPriceRecordAccessors, remainder, this.context
+			)
+			.getPriceRecords();
+		if (perEntityPrices.length == 0) {
+			return narrowedCount == narrowedPrices.length ?
+				narrowedPrices : Arrays.copyOf(narrowedPrices, narrowedCount);
+		}
+
+		final PriceRecordContract[] merged = new PriceRecordContract[narrowedCount + perEntityPrices.length];
+		System.arraycopy(narrowedPrices, 0, merged, 0, narrowedCount);
+		System.arraycopy(perEntityPrices, 0, merged, narrowedCount, perEntityPrices.length);
+		return merged;
 	}
 
 	/**
-	 * Concatenates per-inner-record histogram price records from every accessor into a single flat
-	 * array. Delegates to
-	 * {@link FilteredPriceRecords#mergePerInnerRecordHistogramRecords(Collection, QueryExecutionContext)}
-	 * so the merge algorithm stays in one place — `SelectionFormula` calls the same helper when it
-	 * has to flatten the side-output of wrapped accessors.
+	 * Returns the entity primary keys the histogram must describe — the filtering result widened by the
+	 * entities the `priceBetween` slider inside `userFilter` filtered out, mirroring the union
+	 * {@link #collectViaPriceRecordsCollector()} produces through
+	 * {@link FilteredPriceRecordsCollector#combineResultWithAndReturnPriceRecords}. The histogram is
+	 * supposed to answer *"what prices would be reachable if the user cleared the price slider"*, so the
+	 * relaxed clone contributes to the baseline even though it never contributes to the query result.
 	 */
 	@Nonnull
-	private PriceRecordContract[] collectPerInnerRecordHistogramRecords() {
-		return FilteredPriceRecords.mergePerInnerRecordHistogramRecords(
-			this.filteredPriceRecordAccessors, this.context
+	private PersistentRoaringBitmap computeHistogramBaseline() {
+		final PersistentRoaringBitmap filteringResult = RoaringBitmapBackedBitmap.getRoaringBitmap(
+			this.filteringFormula.compute()
 		);
+		if (this.filteringFormulaWithFilteredOutRecords == null) {
+			return filteringResult;
+		}
+		final Bitmap pricePredicateFilteredOutEntities = this.filteringFormulaWithFilteredOutRecords.compute();
+		return pricePredicateFilteredOutEntities.isEmpty() ?
+			filteringResult :
+			PersistentRoaringBitmap.or(
+				filteringResult,
+				RoaringBitmapBackedBitmap.getRoaringBitmap(pricePredicateFilteredOutEntities)
+			);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/PriceHistogramComputer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/PriceHistogramComputer.java
@@ -526,6 +526,14 @@ public class PriceHistogramComputer implements CacheableEvitaResponseExtraResult
 			return narrowedCount == narrowedPrices.length ?
 				narrowedPrices : Arrays.copyOf(narrowedPrices, narrowedCount);
 		}
+		// pass 2 deliberately queries **every** accessor, including the ones pass 1 already merged. Subtracting
+		// `histogramAccessors` here looks like a free optimization — a remainder entity is by construction one
+		// their histogram side-output did not cover — but it is wrong: this collector reads
+		// `getFilteredPriceRecords()`, not `getFilteredPriceRecordsForHistogram()`, and for `SelectionFormula`
+		// those two deliberately differ. The wrapper reports the per-inner-record side-output of its *exposing*
+		// inners only, while its regular records cover the whole price container. On a prefetched plan that
+		// wrapper is the single accessor, so excluding it leaves nothing to answer for the NONE/SUM remainder
+		// and those entities drop out of the histogram entirely (verified: 8 data points become 4).
 		final PriceRecordContract[] perEntityPrices = FilteredPriceRecords
 			.collectFilteredPriceRecordsFromPriceRecordAccessors(
 				this.filteredPriceRecordAccessors, remainder, this.context

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/CombinedPriceEntityByPriceFilteringFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/CombinedPriceEntityByPriceFilteringFunctionalTest.java
@@ -267,6 +267,9 @@ public class CombinedPriceEntityByPriceFilteringFunctionalTest extends EntityByP
 	@Test
 	@Override
 	void shouldReturnPriceHistogram(Evita evita, List<SealedEntity> originalProductEntities) {
+		// #1433 regression: the histogram must keep per-inner-record granularity for the LOWEST_PRICE
+		// masters even though NONE and SUM neighbours share the candidate pool
+		assertPoolMixesInnerRecordHandling(originalProductEntities);
 		super.shouldReturnPriceHistogram(evita, originalProductEntities);
 	}
 
@@ -275,6 +278,9 @@ public class CombinedPriceEntityByPriceFilteringFunctionalTest extends EntityByP
 	@Test
 	@Override
 	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilter(Evita evita, List<SealedEntity> originalProductEntities) {
+		// #1433 regression: the histogram must keep per-inner-record granularity for the LOWEST_PRICE
+		// masters even though NONE and SUM neighbours share the candidate pool
+		assertPoolMixesInnerRecordHandling(originalProductEntities);
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilter(evita, originalProductEntities);
 	}
 
@@ -283,6 +289,9 @@ public class CombinedPriceEntityByPriceFilteringFunctionalTest extends EntityByP
 	@Test
 	@Override
 	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterAndValidity(Evita evita, List<SealedEntity> originalProductEntities) {
+		// #1433 regression: the histogram must keep per-inner-record granularity for the LOWEST_PRICE
+		// masters even though NONE and SUM neighbours share the candidate pool
+		assertPoolMixesInnerRecordHandling(originalProductEntities);
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterAndValidity(evita, originalProductEntities);
 	}
 
@@ -291,6 +300,9 @@ public class CombinedPriceEntityByPriceFilteringFunctionalTest extends EntityByP
 	@Test
 	@Override
 	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
+		// #1433 regression: the histogram must keep per-inner-record granularity for the LOWEST_PRICE
+		// masters even though NONE and SUM neighbours share the candidate pool
+		assertPoolMixesInnerRecordHandling(originalProductEntities);
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(evita, originalProductEntities);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/EntityByPriceFilteringFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/EntityByPriceFilteringFunctionalTest.java
@@ -64,6 +64,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Currency;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,6 @@ import static io.evitadb.test.TestConstants.TEST_CATALOG;
 import static io.evitadb.test.generator.DataGenerator.*;
 import static io.evitadb.utils.AssertionUtils.assertSortedResultEquals;
 import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.summingInt;
 import static org.junit.jupiter.api.Assertions.*;
 import static io.evitadb.test.TestTags.CONTRACT;
 import static io.evitadb.test.TestTags.FILTER;
@@ -113,12 +113,18 @@ public class EntityByPriceFilteringFunctionalTest {
 	/**
 	 * Verifies histogram integrity against source entities.
 	 *
-	 * Auto-detects the engine path used to build the histogram and dispatches to the matching assertion
-	 * helper. When **every** filtered entity has `LOWEST_PRICE` inner-record handling the engine activates
-	 * the per-inner-record histogram bypass — each inner-record-id contributes one bucket data point. In
-	 * any other case (pure `NONE`, pure `SUM`, or a mixed catalog that contains at least one
-	 * non-LOWEST_PRICE accessor) the engine falls back to the per-entity histogram path, so each entity
-	 * contributes exactly one bucket data point.
+	 * The expected bucket population is derived **per entity from its own
+	 * {@link PriceInnerRecordHandling}** — the granularity contract the histogram promises regardless of
+	 * how homogeneous the candidate pool happens to be:
+	 *
+	 * - `LOWEST_PRICE` entities contribute one data point per inner-record-id (every variant price the
+	 *   pool can reach), not just the winning price for sale;
+	 * - `NONE` and `SUM` entities contribute exactly one data point — their price for sale.
+	 *
+	 * A pool that mixes handling modes therefore expects the union of both rules. This is deliberately
+	 * **not** derived from which engine path fired: an assertion that adapts to the engine cannot detect
+	 * the engine silently dropping to a coarser granularity, which is exactly the defect reported in
+	 * issue #1433.
 	 */
 	protected static void assertHistogramIntegrity(
 		@Nonnull EvitaResponse<SealedEntity> result,
@@ -127,66 +133,188 @@ public class EntityByPriceFilteringFunctionalTest {
 		@Nullable BigDecimal to,
 		@Nullable OffsetDateTime validIn
 	) {
-		// detect whether the engine fired the per-inner-record bypass: requires every accessor to be a
-		// histogram-aware LOWEST_PRICE termination formula, which in practice maps to "every filtered
-		// entity uses LOWEST_PRICE handling"
-		boolean allLowestPrice = !filteredProducts.isEmpty();
-		for (final SealedEntity entity : filteredProducts) {
-			if (entity.getPriceInnerRecordHandling() != PriceInnerRecordHandling.LOWEST_PRICE) {
-				allLowestPrice = false;
-				break;
-			}
-		}
-		if (allLowestPrice) {
-			assertHistogramIntegrityPerInnerRecord(result, filteredProducts, from, to, validIn);
-		} else {
-			assertHistogramIntegrityPerEntity(result, filteredProducts, from, to, validIn);
-		}
+		final PriceHistogram priceHistogram = result.getExtraResult(PriceHistogram.class);
+		assertNotNull(priceHistogram);
+
+		assertHistogramMatchesDataPoints(
+			priceHistogram,
+			collectExpectedHistogramDataPoints(filteredProducts, validIn),
+			from, to,
+			"Histogram data points must follow each entity's own price inner record handling — one per " +
+				"inner-record-id for LOWEST_PRICE entities, one per entity for NONE/SUM entities"
+		);
 	}
 
 	/**
-	 * Verifies histogram integrity against source entities for the per-entity histogram path.
+	 * Asserts the fixture really mixes {@link PriceInnerRecordHandling} values — the precondition the
+	 * mixed-pool histogram assertions exist to exercise (issue #1433). Without it a change to the data
+	 * generator could homogenise the catalog and every mixed-pool test would keep passing while covering
+	 * nothing, which is how the original defect stayed invisible.
 	 *
-	 * The histogram reports one bucket data point per filtered entity — the entity's selling price (the
-	 * winner across the queried price-list priority). Used for pure `NONE` and pure `SUM` handling
-	 * catalogs as well as for mixed catalogs where the engine cannot fire the per-inner-record bypass.
+	 * @param products the whole fixture the histogram queries draw their candidate pools from
 	 */
-	protected static void assertHistogramIntegrityPerEntity(
-		@Nonnull EvitaResponse<SealedEntity> result,
-		@Nonnull List<SealedEntity> filteredProducts,
-		@Nullable BigDecimal from,
-		@Nullable BigDecimal to,
+	protected static void assertPoolMixesInnerRecordHandling(@Nonnull List<SealedEntity> products) {
+		final Set<PriceInnerRecordHandling> handlings = collectInnerRecordHandlings(products);
+		assertTrue(
+			handlings.containsAll(
+				List.of(
+					PriceInnerRecordHandling.NONE,
+					PriceInnerRecordHandling.LOWEST_PRICE,
+					PriceInnerRecordHandling.SUM
+				)
+			),
+			"Mixed-pool histogram tests require a fixture carrying NONE, LOWEST_PRICE and SUM entities " +
+				"(both the LOWEST_PRICE + NONE and the LOWEST_PRICE + SUM combinations reproduce #1433), " +
+				"but the fixture only carries: " + handlings
+		);
+	}
+
+	/**
+	 * Collects the distinct {@link PriceInnerRecordHandling} values present among the passed entities.
+	 */
+	@Nonnull
+	private static Set<PriceInnerRecordHandling> collectInnerRecordHandlings(@Nonnull List<SealedEntity> entities) {
+		final Set<PriceInnerRecordHandling> handlings = EnumSet.noneOf(PriceInnerRecordHandling.class);
+		for (final SealedEntity entity : entities) {
+			handlings.add(entity.getPriceInnerRecordHandling());
+		}
+		return handlings;
+	}
+
+	/**
+	 * Picks up to `count` entities satisfying the predicate, spreading the selection over as many distinct
+	 * {@link PriceInnerRecordHandling} values as the candidates offer and preferring, within each of them,
+	 * the entity contributing the most histogram data points.
+	 *
+	 * Both halves matter for the prefetch histogram tests, which query a handful of entities by primary key:
+	 *
+	 * - without the **spread**, a plain "first N matches" pick can land on a homogeneous subset of an
+	 *   otherwise mixed catalog, and the mixed-pool granularity contract of issue #1433 stops being covered;
+	 * - without the **contribution preference**, the pick can satisfy the spread with single-variant
+	 *   `LOWEST_PRICE` masters, for which per-entity and per-inner-record granularity return the same
+	 *   numbers — a pool that is mixed by handling but cannot tell the two granularities apart. That is not
+	 *   a hypothetical: the balanced-but-toothless `{NONE=2, LOWEST_PRICE=2, SUM=2}` pool is exactly what
+	 *   this method produced before the ordering was added, and the regressed engine passed against it.
+	 *
+	 * @param candidates entities to pick from, in the order they should be preferred among equals
+	 * @param predicate  condition every picked entity has to satisfy
+	 * @param validIn    moment the prices must be valid in, or `null` when validity is not constrained
+	 * @param count      maximum number of entities to pick
+	 * @return the picked entities — fewer than `count` when the candidates cannot supply enough matches
+	 */
+	@Nonnull
+	private static List<SealedEntity> pickSpreadingInnerRecordHandling(
+		@Nonnull List<SealedEntity> candidates,
+		@Nonnull Predicate<SealedEntity> predicate,
+		@Nullable OffsetDateTime validIn,
+		int count
+	) {
+		// stable sort — entities contributing more data points first, encounter order preserved among equals
+		final List<SealedEntity> matching = candidates.stream()
+			.filter(predicate)
+			.sorted(
+				Comparator.comparingInt(
+					(SealedEntity it) -> collectExpectedHistogramDataPoints(List.of(it), validIn).size()
+				).reversed()
+			)
+			.toList();
+		final boolean[] alreadyPicked = new boolean[matching.size()];
+		final List<SealedEntity> picked = new ArrayList<>(count);
+
+		// first pass — take one entity per distinct price inner record handling
+		final Set<PriceInnerRecordHandling> covered = EnumSet.noneOf(PriceInnerRecordHandling.class);
+		for (int i = 0; i < matching.size() && picked.size() < count; i++) {
+			final SealedEntity candidate = matching.get(i);
+			if (covered.add(candidate.getPriceInnerRecordHandling())) {
+				picked.add(candidate);
+				alreadyPicked[i] = true;
+			}
+		}
+
+		// second pass — fill the remaining slots with whatever is left
+		for (int i = 0; i < matching.size() && picked.size() < count; i++) {
+			if (!alreadyPicked[i]) {
+				picked.add(matching.get(i));
+			}
+		}
+
+		return picked;
+	}
+
+	/**
+	 * Expands the passed entities into the price values the histogram is expected to bucket, applying the
+	 * granularity rule of each entity's own {@link PriceInnerRecordHandling}. Entities that resolve to no
+	 * price in the queried scope are skipped — they contribute nothing to the engine's funnel either.
+	 *
+	 * @param entities entities that survived the filter (the histogram's candidate pool)
+	 * @param validIn  moment the prices must be valid in, or `null` when validity is not constrained
+	 * @return every price value expected to appear as a histogram data point, in no particular order
+	 */
+	@Nonnull
+	private static List<BigDecimal> collectExpectedHistogramDataPoints(
+		@Nonnull List<SealedEntity> entities,
 		@Nullable OffsetDateTime validIn
 	) {
-		final PriceHistogram priceHistogram = result.getExtraResult(PriceHistogram.class);
-		assertNotNull(priceHistogram);
+		// capacity hint of `entities.size() * 2` reflects the typical mixed catalog shape — LOWEST_PRICE
+		// masters carry ~2 inner records, the remaining handling modes contribute a single point each
+		final List<BigDecimal> expanded = new ArrayList<>(entities.size() * 2);
+		for (final SealedEntity entity : entities) {
+			if (entity.getPriceInnerRecordHandling() == PriceInnerRecordHandling.LOWEST_PRICE) {
+				final List<PriceContract> allPricesForSale = entity.getAllPricesForSale(
+					CURRENCY_EUR, validIn, PRICE_LIST_VIP, PRICE_LIST_BASIC
+				);
+				for (final PriceContract price : allPricesForSale) {
+					expanded.add(price.priceWithTax());
+				}
+			} else {
+				entity.getPriceForSale(CURRENCY_EUR, validIn, PRICE_LIST_VIP, PRICE_LIST_BASIC)
+					.map(PriceContract::priceWithTax)
+					.ifPresent(expanded::add);
+			}
+		}
+		return expanded;
+	}
+
+	/**
+	 * Shared assertion core for every histogram integrity check — verifies the overall count, the min/max
+	 * span, the per-bucket occurrences and the `requested` flag against a pre-computed list of expected
+	 * data points. Keeping the assertions in one place stops the per-entity, per-inner-record and mixed
+	 * expectations from drifting apart on everything except how they expand entities into prices.
+	 *
+	 * @param priceHistogram histogram returned by the engine
+	 * @param expectedPrices price values expected to populate the histogram
+	 * @param from           lower bound of the user's price slider, or `null` when unconstrained
+	 * @param to             upper bound of the user's price slider, or `null` when unconstrained
+	 * @param countMessage   explanation attached to the overall-count assertion
+	 */
+	private static void assertHistogramMatchesDataPoints(
+		@Nonnull PriceHistogram priceHistogram,
+		@Nonnull List<BigDecimal> expectedPrices,
+		@Nullable BigDecimal from,
+		@Nullable BigDecimal to,
+		@Nonnull String countMessage
+	) {
 		assertTrue(priceHistogram.getBuckets().length <= 20);
 
-		assertEquals(filteredProducts.size(), priceHistogram.getOverallCount());
-		final List<BigDecimal> pricesForSale = filteredProducts
-			.stream()
-			.map(it -> it.getPriceForSale(CURRENCY_EUR, validIn, PRICE_LIST_VIP, PRICE_LIST_BASIC))
-			.filter(Optional::isPresent)
-			.map(Optional::get)
-			.map(PriceContract::priceWithTax)
-			.toList();
+		assertEquals(expectedPrices.size(), priceHistogram.getOverallCount(), countMessage);
+		assertEquals(
+			expectedPrices.stream().min(Comparator.naturalOrder()).orElse(BigDecimal.ZERO),
+			priceHistogram.getMin()
+		);
+		assertEquals(
+			expectedPrices.stream().max(Comparator.naturalOrder()).orElse(BigDecimal.ZERO),
+			priceHistogram.getMax()
+		);
 
-		assertEquals(pricesForSale.stream().min(Comparator.naturalOrder()).orElse(BigDecimal.ZERO), priceHistogram.getMin());
-		assertEquals(pricesForSale.stream().max(Comparator.naturalOrder()).orElse(BigDecimal.ZERO), priceHistogram.getMax());
-
-		// verify bucket occurrences
-		final Map<Integer, Integer> expectedOccurrences = filteredProducts
-			.stream()
-			.collect(
-				Collectors.groupingBy(
-					it -> findIndexInHistogram(it, priceHistogram, validIn),
-					summingInt(entity -> 1)
-				)
-			);
+		// verify bucket occurrences — one data point per expected price
+		final Map<Integer, Integer> expectedOccurrences = new HashMap<>(expectedPrices.size());
+		for (final BigDecimal price : expectedPrices) {
+			expectedOccurrences.merge(findIndexInHistogramByPrice(price, priceHistogram), 1, Integer::sum);
+		}
 
 		final Bucket[] buckets = priceHistogram.getBuckets();
 		for (int i = 0; i < buckets.length; i++) {
-			final Bucket bucket = priceHistogram.getBuckets()[i];
+			final Bucket bucket = buckets[i];
 			if (from == null && to == null) {
 				assertTrue(bucket.requested());
 			} else if (
@@ -221,79 +349,28 @@ public class EntityByPriceFilteringFunctionalTest {
 	) {
 		final PriceHistogram priceHistogram = result.getExtraResult(PriceHistogram.class);
 		assertNotNull(priceHistogram);
-		assertTrue(priceHistogram.getBuckets().length <= 20);
 
 		// expand each entity into its per-inner-record winning prices
-		final List<PriceContract> expandedPrices = collectPerInnerRecordPricesForSale(filteredProducts, validIn);
+		final List<BigDecimal> expandedPrices = new ArrayList<>(filteredProducts.size() * 2);
+		for (final SealedEntity entity : filteredProducts) {
+			final List<PriceContract> allPricesForSale = entity.getAllPricesForSale(
+				CURRENCY_EUR, validIn, PRICE_LIST_VIP, PRICE_LIST_BASIC
+			);
+			for (final PriceContract price : allPricesForSale) {
+				expandedPrices.add(price.priceWithTax());
+			}
+		}
 
-		assertEquals(
-			expandedPrices.size(), priceHistogram.getOverallCount(),
+		assertHistogramMatchesDataPoints(
+			priceHistogram, expandedPrices, from, to,
 			"Per-inner-record histogram overall count must equal the total number of distinct " +
 				"inner-record prices across all LOWEST_PRICE entities"
 		);
-
-		final BigDecimal expectedMin = expandedPrices.stream()
-			.map(PriceContract::priceWithTax)
-			.min(Comparator.naturalOrder())
-			.orElse(BigDecimal.ZERO);
-		final BigDecimal expectedMax = expandedPrices.stream()
-			.map(PriceContract::priceWithTax)
-			.max(Comparator.naturalOrder())
-			.orElse(BigDecimal.ZERO);
-		assertEquals(expectedMin, priceHistogram.getMin());
-		assertEquals(expectedMax, priceHistogram.getMax());
-
-		// verify bucket occurrences — one data point per per-inner-record price
-		final Map<Integer, Integer> expectedOccurrences = new HashMap<>(expandedPrices.size());
-		for (final PriceContract price : expandedPrices) {
-			final int bucketIndex = findIndexInHistogramByPrice(price.priceWithTax(), priceHistogram);
-			expectedOccurrences.merge(bucketIndex, 1, Integer::sum);
-		}
-
-		final Bucket[] buckets = priceHistogram.getBuckets();
-		for (int i = 0; i < buckets.length; i++) {
-			final Bucket bucket = buckets[i];
-			if (from == null && to == null) {
-				assertTrue(bucket.requested());
-			} else if (
-				(from == null || from.compareTo(bucket.threshold()) <= 0) &&
-					(to == null || to.compareTo(bucket.threshold()) >= 0)) {
-				assertTrue(bucket.requested());
-			} else {
-				assertFalse(bucket.requested());
-			}
-			assertEquals(
-				ofNullable(expectedOccurrences.get(i)).orElse(0),
-				bucket.occurrences()
-			);
-		}
 	}
 
 	/**
-	 * Collects per-inner-record selling prices from all passed entities using the same priority rule the
-	 * engine applies (`getAllPricesForSale` for LOWEST_PRICE entities returns one winner per inner record
-	 * id). Entities that resolve to no candidates in scope are silently skipped — they would not appear in
-	 * the engine's histogram funnel either.
-	 */
-	@Nonnull
-	private static List<PriceContract> collectPerInnerRecordPricesForSale(
-		@Nonnull List<SealedEntity> entities,
-		@Nullable OffsetDateTime validIn
-	) {
-		// capacity hint of `entities.size() * 2` reflects the typical LOWEST_PRICE catalog shape — most
-		// entities have ~2 inner records; under-shoots are cheap (ArrayList grows by ~50%), over-shoots are
-		// wasted memory only for the duration of the assertion
-		final List<PriceContract> expanded = new ArrayList<>(entities.size() * 2);
-		for (final SealedEntity entity : entities) {
-			expanded.addAll(entity.getAllPricesForSale(CURRENCY_EUR, validIn, PRICE_LIST_VIP, PRICE_LIST_BASIC));
-		}
-		return expanded;
-	}
-
-	/**
-	 * Locates the histogram bucket index for an arbitrary price value. Mirrors the logic of
-	 * `findIndexInHistogram` but works against a pre-computed price (used when expanding LOWEST_PRICE
-	 * entities into multiple data points — one per inner record id).
+	 * Locates the histogram bucket index for an arbitrary price value — the bucket whose threshold is the
+	 * greatest one still not exceeding the price.
 	 */
 	private static int findIndexInHistogramByPrice(@Nonnull BigDecimal price, @Nonnull HistogramContract histogram) {
 		final Bucket[] buckets = histogram.getBuckets();
@@ -364,25 +441,6 @@ public class EntityByPriceFilteringFunctionalTest {
 			}
 		}
 		fail("There is product that contains price from price lists: " + Arrays.stream(priceLists).map(Object::toString).collect(Collectors.joining(", ")));
-	}
-
-	/**
-	 * Finds appropriate index in the histogram according to histogram thresholds.
-	 */
-	private static int findIndexInHistogram(SealedEntity entity, HistogramContract histogram, OffsetDateTime validIn) {
-		final BigDecimal entityPrice = entity.getPriceForSale(CURRENCY_EUR, validIn, PRICE_LIST_VIP, PRICE_LIST_BASIC)
-			.orElseThrow()
-			.priceWithTax();
-		final Bucket[] buckets = histogram.getBuckets();
-		for (int i = buckets.length - 1; i >= 0; i--) {
-			final Bucket bucket = buckets[i];
-			final int priceCompared = entityPrice.compareTo(bucket.threshold());
-			if (priceCompared >= 0) {
-				return i;
-			}
-		}
-		fail("Histogram span doesn't match current entity price: " + entityPrice);
-		return -1;
 	}
 
 	/**
@@ -1875,29 +1933,65 @@ public class EntityByPriceFilteringFunctionalTest {
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
-				final Predicate<PriceContract> betweenPredicate = it -> it.priceWithTax().compareTo(from) >= 0 && it.priceWithTax().compareTo(to) <= 0;
-				final List<SealedEntity> filteredProducts = Stream.concat(
-					originalProductEntities
-						.stream()
-						.filter(
-							sealedEntity ->
-								sealedEntity.getPriceForSale(CURRENCY_EUR, null, PRICE_LIST_VIP).map(betweenPredicate::test).orElse(false) ||
-									sealedEntity.getPriceForSale(CURRENCY_EUR, null, PRICE_LIST_BASIC).map(betweenPredicate::test).orElse(false)
-						)
-						.limit(3),
-					originalProductEntities
-						.stream()
-						.filter(
-							sealedEntity ->
-							{
-								final Optional<PriceContract> vipPrice = sealedEntity.getPriceForSale(CURRENCY_EUR, null, PRICE_LIST_VIP);
-								final Optional<PriceContract> basicPrice = sealedEntity.getPriceForSale(CURRENCY_EUR, null, PRICE_LIST_BASIC);
-								return (vipPrice.isPresent() && vipPrice.map(it -> !betweenPredicate.test(it)).orElse(true)) &&
-									(basicPrice.map(it -> !betweenPredicate.test(it)).orElse(true));
-							}
-						)
-						.limit(3)
-				).collect(Collectors.toList());
+				// both pool membership and price-between matching are derived from the model contract rather
+				// than hand-rolled per price list — `hasPriceInInterval` applies the very rule the engine does
+				// for each handling mode (price for sale for NONE/SUM, any inner-record price for LOWEST_PRICE),
+				// which is what makes this fixture valid for every subclass' dataset and not just the NONE one
+				final Predicate<SealedEntity> inCandidatePool = it ->
+					hasAnyIndexedPrice(it, CURRENCY_EUR, PRICE_LIST_VIP) ||
+						hasAnyIndexedPrice(it, CURRENCY_EUR, PRICE_LIST_BASIC);
+				final Predicate<SealedEntity> matchesPriceBetween = it -> it.hasPriceInInterval(
+					from, to, QueryPriceMode.WITH_TAX, CURRENCY_EUR, null, PRICE_LIST_VIP, PRICE_LIST_BASIC
+				);
+
+				final List<SealedEntity> matchingProducts = pickSpreadingInnerRecordHandling(
+					originalProductEntities, inCandidatePool.and(matchesPriceBetween), null, 3
+				);
+				final List<SealedEntity> filteredOutProducts = pickSpreadingInnerRecordHandling(
+					originalProductEntities, inCandidatePool.and(matchesPriceBetween.negate()), null, 3
+				);
+
+				// verify our test works — the pool must hold both entities the price filter keeps and entities
+				// it removes, otherwise the histogram could not prove it ignores that filter
+				assertEquals(
+					3, matchingProducts.size(),
+					"Fixture doesn't offer three products matching the price between query!"
+				);
+				assertEquals(
+					3, filteredOutProducts.size(),
+					"Fixture doesn't offer three products the price between query filters out. " +
+						"Test is not testing anything!"
+				);
+
+				final List<SealedEntity> filteredProducts = Stream
+					.concat(matchingProducts.stream(), filteredOutProducts.stream())
+					.collect(Collectors.toList());
+
+				// pin the granularity coverage of the pool the prefetched plan actually sees: it has to span
+				// every handling mode the dataset can supply (capped by how many entities we select), so the
+				// mixed-pool contract of issue #1433 stays exercised here. On the homogeneous subclass datasets
+				// this degrades to the single mode they offer and asserts nothing beyond it.
+				final Set<PriceInnerRecordHandling> availableHandlings = collectInnerRecordHandlings(
+					originalProductEntities.stream().filter(inCandidatePool).toList()
+				);
+				assertTrue(
+					collectInnerRecordHandlings(filteredProducts).size() >= Math.min(3, availableHandlings.size()),
+					"Prefetched pool must span every price inner record handling the dataset offers, but " +
+						"the dataset has " + availableHandlings + " and the pool only " +
+						collectInnerRecordHandlings(filteredProducts)
+				);
+
+				// spanning the handling modes is not enough on its own — a pool of single-variant LOWEST_PRICE
+				// masters returns identical numbers under both granularities, so the regression it is meant to
+				// catch would pass straight through it. Demand at least one entity contributing more than one
+				// data point wherever the dataset can supply one.
+				if (availableHandlings.contains(PriceInnerRecordHandling.LOWEST_PRICE)) {
+					assertTrue(
+						collectExpectedHistogramDataPoints(filteredProducts, null).size() > filteredProducts.size(),
+						"Prefetched pool must contain a multi-inner-record LOWEST_PRICE entity, otherwise " +
+							"per-entity and per-inner-record granularity are indistinguishable here"
+					);
+				}
 
 				final EvitaResponse<SealedEntity> result = session.query(
 					query(
@@ -1922,18 +2016,8 @@ public class EntityByPriceFilteringFunctionalTest {
 					SealedEntity.class
 				);
 
-				// verify our test works
-				final Predicate<SealedEntity> priceForSaleBetweenPredicate = it -> {
-					final BigDecimal price = it.getPriceForSale(CURRENCY_EUR, null, PRICE_LIST_VIP, PRICE_LIST_BASIC)
-						.orElseThrow()
-						.priceWithTax();
-					return price.compareTo(from) >= 0 && price.compareTo(to) <= 0;
-				};
-				assertEquals(3, result.getTotalRecordCount());
-				assertTrue(
-					filteredProducts.size() > filteredProducts.stream().filter(priceForSaleBetweenPredicate).count(),
-					"Price between query didn't filter out any products. Test is not testing anything!"
-				);
+				// the prefetched plan must agree with the model on which entities the price filter keeps
+				assertEquals(matchingProducts.size(), result.getTotalRecordCount());
 
 				// the price between query must be ignored while computing price histogram
 				assertHistogramIntegrity(result, filteredProducts, from, to, null);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/FindFirstPriceEntityByPriceFilteringFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/FindFirstPriceEntityByPriceFilteringFunctionalTest.java
@@ -24,6 +24,7 @@
 package io.evitadb.api.functional.price;
 
 import com.github.javafaker.Faker;
+import io.evitadb.api.query.require.DebugMode;
 import io.evitadb.api.requestResponse.EvitaResponse;
 import io.evitadb.api.requestResponse.data.EntityReferenceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
@@ -52,7 +53,9 @@ import static io.evitadb.api.query.Query.query;
 import static io.evitadb.api.query.QueryConstraints.and;
 import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
 import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.debug;
 import static io.evitadb.api.query.QueryConstraints.entityFetch;
+import static io.evitadb.api.query.QueryConstraints.entityPrimaryKeyInSet;
 import static io.evitadb.api.query.QueryConstraints.filterBy;
 import static io.evitadb.api.query.QueryConstraints.page;
 import static io.evitadb.api.query.QueryConstraints.priceBetween;
@@ -71,6 +74,7 @@ import static io.evitadb.test.generator.DataGenerator.CURRENCY_EUR;
 import static io.evitadb.test.generator.DataGenerator.PRICE_LIST_BASIC;
 import static io.evitadb.test.generator.DataGenerator.PRICE_LIST_REFERENCE;
 import static io.evitadb.test.generator.DataGenerator.PRICE_LIST_VIP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -313,6 +317,7 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 
 	@DisplayName("Should return price histogram for returned products excluding price between query")
 	@UseDataSet(HUNDRED_PRODUCTS_WITH_FIND_FIRST_PRICES)
+	@Test
 	@Override
 	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(evita, originalProductEntities);
@@ -386,9 +391,9 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 	@Test
 	@Tag(HISTOGRAM)
 	void shouldExpandLowestPriceHistogramToPerInnerRecordPrices(@Nonnull Evita evita, @Nonnull List<SealedEntity> originalProductEntities) {
-		// the engine's per-inner-record bypass fires only when every `FilteredPriceRecordAccessor` in
-		// the filtering formula tree is histogram-aware. This requires a pure LOWEST_PRICE catalog
-		// (no `Sum`/`Plain` siblings) and no prefetch wrappers (no `entityPrimaryKeyInSet`).
+		// a pure LOWEST_PRICE catalog — every entity in the pool expands into one data point per
+		// inner-record id, so the expected count is derived from the whole fixture. The mixed-pool
+		// variant of this contract is covered by `CombinedPriceEntityByPriceFilteringFunctionalTest`.
 		final List<SealedEntity> lowestPriceProducts = originalProductEntities
 			.stream()
 			.filter(it -> hasAnyIndexedPrice(it, CURRENCY_EUR, PRICE_LIST_VIP) ||
@@ -421,18 +426,18 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 				"entity count (" + lowestPriceProducts.size() + ") when multi-inner-record entities exist"
 		);
 
-		// case 1: query without priceBetween — verify the basic per-inner-record expansion. The
-		// `VERIFY_ALTERNATIVE_INDEX_RESULTS` / `VERIFY_POSSIBLE_CACHING_TREES` debug modes are
-		// intentionally **not** added here. The per-inner-record bypass now fires both through the
-		// preferred prefetch-eligible plan (`SelectionFormula` propagates the histogram capability
-		// from its inner LP) and through the bare index plan. Both plans therefore agree on the
-		// per-inner-record count when this fixture is used in isolation. The cross-plan verifier is
-		// still disabled because the bypass is only exercised by histogram queries running against a
-		// pure LOWEST_PRICE catalog — the verifier rebuilds alternative plans whose accessor lists
-		// differ in subtle ways (`getFilteredPriceRecordsForHistogram` vs the per-entity collector)
-		// and the resulting `Histogram[overall=N]` counts diverge across plans, which the verifier
-		// would surface as `InconsistentResultsException`. The per-inner-record assertion below is
-		// itself the cross-plan invariant we care about.
+		// case 1: query without priceBetween — verify the basic per-inner-record expansion.
+		//
+		// `VERIFY_ALTERNATIVE_INDEX_RESULTS` and `VERIFY_POSSIBLE_CACHING_TREES` are enabled here on
+		// purpose. They used to be omitted because the alternative plans disagreed on
+		// `Histogram[overall=N]`: the accessor list of a rebuilt plan could differ enough to flip the
+		// old all-or-nothing capability gate, so one plan produced per-inner-record counts and another
+		// per-entity ones, and the verifier surfaced that as `InconsistentResultsException`. Deciding
+		// the granularity per accessor and topping up the uncovered entities from the per-entity
+		// collector (#1433) removed that degree of freedom — every plan now describes the same entity
+		// set at the same granularity. `VERIFY_POSSIBLE_CACHING_TREES` additionally substitutes the
+		// flagged LP with its cached `FlattenedFormulaWithFilteredPricesForHistogram` payload, which is
+		// what gives the cached form of the per-inner-record path its coverage.
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
@@ -447,6 +452,7 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 						),
 						require(
 							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES),
 							entityFetch(),
 							priceHistogram(20)
 						)
@@ -462,8 +468,7 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 
 		// case 2: query with priceBetween — the histogram must still cover the relaxed-baseline scope
 		// (i.e. include inner-record prices outside the [from, to] slider) because the engine's
-		// per-inner-record funnel ignores the sellingPricePredicate. See the note in case 1 for why
-		// the standard debug verification flags are omitted.
+		// per-inner-record funnel ignores the sellingPricePredicate.
 		final BigDecimal from = new BigDecimal("80");
 		final BigDecimal to = new BigDecimal("150");
 		evita.queryCatalog(
@@ -483,6 +488,7 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 						),
 						require(
 							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES),
 							entityFetch(),
 							priceHistogram(20)
 						)
@@ -493,6 +499,69 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 				// the relaxed baseline must still cover the same per-inner-record set — `priceBetween`
 				// in `userFilter` cannot shrink the histogram scope
 				assertHistogramIntegrityPerInnerRecord(result, lowestPriceProducts, from, to, null);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should limit the per-inner-record price histogram to entities matched by a non-price constraint")
+	@UseDataSet(HUNDRED_PRODUCTS_WITH_FIND_FIRST_PRICES)
+	@Test
+	@Tag(HISTOGRAM)
+	void shouldLimitPerInnerRecordHistogramToEntitiesMatchedByNonPriceConstraint(
+		@Nonnull Evita evita,
+		@Nonnull List<SealedEntity> originalProductEntities
+	) {
+		// a `LowestPriceTerminationFormula` collects its per-inner-record side-output from its own price
+		// sub-tree, which knows nothing about the non-price parts of the query. Narrowing that side-output
+		// to the entities the whole filter matched is what keeps the histogram from describing entities the
+		// query excluded — this fixture pins that down with an `entityPrimaryKeyInSet` handle.
+		final List<SealedEntity> selectedProducts = originalProductEntities
+			.stream()
+			.filter(it -> it.getAllPricesForSale(CURRENCY_EUR, null, PRICE_LIST_VIP, PRICE_LIST_BASIC).size() > 1)
+			.limit(5)
+			.toList();
+
+		assertFalse(
+			selectedProducts.isEmpty(),
+			"LOWEST_PRICE-only fixture must contain entities with more than one inner record in scope!"
+		);
+		assertTrue(
+			countInnerRecordPricesInScope(selectedProducts, null) < originalProductEntities.size(),
+			"The selected subset must expand to fewer data points than the whole catalog has entities — " +
+				"otherwise an un-narrowed histogram would be indistinguishable from a narrowed one"
+		);
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<SealedEntity> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(
+									selectedProducts.stream().map(SealedEntity::getPrimaryKey).toArray(Integer[]::new)
+								),
+								priceInCurrency(CURRENCY_EUR),
+								priceInPriceLists(PRICE_LIST_VIP, PRICE_LIST_BASIC)
+							)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES),
+							entityFetch(),
+							priceHistogram(20)
+						)
+					),
+					SealedEntity.class
+				);
+
+				assertEquals(selectedProducts.size(), result.getTotalRecordCount());
+				// only the five selected masters may contribute — and each of them with every one of its
+				// inner-record prices, not just its price for sale
+				assertHistogramIntegrityPerInnerRecord(result, selectedProducts, null, null, null);
 
 				return null;
 			}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/SumPriceEntityByPriceFilteringFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/SumPriceEntityByPriceFilteringFunctionalTest.java
@@ -288,6 +288,7 @@ public class SumPriceEntityByPriceFilteringFunctionalTest extends EntityByPriceF
 
 	@DisplayName("Should return price histogram for returned products excluding price between query")
 	@UseDataSet(HUNDRED_PRODUCTS_WITH_SUM_PRICES)
+	@Test
 	@Override
 	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(evita, originalProductEntities);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/prefetch/SelectionFormulaHistogramCapabilityTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/prefetch/SelectionFormulaHistogramCapabilityTest.java
@@ -32,11 +32,13 @@ import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.AndFormula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.price.FilteredPriceRecordAccessor;
 import io.evitadb.core.query.algebra.price.filteredPriceRecords.FilteredPriceRecords;
 import io.evitadb.core.query.algebra.price.filteredPriceRecords.ResolvedFilteredPriceRecords;
 import io.evitadb.core.query.algebra.price.predicate.PricePredicate;
 import io.evitadb.core.query.algebra.price.termination.LowestPriceTerminationFormula;
 import io.evitadb.core.query.algebra.price.termination.PriceEvaluationContext;
+import io.evitadb.core.query.algebra.price.translate.PriceIdToEntityIdTranslateFormula;
 import io.evitadb.index.bitmap.ArrayBitmap;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.EmptyBitmap;
@@ -50,6 +52,7 @@ import org.mockito.Mockito;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Currency;
+import java.util.List;
 
 import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.HISTOGRAM;
@@ -95,18 +98,20 @@ class SelectionFormulaHistogramCapabilityTest {
 		}
 
 		@Test
-		@DisplayName("should not expose histogram capability when any inner accessor is missing it")
-		void shouldNotExposeHistogramCapabilityWhenAnyInnerAccessorMissing() {
+		@DisplayName("should expose histogram capability when only some inner accessors expose it")
+		void shouldExposeHistogramCapabilityWhenAnyInnerAccessorExposes() {
 			final LowestPriceTerminationFormula withFlag = newLp(new ArrayBitmap(1, 2), true);
 			final LowestPriceTerminationFormula withoutFlag = newLp(new ArrayBitmap(3, 4), false);
 			final SelectionFormula selection = new SelectionFormula(
 				new AndFormula(withFlag, withoutFlag), new NoopBitmapFilter()
 			);
 
-			// the "all-true" semantics mean a single un-flagged accessor poisons the wrapper's capability —
-			// otherwise the histogram producer would try to call `getFilteredPriceRecordsForHistogram` on
-			// the un-flagged LP and trip its `GenericEvitaInternalError` guard
-			assertFalse(selection.exposesPerInnerRecordHistogramRecords());
+			// "any-true" semantics: a single SelectionFormula wraps the whole price filter container, so in
+			// a catalog mixing PriceInnerRecordHandling values its inner set legitimately holds both a
+			// flagged LOWEST_PRICE branch and un-flagged NONE/SUM branches. Poisoning the capability on the
+			// un-flagged one is what silently dropped the histogram to per-entity granularity (issue #1433);
+			// the un-flagged branch's entities are topped up by the producer's per-entity collector pass.
+			assertTrue(selection.exposesPerInnerRecordHistogramRecords());
 		}
 
 		@Test
@@ -145,28 +150,30 @@ class SelectionFormulaHistogramCapabilityTest {
 		}
 
 		/**
-		 * The size-1 fast path must consult `exposesPerInnerRecordHistogramRecords` on the inner accessor
-		 * before delegating to its histogram-side accessor. When the inner accessor does NOT expose the
-		 * per-inner-record side-output (the common case for un-flagged LPs), the fast path must instead
-		 * fall back to the per-entity `getFilteredPriceRecords(...)` — matching the default interface
-		 * behaviour for non-histogram-aware accessors.
+		 * With no exposing inner accessor at all there is nothing per-inner-record to contribute, so the
+		 * wrapper must fall back to its own per-entity `getFilteredPriceRecords(...)` — matching the default
+		 * interface behaviour for non-histogram-aware accessors — rather than tripping the un-flagged LP's
+		 * histogram-collection guard. Defensive only: the producer probes the capability first.
 		 */
 		@Test
-		@DisplayName("should fall back to per-entity records when single inner accessor misses capability")
-		void shouldFallBackToPerEntityRecordsWhenSingleInnerAccessorMissesCapability() {
+		@DisplayName("should fall back to per-entity records when no inner accessor exposes the capability")
+		void shouldFallBackToPerEntityRecordsWhenNoInnerAccessorExposesCapability() {
 			final LowestPriceTerminationFormula unflaggedLp = newLp(EmptyFormula.INSTANCE, false);
 			// trigger compute() so the un-flagged LP populates `filteredPriceRecords` (per-entity side)
-			// while leaving `perInnerRecordPriceRecords` deliberately null — the fast path must therefore
+			// while leaving `perInnerRecordPriceRecords` deliberately null — the fallback must therefore
 			// route to the per-entity records via the capability check rather than tripping the LP's guard
 			unflaggedLp.compute();
-			final FilteredPriceRecords expected = unflaggedLp.getFilteredPriceRecords(null);
 			final SelectionFormula selection = new SelectionFormula(unflaggedLp, new NoopBitmapFilter());
+			// the per-entity fallback asserts a non-null execution context — the production planner always
+			// sets one via initialize() before any histogram fabrication
+			initializeForNonPrefetch(selection);
 
 			final FilteredPriceRecords actual = selection.getFilteredPriceRecordsForHistogram(null);
 
-			// fast path must mirror the default interface behaviour for non-histogram-aware accessors —
-			// delegate to `getFilteredPriceRecords(...)` rather than propagating the LP's guard error
-			assertSame(expected, actual);
+			// per-entity shape, no merge attempt, no guard error — the LP's delegate is EmptyFormula so the
+			// per-entity view is legitimately empty
+			assertInstanceOf(ResolvedFilteredPriceRecords.class, actual);
+			assertEquals(0, ((ResolvedFilteredPriceRecords) actual).getPriceRecords().length);
 		}
 
 		/**
@@ -247,15 +254,15 @@ class SelectionFormulaHistogramCapabilityTest {
 		}
 
 		/**
-		 * When the inner-accessor set is mixed (one flag-on, one flag-off LP), the size>=2 branch of
-		 * `SelectionFormula.getFilteredPriceRecordsForHistogram` must short-circuit on the same
-		 * capability probe the size-1 fast path uses, falling back to per-entity records rather than
-		 * routing the flag-off LP through its histogram side-output (which would trip the LP's guard).
-		 * This mirrors the default interface behaviour for non-histogram-aware accessors.
+		 * The mixed inner-accessor set is the shape a catalog mixing `PriceInnerRecordHandling` values
+		 * produces (issue #1433): one flagged `LOWEST_PRICE` termination formula next to an un-flagged
+		 * branch. The wrapper must contribute the flagged accessor's per-inner-record side-output and
+		 * silently skip the un-flagged one — never route the un-flagged LP through its histogram accessor
+		 * (which would trip its guard) and never discard the flagged contribution.
 		 */
 		@Test
-		@DisplayName("should fall back to per-entity records when accessor set is mixed")
-		void shouldFallBackToPerEntityRecordsWhenAccessorSetIsMixed() {
+		@DisplayName("should contribute only the exposing accessor's records when accessor set is mixed")
+		void shouldContributeOnlyExposingAccessorRecordsWhenAccessorSetIsMixed() {
 			final LowestPriceTerminationFormula flagOn = newLp(EmptyFormula.INSTANCE, true);
 			final LowestPriceTerminationFormula flagOff = newLp(EmptyFormula.INSTANCE, false);
 			flagOn.compute();
@@ -263,25 +270,76 @@ class SelectionFormulaHistogramCapabilityTest {
 			final SelectionFormula selection = new SelectionFormula(
 				new AndFormula(flagOn, flagOff), new NoopBitmapFilter()
 			);
-			// size>=2 fallback routes through `this.getFilteredPriceRecords()` which asserts a non-null
-			// execution context — the production planner always sets one via initialize() before any
-			// histogram fabrication, so the unit test mirrors that invariant rather than testing an
-			// uninitialised formula
-			initializeForNonPrefetch(selection);
 
-			// graceful-fallback contract: the wrapper consults exposesPerInnerRecordHistogramRecords()
-			// before entering the size>=2 merge loop. A flag-off inner accessor poisons the wrapper's
-			// capability, so the producer reads per-entity records instead of tripping the flag-off LP.
-			assertFalse(selection.exposesPerInnerRecordHistogramRecords());
+			assertTrue(selection.exposesPerInnerRecordHistogramRecords());
+
+			// exactly one exposing inner accessor → fast path hands back that accessor's own side-output
+			// instance; reaching the un-flagged LP would have thrown GenericEvitaInternalError instead
 			final FilteredPriceRecords actual = selection.getFilteredPriceRecordsForHistogram(null);
 
-			// no exception, no merge attempt — the wrapper produced a valid per-entity FilteredPriceRecords
-			// matching what `getFilteredPriceRecords(...)` would return. `getFilteredPriceRecords` allocates
-			// a fresh ResolvedFilteredPriceRecords per call, so identity comparison would not hold; the
-			// invariant under test is "fallback returns per-entity shape", which is captured by the
-			// instance check plus an empty-array assertion (both LP delegates wrap EmptyFormula.INSTANCE).
-			assertInstanceOf(ResolvedFilteredPriceRecords.class, actual);
-			assertEquals(0, ((ResolvedFilteredPriceRecords) actual).getPriceRecords().length);
+			assertSame(flagOn.getFilteredPriceRecordsForHistogram(null), actual);
+		}
+	}
+
+	@Nested
+	@DisplayName("Accessor set partitioning")
+	class AccessorPartitioningTest {
+
+		/**
+		 * Regression guard for the second half of issue #1433: `SelectionFormula` implements
+		 * {@link FilteredPriceRecordAccessor} unconditionally, so a wrapper the planner inserted above a
+		 * **price-free** sub-tree is gathered into the histogram's accessor list even though it has no
+		 * prices at all. Under the old all-or-nothing rule that lone empty wrapper closed the
+		 * per-inner-record path for every sibling accessor on its own.
+		 */
+		@Test
+		@DisplayName("should keep the exposing accessor when a price-free wrapper sits beside it")
+		void shouldKeepExposingAccessorBesidePriceFreeWrapper() {
+			final SelectionFormula priceFreeWrapper = new SelectionFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2, 3)), new NoopBitmapFilter()
+			);
+			final LowestPriceTerminationFormula flaggedLp = newLp(new ArrayBitmap(4, 5), true);
+			final List<FilteredPriceRecordAccessor> accessors = List.of(priceFreeWrapper, flaggedLp);
+
+			assertTrue(FilteredPriceRecords.anyAccessorExposesPerInnerRecordHistogram(accessors));
+			assertEquals(
+				List.of(flaggedLp),
+				FilteredPriceRecords.collectPerInnerRecordHistogramAccessors(accessors),
+				"A price-free wrapper must drop out of the partition without taking its siblings with it"
+			);
+		}
+
+		/**
+		 * The raw `PriceIdToEntityIdTranslateFormula` the SHALLOW accessor scan surfaces for the `NONE`
+		 * branch (it pierces the non-accessor `PlainPriceTerminationFormula` above it) must stay out of the
+		 * per-inner-record partition: it holds one record per translated price id rather than per-entity
+		 * winners, so merging it would inflate the buckets. It is served by the per-entity collector instead.
+		 */
+		@Test
+		@DisplayName("should exclude the price-id translate formula from the per-inner-record partition")
+		void shouldExcludeTranslateFormulaFromPerInnerRecordPartition() {
+			final PriceIdToEntityIdTranslateFormula translateFormula = new PriceIdToEntityIdTranslateFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2))
+			);
+			final LowestPriceTerminationFormula flaggedLp = newLp(new ArrayBitmap(3, 4), true);
+			final List<FilteredPriceRecordAccessor> accessors = List.of(translateFormula, flaggedLp);
+
+			assertFalse(translateFormula.exposesPerInnerRecordHistogramRecords());
+			assertEquals(
+				List.of(flaggedLp),
+				FilteredPriceRecords.collectPerInnerRecordHistogramAccessors(accessors)
+			);
+		}
+
+		@Test
+		@DisplayName("should report no exposing accessors when none carry the histogram flag")
+		void shouldReportNoExposingAccessorsWhenNoneCarryTheFlag() {
+			final List<FilteredPriceRecordAccessor> accessors = List.of(
+				newLp(new ArrayBitmap(1, 2), false), newLp(new ArrayBitmap(3, 4), false)
+			);
+
+			assertFalse(FilteredPriceRecords.anyAccessorExposesPerInnerRecordHistogram(accessors));
+			assertTrue(FilteredPriceRecords.collectPerInnerRecordHistogramAccessors(accessors).isEmpty());
 		}
 	}
 


### PR DESCRIPTION
Closes #1433

## Problem

The per-inner-record price histogram shipped in #1159 / PR #1165 only engaged when **every** `FilteredPriceRecordAccessor` in the query exposed the per-inner-record side-output. A `filterBy` builds one price branch per `PriceInnerRecordHandling` present in the catalog, and only the `LOWEST_PRICE` branch has per-inner-record data points to give — so a candidate pool mixing handling modes could never satisfy that rule.

The histogram silently reverted to per-entity granularity, capping its upper bound at the highest *price for sale* and hiding every non-cheapest variant above it. A category listing containing both simple products (`NONE`) and master/variant products (`LOWEST_PRICE`) is the ordinary shape of an e-commerce catalog, not an edge case.

Two independent causes closed the gate, either sufficient on its own:

- the `SHALLOW` accessor scan descends through `PlainPriceTerminationFormula` (not an accessor) and surfaces the inner `PriceIdToEntityIdTranslateFormula`, which inherits the interface default `false`;
- `SelectionFormula` implements the accessor interface unconditionally, so a wrapper above a price-free sub-tree was gathered into the histogram's accessor list and reported `false` on its own.

## Fix

The capability probe is read **per accessor** instead of ANDed across the query:

- `PriceHistogramComputer` partitions the accessor set. Exposing accessors contribute their per-inner-record records; the unchanged per-entity collector then runs over `baseline \ covered` and the two are concatenated. Excluding covered entities makes double counting impossible by construction rather than by argument, which is what makes it hold on the prefetch plan too.
- `SelectionFormula` switches to "any inner exposes" and contributes only its exposing inners. One wrapper sits above the whole price container, so its inner set legitimately mixes flagged and unflagged branches.
- The per-inner-record records are **narrowed to the matched entity set**. `LowestPriceTerminationFormula` fills its funnel from its own price sub-tree, so it covers entities that `entityPrimaryKeyInSet`, attribute filters and hierarchy constraints exclude. This over-count predates the change and was unreachable while the whole path was gated off.

The issue's prescribed remedy for the first cause — making `PlainPriceTerminationFormula` a `FilteredPriceRecordAccessor` so the `SHALLOW` scan stops there — was **declined**. It owns no price records at all; stopping the scan there yields *zero* contribution from the `NONE` branch, so those entities would vanish from the histogram entirely. The translate formula the scan surfaces still answers `false`; that is now inert rather than harmful. Rationale and the third rejected option are in the ADR.

## Tests

The reproduction is in the test suite itself. `assertHistogramIntegrity` used to *dispatch on the pool's composition* — asserting per-entity counts the moment one entity was not `LOWEST_PRICE` — so the assertion adapted to the engine and could not detect the engine getting coarser. It now derives the expectation from each entity's own handling.

The prefetch histogram fixture was selected with hand-rolled per-price-list `getPriceForSale` comparisons and asserted a literal `assertEquals(3, totalRecordCount)`. That models `NONE` handling only, which is why the `FindFirst` and `Sum` overrides had silently been left without `@Test` — enabling them failed on the fixture's own precondition, not on anything the test checks. Selection now goes through `PricesContract.hasPriceInInterval`, the model's own per-handling reading of `priceBetween`. Both overrides now run.

The pool the prefetched plan sees is pinned to span every handling the dataset offers **and** to contain a multi-inner-record master. The second guard is not redundant: an intermediate version of the picker produced a balanced `{NONE=2, LOWEST_PRICE=2, SUM=2}` pool whose masters were all single-variant — per-entity and per-inner-record granularity return identical numbers for such a pool, and the deliberately regressed engine passed against it.

`VERIFY_ALTERNATIVE_INDEX_RESULTS` and `VERIFY_POSSIBLE_CACHING_TREES` are re-enabled on the per-inner-record tests; they had been omitted since #1159 because the old all-or-nothing gate could flip between rebuilt plans.

## Verification

Reproduction — restoring the pre-fix gate on the fixed code fails all four mixed-pool tests:

| Test | Expected | Got |
|---|---|---|
| `shouldReturnPriceHistogram` | 78 | 70 |
| `shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilter` | 78 | 70 |
| `...AndValidity` | 58 | 52 |
| `...UsingPrefetch` | 8 | 6 |

The prefetch variant needs **both** halves of the gate restored to reproduce: on a prefetched plan the single top-level accessor is the `SelectionFormula` wrapper, so the all-or-nothing decision was being taken inside it.

Narrowing counterfactual — with the guard removed, `shouldLimitPerInnerRecordHistogramToEntitiesMatchedByNonPriceConstraint` reports 10 → 108 and the mixed prefetch test 8 → 39.

Full sweep `-P unitAndFunctional -Dgroups="price | histogram | cache"`: **1609 tests, 0 failures, 4 skipped** (1607 before the two prefetch overrides were enabled).

## Notes

- The ADR is `status: proposed` with `prs: []` — to be flipped to `accepted` with the PR number on merge. `date:` stays as written.
- Documentation: the per-entity granularity rule is now stated in `documentation/user/en/query/requirements/histogram.md` (English only; the Czech mirror is machine-translated).
- Out of scope, recorded as a follow-up in the ADR: `shouldReturnProductsHavingPriceInCurrencyAndPriceListInIntervalWithTaxOrderByPriceAscendingWithoutExplicitAnd` is the one remaining `@Test`-less override in the price hierarchy. It is an ordering test, not a histogram one.
