### PR TITLE
fix: refresh a reference's provisional representative key on every commit

### DIFF
--- a/documentation/adr/2026-08-24-refresh-provisional-representative-key.md
+++ b/documentation/adr/2026-08-24-refresh-provisional-representative-key.md
@@ -1,0 +1,211 @@
+---
+title: Refresh a reference's representative key whenever its built state is replaced
+date: 2026-08-24
+updated: 2026-08-24 13:20
+status: accepted
+kind: fix
+issues: [1438]
+prs: [1442, 1443]
+areas: [evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure]
+supersedes: []
+superseded-by: []
+relates: []
+---
+
+# Refresh a reference's representative key whenever its built state is replaced
+
+`InitialReferencesBuilder.createReference` registers a brand new — and therefore still empty —
+reference in its `BuilderReferenceBundle` and only afterwards hands the key back so the caller can
+populate the attributes. The key it registers is derived from the *default* representative values,
+normally `[null]`, and nothing refreshed it once the caller filled the attributes in. Every
+replacement of a reference's built state now re-keys it in the bundle, so a provisional key never
+outlives the state it was derived from. The same work fixes the reference counter the bundle keeps
+alongside those keys, which double-counted in two places.
+
+## Why
+
+An `EvitaIncrementalIndexJob` in production failed with
+
+```
+InvalidMutationException: Cannot add duplicate reference `media` with the same representative
+attributes [null] as it would be indistinguishable from existing reference with internal id -7!
+```
+
+on the **third** duplicate of one business key. Two duplicates always worked; the third never did.
+The client was driving entity proxies, and every `getOrCreate`-style reference method in
+`SetReferenceMethodClassifier` routes to `createReference`, runs the caller's consumer and only then
+propagates the builder back — precisely the create-then-populate order that leaves a stale key
+behind.
+
+The loud rejection was only half of it. Because the bundle never learned the real representative
+values, two references that genuinely *were* indistinguishable were silently accepted into the
+entity instead of being refused: duplicate detection was not merely over-strict on the third
+reference, it was also blind on the second. That half never raised an exception and would have
+written indistinguishable references into an entity.
+
+### Previous state
+
+`createReference` registers into the bundle at creation time; `addOrReplaceReferenceMutations` — the
+path the proxy commits through — only refreshed the reference *collection* and never touched the
+bundle. So:
+
+- reference #1 registers under the generic key and is fine (a lone reference carries no attribute
+  values in its key);
+- reference #2 triggers `convertToDuplicateReference`, which re-derives **its predecessor's** key
+  from that predecessor's already-built state — self-healing #1, but registering #2 itself under
+  `[null]`;
+- reference #3 computes `[null]` too, collides with #2's stale slot, and is rejected.
+
+The `[null]` slot was vacated by accident until `b8400f922` (2026-07-25, first released in
+v2026.2.0): `upsertDuplicateReference` used to remove `previousRRK` unconditionally, including when
+it was the key just written. That commit correctly guarded the removal, which is why the failure
+first appears in 2026.2 even though the missing refresh dates back to v2025.7.0. Empirically:
+v2025.7.0 pass, v2026.1.20 pass, v2026.2.0 fail, `a7c9b78ba` fail.
+
+`ExistingReferencesBuilder` was never affected, and the reason is structural rather than lucky: its
+`addOrReplaceReferenceMutations` passes the **populated** builder to `replaceChangeSet` →
+`upsertWithDuplicateReferenceConversion`, so it re-registers on every commit and the stale-key window
+never opens. `InitialReferencesBuilder` was the only commit path that skipped bundle re-registration
+entirely.
+
+## Options considered
+
+### Option A — refresh the key at the collection choke point (chosen)
+
+Add `BuilderReferenceBundle.refreshRepresentativeKey`, which recomputes a registered reference's
+representative key from its current state, and call it from
+`InitialReferencesBuilder.addOrReplaceReferenceInternal` — the single private method every path that
+replaces a reference's built state funnels through.
+
+- **Pros:** fixes both known entry points (the proxy's `addOrReplaceReferenceMutations` and
+  `mutateReference(ReferenceAttributeMutation)`) and any future one, because it sits at the choke
+  point rather than at a call site. Runs before the collection is touched, so a rejected re-key
+  leaves the builder unchanged.
+- **Cons:** one more method on a class that already carries several near-synonymous upsert paths;
+  the choke point runs on every reference replacement, including the many where it is a no-op.
+
+### Option B — revert the `previousRRK` guard added by `b8400f922` (declined)
+
+Bisection points straight at `b8400f922`, and its guard is the line that stopped vacating `[null]`.
+
+- **Pros:** one-line change; restores the last known-good behaviour on this exact scenario.
+- **Cons:** the unconditional removal it would restore deletes the key the method has just written.
+- **Rejected because:** that guard fixes a real, separate defect — without it a reference is dropped
+  from `repRefKeysToInternalPk` while left in `internalPkToRepRefKeys`, and an indistinguishable twin
+  takes over the vacated slot. Reverting trades the loud third-duplicate rejection for silent
+  reference loss. The vacating was never the design; it was a side effect of a bug that happened to
+  cancel this one out. **Revisit if** the guard is ever shown to be unnecessary — but the refresh in
+  Option A still has to exist, because the guard is not what keys references correctly.
+
+### Option C — do not register in `createReference` until the reference is populated (declined)
+
+Let `createReference` hand back a key without touching the bundle, and register once the caller
+commits the populated builder.
+
+- **Pros:** removes the provisional key entirely rather than repairing it; no re-keying needed.
+- **Cons:** opens a window in which a reference exists in the collection but not in the bundle.
+- **Rejected because:** `convertToDuplicateReference` asserts the *generic* slot is already present
+  when the second reference for a business key arrives, and `getReference(key)` has to resolve
+  between create and populate — the proxy calls it immediately. Both would need redesigning, and a
+  caller that creates a reference and never commits it would leave the two structures permanently out
+  of step. **Revisit if** the bundle ever becomes derived at build time (as `ExistingReferencesBuilder`'s
+  effectively is) rather than maintained incrementally.
+
+### Option D — call the existing `upsertDuplicateReference` from the choke point (declined)
+
+Mirror `ExistingReferencesBuilder` and re-register through the existing upsert; it already drops the
+stale `previousRRK` when it differs, so it *does* re-key correctly.
+
+- **Pros:** no new method; makes the two builders symmetric.
+- **Cons:** it is an insert-or-update that presumes the caller intends registration, and the choke
+  point cannot promise that.
+- **Rejected because:** all three of its preconditions are false at the choke point. It asserts
+  `representativeAttributeDefinition != null`, so it throws for every bundle not in duplicate mode —
+  which is most of them. It registers references it has not seen, but the choke point also runs
+  *inside* `createReference` **before** the bundle registration, so it would register the reference
+  twice and corrupt the create flow. And it would promote a lone reference held under a generic key
+  into an attribute-bearing key, which is wrong while it is still the only one. The choke point needs
+  a *no-op-unless-already-keyed-with-attributes* operation; upsert is the opposite by construction.
+  (The counter inflation that first argued against this option was a real bug and is fixed here —
+  it is no longer a reason, but the three preconditions are structural and remain.)
+
+## Decision
+
+**Chosen: Option A.** It is the only option that keys references from the state they actually have at
+the moment that state becomes current, which is the invariant the bundle needs and none of the others
+establish. B restores a symptom-level accident, C requires redesigning two contracts to remove a key
+that is cheap to refresh, and D is the right *shape* but wrong preconditions.
+
+## Key technical details
+
+- `BuilderReferenceBundle.refreshRepresentativeKey(ReferenceContract)` — recomputes the key, claims the new
+  slot with `putIfAbsent` **before** releasing the old one so a collision is a no-op on the bundle,
+  and throws `InvalidMutationException` when the new key belongs to a different internal primary key.
+- It is a no-op when the bundle never entered duplicate mode (`representativeAttributeDefinition ==
+  null`), or when the reference is registered under a generic key
+  (`representativeAttributeValues().length == 0`) — generic keys carry no attribute values and cannot
+  go stale. Those two guards are the whole reason it is not just `upsertDuplicateReference`; see
+  Option D before merging them.
+- `InitialReferencesBuilder.addOrReplaceReferenceInternal` calls it *before* mutating the collection.
+  The ordering is load-bearing: it is what makes a rejected re-key leave the builder untouched.
+- `RepresentativeReferenceKey` normalizes its `ReferenceKey` to `(referenceName, primaryKey)`, so keys
+  from different internal primary keys compare equal — that is what makes collision detection work at
+  all, and what makes the `putIfAbsent` check meaningful.
+- **`usedReferenceKeys` counts references per business key, and both writers over-counted.**
+  `upsertDuplicateReference` bumped on every call, so a builder that re-registers a reference on each
+  commit counted the same reference repeatedly; `convertToDuplicateReference` bumped for the incoming
+  reference and then called `upsertDuplicateReference`, which bumped for it again. The bump is now
+  gated on `previousRRK == null` — an internal primary key the bundle has not seen before — and
+  `convertToDuplicateReference`'s own bump is gone, since the call that closes it does the counting.
+  Its unreachable `cardinality == null ? 2` fallback went with it: the method asserts the generic slot
+  is present, and that slot is only ever written by `upsertNonDuplicateReference`, which sets the count
+  to 1.
+- The exception message in `upsertDuplicateReference` reported `internalPk` — the *incoming*
+  reference — where it meant `previousValue`, the existing one. The production trace's "internal id
+  -7" was the reference being added, not the one it collided with, which sent the investigation after
+  the wrong reference. Now reports `previousValue`.
+
+## Verification
+
+`CreateReferenceDuplicateBookkeepingTest` — 9 tests, all green; **5 fail without the fix**:
+
+- `shouldAcceptThreeDuplicatesCreatedViaCreateReference` and
+  `shouldAcceptManyDuplicatesCreatedViaCreateReference` (6 duplicates) reproduce the production
+  failure verbatim — `Cannot add duplicate reference ... [null] ...`.
+- `shouldThrowExceptionWhenDuplicatesShareRepresentativeAttributes` pins the other half: without the
+  fix **nothing is thrown** and two identical references are accepted.
+- `shouldRefreshRepresentativeKeyWhenAttributeMutationIsApplied` and
+  `shouldThrowExceptionWhenAttributeMutationCollidesWithSibling` cover
+  `mutateReference(ReferenceAttributeMutation)`, the second entry point the choke point fixes.
+- `shouldAcceptThreeDuplicatesCreatedViaSetOrUpdateReference` is the control: the
+  populate-then-register path was always healthy and stays so.
+- The two `ExistingReferencesBuilder` tests pass with *and* without the fix, confirming that path's
+  structural immunity rather than assuming it.
+
+`BuilderReferenceBundleTest` — 23 tests, all green; the 3 new counting tests
+(`shouldStopReportingReferenceKeyOnceAllDuplicatesAreRemoved`,
+`shouldNotCountRepeatedUpsertsOfTheSameDuplicateReference`,
+`shouldNotCountReKeyingOfAnAlreadyRegisteredDuplicateReference`) fail without the counting fix, each
+on `containsReferenceKey` still answering `true` after every reference under the key was removed.
+`count()` was correct throughout — it reads `internalPkToRepRefKeys`, not the counter — which is what
+localised the bug to `usedReferenceKeys`.
+
+Regression: full `unitAndFunctional` suite, 20 919 tests.
+
+## Consequences & open follow-ups
+
+- The choke point runs on every reference replacement. It is two map lookups and an early return in
+  the overwhelmingly common non-duplicate case, but it is on the write path.
+- `mutateReference(InsertReferenceMutation)` adds a reference to the collection without registering it
+  in the bundle at all. `refreshRepresentativeKey` cannot help — it only re-keys what is already registered.
+  Not investigated; flagged so the next reader does not mistake this record for a claim that every
+  path is now consistent.
+- `convertToDuplicateReference` still does `internalPkToRepRefKeys.remove(genericInternalPk)` followed
+  by `put(previousRefInternalPk, ...)` on what is provably the same key. Harmless, left alone
+  deliberately: it is on a path this change already touches and shrinking it further would have
+  widened the diff without changing behaviour.
+
+## Timeline
+
+- **2026-08-24** — reported from production, diagnosed live over JDWP, issue #1438 filed
+- **2026-08-24** — fixed, counter defect found and fixed alongside, verified, recorded

