### PR TITLE
fix: keep chain index leaf page stamping create-free during the commit flush

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/index/array/UnorderedLookupTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/UnorderedLookupTree.java
@@ -1095,7 +1095,7 @@ public class UnorderedLookupTree implements
 		for (final LeafNode leaf : collectLeaves()) {
 			// create-free reset: this runs at flush time after commit() has forbidden new layer creation, and the walk
 			// visits EVERY leaf including collapse survivors this transaction never touched (which carry no layer) - so
-			// it must NOT route through the create-on-write setPageSequence/clearDirty (see LeafNode.forgetPage)
+			// it must not create a layer either (see LeafNode.forgetPage)
 			leaf.forgetPage();
 		}
 	}
@@ -2838,12 +2838,26 @@ public class UnorderedLookupTree implements
 		}
 
 		/**
-		 * Stamps this leaf's logical persistence page sequence, decoupling into the transactional layer when present.
-		 * Structural bookkeeping only — does NOT flag the leaf dirty.
+		 * Stamps this leaf's logical persistence page sequence, writing through an EXISTING transactional layer when
+		 * one is present but NEVER creating one — the same create-free contract as {@link #forgetPage()}, and for the
+		 * same reason. Structural bookkeeping only — does NOT flag the leaf dirty.
+		 *
+		 * This is called from the flush path ({@code PageStreamRegistry.collectChangedPages}), which runs INSIDE the
+		 * commit — {@code TransactionTrunkFinalizer.commitCatalogChanges} flushes the catalog after
+		 * {@link io.evitadb.core.transaction.memory.TransactionalLayerMaintainer#commit} has already forbidden new
+		 * layer creation. The emitter walks EVERY leaf and stamps each one not yet paged, so a leaf the transaction
+		 * never touched (which carries no layer) reaches this method routinely: a create-on-write stamp would trip the
+		 * "already committed" premise on it and abort the commit. That is exactly what happens on the first write to a
+		 * chain index restored from a legacy, non-paged `ChainIndexStoragePart` — every leaf of such a tree is fresh
+		 * (see issue #1437).
+		 *
+		 * Writing the committed baseline field in place is what the merge carries forward anyway: with no layer,
+		 * {@link #createCopyWithMergedTransactionalMemory} returns `this`. When a layer DOES exist the merge takes the
+		 * layer's value, so the stamp must land there — hence the branch rather than an unconditional field write.
 		 */
 		void setPageSequence(int pageSequence) {
 			final LeafNode layer = this.transactionalLayer ?
-				Transaction.getOrCreateTransactionalMemoryLayer(this) : null;
+				Transaction.getTransactionalMemoryLayerIfExists(this) : null;
 			if (layer == null) {
 				this.pageSequence = pageSequence;
 			} else {
@@ -2861,12 +2875,15 @@ public class UnorderedLookupTree implements
 		}
 
 		/**
-		 * Clears this leaf's dirty flag, decoupling into the transactional layer when present. Called by the page emitter
-		 * once the leaf's page has been collected for the current flush.
+		 * Clears this leaf's dirty flag, writing through an EXISTING transactional layer when one is present but NEVER
+		 * creating one. Called by the page emitter once the leaf's page has been collected for the current flush —
+		 * i.e. from the very same post-{@code commit()} flush pass as {@link #setPageSequence(int)}, and therefore
+		 * bound by the same create-free contract (see that method for the full rationale). Symmetric with the
+		 * create-free read path {@link #isDirty()}: the flag is cleared exactly where it was read from.
 		 */
 		void clearDirty() {
 			final LeafNode layer = this.transactionalLayer ?
-				Transaction.getOrCreateTransactionalMemoryLayer(this) : null;
+				Transaction.getTransactionalMemoryLayerIfExists(this) : null;
 			if (layer == null) {
 				this.dirty = false;
 			} else {
@@ -2877,9 +2894,10 @@ public class UnorderedLookupTree implements
 		/**
 		 * Resets this leaf's page bookkeeping — un-assigns the page sequence and clears the dirty flag — as part of a
 		 * `PAGED->SINGLE` collapse (see {@link #forgetPageStream()}). Writes through an EXISTING transactional layer when
-		 * one is present, but NEVER creates one — unlike {@link #setPageSequence(int)} / {@link #clearDirty()}, which route
-		 * through the create-on-write path. This runs at flush time, INSIDE the commit, after
-		 * {@link io.evitadb.core.transaction.memory.TransactionalLayerMaintainer#commit} has forbidden new layer creation;
+		 * one is present, but NEVER creates one — the same create-free contract the rest of the flush-path page
+		 * bookkeeping ({@link #setPageSequence(int)} / {@link #clearDirty()}) obeys. This runs at flush time, INSIDE
+		 * the commit, after {@link io.evitadb.core.transaction.memory.TransactionalLayerMaintainer#commit} has
+		 * forbidden new layer creation;
 		 * because `forgetPageStream` walks EVERY leaf (a collapse survivor can be a leaf this transaction never touched, so
 		 * it carries no layer), a create-on-write reset would trip the "already committed" premise on that untouched leaf.
 		 * A leaf with no layer has no pending diff, so resetting its committed baseline field in place is what the merge

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ChainIndexLegacyLoadTransactionalFlushTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ChainIndexLegacyLoadTransactionalFlushTest.java
@@ -1,0 +1,318 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.attribute;
+
+import io.evitadb.api.requestResponse.mutation.Mutation;
+import io.evitadb.core.buffer.TrappedChanges;
+import io.evitadb.core.transaction.Transaction;
+import io.evitadb.core.transaction.TransactionHandler;
+import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
+import io.evitadb.dataType.ChainableType;
+import io.evitadb.dataType.Predecessor;
+import io.evitadb.index.array.UnorderedLookupTree;
+import io.evitadb.index.attribute.ChainIndex.ChainElementState;
+import io.evitadb.index.attribute.ChainIndex.ElementState;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.ChainIndexLeafPagePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.ChainIndexStoragePart;
+import io.evitadb.utils.CollectionUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for issue #1437: the first transactional flush of a {@link ChainIndex} restored from a
+ * **legacy, non-paged** `ChainIndexStoragePart` used to abort the whole commit with
+ * `Transaction is already committed / rolled back, no new transactional memory layer may be created at this time!`,
+ * which marks the catalog CORRUPTED.
+ *
+ * The mechanism this class pins down:
+ *
+ * - `AttributeIndexLoader.fetchChain` rebuilds a legacy part through the `int[][] chains` constructor, so **every**
+ *   leaf of the element tree carries `UNASSIGNED_PAGE_SEQUENCE` — unlike a natively-paged index, whose leaves are
+ *   restored with their persisted page sequences;
+ * - the flush that assigns those sequences (`PageStreamRegistry.collectChangedPages`) runs INSIDE the commit:
+ *   `TransactionTrunkFinalizer.commitCatalogChanges` flushes the catalog after
+ *   {@link TransactionalLayerMaintainer} has already forbidden new transactional layer creation;
+ * - the flush walks EVERY leaf, so it stamps leaves the transaction never touched, and those carry no diff layer.
+ *
+ * The fixture therefore builds a legacy-shaped index spanning three leaves, mutates only the LAST one, and performs
+ * the flush from inside {@link TransactionHandler#commit(TransactionalLayerMaintainer)} — the one moment where the
+ * transaction is still bound to the thread but layer creation is already sealed, exactly as on the trunk path.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Legacy (non-paged) chain index flushed inside a sealed commit")
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
+@Tag(TRANSACTION)
+class ChainIndexLegacyLoadTransactionalFlushTest {
+
+	/**
+	 * Primary key of the owning entity index — mirrors the global index of the collection in the reported incident.
+	 */
+	private static final int ENTITY_INDEX_PK = 1;
+	/**
+	 * The chained attribute the reported incident failed on.
+	 */
+	private static final AttributeIndexKey ORDER_KEY = new AttributeIndexKey(null, "order", null);
+	/**
+	 * Number of chained records in the fixture. Leaves of a paged tree hold {@link UnorderedLookupTree#PAGE_RECORDS}
+	 * records, so this spans three leaves (1024 + 1024 + 52) — matching the three-leaf chain index observed in the
+	 * reported incident, and leaving the last leaf room to accept the mutation without splitting.
+	 */
+	private static final int RECORD_COUNT = (2 * UnorderedLookupTree.PAGE_RECORDS) + 52;
+	/**
+	 * Primary key appended by the in-transaction mutation. It lands in the LAST leaf, so the first two leaves stay
+	 * untouched and therefore carry no transactional diff layer when the flush stamps them.
+	 */
+	private static final int APPENDED_PK = RECORD_COUNT + 1;
+
+	/**
+	 * Builds a {@link ChainIndex} exactly the way `AttributeIndexLoader.fetchChain` rebuilds a **legacy** (non-paged)
+	 * `ChainIndexStoragePart`: one chain run `1..RECORD_COUNT` plus the per-element state map, fed through the
+	 * `int[][] chains` constructor. Every leaf of the resulting element tree is unpaged.
+	 *
+	 * @return the legacy-shaped, freshly loaded (clean) chain index
+	 */
+	@Nonnull
+	private static ChainIndex legacyLoadedChainIndex() {
+		final int[] chain = new int[RECORD_COUNT];
+		final Map<Integer, ChainElementState> elementStates = CollectionUtils.createHashMap(RECORD_COUNT);
+		for (int i = 0; i < RECORD_COUNT; i++) {
+			final int primaryKey = i + 1;
+			chain[i] = primaryKey;
+			elementStates.put(
+				primaryKey,
+				new ChainElementState(
+					// every element belongs to the single chain headed by primary key 1
+					1,
+					// the head's predecessor is the HEAD sentinel, every successor points at the previous element
+					i == 0 ? ChainableType.HEAD_PK : primaryKey - 1,
+					i == 0 ? ElementState.HEAD : ElementState.SUCCESSOR
+				)
+			);
+		}
+		return new ChainIndex(null, ORDER_KEY, new int[][]{chain}, elementStates);
+	}
+
+	/**
+	 * Drives one transaction over `chainIndex` the way the trunk-incorporation path does: the mutation runs inside the
+	 * transaction, and the flush (`appendStorageParts`) runs from inside the commit callback — after the maintainer
+	 * sealed layer creation, while the transaction is still bound to the thread. Mirrors
+	 * `TransactionManager.commitChangesToSharedCatalog` → `TransactionTrunkFinalizer.commitCatalogChanges` →
+	 * `Catalog.flush`.
+	 *
+	 * @param chainIndex the index to mutate and flush
+	 * @param mutation   the mutation to apply inside the transaction
+	 * @param sink       collects the storage parts the flush emits
+	 * @return the merged (committed) copy of the index
+	 */
+	@Nonnull
+	private static ChainIndex commitWithTrunkFlush(
+		@Nonnull ChainIndex chainIndex,
+		@Nonnull Runnable mutation,
+		@Nonnull TrappedChanges sink
+	) {
+		final TrunkFlushTransactionHandler handler = new TrunkFlushTransactionHandler(chainIndex, sink);
+		final Transaction transaction = new Transaction(UUID.randomUUID(), handler, false);
+		Transaction.executeInTransactionIfProvided(
+			transaction,
+			() -> {
+				try {
+					mutation.run();
+				} finally {
+					transaction.close();
+				}
+			}
+		);
+		final ChainIndex committed = handler.getCommitted();
+		assertNotNull(committed, "The commit callback must have produced a merged chain index!");
+		return committed;
+	}
+
+	/**
+	 * Splits the parts collected by a flush into the emitted leaf pages and the (optional) root.
+	 *
+	 * @param sink the collected changes
+	 * @return the flush outcome
+	 */
+	@Nonnull
+	private static FlushOutcome readFlush(@Nonnull TrappedChanges sink) {
+		final List<ChainIndexLeafPagePart> leafPages = new ArrayList<>(8);
+		ChainIndexStoragePart root = null;
+		final Iterator<StoragePart> iterator = sink.getTrappedChangesIterator();
+		while (iterator.hasNext()) {
+			final StoragePart part = iterator.next();
+			if (part instanceof final ChainIndexLeafPagePart leafPage) {
+				leafPages.add(leafPage);
+			} else if (part instanceof final ChainIndexStoragePart chainRoot) {
+				root = chainRoot;
+			}
+		}
+		return new FlushOutcome(leafPages, root);
+	}
+
+	@Nested
+	@DisplayName("First flush after a legacy load")
+	class FirstFlushTest {
+
+		@Test
+		@DisplayName("stamps page sequences on leaves the transaction never touched without tripping the sealed layer")
+		void shouldStampUntouchedLeavesDuringSealedCommitFlush() {
+			final ChainIndex chainIndex = legacyLoadedChainIndex();
+			final TrappedChanges sink = new TrappedChanges();
+
+			// before the fix this threw GenericEvitaInternalError: "Transaction is already committed / rolled back,
+			// no new transactional memory layer may be created at this time!" while stamping the first untouched leaf
+			final ChainIndex committed = commitWithTrunkFlush(
+				chainIndex,
+				() -> chainIndex.upsertPredecessor(new Predecessor(RECORD_COUNT), APPENDED_PK),
+				sink
+			);
+
+			final FlushOutcome outcome = readFlush(sink);
+			assertNotNull(outcome.root(), "A first PAGED flush must re-emit the root carrying the new page list!");
+			assertTrue(outcome.root().isPaged(), "A three-leaf chain index must persist in the PAGED shape!");
+			assertArrayEquals(
+				new int[]{0, 1, 2},
+				outcome.root().getPageSequencesOrThrowException(),
+				"Every leaf must have been allocated a page sequence, in ascending key order!"
+			);
+			assertEquals(
+				3, outcome.leafPages().size(),
+				"A legacy index has no persisted pages yet, so all three leaves are fresh and must be written!"
+			);
+			assertEquals(
+				RECORD_COUNT + 1,
+				committed.getUnorderedLookup().size(),
+				"The appended record must be part of the merged index!"
+			);
+		}
+
+		@Test
+		@DisplayName("carries the stamps through the commit merge so the next flush reuses the same pages")
+		void shouldCarryPageStampsThroughCommitMerge() {
+			final ChainIndex chainIndex = legacyLoadedChainIndex();
+			final ChainIndex committed = commitWithTrunkFlush(
+				chainIndex,
+				() -> chainIndex.upsertPredecessor(new Predecessor(RECORD_COUNT), APPENDED_PK),
+				new TrappedChanges()
+			);
+
+			final TrappedChanges secondSink = new TrappedChanges();
+			commitWithTrunkFlush(
+				committed,
+				() -> committed.upsertPredecessor(new Predecessor(APPENDED_PK), APPENDED_PK + 1),
+				secondSink
+			);
+
+			final FlushOutcome outcome = readFlush(secondSink);
+			assertEquals(
+				1, outcome.leafPages().size(),
+				"Only the mutated leaf may be re-written — the stamps assigned by the first flush must have survived " +
+					"the commit merge, otherwise every leaf would look fresh again!"
+			);
+			assertEquals(
+				2, outcome.leafPages().get(0).getPageSequence(),
+				"The mutation lands in the last leaf, so its already-allocated page must be reused!"
+			);
+			// a content-only commit leaves the persisted leaf-page list byte-identical, so the root is skipped; a
+			// re-emitted root here would mean the page stamps had been re-allocated from scratch
+			assertNull(outcome.root(), "The live page list did not change, so the PAGED root must not be re-emitted!");
+		}
+
+	}
+
+	/**
+	 * Carrier for the parts one flush emitted.
+	 *
+	 * @param leafPages the emitted leaf pages, in emission order
+	 * @param root      the emitted PAGED root, or `null` when the flush skipped it
+	 */
+	private record FlushOutcome(
+		@Nonnull List<ChainIndexLeafPagePart> leafPages,
+		@Nullable ChainIndexStoragePart root
+	) {
+	}
+
+	/**
+	 * Transaction handler modelling `TransactionTrunkFinalizer`: the catalog flush runs inside the commit callback,
+	 * i.e. after the maintainer has forbidden new transactional layer creation, and before the state copy with merged
+	 * changes is produced.
+	 */
+	private static class TrunkFlushTransactionHandler implements TransactionHandler {
+		private final ChainIndex chainIndex;
+		private final TrappedChanges sink;
+		@Nullable private ChainIndex committed;
+
+		TrunkFlushTransactionHandler(@Nonnull ChainIndex chainIndex, @Nonnull TrappedChanges sink) {
+			this.chainIndex = chainIndex;
+			this.sink = sink;
+		}
+
+		@Nullable
+		ChainIndex getCommitted() {
+			return this.committed;
+		}
+
+		@Override
+		public void registerMutation(@Nonnull Mutation mutation) {
+			// no mutation bookkeeping is needed for this fixture
+		}
+
+		@Override
+		public void commit(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
+			// the flush precedes the merge on the trunk path — see TransactionTrunkFinalizer.commitCatalogChanges
+			this.chainIndex.appendStorageParts(ENTITY_INDEX_PK, this.sink);
+			this.committed = transactionalLayer.getStateCopyWithCommittedChanges(this.chainIndex);
+			transactionalLayer.verifyLayerWasFullySwept();
+		}
+
+		@Override
+		public void rollback(@Nonnull TransactionalLayerMaintainer transactionalLayer, @Nullable Throwable cause) {
+			throw new IllegalStateException("Rollback is not expected in this fixture!", cause);
+		}
+	}
+
+}


### PR DESCRIPTION
Closes #1437

Forward-port of #1439 (`release_2026-2`) onto `dev`. Same commit, cherry-picked; it auto-merged against `dev`'s diverged `UnorderedLookupTree` (head-aware leaves, `orderKey`).

## Problem

A catalog upgraded to storage protocol 6 by `Migration_2026_2` loads fine, but goes `CORRUPTED` on its **first write**:

```
Transaction is already committed / rolled back, no new transactional memory layer
may be created at this time!
```

The migration itself is not at fault — bootstrap history on the reported dataset confirms it completed cleanly (protocol 4 → 6), and the catalog served reads afterwards. The failure is in the trunk-incorporation flush.

## Root cause

`TransactionTrunkFinalizer.commitCatalogChanges` flushes the catalog **after** `TransactionalLayerMaintainer#commit` has sealed layer creation. During that flush `PageStreamRegistry.collectChangedPages` walks *every* leaf of a paged tree and stamps each one not yet paged.

`UnorderedLookupTree$LeafNode.setPageSequence` and `clearDirty` routed that write through `Transaction.getOrCreateTransactionalMemoryLayer`. A leaf the transaction never touched carries no layer, so the create-on-write path tripped the "already committed" premise and aborted the commit.

Why it only bites upgraded catalogs: `AttributeIndexLoader.fetchChain` restores a legacy, non-paged `ChainIndexStoragePart` into a tree where **every** leaf is fresh, so the very first flush stamps leaves the write never touched. Native 2026.2 catalogs never hit it — warm-up flushes run without a transaction, and after go-live every leaf already holds a page sequence (split-born leaves acquire a layer during the split's own mutation).

The fix has to live in the tree, not the migration: an already-upgraded catalog is at protocol 6, so `Migration_2026_2` never runs again.

## Fix

Both methods now write through an **existing** layer only, never creating one — the same create-free contract `forgetPage()` already obeyed and the read side `isDirty()` already used. With no layer, `createCopyWithMergedTransactionalMemory` returns `this`, so writing the committed baseline in place is exactly what the merge would have carried forward. The sibling paged tree families (`TransactionalLongBPlusTree`, `TransactionalElementBPlusTree`, `TransactionalBucketBPlusTree`) were already create-free here — `UnorderedLookupTree` was the outlier.

## Verification

- **New regression test** `ChainIndexLegacyLoadTransactionalFlushTest` — builds a 3-leaf chain index the legacy way (no page stream), then models the trunk path: flush inside `commit()`, followed by `verifyLayerWasFullySwept()`. Reverting the fix reproduces the production error verbatim. Green on this branch (2/2) after a clean build.
- **Real reported dataset** (verified on the `release_2026-2` branch) — the catalog reaches `ALIVE` and self-heals to `livePages=[0,1,2]`; a second boot loads clean in 8s with no WAL replay.
- **Full `evita_functional_tests`** (on `release_2026-2`) — 20 914 tests. The only two reds are pre-existing and unrelated: `ExportS3ServiceTest` needs Docker (absent on the test machine), and `CdcCallbackDispatcherTest.shouldNotCreateThreadsWhenCallbacksAreRefused` asserts on the JVM-wide `getTotalStartedThreadCount()` and is inflated by concurrently running tests — green 4/4 in isolation.