--- a/documentation/adr/2026-08-24-refresh-provisional-representative-key.md
+++ b/documentation/adr/2026-08-24-refresh-provisional-representative-key.md
@@ -1,7 +1,7 @@
 ---
 title: Keep the reference bundle in step with the reference collection
 date: 2026-08-24
-updated: 2026-08-24 14:05
+updated: 2026-08-24 15:10
 status: accepted
 kind: fix
 issues: [1438, 1444]
@@ -101,10 +101,15 @@ Bisection points straight at `b8400f922`, and its guard is the line that stopped
   cancel this one out. **Revisit if** the guard is ever shown to be unnecessary — but the refresh in
   Option A still has to exist, because the guard is not what keys references correctly.
 
-### Option C — do not register in `createReference` until the reference is populated (declined)
+### Option C — defer only the *bundle registration* until the reference is populated (declined)
 
-Let `createReference` hand back a key without touching the bundle, and register once the caller
-commits the populated builder.
+Let `createReference` assign the internal primary key and add the reference to the collection exactly
+as it does today, but hold off on the `BuilderReferenceBundle` entry until the caller commits the
+populated builder.
+
+**This option does not touch when the internal primary key is assigned.** That assignment must stay
+eager and is not negotiable — see *The early-PK invariant* below. Only the bundle entry is at stake
+here.
 
 - **Pros:** removes the provisional key entirely rather than repairing it; no re-keying needed.
 - **Cons:** opens a window in which a reference exists in the collection but not in the bundle.
@@ -112,8 +117,20 @@ commits the populated builder.
   when the second reference for a business key arrives, and `getReference(key)` has to resolve
   between create and populate — the proxy calls it immediately. Both would need redesigning, and a
   caller that creates a reference and never commits it would leave the two structures permanently out
-  of step. **Revisit if** the bundle ever becomes derived at build time (as `ExistingReferencesBuilder`'s
+  of step. That last shape is not hypothetical: it is exactly the gap that produced #1444.
+  **Revisit if** the bundle ever becomes derived at build time (as `ExistingReferencesBuilder`'s
   effectively is) rather than maintained incrementally.
+
+#### The early-PK invariant
+
+`createReference` assigns the internal primary key **before** returning, and every alternative here
+preserves that. It is load-bearing for the proxy layer: a proxy can be built on top of an
+*uncommitted* `InitialEntityBuilder`, handed to client code, and that client can read a reference back
+off the uncommitted proxy, modify it and reinsert it. Every one of those steps needs a stable identity
+for a reference that has not been committed yet, and the internal primary key is that identity —
+there is nothing else to key it by. Any future redesign that defers the bundle must still assign the
+key eagerly, or the proxy round-trip loses the ability to address the reference it is holding.
+Covered by `EntityEditorProxyingFunctionalTest` / `EntityPojoProxyingFunctionalTest` (179 tests).
 
 ### Option D — call the existing `upsertDuplicateReference` from the choke point (declined)
 
@@ -171,12 +188,27 @@ that is cheap to refresh, and D is the right *shape* but wrong preconditions.
   `upsertWithDuplicateReferenceConversion` like `createReference` does; the internal id is resolved
   *before* the `Reference` is constructed, so the bundle files it under the very key the collection
   stores.
-- **That registration makes mutation emission order load-bearing.** Registering eagerly means two
-  still-empty references collide on their identical default representative values, so a stream ordered
-  `[Insert A, Insert B, Attr A, Attr B]` would break replay. Real streams interleave per reference —
-  `buildChangeSet()` emits each insert followed by its own attribute mutations, which `toMutation()`'s
-  contract states — and `shouldReplayItsOwnMutationStream` exists to keep that guaranteed rather than
-  incidental. Anyone reordering `buildChangeSet` must read that test first.
+- **That registration makes mutation emission order load-bearing, and the exposure is not only
+  internal.** Registering eagerly means two still-empty references collide on their identical default
+  representative values, so a mutation list ordered `[Insert A, Insert B, Attr A, Attr B]` is rejected
+  even though the two references are distinguishable once their attributes land. Scope, measured
+  rather than assumed:
+  - **The server / gRPC path is unaffected.** `EntityUpsertMutation.mutate(...)` delegates to
+    `Entity.mutateEntity(...)`, which builds its references through its own `mutateReferences(...)`
+    helper and never touches `InitialReferencesBuilder` or the bundle. A client submitting a batched
+    mutation list over gRPC does **not** reach this code — verified by applying that exact batched list
+    through both paths and watching only the builder one throw.
+  - **The exposed surface is the client-side `EntityBuilder.mutate(LocalMutation...)` API**, where a
+    caller hand-orders mutations rather than taking them from `buildChangeSet()`. That is broader than
+    "someone refactors `buildChangeSet`", which is how this note originally read.
+  - Anything derived from `buildChangeSet()` is safe by construction: it emits each insert followed by
+    its own attribute mutations, which `toMutation()`'s contract states, and
+    `shouldReplayItsOwnMutationStream` keeps that guaranteed rather than incidental. Anyone reordering
+    `buildChangeSet` must read that test first.
+
+  The failure is loud (`InvalidMutationException`) rather than silent, so a caller in the exposed shape
+  finds out immediately. Accepted on that basis; making the builder tolerate transient collisions means
+  deferring duplicate validation to `build()`, which is Option C's redesign.
 - The exception message in `upsertDuplicateReference` reported `internalPk` — the *incoming*
   reference — where it meant `previousValue`, the existing one. The production trace's "internal id
   -7" was the reference being added, not the one it collided with, which sent the investigation after

--- a/documentation/adr/2026-08-24-refresh-provisional-representative-key.md
+++ b/documentation/adr/2026-08-24-refresh-provisional-representative-key.md
@@ -1,10 +1,10 @@
 ---
-title: Refresh a reference's representative key whenever its built state is replaced
+title: Keep the reference bundle in step with the reference collection
 date: 2026-08-24
-updated: 2026-08-24 13:20
+updated: 2026-08-24 14:05
 status: accepted
 kind: fix
-issues: [1438]
+issues: [1438, 1444]
 prs: [1442, 1443]
 areas: [evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure]
 supersedes: []
@@ -12,15 +12,19 @@ superseded-by: []
 relates: []
 ---
 
-# Refresh a reference's representative key whenever its built state is replaced
+# Keep the reference bundle in step with the reference collection
 
 `InitialReferencesBuilder.createReference` registers a brand new — and therefore still empty —
 reference in its `BuilderReferenceBundle` and only afterwards hands the key back so the caller can
 populate the attributes. The key it registers is derived from the *default* representative values,
 normally `[null]`, and nothing refreshed it once the caller filled the attributes in. Every
 replacement of a reference's built state now re-keys it in the bundle, so a provisional key never
-outlives the state it was derived from. The same work fixes the reference counter the bundle keeps
-alongside those keys, which double-counted in two places.
+outlives the state it was derived from.
+
+Two further gaps in the same invariant — *the bundle must know about every reference the collection
+holds, under the key that reference currently has* — were found and closed alongside it: references
+inserted through `InsertReferenceMutation` were never registered in the bundle at all (#1444), and the
+reference counter the bundle keeps alongside those keys double-counted in two places.
 
 ## Why
 
@@ -160,6 +164,19 @@ that is cheap to refresh, and D is the right *shape* but wrong preconditions.
   Its unreachable `cardinality == null ? 2` fallback went with it: the method asserts the generic slot
   is present, and that slot is only ever written by `upsertNonDuplicateReference`, which sets the count
   to 1.
+- **`mutateReference(InsertReferenceMutation)` registered nothing in the bundle** (#1444, latent since
+  v2025.8.0 — *not* a 2026.2 regression; `mutateReference` did not exist on the references builder
+  before `8e10a5e9f`). Removal of such a reference failed outright with "is not present in the
+  structure", and duplicate detection never ran for it. It now registers through
+  `upsertWithDuplicateReferenceConversion` like `createReference` does; the internal id is resolved
+  *before* the `Reference` is constructed, so the bundle files it under the very key the collection
+  stores.
+- **That registration makes mutation emission order load-bearing.** Registering eagerly means two
+  still-empty references collide on their identical default representative values, so a stream ordered
+  `[Insert A, Insert B, Attr A, Attr B]` would break replay. Real streams interleave per reference —
+  `buildChangeSet()` emits each insert followed by its own attribute mutations, which `toMutation()`'s
+  contract states — and `shouldReplayItsOwnMutationStream` exists to keep that guaranteed rather than
+  incidental. Anyone reordering `buildChangeSet` must read that test first.
 - The exception message in `upsertDuplicateReference` reported `internalPk` — the *incoming*
   reference — where it meant `previousValue`, the existing one. The production trace's "internal id
   -7" was the reference being added, not the one it collided with, which sent the investigation after
@@ -190,16 +207,33 @@ on `containsReferenceKey` still answering `true` after every reference under the
 `count()` was correct throughout — it reads `internalPkToRepRefKeys`, not the counter — which is what
 localised the bug to `usedReferenceKeys`.
 
-Regression: full `unitAndFunctional` suite, 20 919 tests.
+`InsertReferenceMutationBookkeepingTest` — 5 tests, all green; **3 fail without the fix**, two on
+`GenericEvitaInternalError: ... is not present in the structure!` and one on "expected
+`InvalidMutationException`, nothing was thrown". The other two are guards: distinguishable duplicates
+still accepted, and the mutation-stream round-trip described above. The v2025.8.0 dating was confirmed
+by reproducing the removal crash in a worktree at that tag, not by reading the diff.
+
+Rejecting identical representative attributes on the mutation path is not a new restriction:
+`createReference`, `setOrUpdateReference` and `ExistingReferencesBuilder.createReference` were each
+probed and all three already throw the identical `InvalidMutationException` in that situation. The
+mutation path was the one hole that bypassed the rule.
+
+Regression: full `unitAndFunctional` suite, 20 927 tests.
 
 ## Consequences & open follow-ups
 
 - The choke point runs on every reference replacement. It is two map lookups and an early return in
   the overwhelmingly common non-duplicate case, but it is on the write path.
-- `mutateReference(InsertReferenceMutation)` adds a reference to the collection without registering it
-  in the bundle at all. `refreshRepresentativeKey` cannot help — it only re-keys what is already registered.
-  Not investigated; flagged so the next reader does not mistake this record for a claim that every
-  path is now consistent.
+- The four reference-creation entry points are now consistent, but that is a statement about the paths
+  *examined here*, not a proof that the bundle and the collection can no longer drift. The invariant is
+  maintained by convention at each call site rather than enforced structurally — nothing stops the next
+  new path from adding to the collection and forgetting the bundle, which is exactly how #1444 arose.
+  Deriving the bundle at build time would remove the class of bug entirely; see Option C for why that
+  was out of scope here.
+- A reference whose schema declares duplicating cardinality but **no** representative attributes cannot
+  have duplicates at all — every path rejects the second one, because both derive the same empty key.
+  That predates this work and was left alone; it is a schema-validation question (such a schema is
+  arguably invalid at declaration time) rather than a bookkeeping one.
 - `convertToDuplicateReference` still does `internalPkToRepRefKeys.remove(genericInternalPk)` followed
   by `put(previousRefInternalPk, ...)` on what is provably the same key. Harmless, left alone
   deliberately: it is on a path this change already touches and shrinking it further would have
@@ -209,3 +243,4 @@ Regression: full `unitAndFunctional` suite, 20 919 tests.
 
 - **2026-08-24** — reported from production, diagnosed live over JDWP, issue #1438 filed
 - **2026-08-24** — fixed, counter defect found and fixed alongside, verified, recorded
+- **2026-08-24** — follow-up chased: #1444 filed and closed in the same PRs

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-24 | [Refresh a reference's representative key whenever its built state is replaced](2026-08-24-refresh-provisional-representative-key.md) | fix | accepted | #1438, PR #1442, PR #1443 |
 | 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | accepted | #1433, PR #1435, PR #1436 |
 | 2026-08-23 | [Usage statistics are switchable off, and the absence is reported as "not measured" rather than as zero](2026-08-23-usage-statistics-tracking-switch.md) | feature | accepted | #1429, PR #1430 |
 | 2026-08-19 | [Schema-capability usage is counted per schema element in a collection-carried registry, not per physical index](2026-08-19-per-schema-capability-usage-statistics.md) | feature | accepted | #1429, PR #1430 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,8 +33,8 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-24 | [Refresh a reference's representative key whenever its built state is replaced](2026-08-24-refresh-provisional-representative-key.md) | fix | accepted | #1438, PR #1442, PR #1443 |
 | 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | accepted | #1433, PR #1435, PR #1436 |
+| 2026-08-24 | [Keep the reference bundle in step with the reference collection](2026-08-24-refresh-provisional-representative-key.md) | fix | accepted | #1438, #1444, PR #1442, PR #1443 |
 | 2026-08-23 | [Usage statistics are switchable off, and the absence is reported as "not measured" rather than as zero](2026-08-23-usage-statistics-tracking-switch.md) | feature | accepted | #1429, PR #1430 |
 | 2026-08-19 | [Schema-capability usage is counted per schema element in a collection-carried registry, not per physical index](2026-08-19-per-schema-capability-usage-statistics.md) | feature | accepted | #1429, PR #1430 |
 | 2026-08-16 | [An index's usage counters live in a holder passed by reference through every merge copy, not in the index itself](2026-08-16-per-index-usage-statistics.md) | feature | accepted | PR #1423 |

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/BuilderReferenceBundle.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/BuilderReferenceBundle.java
@@ -254,7 +254,7 @@ class BuilderReferenceBundle {
 					"` with the same representative attributes " + Arrays.toString(
 					rrk.representativeAttributeValues()) +
 					" as it would be indistinguishable from existing reference with internal id " +
-					internalPk + "!"
+					previousValue + "!"
 			);
 		} else {
 			final RepresentativeReferenceKey previousRRK = this.internalPkToRepRefKeys.put(internalPk, rrk);
@@ -268,11 +268,77 @@ class BuilderReferenceBundle {
 					() -> "Inconsistent internal structure!"
 				);
 			}
-			this.usedReferenceKeys.compute(
-				rrk.referenceKey(),
-				(rk, cardinality) -> cardinality == null ? 1 : cardinality + 1
+			// only an internal primary key the bundle has not seen before adds to the number of references
+			// the reference key holds - builders re-register a reference on every commit, and re-registering
+			// or re-keying a reference the bundle already knows must leave the count alone
+			if (previousRRK == null) {
+				this.usedReferenceKeys.compute(
+					rrk.referenceKey(),
+					(rk, cardinality) -> cardinality == null ? 1 : cardinality + 1
+				);
+			}
+		}
+	}
+
+	/**
+	 * Refreshes the representative key the passed reference is registered under, so that the key reflects the
+	 * current state of the reference's representative attributes.
+	 *
+	 * References may be registered in this bundle before their attributes are known:
+	 * {@link InitialReferencesBuilder#createReference(String, int)} registers a brand new - and therefore still empty -
+	 * reference and only afterwards hands the key back so the caller can populate it. The key derived at
+	 * registration time is consequently built from the default (usually {@code null}) representative values, and
+	 * goes stale the moment the caller fills the attributes in. A stale key keeps occupying a slot no reference
+	 * matches anymore, and the next reference registered the very same way is rejected as indistinguishable from
+	 * it.
+	 *
+	 * The method is a no-op when the reference is not registered yet, or when it is registered under a generic
+	 * key - generic keys carry no attribute values and therefore cannot go stale. That tolerance is what
+	 * separates it from {@link #upsertDuplicateReference(ReferenceContract)}, which presumes duplicate mode and
+	 * presumes the caller intends to register: this one is safe to call for every reference on every write.
+	 * It never touches {@link #usedReferenceKeys} either, because re-keying an already registered reference
+	 * does not change how many references its reference key holds.
+	 *
+	 * @param reference the reference whose representative key is to be recomputed, must not be null
+	 * @throws InvalidMutationException when the recomputed key is already occupied by a different reference
+	 */
+	public void refreshRepresentativeKey(@Nonnull ReferenceContract reference) {
+		final ReferenceKey referenceKey = reference.getReferenceKey();
+		if (referenceKey.isUnknownReference() || this.representativeAttributeDefinition == null) {
+			// the bundle never entered duplicate mode - there are no attribute bearing keys to refresh
+			return;
+		}
+		final int internalPk = referenceKey.internalPrimaryKey();
+		final RepresentativeReferenceKey currentRRK = this.internalPkToRepRefKeys.get(internalPk);
+		if (currentRRK == null || currentRRK.representativeAttributeValues().length == 0) {
+			// the reference is either not registered yet, or registered under a generic key
+			return;
+		}
+		final RepresentativeReferenceKey newRRK = new RepresentativeReferenceKey(
+			referenceKey,
+			this.representativeAttributeDefinition.getRepresentativeValues(reference)
+		);
+		if (currentRRK.equals(newRRK)) {
+			// the representative attributes did not change - the registered key is still accurate
+			return;
+		}
+		// claim the new slot first, so that a collision leaves the bundle exactly as it was
+		final Integer collidingPk = this.repRefKeysToInternalPk.putIfAbsent(newRRK, internalPk);
+		if (collidingPk != null && !collidingPk.equals(internalPk)) {
+			// this is a problem - we have two different references with the same representative keys
+			throw new InvalidMutationException(
+				"Cannot update duplicate reference `" + reference.getReferenceName() +
+					"` to representative attributes " + Arrays.toString(newRRK.representativeAttributeValues()) +
+					" as it would be indistinguishable from existing reference with internal id " +
+					collidingPk + "!"
 			);
 		}
+		this.internalPkToRepRefKeys.put(internalPk, newRRK);
+		final Integer removedPk = this.repRefKeysToInternalPk.remove(currentRRK);
+		Assert.isPremiseValid(
+			removedPk == null || removedPk == internalPk,
+			() -> "Inconsistent internal structure!"
+		);
 	}
 
 	/**
@@ -317,10 +383,8 @@ class BuilderReferenceBundle {
 			// zero in the map means that there are duplicates for this generic key
 			this.repRefKeysToInternalPk.put(genericRRK, 0);
 			this.repRefKeysToInternalPk.put(newRRK, previousRefInternalPk);
-			this.usedReferenceKeys.compute(
-				genericRRK.referenceKey(),
-				(rk, cardinality) -> cardinality == null ? 2 : cardinality + 1
-			);
+			// the previous reference is only re-keyed here, so it stays counted exactly once; the incoming
+			// one is counted by the upsertDuplicateReference call that closes this method
 			this.internalPkToRepRefKeys.remove(genericInternalPk);
 			this.internalPkToRepRefKeys.put(previousRefInternalPk, newRRK);
 			// now we can add the new duplicate reference

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/InitialReferencesBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/InitialReferencesBuilder.java
@@ -1210,6 +1210,12 @@ public class InitialReferencesBuilder implements ReferencesBuilder {
 	 * If the reference is added for the first time, it is stored. In case of a duplicate, the reference is marked
 	 * with a special indicator for duplicate references.
 	 *
+	 * Every replacement also refreshes the representative key the reference is registered under in its
+	 * {@link BuilderReferenceBundle}. References created through {@link #createReference(String, int)} are
+	 * registered while still empty and are populated only afterwards, so without this refresh the bundle would keep
+	 * them filed under their initial - all defaults, usually {@code null} - representative values forever, and the
+	 * next reference created the same way would be rejected as indistinguishable from that stale entry.
+	 *
 	 * @param reference the reference to be added; must not be null
 	 */
 	private void addOrReplaceReferenceInternal(@Nonnull ReferenceContract reference) {
@@ -1218,6 +1224,15 @@ public class InitialReferencesBuilder implements ReferencesBuilder {
 			this.references = new LinkedHashMap<>(16);
 		}
 		final ReferenceContract referenceWithAssignedInternalId = getReference(reference);
+		// re-key before the collection is touched, so that a genuine collision leaves the builder untouched
+		if (this.referenceBundles != null) {
+			final BuilderReferenceBundle referenceBundle = this.referenceBundles.get(
+				referenceWithAssignedInternalId.getReferenceName()
+			);
+			if (referenceBundle != null) {
+				referenceBundle.refreshRepresentativeKey(referenceWithAssignedInternalId);
+			}
+		}
 		this.references.compute(
 			referenceWithAssignedInternalId.getReferenceKey(),
 			(key, existingValue) -> {

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/InitialReferencesBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/InitialReferencesBuilder.java
@@ -969,17 +969,28 @@ public class InitialReferencesBuilder implements ReferencesBuilder {
     @Override
     public ReferencesBuilder mutateReference(@Nonnull ReferenceMutation<?> referenceMutation) {
         if (referenceMutation instanceof InsertReferenceMutation lm) {
-            final String referenceName = referenceMutation.getReferenceKey().referenceName();
+            final ReferenceKey mutationKey = referenceMutation.getReferenceKey();
+            final String referenceName = mutationKey.referenceName();
             final ReferenceSchemaContract referenceSchema = getReferenceSchemaOrCreateImplicit(
                 referenceName, lm.getReferencedEntityType(), lm.getReferenceCardinality()
             );
-            this.addOrReplaceReferenceInternal(
-                new Reference(
-                    this.entitySchema,
-                    referenceSchema,
-                    referenceMutation.getReferenceKey(),
-                    null
-                )
+            // the internal id is resolved up front rather than inside addOrReplaceReferenceInternal, because the
+            // reference has to be registered in the bundle under the very key the collection stores it with
+            final ReferenceKey referenceKey = mutationKey.isUnknownReference() ?
+                new ReferenceKey(referenceName, mutationKey.primaryKey(), getNextReferenceInternalId()) :
+                mutationKey;
+            final Reference newReference = new Reference(
+                this.entitySchema,
+                referenceSchema,
+                referenceKey,
+                null
+            );
+            this.addOrReplaceReferenceInternal(newReference);
+            // a reference the bundle never learned about cannot be removed (removeNonDuplicateReference fails on
+            // "not present in the structure") and cannot take part in duplicate detection at all
+            getReferenceBundleForUpdate(referenceName, 8).upsertWithDuplicateReferenceConversion(
+                newReference,
+                rk -> this.getReference(rk).orElseThrow()
             );
         } else if (referenceMutation instanceof SetReferenceGroupMutation lm) {
             final ReferenceContract existingReference = this.getReference(lm.getReferenceKey())

--- a/evita_query/src/main/java/io/evitadb/api/query/expression/object/accessor/ObjectAccessorRegistry.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/expression/object/accessor/ObjectAccessorRegistry.java
@@ -34,7 +34,6 @@ import java.util.ServiceLoader;
 import java.util.ServiceLoader.Provider;
 
 import static io.evitadb.utils.CollectionUtils.createConcurrentHashMap;
-import static io.evitadb.utils.CollectionUtils.createHashMap;
 
 /**
  * Singleton registry for {@link ObjectPropertyAccessor}s and {@link ObjectElementAccessor}s. Accessors are registered
@@ -47,7 +46,15 @@ import static io.evitadb.utils.CollectionUtils.createHashMap;
  */
 public class ObjectAccessorRegistry {
 
-	private static ObjectAccessorRegistry INSTANCE;
+	/**
+	 * Holder that defers construction to first access. Class initialization is serialized by the JVM, so the
+	 * instance is published safely without locking on every lookup - a plain lazily assigned static field is
+	 * neither atomic nor visible across threads, and a racing reader would build a second registry and overwrite
+	 * the first, silently discarding accessors registered on it in the meantime.
+	 */
+	private static final class Holder {
+		private static final ObjectAccessorRegistry INSTANCE = new ObjectAccessorRegistry();
+	}
 
 	/**
 	 * Map of property accessors keyed by the exact type they are registered for.
@@ -86,10 +93,7 @@ public class ObjectAccessorRegistry {
 	 */
 	@Nonnull
 	public static ObjectAccessorRegistry getInstance() {
-		if (INSTANCE == null) {
-			INSTANCE = new ObjectAccessorRegistry();
-		}
-		return INSTANCE;
+		return Holder.INSTANCE;
 	}
 
 	private ObjectAccessorRegistry() {
@@ -106,9 +110,9 @@ public class ObjectAccessorRegistry {
 			.map(Provider::get)
 			.toList();
 
-		this.propertyAccessors = createHashMap(foundPropertyAccessors.size());
-		this.elementAccessors = createHashMap(foundElementAccessors.size());
-		this.methodAccessors = createHashMap(foundMethodAccessors.size());
+		this.propertyAccessors = createConcurrentHashMap(foundPropertyAccessors.size());
+		this.elementAccessors = createConcurrentHashMap(foundElementAccessors.size());
+		this.methodAccessors = createConcurrentHashMap(foundMethodAccessors.size());
 		this.propertyAccessorCache = createConcurrentHashMap(Math.round(foundPropertyAccessors.size() * 1.5f));
 		this.elementAccessorCache = createConcurrentHashMap(Math.round(foundElementAccessors.size() * 1.5f));
 		this.methodAccessorCache = createConcurrentHashMap(Math.round(foundMethodAccessors.size() * 1.5f));

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/BuilderReferenceBundleTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/BuilderReferenceBundleTest.java
@@ -449,4 +449,76 @@ class BuilderReferenceBundleTest {
 		bundle.upsertWithDuplicateReferenceConversion(dupl, key -> prev);
 		assertThrows(InvalidMutationException.class, () -> bundle.upsertWithDuplicateReferenceConversion(colliding, key -> prev));
 	}
+
+	@Test
+	@DisplayName("shouldStopReportingReferenceKeyOnceAllDuplicatesAreRemoved")
+	void shouldStopReportingReferenceKeyOnceAllDuplicatesAreRemoved() {
+		final BuilderReferenceBundle bundle = new BuilderReferenceBundle(2);
+		final ReferenceSchemaContract referenceSchema = Mockito.mock(ReferenceSchemaContract.class);
+		Mockito.when(referenceSchema.getAttributes()).thenReturn(representativeSchema());
+
+		final ReferenceContract prev = mockReference(1001, referenceSchema, Collections.singletonMap("country", "CZ"));
+		final ReferenceContract next = mockReference(2002, referenceSchema, Collections.singletonMap("country", "US"));
+
+		bundle.upsertNonDuplicateReference(prev);
+		bundle.convertToDuplicateReference(next, prev);
+		assertTrue(bundle.containsReferenceKey(prev.getReferenceKey()));
+
+		bundle.removeDuplicateReference(next);
+		assertTrue(bundle.containsReferenceKey(prev.getReferenceKey()));
+
+		// the business key holds two references, so exactly two removals must retire it - the conversion
+		// must not count the incoming reference twice
+		bundle.removeDuplicateReference(prev);
+		assertEquals(0, bundle.count());
+		assertFalse(bundle.containsReferenceKey(prev.getReferenceKey()));
+	}
+
+	@Test
+	@DisplayName("shouldNotCountRepeatedUpsertsOfTheSameDuplicateReference")
+	void shouldNotCountRepeatedUpsertsOfTheSameDuplicateReference() {
+		final BuilderReferenceBundle bundle = new BuilderReferenceBundle(2);
+		final ReferenceSchemaContract referenceSchema = Mockito.mock(ReferenceSchemaContract.class);
+		Mockito.when(referenceSchema.getAttributes()).thenReturn(representativeSchema());
+
+		final ReferenceContract prev = mockReference(1001, referenceSchema, Collections.singletonMap("country", "CZ"));
+		final ReferenceContract next = mockReference(2002, referenceSchema, Collections.singletonMap("country", "US"));
+
+		bundle.upsertNonDuplicateReference(prev);
+		bundle.convertToDuplicateReference(next, prev);
+
+		// committing the very same reference again is an update, not an insertion - builders re-register a
+		// reference on every commit, and each re-registration must leave the reference count alone
+		bundle.upsertDuplicateReference(next);
+		bundle.upsertDuplicateReference(next);
+		assertEquals(2, bundle.count());
+
+		bundle.removeDuplicateReference(next);
+		bundle.removeDuplicateReference(prev);
+		assertEquals(0, bundle.count());
+		assertFalse(bundle.containsReferenceKey(prev.getReferenceKey()));
+	}
+
+	@Test
+	@DisplayName("shouldNotCountReKeyingOfAnAlreadyRegisteredDuplicateReference")
+	void shouldNotCountReKeyingOfAnAlreadyRegisteredDuplicateReference() {
+		final BuilderReferenceBundle bundle = new BuilderReferenceBundle(2);
+		final ReferenceSchemaContract referenceSchema = Mockito.mock(ReferenceSchemaContract.class);
+		Mockito.when(referenceSchema.getAttributes()).thenReturn(representativeSchema());
+
+		final ReferenceContract prev = mockReference(1001, referenceSchema, Collections.singletonMap("country", "CZ"));
+		final ReferenceContract next = mockReference(2002, referenceSchema, Collections.singletonMap("country", "US"));
+		// same internal primary key as `next`, but a different representative value
+		final ReferenceContract reKeyed = mockReference(2002, referenceSchema, Collections.singletonMap("country", "SK"));
+
+		bundle.upsertNonDuplicateReference(prev);
+		bundle.convertToDuplicateReference(next, prev);
+		bundle.upsertDuplicateReference(reKeyed);
+		assertEquals(2, bundle.count());
+
+		bundle.removeDuplicateReference(reKeyed);
+		bundle.removeDuplicateReference(prev);
+		assertEquals(0, bundle.count());
+		assertFalse(bundle.containsReferenceKey(prev.getReferenceKey()));
+	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/CreateReferenceDuplicateBookkeepingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/CreateReferenceDuplicateBookkeepingTest.java
@@ -1,0 +1,364 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.data.structure;
+
+import io.evitadb.api.exception.InvalidMutationException;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.api.requestResponse.data.ReferenceContract;
+import io.evitadb.api.requestResponse.data.ReferenceEditor.ReferenceBuilder;
+import io.evitadb.api.requestResponse.data.ReferencesContract;
+import io.evitadb.api.requestResponse.data.ReferencesEditor.ReferencesBuilder;
+import io.evitadb.api.requestResponse.data.mutation.attribute.UpsertAttributeMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceAttributeMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
+import io.evitadb.api.requestResponse.data.structure.predicate.ReferenceContractSerializablePredicate;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.api.requestResponse.schema.builder.InternalEntitySchemaBuilder;
+import io.evitadb.utils.Functions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies the duplicate-reference bookkeeping of the create-then-populate flow.
+ *
+ * {@link InitialReferencesBuilder#createReference(String, int)} registers a brand new - and therefore
+ * still empty - reference in its {@link BuilderReferenceBundle} straight away, and only afterwards hands
+ * the {@link ReferenceKey} back so the caller can populate the attributes. At registration time the
+ * representative attribute values are consequently all {@code null}, so the reference is filed under the
+ * representative key {@code [null]}.
+ *
+ * That key is provisional: it must be refreshed once the caller commits the populated builder back, or the
+ * {@code [null]} slot stays occupied by a reference that no longer matches it. Until the refresh existed,
+ * exactly two references per business key stayed healthy - the second one self-healed only its predecessor
+ * through {@link BuilderReferenceBundle#convertToDuplicateReference(ReferenceContract, ReferenceContract)} -
+ * and the third collided with the stale slot and was rejected with representative attributes {@code [null]}.
+ *
+ * The production trigger is the entity proxy: every {@code getOrCreate}-style reference method in
+ * {@code SetReferenceMethodClassifier} routes to {@code createReference}, runs the caller's consumer and
+ * only then propagates the builder back, which is precisely the order reproduced here.
+ *
+ * The tests pin both halves of the contract - the refresh has to vacate the stale slot, and it must not
+ * weaken the detection of references that genuinely are indistinguishable.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("createReference duplicate bookkeeping")
+@Tag(CONTRACT)
+@Tag(REFERENCE)
+@Tag(ATTRIBUTE)
+class CreateReferenceDuplicateBookkeepingTest extends AbstractBuilderTest {
+
+	private static final String BRAND = "brand";
+	private static final String STORE = "store";
+	private static final String COUNTRY = "country";
+	private static final int BRAND_PK = 143434;
+
+	/**
+	 * Builds a schema whose {@link #BRAND} reference allows duplicates and is discriminated by the
+	 * representative {@link #COUNTRY} attribute.
+	 *
+	 * @return the entity schema used by all tests in this class
+	 */
+	@Nonnull
+	private static EntitySchemaContract createSchemaWithDuplicableReference() {
+		return new InternalEntitySchemaBuilder(CATALOG_SCHEMA, PRODUCT_SCHEMA)
+			.withReferenceToEntity(
+				STORE, STORE, Cardinality.ZERO_OR_MORE,
+				r -> {}
+			)
+			.withReferenceToEntity(
+				BRAND, BRAND, Cardinality.ZERO_OR_MORE_WITH_DUPLICATES,
+				r -> r.withAttribute(COUNTRY, String.class, AttributeSchemaEditor::representative)
+			)
+			.toInstance();
+	}
+
+	/**
+	 * Replays exactly what the entity proxy does for a single {@code addOrUpdateXxx(id, discriminator,
+	 * consumer)} call: create the reference first, populate its representative attribute afterwards,
+	 * then propagate the populated builder back into the entity.
+	 *
+	 * @param builder the references builder under test
+	 * @param schema  the owning entity schema
+	 * @param country the representative attribute value assigned after creation
+	 * @return the key of the reference that was created
+	 */
+	@Nonnull
+	private static ReferenceKey createThenPopulate(
+		@Nonnull ReferencesBuilder builder,
+		@Nonnull EntitySchemaContract schema,
+		@Nonnull String country
+	) {
+		final ReferenceKey referenceKey = builder.createReference(BRAND, BRAND_PK);
+		final ReferenceContract created = builder.getReference(referenceKey).orElseThrow();
+		final ReferenceBuilder referenceBuilder = new ExistingReferenceBuilder(
+			created, schema, new HashMap<>()
+		);
+		referenceBuilder.setAttribute(COUNTRY, country);
+		builder.addOrReplaceReferenceMutations(referenceBuilder, true);
+		return referenceKey;
+	}
+
+	/**
+	 * Applies a single representative attribute change through the mutation replay path, which refreshes
+	 * the reference in the collection without ever going through a {@link ReferenceBuilder}.
+	 *
+	 * @param builder      the references builder under test
+	 * @param referenceKey the key of the reference to update
+	 * @param country      the new representative attribute value
+	 */
+	private static void mutateCountry(
+		@Nonnull ReferencesBuilder builder,
+		@Nonnull ReferenceKey referenceKey,
+		@Nonnull String country
+	) {
+		builder.mutateReference(
+			new ReferenceAttributeMutation(
+				referenceKey,
+				new UpsertAttributeMutation(new AttributeKey(COUNTRY), country)
+			)
+		);
+	}
+
+	/**
+	 * Returns the representative attribute values of every {@link #BRAND} reference pointing at
+	 * {@link #BRAND_PK}. The result is sorted, because {@link References} orders its references by
+	 * {@link ReferenceContract#FULL_COMPARATOR} rather than by insertion order - which of the two
+	 * orders comes out is irrelevant to what these tests assert.
+	 *
+	 * @param references the built references
+	 * @return sorted list of {@link #COUNTRY} values
+	 */
+	@Nonnull
+	private static List<String> countriesOf(@Nonnull ReferencesContract references) {
+		return references.getReferences(BRAND)
+			.stream()
+			.map(it -> it.getAttributeValue(COUNTRY).map(av -> (String) av.value()).orElse(null))
+			.sorted(Comparator.nullsFirst(Comparator.naturalOrder()))
+			.toList();
+	}
+
+	@Nested
+	@DisplayName("InitialReferencesBuilder (new entity)")
+	class InitialBuilderTest {
+
+		@Test
+		@DisplayName("two duplicates created via createReference are accepted")
+		void shouldAcceptTwoDuplicatesCreatedViaCreateReference() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			createThenPopulate(builder, schema, "CZ");
+			createThenPopulate(builder, schema, "DE");
+
+			final References built = builder.build();
+			assertEquals(2, built.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE"), countriesOf(built));
+		}
+
+		@Test
+		@DisplayName("three duplicates created via createReference are accepted")
+		void shouldAcceptThreeDuplicatesCreatedViaCreateReference() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			createThenPopulate(builder, schema, "CZ");
+			createThenPopulate(builder, schema, "DE");
+			// this third call used to fail, because the second reference still occupied the `[null]`
+			// representative slot it had been registered under before it was populated
+			createThenPopulate(builder, schema, "SK");
+
+			final References built = builder.build();
+			assertEquals(3, built.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE", "SK"), countriesOf(built));
+		}
+
+		@Test
+		@DisplayName("arbitrarily many duplicates created via createReference are accepted")
+		void shouldAcceptManyDuplicatesCreatedViaCreateReference() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			final List<String> countries = List.of("AT", "CZ", "DE", "HU", "PL", "SK");
+			for (final String country : countries) {
+				createThenPopulate(builder, schema, country);
+			}
+
+			final References built = builder.build();
+			assertEquals(countries.size(), built.getReferences(BRAND).size());
+			assertEquals(countries, countriesOf(built));
+		}
+
+		@Test
+		@DisplayName("populate-then-register via setOrUpdateReference stays healthy")
+		void shouldAcceptThreeDuplicatesCreatedViaSetOrUpdateReference() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			// setOrUpdateReference runs the consumer BEFORE registering in the bundle, so the
+			// representative values are present at registration time - this is the control case
+			builder.setOrUpdateReference(
+				BRAND, BRAND_PK, Functions.alwaysFalse(), ref -> ref.setAttribute(COUNTRY, "CZ")
+			);
+			builder.setOrUpdateReference(
+				BRAND, BRAND_PK, Functions.alwaysFalse(), ref -> ref.setAttribute(COUNTRY, "DE")
+			);
+			builder.setOrUpdateReference(
+				BRAND, BRAND_PK, Functions.alwaysFalse(), ref -> ref.setAttribute(COUNTRY, "SK")
+			);
+
+			final References built = builder.build();
+			assertEquals(3, built.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE", "SK"), countriesOf(built));
+		}
+
+		@Test
+		@DisplayName("duplicates sharing representative attributes are still rejected")
+		void shouldThrowExceptionWhenDuplicatesShareRepresentativeAttributes() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			createThenPopulate(builder, schema, "CZ");
+
+			// refreshing the provisional key must not weaken duplicate detection - these two references
+			// really are indistinguishable and the second one has to be refused
+			assertThrows(
+				InvalidMutationException.class,
+				() -> createThenPopulate(builder, schema, "CZ")
+			);
+		}
+
+		@Test
+		@DisplayName("representative attribute change is reflected in the bundle")
+		void shouldRefreshRepresentativeKeyWhenAttributeMutationIsApplied() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			final ReferenceKey first = createThenPopulate(builder, schema, "CZ");
+			createThenPopulate(builder, schema, "DE");
+
+			// the mutation replay path refreshes the reference in the collection directly - the bundle
+			// has to follow, otherwise `CZ` would stay reserved and `FR` would never be claimed
+			mutateCountry(builder, first, "FR");
+
+			final References built = builder.build();
+			assertEquals(2, built.getReferences(BRAND).size());
+			assertEquals(List.of("DE", "FR"), countriesOf(built));
+
+			// the vacated `CZ` slot must be free for a brand new duplicate
+			createThenPopulate(builder, schema, "CZ");
+			assertEquals(List.of("CZ", "DE", "FR"), countriesOf(builder.build()));
+		}
+
+		@Test
+		@DisplayName("attribute change colliding with a sibling duplicate is rejected")
+		void shouldThrowExceptionWhenAttributeMutationCollidesWithSibling() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			final ReferenceKey first = createThenPopulate(builder, schema, "CZ");
+			createThenPopulate(builder, schema, "DE");
+
+			assertThrows(
+				InvalidMutationException.class,
+				() -> mutateCountry(builder, first, "DE")
+			);
+
+			// the rejected re-key must have left the builder exactly as it was
+			final References built = builder.build();
+			assertEquals(2, built.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE"), countriesOf(built));
+		}
+	}
+
+	@Nested
+	@DisplayName("ExistingReferencesBuilder (existing entity)")
+	class ExistingBuilderTest {
+
+		/**
+		 * Creates an {@link ExistingReferencesBuilder} on top of an entity that carries no references yet.
+		 *
+		 * @param schema the owning entity schema
+		 * @return the builder under test
+		 */
+		@Nonnull
+		private ExistingReferencesBuilder createBuilder(@Nonnull EntitySchemaContract schema) {
+			final References base = new InitialReferencesBuilder(schema).build();
+			return new ExistingReferencesBuilder(
+				schema, base,
+				ReferenceContractSerializablePredicate.DEFAULT_INSTANCE,
+				key -> Optional.empty()
+			);
+		}
+
+		@Test
+		@DisplayName("three duplicates created via createReference are accepted")
+		void shouldAcceptThreeDuplicatesCreatedViaCreateReference() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final ExistingReferencesBuilder builder = createBuilder(schema);
+
+			createThenPopulate(builder, schema, "CZ");
+			createThenPopulate(builder, schema, "DE");
+			createThenPopulate(builder, schema, "SK");
+
+			final References built = builder.build();
+			assertNotNull(built);
+			assertEquals(3, built.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE", "SK"), countriesOf(built));
+		}
+
+		@Test
+		@DisplayName("arbitrarily many duplicates created via createReference are accepted")
+		void shouldAcceptManyDuplicatesCreatedViaCreateReference() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final ExistingReferencesBuilder builder = createBuilder(schema);
+
+			final List<String> countries = List.of("AT", "CZ", "DE", "HU", "PL", "SK");
+			for (final String country : countries) {
+				createThenPopulate(builder, schema, country);
+			}
+
+			final References built = builder.build();
+			assertEquals(countries.size(), built.getReferences(BRAND).size());
+			assertEquals(countries, countriesOf(built));
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/InsertReferenceMutationBookkeepingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/InsertReferenceMutationBookkeepingTest.java
@@ -1,0 +1,259 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.data.structure;
+
+import io.evitadb.api.exception.InvalidMutationException;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.api.requestResponse.data.ReferenceContract;
+import io.evitadb.api.requestResponse.data.ReferencesContract;
+import io.evitadb.api.requestResponse.data.ReferencesEditor.ReferencesBuilder;
+import io.evitadb.api.requestResponse.data.mutation.LocalMutation;
+import io.evitadb.api.requestResponse.data.mutation.attribute.UpsertAttributeMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.InsertReferenceMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceAttributeMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
+import io.evitadb.api.requestResponse.data.mutation.reference.RemoveReferenceMutation;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.api.requestResponse.schema.builder.InternalEntitySchemaBuilder;
+import io.evitadb.utils.Functions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that a reference inserted through {@link InsertReferenceMutation} is registered in the
+ * {@link BuilderReferenceBundle}, exactly like one created through
+ * {@link InitialReferencesBuilder#createReference(String, int)}.
+ *
+ * The mutation replay path used to add the reference straight to the reference collection without
+ * telling the bundle about it. Everything the bundle is responsible for was therefore skipped for such
+ * a reference:
+ *
+ * - removing it failed outright, because `removeNonDuplicateReference` looks the reference up in the
+ *   bundle and rejects what it cannot find with "is not present in the structure";
+ * - duplicate detection never ran, so two references with identical representative attributes were
+ *   accepted into the entity without complaint.
+ *
+ * The path is reachable through {@code InitialEntityBuilder.mutate(...)}, which is how a mutation
+ * stream is replayed - from the WAL, from gRPC, or from an entity's own {@code toMutation()} output.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("InsertReferenceMutation bundle bookkeeping")
+@Tag(CONTRACT)
+@Tag(REFERENCE)
+@Tag(ATTRIBUTE)
+class InsertReferenceMutationBookkeepingTest extends AbstractBuilderTest {
+
+	private static final String BRAND = "brand";
+	private static final String COUNTRY = "country";
+	private static final int BRAND_PK = 100;
+
+	/**
+	 * Builds a schema whose {@link #BRAND} reference allows duplicates discriminated by the
+	 * representative {@link #COUNTRY} attribute.
+	 *
+	 * @return the entity schema used by all tests in this class
+	 */
+	@Nonnull
+	private static EntitySchemaContract createSchemaWithDuplicableReference() {
+		return new InternalEntitySchemaBuilder(CATALOG_SCHEMA, PRODUCT_SCHEMA)
+			.withReferenceToEntity(
+				BRAND, BRAND, Cardinality.ZERO_OR_MORE_WITH_DUPLICATES,
+				r -> r.withAttribute(COUNTRY, String.class, AttributeSchemaEditor::representative)
+			)
+			.toInstance();
+	}
+
+	/**
+	 * Replays the pair of mutations a builder emits for one populated reference: the insert followed by
+	 * its own representative attribute.
+	 *
+	 * @param builder     the references builder under test
+	 * @param internalPk  the internal primary key the reference is inserted under
+	 * @param country     the representative attribute value assigned to it
+	 */
+	private static void insertThenPopulate(
+		@Nonnull ReferencesBuilder builder,
+		int internalPk,
+		@Nonnull String country
+	) {
+		final ReferenceKey referenceKey = new ReferenceKey(BRAND, BRAND_PK, internalPk);
+		builder.mutateReference(
+			new InsertReferenceMutation(referenceKey, Cardinality.ZERO_OR_MORE_WITH_DUPLICATES, BRAND)
+		);
+		builder.mutateReference(
+			new ReferenceAttributeMutation(
+				referenceKey,
+				new UpsertAttributeMutation(new AttributeKey(COUNTRY), country)
+			)
+		);
+	}
+
+	/**
+	 * Returns the sorted representative attribute values of every {@link #BRAND} reference.
+	 *
+	 * @param references the built references
+	 * @return sorted list of {@link #COUNTRY} values
+	 */
+	@Nonnull
+	private static List<String> countriesOf(@Nonnull ReferencesContract references) {
+		return references.getReferences(BRAND)
+			.stream()
+			.map(it -> it.getAttributeValue(COUNTRY).map(av -> (String) av.value()).orElse(null))
+			.sorted(Comparator.nullsFirst(Comparator.naturalOrder()))
+			.toList();
+	}
+
+	@Nested
+	@DisplayName("removal of a mutation-inserted reference")
+	class RemovalTest {
+
+		@Test
+		@DisplayName("removeReference finds a reference inserted through a mutation")
+		void shouldRemoveReferenceInsertedThroughMutation() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			builder.mutateReference(
+				new InsertReferenceMutation(
+					new ReferenceKey(BRAND, BRAND_PK), Cardinality.ZERO_OR_MORE_WITH_DUPLICATES, BRAND
+				)
+			);
+			// used to fail with GenericEvitaInternalError "is not present in the structure", because the
+			// mutation path never registered the reference in the bundle the removal looks it up in
+			builder.removeReference(BRAND, BRAND_PK);
+
+			assertEquals(0, builder.build().getReferences(BRAND).size());
+		}
+
+		@Test
+		@DisplayName("RemoveReferenceMutation undoes a preceding InsertReferenceMutation")
+		void shouldRemoveReferenceThroughRemoveReferenceMutation() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			final ReferenceKey referenceKey = new ReferenceKey(BRAND, BRAND_PK);
+			builder.mutateReference(
+				new InsertReferenceMutation(referenceKey, Cardinality.ZERO_OR_MORE_WITH_DUPLICATES, BRAND)
+			);
+			// an add-then-remove pair inside one replayed stream is ordinary, and used to abort the replay
+			builder.mutateReference(new RemoveReferenceMutation(referenceKey));
+
+			assertEquals(0, builder.build().getReferences(BRAND).size());
+		}
+	}
+
+	@Nested
+	@DisplayName("duplicate detection for mutation-inserted references")
+	class DuplicateDetectionTest {
+
+		@Test
+		@DisplayName("distinguishable duplicates are accepted")
+		void shouldAcceptDistinguishableReferencesInsertedThroughMutations() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			insertThenPopulate(builder, -1, "CZ");
+			insertThenPopulate(builder, -2, "DE");
+			insertThenPopulate(builder, -3, "SK");
+
+			final References built = builder.build();
+			assertEquals(3, built.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE", "SK"), countriesOf(built));
+		}
+
+		@Test
+		@DisplayName("indistinguishable duplicates are rejected")
+		void shouldRejectIndistinguishableReferencesInsertedThroughMutations() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			insertThenPopulate(builder, -1, "CZ");
+
+			// these two carry the very same representative attributes - without bundle registration the
+			// collision went undetected and both were written into the entity
+			assertThrows(
+				InvalidMutationException.class,
+				() -> insertThenPopulate(builder, -2, "CZ")
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("mutation stream round-trip")
+	class RoundTripTest {
+
+		@Test
+		@DisplayName("an entity replays its own mutation stream")
+		void shouldReplayItsOwnMutationStream() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialEntityBuilder source = new InitialEntityBuilder(schema, 1);
+			source.setOrUpdateReference(
+				BRAND, BRAND_PK, Functions.alwaysFalse(), r -> r.setAttribute(COUNTRY, "CZ")
+			);
+			source.setOrUpdateReference(
+				BRAND, BRAND_PK, Functions.alwaysFalse(), r -> r.setAttribute(COUNTRY, "DE")
+			);
+			source.setOrUpdateReference(
+				BRAND, BRAND_PK, Functions.alwaysFalse(), r -> r.setAttribute(COUNTRY, "SK")
+			);
+
+			final Collection<? extends LocalMutation<?, ?>> mutations = source.toMutation()
+				.orElseThrow()
+				.getLocalMutations();
+
+			// registering the reference eagerly makes the emission order load-bearing: each insert must be
+			// followed by its own attributes before the next insert, or two still-empty references would
+			// collide on their identical default representative values. buildChangeSet emits exactly that,
+			// and this test is what keeps it that way.
+			final InitialEntityBuilder target = new InitialEntityBuilder(schema, 1);
+			for (final LocalMutation<?, ?> mutation : mutations) {
+				target.mutate(mutation);
+			}
+
+			final ReferencesContract replayed = target.toInstance();
+			assertEquals(3, replayed.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE", "SK"), countriesOf(replayed));
+			assertTrue(
+				source.toInstance().getReferences(BRAND).stream().map(ReferenceContract::getReferenceName).allMatch(BRAND::equals)
+			);
+		}
+	}
+}


### PR DESCRIPTION
Ref: #1438 — dev-line counterpart of #1442 (same commit, cherry-picked).

## What was wrong

`InitialReferencesBuilder.createReference` registers a brand new — and therefore still empty — reference in its `BuilderReferenceBundle`, and only afterwards hands the key back so the caller can populate the attributes. The key it registers is derived from the **default** representative values, normally `[null]`. `addOrReplaceReferenceMutations` — the path entity proxies commit through — only refreshed the reference *collection* and never touched the bundle, so the `[null]` slot stayed occupied by a reference that no longer matched it.

Two failure modes came out of that, and only the first one was reported:

- **The third duplicate of a business key was rejected**, colliding with the stale slot:
  `Cannot add duplicate reference `media` with the same representative attributes [null] as it would be indistinguishable from existing reference with internal id -7!`
- **The second duplicate was silently accepted even when it genuinely was indistinguishable.** Because the bundle never learned the real representative values, it could not detect the collision it exists to detect. This one never raised an exception and would have written indistinguishable references into an entity.

The production trigger is the entity proxy: every `getOrCreate`-style reference method in `SetReferenceMethodClassifier` routes to `createReference`, runs the caller's consumer, and only then propagates the builder back — exactly the create-then-populate order that leaves the stale key behind.

## Why it appears in 2026.2

The `[null]` slot used to be vacated *by accident*. Before `b8400f922` (2026-07-25, first released in v2026.2.0), `upsertDuplicateReference` removed `previousRRK` unconditionally — including when it was the key it had just written. That commit correctly guarded the removal, which exposed the missing refresh underneath.

Bisected: **v2025.7.0 pass · v2026.1.20 pass · v2026.2.0 fail · `a7c9b78ba` fail.**

The guard is right and is **not** reverted here — without it a reference is dropped from `repRefKeysToInternalPk` while left in `internalPkToRepRefKeys`, and an indistinguishable twin takes over the vacated slot. Reverting would trade the loud rejection for silent reference loss.

`ExistingReferencesBuilder` was never affected, structurally rather than luckily: it passes the **populated** builder to `replaceChangeSet` → `upsertWithDuplicateReferenceConversion`, so it re-registers on every commit and the stale-key window never opens.

## The fix

- **`BuilderReferenceBundle.refreshRepresentativeKey`** recomputes a registered reference's representative key from its current state. It claims the new slot with `putIfAbsent` **before** releasing the old one, so a genuine collision is a no-op on the bundle. It is a no-op when the bundle never entered duplicate mode or when the reference is held under a generic key — those two guards are why it is not simply `upsertDuplicateReference`, which presumes duplicate mode and presumes the caller intends registration.
- **`InitialReferencesBuilder.addOrReplaceReferenceInternal`** calls it *before* mutating the collection — the single method every reference replacement funnels through, so this also covers `mutateReference(ReferenceAttributeMutation)`, which had the same gap. The ordering is load-bearing: it is what makes a rejected re-key leave the builder untouched.

### Also fixed: `usedReferenceKeys` over-counted

The per-business-key reference counter was inflated from two sides — `upsertDuplicateReference` bumped on every call including plain re-registrations, and `convertToDuplicateReference` bumped for the incoming reference before calling it, which bumped for it again. The bump is now gated on an internal primary key the bundle has not seen before, and the redundant one is gone along with its unreachable null-cardinality fallback. Symptom was `containsReferenceKey` answering `true` for a business key whose last reference had already been removed.

### Also fixed: misleading message

`upsertDuplicateReference` reported the **incoming** reference's internal id where it meant the **existing** one's. The production trace's "internal id -7" was the reference being added, not the one it collided with — which sent the investigation after the wrong reference.

## Verification

`CreateReferenceDuplicateBookkeepingTest` — 9 tests, **5 of which fail without the fix**:

| Test | Pins |
|---|---|
| `shouldAcceptThreeDuplicatesCreatedViaCreateReference` | the reported failure, verbatim |
| `shouldAcceptManyDuplicatesCreatedViaCreateReference` | 6 duplicates — not an off-by-one |
| `shouldThrowExceptionWhenDuplicatesShareRepresentativeAttributes` | the silent-acceptance half (without the fix, **nothing is thrown**) |
| `shouldRefreshRepresentativeKeyWhenAttributeMutationIsApplied` | the `ReferenceAttributeMutation` entry point |
| `shouldThrowExceptionWhenAttributeMutationCollidesWithSibling` | rejected re-key leaves the builder untouched |
| `shouldAcceptThreeDuplicatesCreatedViaSetOrUpdateReference` | control — populate-then-register was always healthy |
| 2 × `ExistingReferencesBuilder` | pass **with and without** the fix, confirming that path's immunity rather than assuming it |

`BuilderReferenceBundleTest` — 23 tests; the 3 new counting tests fail without the counting fix. `count()` was correct throughout (it reads `internalPkToRepRefKeys`, not the counter), which is what localised the bug.

Regression: full `unitAndFunctional` suite, 20 922 tests. The only two failures are pre-existing and environmental — `ExportS3ServiceTest` (Testcontainers needs Docker) and `CdcCallbackDispatcherTest.shouldNotCreateThreadsWhenCallbacksAreRefused` (thread-count assertion under parallel-fork contention; passes in isolation). Both fail identically on the unmodified tree.


---

## Also in this PR: #1444 — references inserted through `InsertReferenceMutation`

Added after the initial review request. The ADR for this work carried it as an open follow-up; chasing it showed it was not a "someday" item.

`mutateReference(InsertReferenceMutation)` added the reference straight to the collection and never registered it in the bundle, so everything the bundle is responsible for was skipped:

| Scenario | Before |
|---|---|
| insert → `removeReference(name, pk)` | `GenericEvitaInternalError: Reference brand: 100/-1 is not present in the structure!` |
| insert → `RemoveReferenceMutation` | same crash |
| two inserts, **identical** representative attrs | silently accepted — 2 indistinguishable references |

An add-then-remove pair inside a single replayed mutation stream aborted the replay. Reachable through `InitialEntityBuilder.mutate(...)` — the WAL, gRPC and `toMutation()` all go through it.

**Latent since v2025.8.0**, not a 2026.2 regression — `mutateReference` did not exist on the references builder before `8e10a5e9f`. Confirmed by reproducing the crash in a worktree at that tag rather than by reading the diff.

### Two things worth a reviewer's attention

**Emission order became load-bearing.** Registering eagerly means two still-*empty* references collide on their identical default representative values, so a stream ordered `[Insert A, Insert B, Attr A, Attr B]` would break replay. Real streams interleave per reference — `buildChangeSet()` emits each insert followed by its own attributes, which `toMutation()`'s contract states. `shouldReplayItsOwnMutationStream` round-trips a real 3-duplicate entity through its own stream and exists to keep that guaranteed rather than incidental. **Anyone reordering `buildChangeSet` must read that test first.**

**Not a new restriction.** `createReference`, `setOrUpdateReference` and `ExistingReferencesBuilder.createReference` were each probed, and all three already throw the identical `InvalidMutationException` for two same-business-key references with identical or absent representative attributes. The mutation path was the one hole that bypassed the rule.

`InsertReferenceMutationBookkeepingTest` — 5 tests, **3 fail without the fix**. Full suite re-run: 20 927 tests, same two pre-existing environmental failures and nothing else.
