### PR TITLE
fix: pace gRPC server-streaming producers and give streams their own timeout budget

### DIFF
--- a/documentation/adr/2026-08-05-streaming-calls-must-not-be-retry-decorated.md
+++ b/documentation/adr/2026-08-05-streaming-calls-must-not-be-retry-decorated.md
@@ -1,7 +1,7 @@
 ---
 title: Never decorate a streaming gRPC channel with RetryingClient
 date: 2026-08-05
-updated: 2026-08-05 09:45
+updated: 2026-08-24 14:20
 status: accepted
 kind: fix
 issues: [1388]
@@ -9,7 +9,7 @@ prs: [1389]
 areas: [evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver]
 supersedes: []
 superseded-by: []
-relates: [2026-08-03-driver-connection-resilience, 2026-08-04-client-pool-fail-fast-and-cdc-channel-isolation]
+relates: [2026-08-03-driver-connection-resilience, 2026-08-04-client-pool-fail-fast-and-cdc-channel-isolation, 2026-08-24-grpc-streaming-backpressure-readiness-gate]
 ---
 
 # Never decorate a streaming gRPC channel with RetryingClient
@@ -238,6 +238,9 @@ through the rewired stubs.
   *Consequences*.
 - `2026-08-04-client-pool-fail-fast-and-cdc-channel-isolation` — the CDC channel/event-loop isolation this
   builder split sits alongside; both landed in PR #1389, which two agents staged together.
+- `2026-08-24-grpc-streaming-backpressure-readiness-gate` — the server-side half of the same call sites:
+  this record says the driver must not retry a stream, that one says the server must pace it against
+  transport readiness rather than pushing at disk speed.
 
 ## Timeline
 

--- a/documentation/adr/2026-08-24-grpc-streaming-backpressure-readiness-gate.md
+++ b/documentation/adr/2026-08-24-grpc-streaming-backpressure-readiness-gate.md
@@ -1,0 +1,480 @@
+---
+title: Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers
+date: 2026-08-24
+updated: 2026-08-24 19:40
+status: accepted
+kind: fix
+issues: [1441]
+prs: []
+areas:
+  - evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils
+  - evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services
+  - evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/interceptors
+  - evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver
+supersedes: []
+superseded-by: []
+relates: [2026-08-05-streaming-calls-must-not-be-retry-decorated]
+---
+
+# Pace gRPC server-streaming producers with a readiness gate that parks the worker
+
+Server-streaming RPCs used to push messages into Armeria's outbound queue as fast as they could
+produce them, without ever asking whether the transport could take another one. The queue is
+unbounded, so a client slower than the producer made the server materialise the entire payload in
+memory. `fetchFile` was the acute case: a 690 MB backup download over a slow tunnel died part-way
+through with a bare `UNKNOWN`. Producers now pace themselves against `ServerCallStreamObserver.isReady()`
+through a shared helper, `GrpcOutboundGate`, which parks the producing worker until the transport
+drains. `restoreCatalog`, the upload counterpart, moved its blocking file IO off the event loop and
+replaced the throttle it lost in the process with explicit inbound demand. Two size caps found along
+the way — both pre-existing, both making a large transfer fail with a status that explained nothing —
+were fixed on the driver side in the same line of work.
+
+## Why
+
+gRPC-Java's send path never blocks — a fact that is easy to get wrong, because grpc-go and the
+gRPC C++ sync API *do* block on the flow-control window. `StreamObserver.onNext` marshals the message
+and hands it to Armeria's `StreamMessage`, whose `tryWrite` refuses a message only once the stream is
+closed, never because it is full. `isReady()` is the only back-pressure signal there is, and nothing
+in the module consulted it: `setOnReadyHandler` appeared **zero** times across all 20 server-streaming
+RPCs.
+
+The cost is paid off-heap and is worse than the payload. Because marshalling is eager, the queued
+objects are pooled Netty buffers: a 512 MiB file measured **1035 MiB** of retained direct memory,
+about 2x the payload once pooled-arena reservation is counted. The ceiling such a download hits is
+therefore `-XX:MaxDirectMemorySize`, not `-Xmx`, and the failure surfaces as `UNKNOWN` with no message
+because the allocation that finally fails does so inside Armeria, whose fallback for an escaping
+`Throwable` is exactly that.
+
+Two constraints made the fix non-obvious, and both are the reason this record exists rather than a
+commit message:
+
+- **`ServerCall.isReady()` is not abstract.** It ships a default returning an unconditional `true`.
+  `ObservabilityInterceptor` decorated the call without extending `ForwardingServerCall`, so it
+  answered `true` forever — any readiness-driven loop written against it would have been a silent
+  no-op. Nothing about the service method reveals this.
+- **The producing loop's thread is not guaranteed to be a worker.** `executeWithClientContext` hands
+  off to `Evita.getRequestExecutor()`, which for an engine built with `directExecutor = true` is an
+  `ImmediateExecutorService` that runs the task inline — on the transport event loop.
+
+### Previous state
+
+`fetchFile` read the file in 64 KB chunks in a tight `while` loop, calling `onNext` per chunk with no
+gating (`EvitaManagementService.java:721-727` before this change). `getMutationsHistory` and
+`getTrafficRecordingHistory` had the same shape via `Stream.forEach`. This was invisible for as long
+as every consumer kept up, which is the normal case on a LAN.
+
+`restoreCatalog` performed `Files.createTempFile`, a per-chunk `writeTo` against an **unbuffered**
+stream, and `close`/`Files.size`/`newInputStream` directly on the event loop. It was never throttled
+deliberately: gRPC auto-requests the next message only after `onMessage` returns, so the inline
+blocking write *was* the throttle — accidentally, and at the price of thousands of blocking write
+syscalls on a thread shared with every other connection.
+
+## Options considered
+
+### Option A — park the producing worker on a readiness gate (chosen)
+
+A small shared helper attached synchronously in the service method; the producing loop calls
+`awaitWritable()` before each `onNext` and stops when it returns `false`.
+
+- **Pros:** keeps the loop's straight-line shape, so try-with-resources, tracing scope and error
+  handling stay in one method. Pins no thread the RPC did not already own for its whole duration.
+  One helper covers every call site.
+- **Cons:** holds a request-executor thread for the duration of a slow download rather than for the
+  duration of a fast disk read. Needs a stall timeout so a client that stops reading without hanging
+  up cannot pin that thread forever.
+
+### Option B — drive the loop from the on-ready callback (declined)
+
+Turn each producer into a pump re-entered by `setOnReadyHandler`, holding the source and buffer as
+call state.
+
+- **Pros:** parks no thread at all; the natural shape for a purely async server.
+- **Rejected because:** the on-ready callback runs on the Armeria event loop, so the pump would have
+  to bounce every chunk back to a worker anyway — and then needs its own serialization guard to stop
+  two callbacks from pumping concurrently. That buys back the thread at the cost of turning three
+  straight-line loops into three hand-written state machines, each with its own resource-lifetime and
+  tracing-context problem. Worth revisiting only if request-executor exhaustion from slow downloads
+  is ever actually observed.
+
+### Option C — annotate the handlers `@Blocking` (declined, for `restoreCatalog`)
+
+Armeria supports the annotation per method and it would route the handler and its listener callbacks
+to `evita.getServiceExecutor()` in one line.
+
+- **Pros:** one-line change; no explicit flow control to maintain.
+- **Rejected because:** `AbstractServerCall` dispatches each message as
+  `blockingExecutor.execute(() -> invokeOnMessage(...))` onto a **shared pool**, so per-call ordering
+  would rest on an undocumented implicit invariant — that auto-request never lets a second message be
+  dispatched before the first returns. If that ever fails, the symptom is a silently corrupted catalog
+  ZIP, discovered at restore time. Revisit only if Armeria documents the ordering guarantee.
+
+## Decision
+
+**Chosen: Option A**, with Option C explicitly rejected for the upload path in favour of an explicit
+ordered chain.
+
+The deciding driver was that a slow download already owns its worker thread for the whole transfer;
+gating changes how *long* it is held, not whether. That is a bounded, measurable cost, and it is
+bounded further by a stall timeout. Option B's cost — three bespoke state machines whose failure modes
+are resource leaks and lost tracing context — is unbounded in review effort and lands on every future
+streaming RPC someone adds.
+
+Option B wins the day request-executor exhaustion from concurrent slow downloads is observed in
+production. That is the trigger for an ADR superseding this one.
+
+## Key technical details
+
+- **`GrpcOutboundGate.attach(...)` must be called synchronously in the service method, before it
+  returns.** gRPC's `ServerCallStreamObserverImpl` freezes handler registration the moment the service
+  method returns and throws for any later `setOnReadyHandler`/`setOnCancelHandler`. Only the loop
+  belongs on the worker. The codebase already documents the same constraint for cancel handlers in
+  `AbstractChangeCaptureSubscriber`.
+- **The gate owns the call's cancel handler.** gRPC keeps only the last one registered, so cleanup
+  that service methods used to register themselves (closing the underlying `Stream`) is passed into
+  `attach(...)` instead.
+- **`awaitWritable()` checks cancellation *before* readiness, in every branch.** Armeria increments
+  its pending-message counter in `sendMessage` and only unwinds it once the payload is genuinely
+  consumed, which never happens for a cancelled call — so readiness stays false forever. A gate that
+  consulted readiness first would pin a worker for the full stall timeout every time a client pressed
+  cancel. Registering a cancel handler also stops gRPC throwing `CANCELLED` from `onNext`, so this
+  check is the only thing left that stops a producing loop from reading its whole source into a dead
+  call.
+- **Producing on the event loop is detected and degrades to ungated**, with one warning per call.
+  Waiting there is a self-deadlock, not back-pressure: the parked thread is the only one that could
+  make readiness true again. This is reachable only for an engine built with `directExecutor = true`
+  (embedded test runs); `EvitaServer` always uses real pools. The consequence for tests is in
+  *Verification* below.
+- **`fetchFile`'s chunk size is 1 MB, and that is load-bearing, not cosmetic.** Armeria's readiness
+  is `pendingMessages == 0`, so a gated loop keeps exactly one message in flight and every chunk costs
+  an event-loop round trip; at the original 64 KB a large backup would have been over ten thousand
+  sequential round trips and slower than the unbounded loop for clients that keep up. The ceiling is
+  the receiver's maximum inbound message size — 4 MB in gRPC-Java, unlimited in Armeria's client.
+- **`ObservabilityServerCall` now extends `SimpleForwardingServerCall`.** Forwarding by default is the
+  invariant: `isReady`, `setOnReadyThreshold`, `getAttributes`, `getAuthority`, `getSecurityLevel`,
+  `setCompression` and `setMessageCompression` all have non-abstract defaults that silently disagree
+  with the transport.
+- **Repairing readiness broke a hidden dependency on it.**
+  `GlobalExceptionHandlerInterceptor.handleException` guarded its `close(...)` with
+  `if (serverCall.isReady())`. That only ever read as an open/closed test because readiness was
+  hard-wired to `true`; once real, it would have swallowed the error status for any RPC that had
+  already sent data, leaving the client on a stream that is never closed. It now guards on
+  `isCancelled()`.
+- **`restoreCatalog` serialises its file work on one `CompletableFuture` chain per call**, and issues
+  `request(1)` only once each chunk is on disk (`disableAutoRequest()` in the service method).
+  The `request(1)` is dispatched back onto the event loop: Armeria's `StreamingServerCall` keeps its
+  upstream subscription in a plain, non-volatile field, so raising demand from an arbitrary thread
+  relies on a happens-before its own code does not promise. Chunk ordering is the invariant here; its
+  loss is a corrupted ZIP, not an exception.
+- **The driver's streaming channels no longer carry a total-response-length cap.** Armeria defaults
+  `maxResponseLength` to 10 MiB and counts the *whole* HTTP body, which for a server-streaming call is
+  every message added together. `EvitaClient` never overrode it, so `fetchFile` could not download a
+  backup larger than 10 MiB at all — it died part-way through with `RESOURCE_EXHAUSTED`. This is a
+  pre-existing defect independent of the buffering one, found because the new upload test needed a
+  14 MB backup. The cap is lifted on the streaming and CDC channels and **kept on the unary channel**,
+  where a 10 MiB reply genuinely is anomalous. Lifting it globally was rejected: it would remove the
+  only guard against a runaway unary response, and unary replies have no other bound.
+- **The driver uploads a catalog restore through `RestoreCatalogUnary`, not the client-streaming RPC.**
+  A client-streaming upload is a *single* HTTP request, so `maxRequestLength` — which evitaDB wires to
+  `api.maxEntitySizeInBytes`, 2 MB by default (`ExternalApiServer.java:617`) — bounded the **whole
+  backup** rather than a chunk. Any real-sized catalog therefore died part-way through the upload with
+  a bare `RESOURCE_EXHAUSTED`, making `EvitaClient`'s restore unusable. `RestoreCatalogUnary` (on the
+  wire since 2024-09) sends each chunk as its own request, so only the chunk has to fit; the server
+  accumulates them into one temp file keyed by the `fileId` it returns and submits the restoration task
+  when the accumulated size reaches the announced total. Raising `maxEntitySizeInBytes` instead was
+  rejected — it is a deliberate operator guard that applies to REST and GraphQL too, and overriding a
+  security setting to make one RPC work is the wrong trade. Chunk size is 512 KB, which must stay under
+  whatever the operator configures; nothing client-side can discover that value.
+- **The upload stub is built on the *streaming* channel even though the call is unary.** The unary
+  channel carries the retry decorator, and with `retry` enabled that rule set replays on timeouts and
+  on 503/504/UNKNOWN. Replaying an append would add the chunk twice. The server catches the overshoot,
+  so the damage is a spurious failure rather than a corrupt catalog — but appends are not idempotent
+  and have no business on a channel that replays.
+- **An oversized request now says which limit it hit.** `GrpcProviderRegistrar` maps Armeria's
+  `ContentTooLargeException` to `RESOURCE_EXHAUSTED` *with a description* naming
+  `api.maxEntitySizeInBytes` and pointing at `RestoreCatalogUnary`. The driver no longer needs it, but
+  gRPC-Web and third-party clients still use the streaming RPC and previously got a bare status
+  indistinguishable from any other resource failure.
+- **A stalled stream is abandoned with `DEADLINE_EXCEEDED`, not `UNKNOWN`.**
+  `StalledGrpcStreamException` is mapped explicitly in `GlobalExceptionHandlerInterceptor` and logged
+  at WARN — it is a client/network condition, not a server fault.
+
+## Verification
+
+- `LongRunningGrpcFetchFileBackpressureTest` (long-running module, `useRealThreadPools = true`) —
+  512 MiB file, gRPC-Web framing, a manual-flow-control client that takes 4 chunks and stops.
+  Retained memory (heap **plus** Netty and NIO direct counters, which is the whole point — heap alone
+  moved 6.2 MiB and would have reported the bug as absent):
+  **1035 MiB before the fix, 14.4 MiB after**, of which 12.0 MiB was still present after the client
+  drained the stream, i.e. allocator arena growth rather than queued messages. Genuine in-flight data
+  ~2.4 MiB, about two chunks. The thread-state line flipped from `0` threads inside `fetchFile` (the
+  loop had run to completion) to `1` (parked in the gate). The client then resumes and the whole file
+  arrives with a matching CRC32.
+- `LongRunningGrpcFetchFileDeadlineTest` (long-running module, `useRealThreadPools = true`) — 64 MiB
+  to a client that drip-feeds `request(1)` every 100 ms, with a 2000 ms server deadline injected as a
+  `grpc-timeout` header by a `ClientInterceptor` so it binds on the server and nowhere else.
+  **Completes in 6819 ms with the re-arm, dies at 2144 ms after 19 chunks without it.** The test asserts
+  the scenario as well as the outcome — a machine fast enough to finish inside the deadline fails the
+  precondition rather than passing vacuously.
+- `GrpcTimeoutUtilTest` (functional module) — three cases pinning how a streaming deadline is rolled
+  forward. The load-bearing one runs both strategies **side by side on two real
+  `ServiceRequestContext`s**: three re-arms 120 ms apart from a captured budget leave the horizon at
+  1364 ms (last message + the configured 1000 ms), while re-reading `requestTimeoutMillis()` each time
+  leaves it at ~1720 ms and climbing. The counterfactual is therefore inside the test rather than
+  reachable only by reverting the fix. It is deliberately a **characterisation test of Armeria**: the
+  compounding is not part of its documented contract, so an upgrade that changes it fails here loudly
+  instead of silently restoring the ratchet. The `Thread.sleep` between re-arms is a detection widener —
+  a loaded machine makes the two strategies diverge further, never less.
+- `GrpcOutboundGateTest` (functional module) — six deterministic cases against a fake observer:
+  pass-through when ready, wake on the on-ready callback, refuse a cancelled call **without parking**,
+  release a waiting producer on cancel and on close, and abandon a stream nobody reads.
+- `ObservabilityInterceptorReadinessTest` (functional module) — pins the forwarding of `isReady()`.
+- `EvitaClientReadWriteTest#shouldBackupAndRestoreCatalogViaDownloadingAndUploadingFileContents` —
+  end-to-end backup → `fetchFile` → streaming `restoreCatalog` → restored catalog queried for a
+  matching entity count. Its dataset already carries `useRealThreadPools = true`, so it exercises the
+  gated download and the ordered upload chain for real, not the collapsed topology. What it does *not*
+  exercise is the multi-message path: its ten-product catalog archives into a single 64 KB message.
+- `LongRunningGrpcRestoreCatalogUploadTest` — three cases. (1) A **5.47 MB** backup (2.6x the 2 MB
+  request-body limit that used to be the ceiling) uploaded across ~10 unary chunks, restored, and every
+  one of its 200 entities' 32 KB payloads compared byte for byte against what was backed up; it asserts
+  its own size against that limit from below, so shrinking the payload can no longer hide the ceiling
+  being gone. (2) A **549 KB** backup of a second, deliberately small catalog pushed through the raw
+  client-streaming RPC in ~17 messages and verified the same way — the only end-to-end coverage of
+  `RestoreCatalogUploadObserver`; it asserts its size against the limit from *above*, the mirror of
+  case (1), because that RPC is one request and would otherwise fail as oversize rather than as a
+  regression. Calibrated: deleting the per-write `request(1)` stalls the upload and fails its 30 s latch
+  deterministically. (3) A client that still uses the client-streaming RPC pushing past the limit,
+  asserting the rejection carries a description naming `maxEntitySizeInBytes` and `RestoreCatalogUnary`
+  rather than a bare status. Writing case (1) is what surfaced the driver's 10 MiB response cap.
+- `LongRunningEvitaClientLargeFileDownloadTest` — 24 MiB fetched through `EvitaClient` with its
+  **default** channel configuration, CRC32 verified. This is the only test that covers the
+  response-cap fix: the functional round trip downloads ~1 MB, and
+  `LongRunningGrpcFetchFileBackpressureTest` moves 512 MiB through its own stub built with
+  `maxResponseLength(0)`, so neither exercises the driver default. It asserts its own file size against
+  the 10 MiB cap so it cannot be shrunk below the thing it guards.
+- Regression: 648 tests across `driver | (grpc & external_api)`, green.
+
+**The default test engine cannot exercise the gate.** `EvitaParameterResolver` builds the engine with
+`directExecutor = !useRealThreadPools`, so `executeWithClientContext` runs inline on the event loop and
+every functional test takes the ungated branch. A test that means to cover back-pressure must say
+`@DataSet(..., useRealThreadPools = true)` and say why; without it the test measures the unbounded
+path no matter what the server does, and can never fail.
+
+## Consequences & open follow-ups
+
+- A slow download now holds a request-executor thread for the duration of the transfer (bounded by
+  `GrpcOutboundGate.DEFAULT_STALL_TIMEOUT_MILLIS`, 5 minutes of *zero* progress). The pool is
+  `availableProcessors() * 4` by default. If concurrent slow downloads ever exhaust it, that is the
+  trigger for Option B.
+- **CDC demand gating was deliberately not done.** Both shared publishers are pull-based, so
+  withholding demand is lossless for engine mutations — it only moves a subscriber from the ring
+  buffer to the WAL. But `DefaultChangeCaptureSubscription.deliverImmediate` **silently drops** host
+  events when `requested == 0`, so gating would widen a microsecond drop window to however long the
+  client lags. It is blocked on a second defect anyway: a subscriber whose WAL pointer has been purged
+  (`walFileCountKept`, default 8) gets `findWalIndexFor == -1`, a nonexistent file, a null supplier and
+  an empty stream — no error, no advance, re-requesting the same pointer forever. Filed as **#1446**
+  (milestone 2026.3); it has to land before CDC gating does.
+- **The ungated producer plausibly starved *sibling* RPCs on the same connection, not just memory.**
+  Reported from production: while a backup download was in flight, unrelated gRPC calls issued by other
+  browser threads failed. Memory exhaustion does not explain that on its own. Three mechanisms do, and
+  gating addresses all three — but the ordering below matters, because the first draft of this bullet
+  led with the least likely one.
+
+  1. **Bandwidth saturation of the shared connection (leading explanation).** The ungated loop pushed
+     the whole file into Armeria's unbounded queue at disk speed, so the link ran at capacity for the
+     duration. A sibling call's handful of bytes queues behind that backlog, and only has
+     `api.requestTimeoutInMillis` — 2 s shipped — before it is killed. No flow-control subtlety
+     required; a saturated tunnel is sufficient.
+  2. **Event-loop saturation.** Marshalling happens in `doSendMessage` on the event loop, and Armeria
+     pins a connection to one. A 690 MB file at the old 64 KB chunk size meant ~10,500 marshal tasks
+     queued onto the one thread that also serves every other call on that connection.
+  3. **HTTP/2 connection-window exhaustion (least likely — see the correction below).**
+
+  Gating addresses all three structurally rather than incidentally: readiness in Armeria is
+  `pendingMessages == 0`, so a gated producer never writes more than one message ahead of what the
+  transport has actually consumed. The backlog, the marshal-task flood and the window pressure all
+  disappear together.
+
+  **Correction to an earlier revision of this record, which had the flow-control argument wrong in two
+  ways.** It cited Armeria's `http2InitialConnectionWindowSize` / `http2InitialStreamWindowSize`
+  defaults (1 MiB) as the operative numbers: those are what the evitaDB server advertises for *inbound*
+  (client→server) data and play no part in bounding server→client writes. It is indeed the **client's**
+  advertised windows that bound what the server may write — for Chrome, roughly 6 MiB per stream against
+  a session window raised to ~15 MiB. And the starvation step needs a condition the earlier text
+  asserted without stating: one stream can only exhaust the *connection* window if the client returns
+  connection-level credit as the application consumes. Browsers deliberately do the opposite — session
+  credit is returned as data lands in per-stream buffers, and only stream-level credit tracks the
+  consumer, precisely to stop one stream starving the others. Under that policy a stalled download pins
+  at most its own stream window and siblings keep flowing, so "no other stream can send a byte" is
+  unlikely for a browser client. It remains plausible for a non-browser peer with a naive
+  window-management policy.
+
+  **Not confirmed**, and worth confirming before it is treated as closed: the failed siblings' statuses
+  would distinguish the mechanisms — `DEADLINE_EXCEEDED`/cancellation points at saturation or window
+  starvation plus the request timeout, a bare `UNKNOWN` with no description at direct-memory exhaustion
+  (the signature recorded above), and if evitaLab was on HTTP/1.1 gRPC-Web the cause would instead be the
+  browser's ~6-connection-per-origin pool, which gating does not address.
+- **Which streaming paths got the new budget, and the two that deliberately did not.**
+  `api.endpoints.gRPC.streamingRequestTimeoutInMillis` is resolved once per call through
+  `GrpcTimeoutUtil.resolveStreamingBudgetMillis`, which returns `0` when the call carries no deadline so
+  that "the caller asked for none" survives the substitution. Five sites use it: `GrpcOutboundGate` (all
+  three gated server-streaming loops), the client-streaming `RestoreCatalogUploadObserver`,
+  `goLiveAndCloseWithProgress`, and `streamBackupProgress`. The last of those was already safe by
+  accident — its 1 s poll re-arms whether or not anything was sent — but safety resting on a poll
+  interval is not a property anyone should have to preserve.
+
+  Two sites were left on the whole-request budget, and neither is an oversight:
+
+  - **`RestoreCatalogUnary` — cannot be widened from the handler.** Armeria's `UnaryServerCall`
+    aggregates the request body and deframes only in the aggregation callback, so the handler runs
+    strictly *after* full body receipt: by the time our code could re-arm anything, the window it would
+    need to widen is already spent. The consequence is a real floor on uploads — the driver's 512 KB
+    chunk against the shipped 2 s budget needs roughly **2.1 Mbit/s** upstream — and the escape hatch, if
+    slow-uplink restores ever matter, is an HTTP-level decorator on that route extending the context
+    timeout at request start, before aggregation. Not built, because no report has yet demanded it.
+  - **CDC (`AbstractChangeCaptureSubscriber`) — the budget is load-bearing elsewhere.** It feeds
+    `resolveHeartBeatDelay`, which is `clamp(min(requestTimeout, idleTimeout) − 5 s, 1 s, 5 min)`.
+    Substituting 300 s does **not** break it — the 60 s idle timeout caps the result at 55 s, which still
+    keeps both the deadline and the idle timeout alive — but it coarsens liveness detection from the
+    clamped 1 s floor to 55 s, a ~55x change made for a subsystem that never exhibited the symptom. CDC
+    demand gating is blocked on **#1446** regardless; whoever does that work should revisit this
+    together with the heartbeat, rather than change one clock in isolation now.
+
+    (An earlier revision of this reasoning claimed ~150x and implied the substitution would break the
+    heartbeat outright. Both were wrong — the arithmetic above is what the code actually computes.)
+- **Gating trades unbounded memory for a parked request-executor thread.** The gate parks the producing
+  worker rather than driving the loop from the on-ready callback, so a download now holds one pool
+  thread for its whole duration instead of returning immediately. `K` concurrent slow downloads hold `K`
+  threads, bounded only by `api.endpoints.gRPC.streamingRequestTimeoutInMillis`. This is a deliberate trade — the
+  callback-driven pump gRPC-Java intends would avoid it but turns each producing loop into a state
+  machine, losing its try-with-resources, tracing scope and error handling — but it is a capacity
+  consideration that did not exist before, and a deployment serving many concurrent large downloads
+  should size the request executor with it in mind.
+
+  Note what the streaming budget does **not** lengthen: a gRPC deadline is enforced by the *client*
+  (Armeria's client maps `withDeadlineAfter` onto its own response timeout, and grpc-java runs a deadline
+  timer), so a client that asked for 500 ms still sees its call end at 500 ms and the resulting cancel
+  releases the parked worker promptly. What the server-side substitution changes is only how long a
+  **live but silent** peer can pin a worker. That is why re-arming to the streaming budget rather than
+  the client's own `grpc-timeout` is safe rather than an override of the caller's intent.
+- **Gating put `fetchFile` under the request deadline, which exposed that the per-message re-arm was
+  wrong everywhere.** Before the gate the loop drained into Armeria's outbound queue at disk speed and
+  returned, so the request timeout never bound it. Now the handler lives as long as the client takes to
+  consume — and `fetchFile` was the only streaming producer in the module not re-arming the deadline at
+  all. Adding the re-arm there is what surfaced the deeper defect: **the other five sites were re-arming
+  from a budget that compounds.**
+
+  `serviceContext.requestTimeoutMillis()` reads like "the configured timeout" and is neither that nor
+  the time remaining. Armeria stores the timeout **relative to the request's start**, and
+  `SET_FROM_NOW` writes `elapsed + newTimeout` into that same field
+  (`DefaultCancellationScheduler#setTimeoutNanosFromNow0`, 1.40.0), which the getter returns verbatim.
+  Feeding it back into the next re-arm therefore *ratchets*: a 2 s budget re-armed every 100 ms becomes
+  2.1 s, then 2.3 s, then 2.6 s, growing without bound. The rolling stall window the whole design rests
+  on had quietly become an ever-receding horizon that a genuinely stalled client never reaches — the
+  opposite failure from the one being chased, and invisible because it only ever makes calls *survive*.
+
+  Fixed by capturing the budget once, before the first message, via the new
+  `GrpcTimeoutUtil.captureRequestTimeoutMillis`. All eight sites now do this;
+  `AbstractChangeCaptureSubscriber` already did, which is why CDC never showed the symptom.
+
+  **The re-arm is now the gate's job, not the call site's.** `GrpcOutboundGate` captures the budget at
+  `attach()` — by construction "before the loop" — and re-arms on every `awaitWritable()` that grants a
+  send, on all three of its return paths (a fast-path-only re-arm would leave a *fast* client's transfer
+  un-armed, which is the original bug with extra steps). The hand-written re-arms in the three gated
+  loops are gone; the ungated producers keep theirs, corrected. This is the structural half: a new gated
+  streaming method cannot forget, because the grant and the re-arm are the same act.
+
+  One asymmetry this introduced, and why `grantCompletionWindow()` exists: a grant happens *before* each
+  message, whereas the deleted hand-written re-arms happened *after*. So moving the re-arm into the gate
+  silently orphaned the **last** message of every stream — the deadline would stay frozen at the final
+  grant while the half-close and the residual queue were still in flight, and the residual is exactly
+  what a slow client is slowest at. The three gated loops now call `grantCompletionWindow()` immediately
+  before `onCompleted()`. Anyone adding a gated producer must do the same; the loop-shaped alternative
+  (grant *after* the write) was rejected because it would leave the first message un-armed instead.
+
+  **Re-measured against the corrected code**, with `LongRunningGrpcFetchFileDeadlineTest`: 64 MiB in
+  64 chunks to a client that drip-feeds `request(1)` every 100 ms, server armed to 2000 ms by an
+  injected `grpc-timeout`.
+
+  | | outcome |
+  |---|---|
+  | with the re-arm | **completes in 6819 ms**, all 64 chunks, CRC matches |
+  | re-arm removed | **dies at 2144 ms**, 19 chunks, `RST_STREAM: INTERNAL_ERROR` |
+
+  So the deadline now bounds silence rather than the transfer: 3.4× the budget elapses without the call
+  being touched. The earlier "8696 ms with the re-arm" figure was measured against the *ratcheting*
+  version and is not comparable — since the ratchet only ever extends the deadline, whatever ended that
+  run was not the request timeout. It is not worth chasing: the scenario is now covered by a test that
+  passes for the right reason and fails at the budget when the guard is removed.
+
+  The earlier note in this record that a client sending no `grpc-timeout` leaves the server timeout
+  *disabled* was **wrong**, and the correction matters. Armeria's `FramedGrpcService` overrides the
+  context timeout only when the header is present; absent it the server's own
+  `api.requestTimeoutInMillis` stays in force — 1 s in code, 2 s in the shipped configuration. A client
+  that sets no deadline therefore gets the *shortest* budget of anyone, which makes the re-arm load-
+  bearing for exactly the clients least able to compensate. What the earlier test actually hit was
+  `responseTimeoutMillis(0)` suppressing the header Armeria would otherwise have derived from the
+  deadline, leaving the harness's 10-minute server budget in force.
+- **The driver's management facade had no notion of timeout tiers, and now does.**
+  `EvitaClientManagement` took `ClientTimeoutOptions.timeout` — the **unary, whole-call** budget, 5 s by
+  default — for every call it made, including `fetchFile`. So a default-configured `EvitaClient` could
+  not fetch a file that took longer than 5 s whatever the server did, and every test missed it because
+  the harness and each test build clients with `.timeout(10, MINUTES)`. `EvitaClientSession` had the
+  two-tier regime all along; the facade was simply never given it.
+
+  Rather than fix the call site, the tier is now carried by `EvitaClientChannel.TimeoutTier` and paired
+  with each stub at construction, where the channel is in scope — the same seam that already makes
+  "streaming stub off the retrying channel" not compile (#1388). A management method cannot pick a tier,
+  and therefore cannot pick the wrong one. `EvitaClient.resolveTimeout` keeps an explicit
+  `executeWithExtendedTimeout` override winning over both tiers, since that API's whole purpose is to
+  name a duration for the work inside it.
+
+  `fetchFile` needed all three of its caps addressed, not one: the gRPC deadline (now `PER_MESSAGE`), a
+  missing per-message `setResponseTimeout` re-arm in `onNext`, and `downloadFuture.get(timeout)` — an
+  independent whole-download budget on the calling thread, now a stall-based wait recomputed from the
+  last message. A plain unbounded `get()` was rejected: it would hang forever on a stream that never
+  produces a terminal event, and a spurious timeout is recoverable where a parked application thread is
+  not.
+- **`GrpcFetchFileRequest` still cannot resume.** It carries only `fileId`, so any retry restarts at
+  byte 0. An additive `optional int64 offset = 2` is wire-compatible both ways, but *silently* so — an
+  old server ignores it and streams from byte 0 with no error — so it needs an echo field on the
+  response for the client to confirm the offset was honoured.
+- **The client-streaming `RestoreCatalog` is covered again, but not for the invariant we assumed.**
+  Rerouting the driver to `RestoreCatalogUnary` had left nothing driving the ordered chain end to end.
+  `LongRunningGrpcRestoreCatalogUploadTest#shouldRestoreCatalogUploadedThroughClientStreamingRpc` closes
+  that: a 549 KB backup — deliberately *under* `SERVER_REQUEST_LIMIT`, since a client-streaming upload
+  is one request — pushed through the raw `EvitaManagementServiceStub` in ~17 messages, restored, and
+  every payload compared byte for byte. The await that made this awkward turned out to be a non-problem:
+  `EvitaClientManagement.createTask(TaskStatus)` is public, so the test converts the response's
+  `GrpcTaskStatus` and gets a real `ClientTaskTracker`-backed future — no sleep-polling.
+
+  **What calibrating it actually found is worth more than the test.** The intended counterfactual —
+  unchaining `submitRestoration` from `onCompleted` — *does not fail*. Demand for chunk N+1 is issued
+  from inside the **completed** write step for chunk N, so the demand protocol both orders the writes
+  and withholds half-close until the last one has landed. The chain and `disableAutoRequest()` +
+  `request(1)` are **redundant**, and removing either alone is unobservable. Removing *both*, with a
+  2 ms widener in the write step, also stayed green at nine chunks — a failure to detect, not evidence
+  of safety.
+
+  Two things follow. First, the ordering invariant is **still unverified**; what the new test
+  demonstrably guards is the hand-issued demand protocol, whose removal stalls the upload dead and fails
+  the 30 s latch deterministically. Second, the `@Blocking` rejection above is weaker than it reads:
+  with one-message-at-a-time demand, `AbstractServerCall`'s dispatch assumption is no longer the thing
+  ordering rests on. The rejection stands on the remaining ground — an explicit chain over an
+  undocumented scheduling property — but it is no longer the sole guarantee, and the class JavaDoc on
+  `RestoreCatalogUploadObserver` now says so.
+
+  The deprecation option is still open and still deliberate: gRPC-Web uses the unary RPC (the proto says
+  so) and the driver now does too, so the client-streaming variant has **no known first-party client**.
+  Keeping it costs one long-running test; that seems the right trade while third-party clients may exist.
+- The long-running restore counterpart exercises tens of chunks, not thousands. The scale is not
+  covered.
+
+## Related work
+
+- `2026-08-05-streaming-calls-must-not-be-retry-decorated` — same streaming call sites; that record
+  explains why the driver must not retry them, this one why the server must pace them.
+
+## Timeline
+
+- **2026-08-24** — diagnosis confirmed by measurement, issue #1441 filed
+- **2026-08-24** — implemented and verified

--- a/documentation/adr/2026-08-24-grpc-streaming-backpressure-readiness-gate.md
+++ b/documentation/adr/2026-08-24-grpc-streaming-backpressure-readiness-gate.md
@@ -1,11 +1,11 @@
 ---
 title: Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers
 date: 2026-08-24
-updated: 2026-08-24 19:40
+updated: 2026-08-25 05:00
 status: accepted
 kind: fix
 issues: [1441]
-prs: []
+prs: [1450, 1451]
 areas:
   - evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils
   - evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services
@@ -261,6 +261,44 @@ path no matter what the server does, and can never fail.
 
 ## Consequences & open follow-ups
 
+- **A restore upload's temporary archive is owned by whoever created it, and the owner must survive a
+  hand-off the request pool refuses.** Both restore paths assemble the upload into a temporary file that
+  nothing else will ever collect: `FileManagementService.createTempFile` deliberately does *not* reserve
+  the file (that is `createManagedTempFile`), no sweeper walks the work directory, and the restore step
+  that deletes it — `deleteAfterRestore` — only runs for an upload that completed. An upload that stops
+  half way therefore leaves an archive the size of a catalog behind for the lifetime of the process.
+
+  The two paths hang that cleanup on different things, and neither is obvious from the call site:
+  - **Client-streaming** (`RestoreCatalogUploadObserver`) owns the file directly and discards it in
+    `failUpload`. Because the request pool is bounded and *throws* once its queue fills
+    (`EvitaRejectingExecutorHandler`), every hand-off to it has to be made by hand rather than through
+    `thenRunAsync`: a rejection raised while a previous step is in flight surfaces on that worker inside
+    `CompletableFuture#postComplete`, unrelated to the call, and the stage simply never completes.
+    Worse, a rejection raised once the chain is idle throws *before* `uploadChain` is reassigned, leaving
+    the chain looking healthy — so the next chunk reopens the archive that was just deleted. Poisoning
+    the successor stage in both cases is what closes that second hole.
+  - **Chunked unary** (`restoreCatalogUnary`) has no half-close to notice, so the *restoration task's
+    future* carries the cleanup. It completes on every terminal outcome, including the scheduler's
+    ten-minute purge of tasks still waiting for a precondition, which is what catches a client that
+    crashed or lost the network. The driver additionally cancels the task on its way out
+    (`EvitaClientManagement#abandonRestoreUpload`), which only makes the reclaim prompt — it is best
+    effort by construction, since the failure that triggers it may have taken the channel with it.
+
+  Anything that later adds a third upload path inherits this obligation. One invariant is worth stating
+  because nothing enforces it locally: the unary hook is registered on the *first* chunk, while the
+  over-size branch that relies on it can fire on any chunk. It works because `getWaitingTask` hands back
+  the same task instance across requests — a cross-request dependency that a future change to task
+  lookup could quietly break.
+
+  Both halves are verified, and both tests were calibrated against the pre-fix code rather than merely
+  observed to pass:
+  - `RestoreCatalogUploadObserverTest` — three rejection cases, each of which hangs for the full 30 s
+    latch without the fix instead of terminating the call, plus a control case that a progressing upload
+    keeps its archive.
+  - `EvitaClientReadWriteTest#shouldDiscardTheArchiveOfAnAbandonedChunkedRestoreUpload` — drives a real
+    chunked upload whose source dies after the first chunk and asserts the work directory is unchanged.
+    With the task-future hook removed it fails with the archive still present
+    (`[.lock, 69cb300e-….zip]`), which is precisely the leak being fixed.
 - A slow download now holds a request-executor thread for the duration of the transfer (bounded by
   `GrpcOutboundGate.DEFAULT_STALL_TIMEOUT_MILLIS`, 5 minutes of *zero* progress). The pool is
   `availableProcessors() * 4` by default. If concurrent slow downloads ever exhaust it, that is the

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-24 | [Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers](2026-08-24-grpc-streaming-backpressure-readiness-gate.md) | fix | accepted | #1441 |
+| 2026-08-24 | [Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers](2026-08-24-grpc-streaming-backpressure-readiness-gate.md) | fix | accepted | #1441, PR #1450, PR #1451 |
 | 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-24 | [Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers](2026-08-24-grpc-streaming-backpressure-readiness-gate.md) | fix | accepted | #1441 |
 | 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |

--- a/documentation/user/en/operate/configure.md
+++ b/documentation/user/en/operate/configure.md
@@ -160,6 +160,7 @@ api:                                              # [see API configuration](#api
       tlsMode: null
       keepAlive: null
       exposeDocsService: false
+      streamingRequestTimeoutInMillis: 300K
       mTLS:
         enabled: null
         allowedClientCertificatePaths: null
@@ -1104,7 +1105,10 @@ This section of the configuration allows you to selectively enable, disable, and
     <dt>requestTimeoutInMillis</dt>
     <dd>
         <p>**Default:** `2K`</p>
-        <p>The amount of time a connection can sit idle without processing a request, before it is closed by the server.</p>
+        <p>The budget for handling a **whole request**, measured from its start until the response has been fully sent.
+            This is the right shape for a unary call, where the work is one bounded round trip. It is the wrong shape
+            for a long-lived streaming response, which is why the gRPC API has a separate
+            [streamingRequestTimeoutInMillis](#grpc-api-configuration).</p>
     </dd> 
     <dt>maxEntitySizeInBytes</dt>
     <dd>
@@ -1386,6 +1390,22 @@ This allows you to set common settings for all endpoints in one place.
         <p>**Default:** `false`</p>
         <p>It enables / disables the gRPC service, which provides documentation for the gRPC API and allows to
         experimentally call any of the services from the web UI and examine its output.</p>
+    </dd>
+    <dt>streamingRequestTimeoutInMillis</dt>
+    <dd>
+        <p>**Default:** `300K`</p>
+        <p>How long a **streaming** RPC may make no progress before the server abandons it. Unlike the shared
+            [requestTimeoutInMillis](#api-configuration) this bounds *silence* rather than total duration: it is
+            re-armed every time a message is handed to the transport, so a slow but steadily progressing transfer never
+            reaches it however long it runs.</p>
+        <p>A whole-request budget cannot serve a stream, because a download's duration is a function of the file's size
+            and the link's speed - neither of which the server knows. Size this against the slowest client you intend to
+            serve: it must comfortably exceed the time a **single message** takes to reach that client. Lowering it
+            towards `requestTimeoutInMillis` reintroduces a minimum viable link speed for large downloads - the file
+            download RPC streams 1 MB chunks, so a 2 s budget would demand roughly 4 Mbit/s sustained.</p>
+        <p>The same value bounds how long a server worker stays parked waiting for a client that has stopped reading, so
+            it is also the point at which such a stream is abandoned with `DEADLINE_EXCEEDED`. A non-positive value
+            falls back to the default.</p>
     </dd>
     <dt>mTls.enabled</dt>
     <dd>

--- a/evita_common/src/main/java/io/evitadb/utils/ExceptionUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/ExceptionUtils.java
@@ -25,6 +25,7 @@ package io.evitadb.utils;
 
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
@@ -79,15 +80,39 @@ public class ExceptionUtils {
 		@Nonnull Throwable throwable,
 		@Nonnull Class<? extends Throwable> exceptionType
 	) {
+		return findInCauseChain(throwable, exceptionType) != null;
+	}
+
+	/**
+	 * Returns the first throwable in the causal chain that matches the specified exception type - the
+	 * instance itself rather than a mere yes/no, so the caller can read state off it (a configured
+	 * limit, a status code, a file name) when building a diagnostic.
+	 *
+	 * Prefer this over an ad-hoc `while (current != null) current = current.getCause()` loop at the
+	 * call site: the traversal handles circular references, which a naive loop turns into an infinite
+	 * one. Guarding only against a self-referencing cause (`current.getCause() == current`) is *not*
+	 * enough - a two-element cycle `A -> B -> A` passes that check and spins forever.
+	 *
+	 * @param throwable the throwable to evaluate, must not be null
+	 * @param exceptionType the class of the exception type to look for, must not be null
+	 * @return the first matching throwable in the causal chain, or null when the chain holds none
+	 * @param <T> the exception type being looked for
+	 */
+	@Nullable
+	public static <T extends Throwable> T findInCauseChain(
+		@Nonnull Throwable throwable,
+		@Nonnull Class<T> exceptionType
+	) {
 		final Set<Throwable> visited = new HashSet<>();
 		Throwable current = throwable;
+		// `visited.add` returning false means the chain has looped back on itself - stop rather than spin
 		while (current != null && visited.add(current)) {
 			if (exceptionType.isInstance(current)) {
-				return true;
+				return exceptionType.cast(current);
 			}
 			current = current.getCause();
 		}
-		return false;
+		return null;
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
@@ -78,6 +78,7 @@ import io.evitadb.api.requestResponse.system.SystemStatus;
 import io.evitadb.driver.cdc.ClientChangeCapturePublisher;
 import io.evitadb.driver.cdc.ClientChangeSystemCaptureProcessor;
 import io.evitadb.driver.config.ClientConnectionOptions;
+import io.evitadb.driver.EvitaClientChannel.TimeoutTier;
 import io.evitadb.driver.config.ClientTimeoutOptions;
 import io.evitadb.driver.config.ClientTlsOptions;
 import io.evitadb.driver.config.EvitaClientConfiguration;
@@ -192,6 +193,12 @@ public class EvitaClient implements EvitaContract {
 	private static final long CDC_CALLBACK_DRAIN_TIMEOUT_MS = 5_000L;
 	/**
 	 * Client call timeout.
+	 *
+	 * The bottom of the stack is the configured {@link ClientTimeoutOptions#timeout()} - the *whole-call*
+	 * tier. Anything above it was pushed by {@link #executeWithExtendedTimeout} and is an explicit
+	 * caller override. Prefer {@link #resolveTimeout(TimeoutTier)} over reading this directly: peeking
+	 * at it hands every call the whole-call budget, which is wrong for a stream and is precisely the bug
+	 * {@link TimeoutTier} was introduced to end.
 	 */
 	final ThreadLocal<LinkedList<Timeout>> timeout;
 	/**
@@ -489,6 +496,9 @@ public class EvitaClient implements EvitaContract {
 	 *                          those paths this value is overwritten anyway. Measured: disabling it changes
 	 *                          nothing (see the ADR's *Verification*). It is kept so that a future call site
 	 *                          which forgets the deadline still gets a sane window rather than 15 s.
+	 * @param streaming         `true` for a channel carrying server-streaming calls, which lifts Armeria's
+	 *                          10 MiB total-response-length cap - see the call site for why that cap is
+	 *                          meaningless on a stream and fatal for large file downloads
 	 * @param connectionOptions connection options providing the client id reported to the server
 	 * @param clientVersion     semantic version of this client, or NULL when it could not be parsed
 	 * @param grpcConfigurator  optional caller-supplied customization applied last, so it can override defaults
@@ -500,6 +510,7 @@ public class EvitaClient implements EvitaContract {
 		@Nonnull ClientFactory clientFactory,
 		@Nullable RetryRule retryRule,
 		@Nullable Duration responseTimeout,
+		boolean streaming,
 		@Nonnull ClientConnectionOptions connectionOptions,
 		@Nullable SemVer clientVersion,
 		@Nullable Consumer<GrpcClientBuilder> grpcConfigurator
@@ -522,6 +533,16 @@ public class EvitaClient implements EvitaContract {
 		}
 		if (responseTimeout != null) {
 			grpcClientBuilder.responseTimeout(responseTimeout);
+		}
+		if (streaming) {
+			// Armeria caps a response at 10 MiB by default, and the cap counts the *entire* HTTP body -
+			// which for a server-streaming call is every message added together, not the largest one.
+			// That is a sane guard on a unary reply and a hard ceiling on a stream: `fetchFile` could not
+			// download a backup larger than 10 MiB at all, dying part-way through with
+			// RESOURCE_EXHAUSTED. A stream's total length is not a meaningful safety bound - what needs
+			// bounding is how much is in flight at once, which is the server's job (see
+			// `GrpcOutboundGate`) - so the cap is lifted here and left in place for unary calls.
+			grpcClientBuilder.maxResponseLength(0);
 		}
 
 		ofNullable(grpcConfigurator).ifPresent(it -> it.accept(grpcClientBuilder));
@@ -797,20 +818,20 @@ public class EvitaClient implements EvitaContract {
 		// response-timeout deadline at call start and caps every stream at 15 s (issue #1388).
 		this.unaryChannel = new EvitaClientChannel.Unary(
 			createGrpcClientBuilder(
-				uri, this.clientFactory, createRetryRule(configuration.retry()), null, connectionOptions,
-				clientVersion, grpcConfigurator
+				uri, this.clientFactory, createRetryRule(configuration.retry()), null, false,
+				connectionOptions, clientVersion, grpcConfigurator
 			)
 		);
 		this.streamingChannel = new EvitaClientChannel.Streaming(
 			createGrpcClientBuilder(
-				uri, this.clientFactory, null, this.streamingTimeout, connectionOptions, clientVersion,
-				grpcConfigurator
+				uri, this.clientFactory, null, this.streamingTimeout, true,
+				connectionOptions, clientVersion, grpcConfigurator
 			)
 		);
 		this.cdcChannel = new EvitaClientChannel.Cdc(
 			createGrpcClientBuilder(
-				uri, this.cdcClientFactory, null, this.streamingTimeout, connectionOptions, clientVersion,
-				grpcConfigurator
+				uri, this.cdcClientFactory, null, this.streamingTimeout, true,
+				connectionOptions, clientVersion, grpcConfigurator
 			)
 		);
 		this.evitaServiceFutureStub = this.unaryChannel.stub(EvitaServiceFutureStub.class);
@@ -1615,6 +1636,27 @@ public class EvitaClient implements EvitaContract {
 		} finally {
 			callTimeouts.pop();
 		}
+	}
+
+	/**
+	 * Resolves the deadline a call of the passed tier runs under.
+	 *
+	 * An explicit {@link #executeWithExtendedTimeout} override wins over both tiers: the caller named a
+	 * duration for the work inside that lambda, and silently substituting a configured default for it -
+	 * in either direction - would defeat the point of the API. Absent an override, the tier decides, so
+	 * that a streaming call is budgeted per message rather than per call.
+	 *
+	 * @param tier which of the configured budgets applies, normally taken from the channel the call's
+	 *             stub was built from
+	 * @return the timeout to deadline the call with
+	 */
+	@Nonnull
+	Timeout resolveTimeout(@Nonnull TimeoutTier tier) {
+		final LinkedList<Timeout> callTimeouts = this.timeout.get();
+		// the stack is seeded with exactly one element, so anything beyond that is a caller override
+		return callTimeouts.size() > 1 ?
+			Objects.requireNonNull(callTimeouts.peek()) :
+			tier.resolve(this.configuration.timeouts());
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientChannel.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientChannel.java
@@ -24,6 +24,7 @@
 package io.evitadb.driver;
 
 import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
+import io.evitadb.driver.config.ClientTimeoutOptions;
 
 import javax.annotation.Nonnull;
 
@@ -64,6 +65,14 @@ public sealed interface EvitaClientChannel {
 	GrpcClientBuilder builder();
 
 	/**
+	 * Which of the two configured budgets a call on this channel is deadlined from.
+	 *
+	 * @return the tier every stub built from this channel must be budgeted with
+	 */
+	@Nonnull
+	TimeoutTier timeoutTier();
+
+	/**
 	 * Builds a stub bound to this channel.
 	 *
 	 * @param stubType the generated gRPC stub class to instantiate
@@ -82,6 +91,12 @@ public sealed interface EvitaClientChannel {
 	 * @param builder the retry-decorated builder bound to the main client factory
 	 */
 	record Unary(@Nonnull GrpcClientBuilder builder) implements EvitaClientChannel {
+
+		@Nonnull
+		@Override
+		public TimeoutTier timeoutTier() {
+			return TimeoutTier.WHOLE_CALL;
+		}
 	}
 
 	/**
@@ -91,6 +106,12 @@ public sealed interface EvitaClientChannel {
 	 * @param builder the undecorated builder bound to the main client factory
 	 */
 	record Streaming(@Nonnull GrpcClientBuilder builder) implements EvitaClientChannel {
+
+		@Nonnull
+		@Override
+		public TimeoutTier timeoutTier() {
+			return TimeoutTier.PER_MESSAGE;
+		}
 	}
 
 	/**
@@ -101,6 +122,52 @@ public sealed interface EvitaClientChannel {
 	 * @param builder the undecorated builder bound to the dedicated CDC client factory
 	 */
 	record Cdc(@Nonnull GrpcClientBuilder builder) implements EvitaClientChannel {
+
+		@Nonnull
+		@Override
+		public TimeoutTier timeoutTier() {
+			return TimeoutTier.PER_MESSAGE;
+		}
+	}
+
+	/**
+	 * Which of {@link ClientTimeoutOptions}' two budgets deadlines a call, and - just as importantly -
+	 * *what the number means*. The two are not interchangeable, and pairing a call with the wrong one is
+	 * the mistake this enum exists to make un-makeable: the tier travels with the channel, so a stub
+	 * cannot be budgeted from a tier its channel does not carry.
+	 *
+	 * The management facade is what motivated it. It had no notion of tiers at all and took the
+	 * whole-call budget for everything, including `fetchFile` - so a default-configured client could not
+	 * download a backup that took longer than {@link ClientTimeoutOptions#timeout()} (5 s), whatever the
+	 * server did. No test caught it, because every harness client raises that value.
+	 */
+	enum TimeoutTier {
+
+		/**
+		 * {@link ClientTimeoutOptions#timeout()} - a budget for the **entire call**, appropriate where the
+		 * work is one bounded round trip. Nothing re-arms it, and nothing should.
+		 */
+		WHOLE_CALL,
+		/**
+		 * {@link ClientTimeoutOptions#streamingTimeout()} - the wait for the **next message**, not the
+		 * length of the exchange. A call budgeted from this tier must re-arm its response timeout on
+		 * every message received, or the rolling deadline silently degenerates into a whole-call one that
+		 * merely happens to be larger.
+		 */
+		PER_MESSAGE;
+
+		/**
+		 * Resolves this tier against the client's configured timeouts.
+		 *
+		 * @param timeouts the client's timeout configuration
+		 * @return the budget calls of this tier are deadlined from
+		 */
+		@Nonnull
+		public Timeout resolve(@Nonnull ClientTimeoutOptions timeouts) {
+			return this == WHOLE_CALL ?
+				new Timeout(timeouts.timeout(), timeouts.timeoutUnit()) :
+				new Timeout(timeouts.streamingTimeout(), timeouts.streamingTimeoutUnit());
+		}
 	}
 
 }

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientManagement.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientManagement.java
@@ -25,9 +25,12 @@ package io.evitadb.driver;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.google.protobuf.Empty;
 import com.google.protobuf.StringValue;
 import io.evitadb.api.CatalogStatistics;
+import io.evitadb.driver.EvitaClientChannel.TimeoutTier;
 import io.evitadb.api.EvitaManagementContract;
 import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.exception.FileForFetchNotFoundException;
@@ -60,7 +63,6 @@ import java.io.Closeable;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -69,15 +71,14 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter.toGrpcUuid;
@@ -89,6 +90,18 @@ import static io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter.toGrp
  */
 @Slf4j
 public class EvitaClientManagement implements EvitaManagementContract, Closeable {
+	/**
+	 * Size of a single chunk uploaded by {@link #restoreCatalog(String, long, InputStream)}.
+	 *
+	 * Each chunk travels as its own unary request, so the binding constraint is the server's
+	 * `maxRequestLength` - evitaDB wires that to `api.maxEntitySizeInBytes`, whose default is 2 MB.
+	 * 512 KB leaves generous room for the protobuf envelope underneath that default while cutting the
+	 * number of round trips eightfold against the 64 KB the client-streaming upload used. Nothing here
+	 * can discover the server's actual setting, so an operator who lowers `maxEntitySizeInBytes` below
+	 * this value has to raise it back above the chunk size.
+	 */
+	private static final int RESTORE_CHUNK_SIZE = 524_288;
+
 	/**
 	 * Evita client used for communication with the server side.
 	 */
@@ -105,6 +118,29 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 	 * Created evita service stub that returns futures.
 	 */
 	private final EvitaManagementServiceFutureStub evitaManagementServiceFutureStub;
+	/**
+	 * Stub used to upload a catalog backup chunk by chunk.
+	 *
+	 * Deliberately built on the **streaming** channel even though `RestoreCatalogUnary` is a unary call.
+	 * The unary channel carries the retry decorator, and with `retry` enabled that rule set replays on
+	 * timeouts and on 503/504/UNKNOWN. Replaying a chunk would append it to the uploaded archive a second
+	 * time - the server notices the overshoot and fails the restore, so the damage is a spurious failure
+	 * rather than a corrupted catalog, but appending is not idempotent and has no business running on a
+	 * channel that replays.
+	 */
+	private final EvitaManagementServiceFutureStub evitaManagementServiceUploadStub;
+	/**
+	 * Deadline tier of {@link #evitaManagementServiceStub}, taken from the channel it was built on.
+	 */
+	private final TimeoutTier streamingStubTier;
+	/**
+	 * Deadline tier of {@link #evitaManagementServiceFutureStub}, taken from the channel it was built on.
+	 */
+	private final TimeoutTier unaryStubTier;
+	/**
+	 * Deadline tier of {@link #evitaManagementServiceUploadStub}, taken from the channel it was built on.
+	 */
+	private final TimeoutTier uploadStubTier;
 
 	/**
 	 * Creates the management facade.
@@ -132,6 +168,12 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 		);
 		this.evitaManagementServiceStub = streamingChannel.stub(EvitaManagementServiceStub.class);
 		this.evitaManagementServiceFutureStub = unaryChannel.stub(EvitaManagementServiceFutureStub.class);
+		this.evitaManagementServiceUploadStub = streamingChannel.stub(EvitaManagementServiceFutureStub.class);
+		// each stub is budgeted from the tier its own channel carries, paired here - the one place where
+		// both are in scope - so that no method below can pick a tier at all, let alone the wrong one
+		this.streamingStubTier = streamingChannel.timeoutTier();
+		this.unaryStubTier = unaryChannel.timeoutTier();
+		this.uploadStubTier = streamingChannel.timeoutTier();
 	}
 
 	@Nonnull
@@ -183,75 +225,69 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 	) throws UnexpectedIOException {
 		this.evitaClient.assertActive();
 
-		return executeWithEvitaBlockingService(
-			evitaService -> {
-				final CompletableFuture<TaskStatus<?, ?>> result = new CompletableFuture<>();
-				final AtomicLong bytesSent = new AtomicLong(0);
-				final AtomicReference<TaskStatus<?, ?>> taskStatus = new AtomicReference<>();
-				final StreamObserver<GrpcRestoreCatalogRequest> requestObserver = evitaService.restoreCatalog(
-					new StreamObserver<>() {
-						final AtomicLong bytesReceived = new AtomicLong(0);
-
-						@Override
-						public void onNext(GrpcRestoreCatalogResponse value) {
-							this.bytesReceived.accumulateAndGet(value.getRead(), Math::max);
-							if (value.hasTask()) {
-								taskStatus.set(EvitaDataTypesConverter.toTaskStatus(value.getTask()));
-							}
-						}
-
-						@Override
-						public void onError(Throwable t) {
-							log.error("Error occurred during catalog restoration: {}", t.getMessage(), t);
-							result.completeExceptionally(t);
-						}
-
-						@Override
-						public void onCompleted() {
-							if (bytesSent.get() == this.bytesReceived.get()) {
-								result.complete(taskStatus.get());
-							} else {
-								result.completeExceptionally(
-									new UnexpectedIOException(
-										"Number of bytes sent and received during catalog restoration does not match (sent " + bytesSent.get() + ", received " + this.bytesReceived.get() + ")!",
-										"Number of bytes sent and received during catalog restoration does not match!"
-									)
-								);
-							}
-						}
-					}
-				);
-
-				// Send data in chunks
-				final ByteBuffer buffer = ByteBuffer.allocate(65_536);
-				try (inputStream) {
-					while (inputStream.available() > 0) {
-						final int read = inputStream.read(buffer.array());
-						if (read == -1) {
-							requestObserver.onCompleted();
-						}
-						buffer.limit(read);
-						requestObserver.onNext(
-							GrpcRestoreCatalogRequest.newBuilder()
-								.setCatalogName(catalogName)
-								.setBackupFile(ByteString.copyFrom(buffer))
-								.build()
-						);
-						buffer.clear();
-						bytesSent.addAndGet(read);
-					}
-
-					requestObserver.onCompleted();
-				} catch (IOException e) {
-					requestObserver.onError(e);
-					throw new RuntimeException(e);
+		// Uploaded through the chunked unary RPC rather than the client-streaming one, deliberately.
+		// A client-streaming upload is a *single* HTTP request, so the server's `maxRequestLength` -
+		// which evitaDB wires to `api.maxEntitySizeInBytes`, 2 MB by default - caps the whole backup;
+		// anything larger died part-way through with a bare RESOURCE_EXHAUSTED, which made the streaming
+		// variant unusable for a catalog of any real size. With the unary variant every chunk is its own
+		// request, so only the chunk has to fit under that limit. The server accumulates the chunks into
+		// one temporary file keyed by the `fileId` it echoes back in the first response, and submits the
+		// restoration task once the accumulated size reaches `totalBytesExpected`.
+		final byte[] buffer = new byte[RESTORE_CHUNK_SIZE];
+		GrpcTaskStatus restorationTask = null;
+		GrpcUuid uploadFileId = null;
+		long bytesSent = 0L;
+		try (inputStream) {
+			int bytesRead;
+			while ((bytesRead = inputStream.read(buffer)) != -1) {
+				final GrpcRestoreCatalogUnaryRequest.Builder requestBuilder = GrpcRestoreCatalogUnaryRequest
+					.newBuilder()
+					.setCatalogName(catalogName)
+					.setTotalSizeInBytes(totalBytesExpected)
+					.setBackupFile(ByteString.copyFrom(buffer, 0, bytesRead));
+				// every chunk but the first names the upload it belongs to
+				if (uploadFileId != null) {
+					requestBuilder.setFileId(uploadFileId);
 				}
-
-				//noinspection unchecked
-				return (Task<?, Void>) this.clientTaskTracker.createTask(
-					Objects.requireNonNull(result.get())
+				final GrpcRestoreCatalogUnaryRequest request = requestBuilder.build();
+				final GrpcRestoreCatalogUnaryResponse response = executeWithEvitaUploadService(
+					evitaService -> evitaService.restoreCatalogUnary(request)
 				);
+				restorationTask = response.getTask();
+				if (uploadFileId == null) {
+					// the response's own `fileId` is the documented handle for the upload - the id on the
+					// task's file descriptor is not populated on the first chunk
+					uploadFileId = response.getFileId();
+				}
+				bytesSent += bytesRead;
 			}
+		} catch (IOException e) {
+			throw new UnexpectedIOException(
+				"Failed to read the backup file being restored: " + e.getMessage(),
+				"Failed to read the backup file being restored.",
+				e
+			);
+		}
+
+		if (restorationTask == null) {
+			throw new UnexpectedIOException(
+				"The backup file being restored contains no data.",
+				"The backup file being restored contains no data."
+			);
+		}
+		// the server submits the restoration task only once the uploaded size reaches the announced one,
+		// so a mismatch here would otherwise hand back a task that is never going to run
+		if (bytesSent != totalBytesExpected) {
+			throw new UnexpectedIOException(
+				"Number of bytes uploaded during catalog restoration does not match the announced size " +
+					"(announced " + totalBytesExpected + ", uploaded " + bytesSent + ")!",
+				"Number of bytes uploaded during catalog restoration does not match the announced size!"
+			);
+		}
+
+		//noinspection unchecked
+		return (Task<?, Void>) this.clientTaskTracker.createTask(
+			EvitaDataTypesConverter.toTaskStatus(restorationTask)
 		);
 	}
 
@@ -414,6 +450,11 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 			// Create a temporary file
 			Path tempFile = Files.createTempFile("downloadedFile", ".tmp");
 			CompletableFuture<Void> downloadFuture = new CompletableFuture<>();
+			// A download is deadlined per message, not per call - see `TimeoutTier#PER_MESSAGE`. Both
+			// clocks below are driven from this one stamp: the transport's response timeout, re-armed in
+			// `onNext`, and the caller's own wait, which is recomputed from it rather than fixed.
+			final Timeout stallTimeout = this.evitaClient.resolveTimeout(this.streamingStubTier);
+			final AtomicLong lastProgressNanos = new AtomicLong(System.nanoTime());
 
 			// Download the file asynchronously
 			executeWithEvitaBlockingService(
@@ -426,6 +467,19 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 								try {
 									// Write chunks to the temporary file
 									Files.write(tempFile, response.getFileContents().toByteArray(), StandardOpenOption.APPEND);
+									lastProgressNanos.set(System.nanoTime());
+									// Roll the transport deadline forward: without this the response
+									// timeout bounds the *whole* download, so a backup simply larger than
+									// the link is fast enough to move in one window can never arrive, no
+									// matter how healthily it is progressing. Same re-arm the session's
+									// streaming observers do.
+									ClientRequestContext.current().setResponseTimeout(
+										TimeoutMode.SET_FROM_NOW,
+										Duration.of(
+											stallTimeout.timeout(),
+											stallTimeout.timeoutUnit().toChronoUnit()
+										)
+									);
 								} catch (IOException e) {
 									onError(e);
 								}
@@ -446,13 +500,14 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 				}
 			);
 
-			// Wait for the download to complete with timeout
-			final Timeout timeout = Objects.requireNonNull(this.evitaClient.timeout.get().peek());
+			// Wait for the download to stop making progress, rather than for it to fit in a fixed budget.
+			// A plain `get(stallTimeout)` here would reintroduce the whole-call cap the tier and the
+			// per-message re-arm above just removed - it would simply cap the download at a larger number.
 			try {
-				downloadFuture.get(timeout.timeout(), timeout.timeoutUnit());
+				awaitDownloadProgress(downloadFuture, lastProgressNanos, stallTimeout);
 			} catch (TimeoutException e) {
 				downloadFuture.cancel(true);
-				throw new EvitaClientTimedOutException(timeout.timeout(), timeout.timeoutUnit());
+				throw new EvitaClientTimedOutException(stallTimeout.timeout(), stallTimeout.timeoutUnit());
 			} catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 				throw new EvitaClientServerCallException("File download interrupted.", e);
@@ -563,6 +618,48 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 	}
 
 	/**
+	 * Waits for a streamed download to finish, giving up only once it has made **no progress** for
+	 * `stallTimeout` - not once it has taken `stallTimeout` in total.
+	 *
+	 * The distinction is the whole point of {@link TimeoutTier#PER_MESSAGE}: a download's duration is a
+	 * function of the file's size and the link's speed, neither of which the client knows, so any fixed
+	 * budget is a guess that a large enough backup will always lose. What can be bounded is silence.
+	 *
+	 * Waiting in recomputed slices, rather than simply blocking forever and trusting the transport to
+	 * fail the future, is deliberate: it keeps a caller-side bound on a hang that never produces a
+	 * terminal event. A spurious timeout is recoverable, a permanently parked application thread is not.
+	 *
+	 * @param downloadFuture    future completed by the stream's terminal event
+	 * @param lastProgressNanos `System.nanoTime()` stamp of the most recently received message, updated
+	 *                          by the observer as the download proceeds
+	 * @param stallTimeout      how long the stream may stay silent before it is considered dead
+	 * @throws TimeoutException     when nothing arrived for the whole `stallTimeout`
+	 * @throws InterruptedException when the waiting thread is interrupted
+	 * @throws ExecutionException   when the download itself failed
+	 */
+	private static void awaitDownloadProgress(
+		@Nonnull CompletableFuture<Void> downloadFuture,
+		@Nonnull AtomicLong lastProgressNanos,
+		@Nonnull Timeout stallTimeout
+	) throws TimeoutException, InterruptedException, ExecutionException {
+		final long stallNanos = stallTimeout.timeoutUnit().toNanos(stallTimeout.timeout());
+		while (true) {
+			final long remainingNanos = stallNanos - (System.nanoTime() - lastProgressNanos.get());
+			if (remainingNanos <= 0L) {
+				throw new TimeoutException();
+			}
+			try {
+				downloadFuture.get(remainingNanos, TimeUnit.NANOSECONDS);
+				return;
+			} catch (TimeoutException e) {
+				// the window elapsed - but a message may have landed while we waited, which moves
+				// `lastProgressNanos` and makes the recomputed window positive again. Only a genuinely
+				// silent stream leaves it non-positive and exits above.
+			}
+		}
+	}
+
+	/**
 	 * Creates a new client task. If the task is not yet completed (finished or failed), it is added to the queue of
 	 * tracked tasks and its status is updated in the background, so that the {@link Task#getFutureResult()} is completed
 	 * when the task is finished.
@@ -588,7 +685,7 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 	private <T> T executeWithEvitaBlockingService(
 		@Nonnull AsyncCallFunction<EvitaManagementServiceStub, T> lambda
 	) {
-		final Timeout timeout = Objects.requireNonNull(this.evitaClient.timeout.get().peek());
+		final Timeout timeout = this.evitaClient.resolveTimeout(this.streamingStubTier);
 		try {
 			return lambda.apply(
 				this.evitaManagementServiceStub.withDeadlineAfter(timeout.timeout(), timeout.timeoutUnit())
@@ -619,9 +716,40 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 	private <T> T executeWithEvitaService(
 		@Nonnull AsyncCallFunction<EvitaManagementServiceFutureStub, ListenableFuture<T>> lambda
 	) {
-		final Timeout timeout = Objects.requireNonNull(this.evitaClient.timeout.get().peek());
+		return executeWithStub(this.evitaManagementServiceFutureStub, this.unaryStubTier, lambda);
+	}
+
+	/**
+	 * Runs a unary call on the non-retrying {@link #evitaManagementServiceUploadStub} - see that field
+	 * for why an append must not travel on a channel that replays.
+	 *
+	 * @param lambda function that holds a logic passed by the caller
+	 * @param <T>    return type of the function
+	 * @return result of the applied function
+	 */
+	private <T> T executeWithEvitaUploadService(
+		@Nonnull AsyncCallFunction<EvitaManagementServiceFutureStub, ListenableFuture<T>> lambda
+	) {
+		return executeWithStub(this.evitaManagementServiceUploadStub, this.uploadStubTier, lambda);
+	}
+
+	/**
+	 * Applies the passed logic on the given stub under the timeout its channel's tier resolves to.
+	 *
+	 * @param stub   stub to issue the call on
+	 * @param tier   deadline tier of that stub, i.e. the one its channel carries
+	 * @param lambda function that holds a logic passed by the caller
+	 * @param <T>    return type of the function
+	 * @return result of the applied function
+	 */
+	private <T> T executeWithStub(
+		@Nonnull EvitaManagementServiceFutureStub stub,
+		@Nonnull TimeoutTier tier,
+		@Nonnull AsyncCallFunction<EvitaManagementServiceFutureStub, ListenableFuture<T>> lambda
+	) {
+		final Timeout timeout = this.evitaClient.resolveTimeout(tier);
 		try {
-			return lambda.apply(this.evitaManagementServiceFutureStub.withDeadlineAfter(timeout.timeout(), timeout.timeoutUnit()))
+			return lambda.apply(stub.withDeadlineAfter(timeout.timeout(), timeout.timeoutUnit()))
 				.get(timeout.timeout(), timeout.timeoutUnit());
 		} catch (ExecutionException e) {
 			throw EvitaClient.transformException(

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientManagement.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientManagement.java
@@ -237,58 +237,95 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 		GrpcTaskStatus restorationTask = null;
 		GrpcUuid uploadFileId = null;
 		long bytesSent = 0L;
-		try (inputStream) {
-			int bytesRead;
-			while ((bytesRead = inputStream.read(buffer)) != -1) {
-				final GrpcRestoreCatalogUnaryRequest.Builder requestBuilder = GrpcRestoreCatalogUnaryRequest
-					.newBuilder()
-					.setCatalogName(catalogName)
-					.setTotalSizeInBytes(totalBytesExpected)
-					.setBackupFile(ByteString.copyFrom(buffer, 0, bytesRead));
-				// every chunk but the first names the upload it belongs to
-				if (uploadFileId != null) {
-					requestBuilder.setFileId(uploadFileId);
+		// flipped only once the upload is the caller's problem rather than ours - every other way out of
+		// this method leaves a half-written archive on the server that nobody has been told to discard
+		boolean handedOver = false;
+		try {
+			try (inputStream) {
+				int bytesRead;
+				while ((bytesRead = inputStream.read(buffer)) != -1) {
+					final GrpcRestoreCatalogUnaryRequest.Builder requestBuilder = GrpcRestoreCatalogUnaryRequest
+						.newBuilder()
+						.setCatalogName(catalogName)
+						.setTotalSizeInBytes(totalBytesExpected)
+						.setBackupFile(ByteString.copyFrom(buffer, 0, bytesRead));
+					// every chunk but the first names the upload it belongs to
+					if (uploadFileId != null) {
+						requestBuilder.setFileId(uploadFileId);
+					}
+					final GrpcRestoreCatalogUnaryRequest request = requestBuilder.build();
+					final GrpcRestoreCatalogUnaryResponse response = executeWithEvitaUploadService(
+						evitaService -> evitaService.restoreCatalogUnary(request)
+					);
+					restorationTask = response.getTask();
+					if (uploadFileId == null) {
+						// the response's own `fileId` is the documented handle for the upload - the id on the
+						// task's file descriptor is not populated on the first chunk
+						uploadFileId = response.getFileId();
+					}
+					bytesSent += bytesRead;
 				}
-				final GrpcRestoreCatalogUnaryRequest request = requestBuilder.build();
-				final GrpcRestoreCatalogUnaryResponse response = executeWithEvitaUploadService(
-					evitaService -> evitaService.restoreCatalogUnary(request)
+			} catch (IOException e) {
+				throw new UnexpectedIOException(
+					"Failed to read the backup file being restored: " + e.getMessage(),
+					"Failed to read the backup file being restored.",
+					e
 				);
-				restorationTask = response.getTask();
-				if (uploadFileId == null) {
-					// the response's own `fileId` is the documented handle for the upload - the id on the
-					// task's file descriptor is not populated on the first chunk
-					uploadFileId = response.getFileId();
-				}
-				bytesSent += bytesRead;
 			}
-		} catch (IOException e) {
-			throw new UnexpectedIOException(
-				"Failed to read the backup file being restored: " + e.getMessage(),
-				"Failed to read the backup file being restored.",
-				e
-			);
-		}
 
-		if (restorationTask == null) {
-			throw new UnexpectedIOException(
-				"The backup file being restored contains no data.",
-				"The backup file being restored contains no data."
-			);
-		}
-		// the server submits the restoration task only once the uploaded size reaches the announced one,
-		// so a mismatch here would otherwise hand back a task that is never going to run
-		if (bytesSent != totalBytesExpected) {
-			throw new UnexpectedIOException(
-				"Number of bytes uploaded during catalog restoration does not match the announced size " +
-					"(announced " + totalBytesExpected + ", uploaded " + bytesSent + ")!",
-				"Number of bytes uploaded during catalog restoration does not match the announced size!"
-			);
-		}
+			if (restorationTask == null) {
+				throw new UnexpectedIOException(
+					"The backup file being restored contains no data.",
+					"The backup file being restored contains no data."
+				);
+			}
+			// the server submits the restoration task only once the uploaded size reaches the announced one,
+			// so a mismatch here would otherwise hand back a task that is never going to run
+			if (bytesSent != totalBytesExpected) {
+				throw new UnexpectedIOException(
+					"Number of bytes uploaded during catalog restoration does not match the announced size " +
+						"(announced " + totalBytesExpected + ", uploaded " + bytesSent + ")!",
+					"Number of bytes uploaded during catalog restoration does not match the announced size!"
+				);
+			}
 
-		//noinspection unchecked
-		return (Task<?, Void>) this.clientTaskTracker.createTask(
-			EvitaDataTypesConverter.toTaskStatus(restorationTask)
-		);
+			handedOver = true;
+			//noinspection unchecked
+			return (Task<?, Void>) this.clientTaskTracker.createTask(
+				EvitaDataTypesConverter.toTaskStatus(restorationTask)
+			);
+		} finally {
+			if (!handedOver && restorationTask != null) {
+				abandonRestoreUpload(restorationTask);
+			}
+		}
+	}
+
+	/**
+	 * Tells the server to discard a restore upload this client has given up on.
+	 *
+	 * Once the first chunk has been accepted the server holds a temporary archive and a task waiting for
+	 * the rest of it, and a chunked unary upload has no half-close for the server to notice its absence
+	 * by. Cancelling the task is the abort signal: the task's completion hook is what deletes the partial
+	 * archive.
+	 *
+	 * Deliberately best effort. The server does not depend on this - the scheduler purges a task left
+	 * waiting for its precondition after ten minutes and the same hook runs then - and the failure that
+	 * brought us here has quite possibly taken the channel with it, so a cancellation that cannot be
+	 * delivered must not replace the original exception with a less informative one. All this buys is
+	 * releasing the disk space now rather than ten minutes from now.
+	 *
+	 * @param restorationTask status of the waiting restoration task, as returned by the last accepted chunk
+	 */
+	private void abandonRestoreUpload(@Nonnull GrpcTaskStatus restorationTask) {
+		try {
+			cancelTask(EvitaDataTypesConverter.toTaskStatus(restorationTask).taskId());
+		} catch (Exception ex) {
+			log.debug(
+				"Failed to abandon an unfinished catalog restore upload - the server will reclaim it when " +
+					"the waiting task is purged: {}", ex.getMessage()
+			);
+		}
 	}
 
 	@Nonnull

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/GrpcProviderRegistrar.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/GrpcProviderRegistrar.java
@@ -23,7 +23,9 @@
 
 package io.evitadb.externalApi.grpc;
 
+import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.grpc.GrpcExceptionHandlerFunction;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.server.cors.CorsService;
@@ -43,6 +45,8 @@ import io.evitadb.externalApi.grpc.services.interceptors.ServerSessionIntercepto
 import io.evitadb.externalApi.http.ExternalApiProvider;
 import io.evitadb.externalApi.http.ExternalApiProviderRegistrar;
 import io.evitadb.externalApi.http.ExternalApiServer;
+import io.evitadb.utils.ExceptionUtils;
+import io.grpc.Status;
 import io.grpc.protobuf.services.ProtoReflectionService;
 
 import javax.annotation.Nonnull;
@@ -53,6 +57,33 @@ import javax.annotation.Nonnull;
  * @author Tomáš Pozler, 2022
  */
 public class GrpcProviderRegistrar implements ExternalApiProviderRegistrar<GrpcOptions> {
+
+	/**
+	 * Turns Armeria's "request body too large" rejection into a status a client can act on.
+	 *
+	 * A client-streaming upload travels as a **single** HTTP request, so `maxRequestLength` - which
+	 * evitaDB wires to `api.maxEntitySizeInBytes` - bounds the whole upload rather than one message.
+	 * `RestoreCatalog` is the RPC that runs into it, and Armeria's default mapping is a bare
+	 * `RESOURCE_EXHAUSTED` with no description, indistinguishable from any other resource failure - the
+	 * client cannot tell that it hit a configured limit, let alone which one or what to do instead.
+	 *
+	 * Returning `null` for anything else hands the exception back to Armeria's default handler.
+	 */
+	private static final GrpcExceptionHandlerFunction OVERSIZED_REQUEST_HANDLER =
+		(ctx, status, cause, metadata) -> {
+			final ContentTooLargeException tooLarge = cause == null ?
+				null : ExceptionUtils.findInCauseChain(cause, ContentTooLargeException.class);
+			return tooLarge == null ?
+				null :
+				Status.RESOURCE_EXHAUSTED
+					.withDescription(
+						"Request body exceeds the server limit of " + tooLarge.maxContentLength() +
+							" B (`api.maxEntitySizeInBytes`). A client-streaming upload is one request, so " +
+							"the limit applies to the whole upload - send a large catalog backup through " +
+							"`RestoreCatalogUnary` instead, where every chunk is a request of its own."
+					)
+					.withCause(tooLarge);
+		};
 
 	@Nonnull
 	@Override
@@ -76,9 +107,15 @@ public class GrpcProviderRegistrar implements ExternalApiProviderRegistrar<GrpcO
 	) {
 		final GrpcServiceBuilder grpcServiceBuilder = GrpcService.builder()
 			.addService(new EvitaService(evita, apiOptions.headers()))
-			.addService(new EvitaManagementService(evita, externalApiServer, apiOptions.headers()))
-			.addService(new EvitaSessionService(evita, apiOptions.headers()))
-			.addService(new EvitaTrafficRecordingService(evita, apiOptions.headers()))
+			.addService(new EvitaManagementService(
+				evita, externalApiServer, apiOptions.headers(), grpcAPIConfig.getStreamingRequestTimeoutInMillis()
+			))
+			.addService(new EvitaSessionService(
+				evita, apiOptions.headers(), grpcAPIConfig.getStreamingRequestTimeoutInMillis()
+			))
+			.addService(new EvitaTrafficRecordingService(
+				evita, apiOptions.headers(), grpcAPIConfig.getStreamingRequestTimeoutInMillis()
+			))
 			.addService(ProtoReflectionService.newInstance())
 			.intercept(new ServerSessionInterceptor(evita))
 			.intercept(new GlobalExceptionHandlerInterceptor())
@@ -86,7 +123,8 @@ public class GrpcProviderRegistrar implements ExternalApiProviderRegistrar<GrpcO
 			.supportedSerializationFormats(GrpcSerializationFormats.values())
 			.enableHttpJsonTranscoding(true)
 			.enableUnframedRequests(true)
-			.useClientTimeoutHeader(true);
+			.useClientTimeoutHeader(true)
+			.exceptionHandler(OVERSIZED_REQUEST_HANDLER.orElse(GrpcExceptionHandlerFunction.of()));
 
 		final CorsServiceBuilder corsBuilder = CorsService.builderForAnyOrigin()
 			.allowRequestMethods(HttpMethod.POST) // Allow POST method.

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/configuration/GrpcOptions.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/configuration/GrpcOptions.java
@@ -49,9 +49,36 @@ public class GrpcOptions extends AbstractApiOptions {
 	 */
 	public static final int DEFAULT_GRPC_PORT = 5555;
 	/**
+	 * Default value of {@link #getStreamingRequestTimeoutInMillis()}.
+	 */
+	public static final long DEFAULT_STREAMING_REQUEST_TIMEOUT_IN_MILLIS = 300_000L;
+	/**
 	 * Allows to expose the Armeria specific docs service on the gRPC API.
 	 */
 	@Getter private final boolean exposeDocsService;
+
+	/**
+	 * How long a **streaming** RPC may make no progress before the server abandons it, in milliseconds.
+	 *
+	 * `api.requestTimeoutInMillis` is a budget for a *whole request*. That is the right shape for a unary
+	 * call, where the work is one bounded round trip, and the wrong shape for a server-streaming one: a
+	 * download's duration is a function of the file's size and the link's speed, neither of which the
+	 * server knows, so any whole-request budget silently becomes a cap on what can be transferred at all.
+	 * This option is the streaming counterpart - it bounds *silence*. It is re-armed every time a message
+	 * is handed to the transport, so a slow but steadily progressing transfer never reaches it however
+	 * long it runs.
+	 *
+	 * The same value bounds how long {@link io.evitadb.externalApi.grpc.utils.GrpcOutboundGate} parks a
+	 * producing worker waiting for a client that has stopped reading, so it is also the point at which
+	 * such a stream is abandoned with `DEADLINE_EXCEEDED`. Size it against the slowest client to be
+	 * served: it must comfortably exceed the time a **single message** takes to reach that client.
+	 * Lowering it towards `requestTimeoutInMillis` reintroduces a minimum viable link speed - `fetchFile`
+	 * streams 1 MB chunks, so a 2 s budget would demand roughly 4 Mbit/s sustained.
+	 *
+	 * This lives here rather than in `ApiOptions` because it is enforced by gRPC-specific machinery. The
+	 * other APIs' long-lived endpoints (the REST and GraphQL WebSocket handlers) do not consume it.
+	 */
+	@Getter private final long streamingRequestTimeoutInMillis;
 
 	/**
 	 * Controls the prefix gRPC API will react on.
@@ -64,12 +91,14 @@ public class GrpcOptions extends AbstractApiOptions {
 		super(true, ":" + DEFAULT_GRPC_PORT);
 		this.exposeDocsService = false;
 		this.prefix = BASE_GRPC_PATH;
+		this.streamingRequestTimeoutInMillis = DEFAULT_STREAMING_REQUEST_TIMEOUT_IN_MILLIS;
 	}
 
 	public GrpcOptions(@Nonnull String host) {
 		super(true, host);
 		this.exposeDocsService = false;
 		this.prefix = BASE_GRPC_PATH;
+		this.streamingRequestTimeoutInMillis = DEFAULT_STREAMING_REQUEST_TIMEOUT_IN_MILLIS;
 	}
 
 	@JsonCreator
@@ -80,11 +109,17 @@ public class GrpcOptions extends AbstractApiOptions {
 	                   @Nullable @JsonProperty("keepAlive") Boolean keepAlive,
 	                   @Nullable @JsonProperty("exposeDocsService") Boolean exposeDocsService,
 	                   @Nullable @JsonProperty("prefix") String prefix,
+	                   @Nullable @JsonProperty("streamingRequestTimeoutInMillis") Long streamingRequestTimeoutInMillis,
 	                   @Nullable @JsonProperty("mTLS") MtlsConfiguration mtlsConfiguration
 	) {
 		super(enabled, host, exposeOn, tlsMode, keepAlive, mtlsConfiguration);
 		this.exposeDocsService = ofNullable(exposeDocsService).orElse(false);
 		this.prefix = ofNullable(prefix).orElse(BASE_GRPC_PATH);
+		// a non-positive value is meaningless for a stall budget and would disable the re-arm entirely,
+		// so it falls back to the default rather than silently reinstating the whole-request budget
+		this.streamingRequestTimeoutInMillis = ofNullable(streamingRequestTimeoutInMillis)
+			.filter(it -> it > 0L)
+			.orElse(DEFAULT_STREAMING_REQUEST_TIMEOUT_IN_MILLIS);
 	}
 
 	@Override

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/exception/StalledGrpcStreamException.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/exception/StalledGrpcStreamException.java
@@ -1,0 +1,58 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc.exception;
+
+import io.evitadb.exception.EvitaInvalidUsageException;
+
+import javax.annotation.Nonnull;
+import java.io.Serial;
+
+/**
+ * Raised when a server-streaming RPC has been waiting for the client to consume already-sent data for
+ * longer than the configured stall timeout, while the connection itself is still alive.
+ *
+ * This is the "the client stopped reading but never hung up" case — a paused SSH/`kubectl port-forward`
+ * tunnel, a suspended browser tab, a consumer blocked on its own downstream. The transport never
+ * cancels, so nothing else would ever end the call: without this exception the producing worker thread
+ * would park indefinitely and the RPC would hang forever from both sides.
+ *
+ * It is a client/network condition rather than a server fault, so it is logged at WARN and translated
+ * to `DEADLINE_EXCEEDED` by
+ * {@link io.evitadb.externalApi.grpc.services.interceptors.GlobalExceptionHandlerInterceptor} — a
+ * status the client can act on, unlike the bare `UNKNOWN` that an exhausted allocator used to produce.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class StalledGrpcStreamException extends EvitaInvalidUsageException {
+	@Serial private static final long serialVersionUID = -3255905625734017402L;
+
+	public StalledGrpcStreamException(@Nonnull String methodName, long stallTimeoutMillis) {
+		super(
+			"Client of `" + methodName + "` has not consumed any data for " + stallTimeoutMillis +
+				" ms while the stream stayed open; abandoning the response stream.",
+			"The client stopped consuming the response stream and the transfer timed out."
+		);
+	}
+
+}

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaManagementService.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaManagementService.java
@@ -85,6 +85,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
@@ -394,6 +395,8 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 		return new RestoreCatalogUploadObserver(
 			serverCallObserver,
 			ServiceRequestContext.current(),
+			this.evita.getConfiguration().transaction().transactionWorkDirectory(),
+			this.management,
 			this.evita.getRequestExecutor(),
 			this.streamingRequestTimeoutInMillis
 		);
@@ -434,6 +437,27 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 							request.getTotalSizeInBytes(),
 							true
 						);
+						// The archive assembled here has no other owner. `createTempFile` deliberately does
+						// not reserve the file (that is `createManagedTempFile`), nothing sweeps the work
+						// directory, and the restore step - which deletes it once it runs, because
+						// `deleteAfterRestore` is set - only runs for an upload that actually completed. An
+						// upload that stops half way would therefore leave an archive the size of a catalog
+						// behind for the lifetime of the process.
+						//
+						// A chunked upload has no half-close to hang that cleanup on, so the task's future
+						// carries it: it completes on every terminal outcome, including the scheduler's purge
+						// of tasks left waiting for a precondition for longer than ten minutes
+						// (`Scheduler#purgeFinishedAndLongWaitingTasks`). That purge is what catches the cases
+						// no protocol-level signal ever reaches us for - a client that was killed, crashed, or
+						// simply lost the network mid-upload.
+						final Path uploadedFilePath = backupFilePath;
+						restorationTask.getFutureResult().whenComplete(
+							(result, exception) -> {
+								if (exception != null) {
+									deleteFileIfExists(uploadedFilePath, "restore");
+								}
+							}
+						);
 						this.management.registerWaitingTask(restorationTask);
 					} else {
 						backupFilePath = this.management.fileManagementService().getTempFile(fileId + ".zip");
@@ -446,9 +470,26 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 						backupFile.writeTo(outputStream);
 					}
 
-					// we've reached the expected size of the file
 					final long actualSize = Files.size(backupFilePath);
-					if (actualSize == request.getTotalSizeInBytes()) {
+
+					// An over-long upload has to be rejected *before* the client is told the chunk was
+					// accepted. Reporting success first and throwing afterwards left the error being written
+					// into an already-completed observer - so the client saw the upload succeed - while the
+					// archive was deleted underneath a task that stayed registered, making the next chunk fail
+					// on `getTempFile`'s existence check instead of on the size that was actually wrong.
+					//
+					// Cancelling the task is what discards the archive: its completion hook owns that file.
+					if (actualSize > totalSizeInBytes) {
+						this.management.cancelTask(restorationTask.getStatus().taskId());
+						throw new UnexpectedIOException(
+							"Backup file size exceeds the expected size.",
+							"Backup file size exceeds the expected size (expected " + totalSizeInBytes +
+								", actual " + actualSize + " Bytes)."
+						);
+					}
+
+					// we've reached the expected size of the file
+					if (actualSize == totalSizeInBytes) {
 						this.management.submitWaitingTask(createRestoreTaskFindPredicate(fileId));
 					}
 
@@ -460,14 +501,6 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 							.build()
 					);
 					responseObserver.onCompleted();
-
-					if (actualSize > totalSizeInBytes) {
-						deleteFileIfExists(backupFilePath, "restore");
-						throw new UnexpectedIOException(
-							"Backup file size exceeds the expected size.",
-							"Backup file size exceeds the expected size (expected " + totalSizeInBytes + ", actual " + actualSize + " Bytes)."
-						);
-					}
 				} catch (IOException e) {
 					throw new UnexpectedIOException(
 						"Failed to store data to the designated file: " + e.getMessage(),
@@ -840,7 +873,7 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 	 * one. Neither is covered by a test that fails when it goes, so the redundancy is the only thing
 	 * standing between a plausible-looking simplification and a silently corrupted archive.
 	 */
-	private final class RestoreCatalogUploadObserver implements StreamObserver<GrpcRestoreCatalogRequest> {
+	static final class RestoreCatalogUploadObserver implements StreamObserver<GrpcRestoreCatalogRequest> {
 		/**
 		 * Size of the write buffer wrapped around the temporary file. Writes larger than the buffer
 		 * bypass it, so this only matters for clients that upload in small chunks - which the previous
@@ -850,6 +883,13 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 
 		private final ServerCallStreamObserver<GrpcRestoreCatalogResponse> responseObserver;
 		private final ServiceRequestContext serviceContext;
+		/**
+		 * Directory the assembled archive is written into. Resolved once at construction rather than per
+		 * chunk - it is a configuration read, and doing it here is what lets this observer be driven from
+		 * a test without an engine behind it.
+		 */
+		private final Path workDirectory;
+		private final EvitaManagement management;
 		private final Executor uploadExecutor;
 		/**
 		 * The call's configured request timeout, captured once at construction - i.e. before the first
@@ -880,11 +920,15 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 		RestoreCatalogUploadObserver(
 			@Nonnull ServerCallStreamObserver<GrpcRestoreCatalogResponse> responseObserver,
 			@Nonnull ServiceRequestContext serviceContext,
+			@Nonnull Path workDirectory,
+			@Nonnull EvitaManagement management,
 			@Nonnull Executor uploadExecutor,
 			long streamingRequestTimeoutInMillis
 		) {
 			this.responseObserver = responseObserver;
 			this.serviceContext = serviceContext;
+			this.workDirectory = workDirectory;
+			this.management = management;
 			this.uploadExecutor = uploadExecutor;
 			this.configuredRequestTimeoutMillis = GrpcTimeoutUtil.resolveStreamingBudgetMillis(
 				serviceContext, streamingRequestTimeoutInMillis
@@ -918,15 +962,8 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 		public void onError(Throwable t) {
 			// the client aborted mid-upload - let whatever is already in flight finish before the
 			// partial file is closed and discarded, so no worker is writing into a closed stream
-			this.uploadChain.whenCompleteAsync(
-				(ignored, throwable) -> {
-					closeOutputStream();
-					deleteFileIfExists(this.backupFilePath, "restore");
-					if (this.terminated.compareAndSet(false, true)) {
-						sendErrorToClient(t, this.responseObserver);
-					}
-				},
-				this.uploadExecutor
+			this.uploadChain.whenComplete(
+				(ignored, throwable) -> handOffCleanupToUploadExecutor(() -> failUpload(t))
 			);
 		}
 
@@ -940,26 +977,94 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 		 * client once and then poisons the rest of the chain, so nothing downstream - the restoration
 		 * submission above all - ever runs against a half-written file.
 		 *
+		 * The hand-off to {@link #uploadExecutor} is made by hand rather than by `thenRunAsync`, because
+		 * the request pool is bounded and rejects work once its queue fills
+		 * (`EvitaRejectingExecutorHandler` throws). Letting `CompletableFuture` schedule the step loses
+		 * that rejection in two different ways, and the second one is worse than a lost error:
+		 *
+		 * - while the previous step is still running, the rejection surfaces on *that* worker, inside
+		 *   `CompletableFuture#postComplete`, with no relation to this call - the stage simply never
+		 *   completes and the client waits out its deadline;
+		 * - once the previous step has completed, `thenRunAsync` throws on the calling thread *before*
+		 *   `this.uploadChain` is reassigned, so the chain is left looking healthy. The next chunk then
+		 *   appends successfully, {@link #openBackupFileIfNeeded()} finds a null stream and reopens the
+		 *   temporary file in `APPEND` mode - leaking a second archive on the very path being handled.
+		 *
+		 * Completing `next` exceptionally in both cases is what keeps the chain poisoned, and therefore
+		 * what stops that reopen.
+		 *
 		 * @param step the operation to append
 		 */
 		private void appendToChain(@Nonnull UploadStep step) {
-			this.uploadChain = this.uploadChain.thenRunAsync(
-				() -> {
-					try {
-						step.run();
-					} catch (Exception ex) {
-						failUpload(ex);
-						throw ex instanceof RuntimeException runtimeException ?
-							runtimeException :
-							new UnexpectedIOException(
-								"Failed to store the uploaded backup file: " + ex.getMessage(),
-								"Failed to store the uploaded backup file.",
-								ex
-							);
+			final CompletableFuture<Void> previous = this.uploadChain;
+			final CompletableFuture<Void> next = new CompletableFuture<>();
+			this.uploadChain = next;
+			// deliberately `whenComplete` and not `whenCompleteAsync`: this stage only *submits* work, so
+			// running it inline (or on whichever worker completed the previous step) costs nothing and,
+			// crucially, cannot itself be rejected
+			previous.whenComplete(
+				(ignored, previousFailure) -> {
+					if (previousFailure != null) {
+						// a poisoned chain stays poisoned - nothing may run against a discarded file
+						next.completeExceptionally(previousFailure);
+						return;
 					}
-				},
-				this.uploadExecutor
+					handOffToUploadExecutor(
+						() -> {
+							try {
+								step.run();
+								next.complete(null);
+							} catch (Exception ex) {
+								failUpload(ex);
+								next.completeExceptionally(ex);
+							}
+						},
+						next
+					);
+				}
 			);
+		}
+
+		/**
+		 * Hands a step to {@link #uploadExecutor}, falling back to running it on the calling thread when
+		 * the pool refuses it.
+		 *
+		 * The fallback puts a `close` and an `unlink` on whichever thread got here - the event loop, in
+		 * the worst case - which is exactly what this observer exists to avoid. It is still the right
+		 * trade: the alternative to a few microseconds of blocking on an already-degraded server is a
+		 * part-uploaded archive, up to the full size of a catalog, left in the work directory for the
+		 * lifetime of the process. Nothing sweeps that directory.
+		 *
+		 * @param step             the work to run on the upload executor
+		 * @param rejectionOutcome poisoned with the rejection when the pool refuses the hand-off, so the
+		 *                         chain cannot continue past a step that never ran
+		 */
+		private void handOffToUploadExecutor(
+			@Nonnull Runnable step,
+			@Nonnull CompletableFuture<Void> rejectionOutcome
+		) {
+			try {
+				this.uploadExecutor.execute(step);
+			} catch (RejectedExecutionException ex) {
+				failUpload(ex);
+				rejectionOutcome.completeExceptionally(ex);
+			}
+		}
+
+		/**
+		 * Hands terminal cleanup to {@link #uploadExecutor}, running it on the calling thread when the
+		 * pool refuses it. Unlike {@link #handOffToUploadExecutor(Runnable, CompletableFuture)} there is
+		 * no stage left to poison - the call is already ending - so the rejection only has to not
+		 * prevent the cleanup from happening at all.
+		 *
+		 * @param cleanup the cleanup to run; idempotent, so running it on either thread is equivalent
+		 */
+		private void handOffCleanupToUploadExecutor(@Nonnull Runnable cleanup) {
+			try {
+				this.uploadExecutor.execute(cleanup);
+			} catch (RejectedExecutionException ex) {
+				cleanup.run();
+			}
 		}
 
 		/**
@@ -971,14 +1076,14 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 			if (this.outputStream != null) {
 				return;
 			}
-			final Path workDirectory = EvitaManagementService.this.evita.getConfiguration()
-				.transaction().transactionWorkDirectory();
-			if (!workDirectory.toFile().exists()) {
+			if (!this.workDirectory.toFile().exists()) {
 				Assert.isTrue(
-					workDirectory.toFile().mkdirs(), "Failed to create work directory for catalog restore."
+					this.workDirectory.toFile().mkdirs(), "Failed to create work directory for catalog restore."
 				);
 			}
-			this.backupFilePath = Files.createTempFile(workDirectory, "catalog_backup_for_restore-", ".zip");
+			this.backupFilePath = Files.createTempFile(
+				this.workDirectory, "catalog_backup_for_restore-", ".zip"
+			);
 			this.outputStream = new BufferedOutputStream(
 				Files.newOutputStream(this.backupFilePath, StandardOpenOption.APPEND), UPLOAD_BUFFER_SIZE
 			);
@@ -994,7 +1099,7 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 			Assert.isPremiseValid(theOutputStream != null, "Output stream has already been closed.");
 			theOutputStream.close();
 			this.outputStream = null;
-			final Task<?, Void> restorationTask = EvitaManagementService.this.management.restoreCatalog(
+			final Task<?, Void> restorationTask = this.management.restoreCatalog(
 				this.catalogNameToRestore,
 				Files.size(this.backupFilePath),
 				Files.newInputStream(this.backupFilePath, StandardOpenOption.READ)

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaManagementService.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaManagementService.java
@@ -53,6 +53,7 @@ import io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter;
 import io.evitadb.externalApi.grpc.generated.*;
 import io.evitadb.externalApi.grpc.generated.GrpcTaskStatusesResponse.Builder;
 import io.evitadb.externalApi.grpc.requestResponse.EvitaEnumConverter;
+import io.evitadb.externalApi.grpc.utils.GrpcOutboundGate;
 import io.evitadb.externalApi.grpc.utils.GrpcTimeoutUtil;
 import io.evitadb.externalApi.http.ExternalApiProvider;
 import io.evitadb.externalApi.http.ExternalApiServer;
@@ -64,11 +65,13 @@ import io.evitadb.utils.ClassifierUtils;
 import io.evitadb.utils.ClassifierUtils.Keyword;
 import io.evitadb.utils.UUIDUtil;
 import io.grpc.Metadata;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -80,6 +83,9 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -102,6 +108,24 @@ import static java.util.Optional.ofNullable;
  */
 @Slf4j
 public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaManagementServiceImplBase {
+	/**
+	 * Size of a single chunk streamed by {@link #fetchFile(GrpcFetchFileRequest, StreamObserver)}.
+	 *
+	 * The value is a direct consequence of the readiness gating that loop performs. Armeria reports a
+	 * server call as ready only while `pendingMessages == 0`, so a gated producer keeps exactly one
+	 * message in flight and every chunk costs a full event-loop round trip - at the original 64 KB that
+	 * is over ten thousand sequential round trips for a large backup, and it would make downloads for
+	 * clients that keep up measurably slower than the unbounded loop it replaces. 1 MB restores the
+	 * throughput while keeping the worst-case in-flight footprint at a couple of megabytes instead of
+	 * the whole file.
+	 *
+	 * The binding ceiling is the receiving side's maximum inbound message size: gRPC-Java defaults to
+	 * 4 MB and Armeria's gRPC client to no limit at all, so 1 MB is safe for every client - and chunk
+	 * size is not part of the wire contract anyway, since `totalSizeInBytes` carries the whole file
+	 * size on every message.
+	 */
+	private static final int FETCH_FILE_CHUNK_SIZE = 1_048_576;
+
 	/**
 	 * Instance of Evita upon which will be executed service calls
 	 */
@@ -146,7 +170,20 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 			fileIdCarrier.fileId().equals(theFileId);
 	}
 
-	public EvitaManagementService(@Nonnull Evita evita, @Nonnull ExternalApiServer externalApiServer, HeaderOptions headers) {
+	/**
+	 * How long a streamed response may make no progress before it is abandoned -
+	 * `api.endpoints.gRPC.streamingRequestTimeoutInMillis`.
+	 * Handed to every {@link GrpcOutboundGate} this service attaches.
+	 */
+	private final long streamingRequestTimeoutInMillis;
+
+	public EvitaManagementService(
+		@Nonnull Evita evita,
+		@Nonnull ExternalApiServer externalApiServer,
+		HeaderOptions headers,
+		long streamingRequestTimeoutInMillis
+	) {
+		this.streamingRequestTimeoutInMillis = streamingRequestTimeoutInMillis;
 		this.evita = evita;
 		this.externalApiServer = externalApiServer;
 		this.management = evita.management();
@@ -340,85 +377,26 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 	 */
 	@Override
 	public StreamObserver<GrpcRestoreCatalogRequest> restoreCatalog(StreamObserver<GrpcRestoreCatalogResponse> responseObserver) {
-		Path backupFilePath = null;
-		try {
-			try {
-				final Path workDirectory = this.evita.getConfiguration().transaction().transactionWorkDirectory();
-				if (!workDirectory.toFile().exists()) {
-					Assert.isTrue(workDirectory.toFile().mkdirs(), "Failed to create work directory for catalog restore.");
-				}
-				backupFilePath = Files.createTempFile(workDirectory, "catalog_backup_for_restore-", ".zip");
-				final Path finalBackupFilePath = backupFilePath;
-				@SuppressWarnings("resource") final OutputStream outputStream = Files.newOutputStream(finalBackupFilePath, StandardOpenOption.APPEND);
-				final AtomicLong bytesRead = new AtomicLong(0);
-				final ServiceRequestContext serviceContext = ServiceRequestContext.current();
+		final ServerCallStreamObserver<GrpcRestoreCatalogResponse> serverCallObserver =
+			(ServerCallStreamObserver<GrpcRestoreCatalogResponse>) responseObserver;
+		// Inbound demand has to become explicit here. gRPC auto-requests the next message only after
+		// `onMessage` returns, so the inline blocking write this method used to perform *was* the
+		// throttle that kept a client from outrunning the disk - an accidental one, paid for by doing
+		// file IO on the Armeria event loop. Moving the write onto a worker removes that side effect,
+		// so the demand it used to provide is now issued by hand: one message at a time, the next one
+		// requested only once the previous chunk is on disk.
+		//
+		// Both calls must happen before this method returns - gRPC freezes the observer immediately
+		// afterwards and rejects any later attempt to change the flow-control mode.
+		serverCallObserver.disableAutoRequest();
+		serverCallObserver.request(1);
 
-				return new StreamObserver<>() {
-					private String catalogNameToRestore;
-
-					@Override
-					public void onNext(GrpcRestoreCatalogRequest request) {
-						this.catalogNameToRestore = request.getCatalogName();
-						try {
-							final ByteString backupFile = request.getBackupFile();
-							backupFile.writeTo(outputStream);
-							bytesRead.addAndGet(backupFile.size());
-							GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, serviceContext.requestTimeoutMillis());
-
-						} catch (IOException e) {
-							throw new UnexpectedIOException(
-								"Failed to write backup file to temporary file.",
-								"Failed to write backup file to temporary file.",
-								e
-							);
-						}
-					}
-
-					@Override
-					public void onError(Throwable t) {
-						try {
-							outputStream.close();
-						} catch (IOException e) {
-							log.error("Failed to close output stream for backup file: {}", finalBackupFilePath, e);
-						} finally {
-							deleteFileIfExists(finalBackupFilePath, "restore");
-							sendErrorToClient(t, responseObserver);
-						}
-					}
-
-					@Override
-					public void onCompleted() {
-						try {
-							outputStream.close();
-							Assert.isPremiseValid(this.catalogNameToRestore != null, "Catalog name to restore must be provided.");
-							final Task<?, Void> restorationTask = EvitaManagementService.this.management.restoreCatalog(
-								this.catalogNameToRestore,
-								Files.size(finalBackupFilePath),
-								Files.newInputStream(finalBackupFilePath, StandardOpenOption.READ)
-							);
-							responseObserver.onNext(
-								GrpcRestoreCatalogResponse.newBuilder()
-									.setTask(toGrpcTaskStatus(restorationTask.getStatus()))
-									.setRead(bytesRead.get())
-									.build()
-							);
-							responseObserver.onCompleted();
-						} catch (Exception e) {
-							deleteFileIfExists(finalBackupFilePath, "restore");
-							sendErrorToClient(e, responseObserver);
-						}
-					}
-				};
-			} catch (IOException e) {
-				sendErrorToClient(e, responseObserver);
-				throw e;
-			}
-		} catch (Exception e) {
-			if (backupFilePath != null) {
-				deleteFileIfExists(backupFilePath, "restore");
-			}
-			return new NoopStreamObserver<>();
-		}
+		return new RestoreCatalogUploadObserver(
+			serverCallObserver,
+			ServiceRequestContext.current(),
+			this.evita.getRequestExecutor(),
+			this.streamingRequestTimeoutInMillis
+		);
 	}
 
 	/**
@@ -700,9 +678,20 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 
 	/**
 	 * Method streams contents of the single file identified by its unique UUID to the client.
+	 *
+	 * The producing loop is gated on transport readiness, so the file is streamed at the speed the
+	 * client actually consumes it. Without the gate the loop pushes the whole file into Armeria's
+	 * unbounded outbound queue at disk speed, which for a large backup over a slow link exhausts the
+	 * direct-memory allocator and kills the RPC with a bare `UNKNOWN` part-way through.
 	 */
 	@Override
 	public void fetchFile(GrpcFetchFileRequest request, StreamObserver<GrpcFetchFileResponse> responseObserver) {
+		// the gate has to be wired up here, on the thread that invoked the service method and before it
+		// returns - gRPC freezes handler registration afterwards, and the loop below runs on a worker
+		final GrpcOutboundGate outboundGate = GrpcOutboundGate.attach(
+			(ServerCallStreamObserver<GrpcFetchFileResponse>) responseObserver,
+			"fetchFile", null, this.streamingRequestTimeoutInMillis
+		);
 		executeWithClientContext(
 			() -> {
 				final UUID fileId = toUuid(request.getFileId());
@@ -710,21 +699,36 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 				if (fileToFetch.isEmpty()) {
 					sendErrorToClient(new FileForFetchNotFoundException(fileId), responseObserver);
 				} else {
+					final long totalSizeInBytes = fileToFetch.get().totalSizeInBytes();
 					try (
 						final InputStream inputStream = this.management.fetchFile(
 							fileId
 						)
 					) {
 						//noinspection CheckForOutOfMemoryOnLargeArrayAllocation
-						byte[] buffer = new byte[65_536];
+						final byte[] buffer = new byte[FETCH_FILE_CHUNK_SIZE];
 						int bytesRead;
 						while ((bytesRead = inputStream.read(buffer)) != -1) {
-							GrpcFetchFileResponse response = GrpcFetchFileResponse.newBuilder()
+							if (!outboundGate.awaitWritable()) {
+								// the client is gone - abandon the transfer without completing the
+								// stream, since completing it would claim a file that never arrived
+								log.debug("Client of `fetchFile` disconnected, abandoning transfer of {}.", fileId);
+								return;
+							}
+							final GrpcFetchFileResponse response = GrpcFetchFileResponse.newBuilder()
 								.setFileContents(ByteString.copyFrom(buffer, 0, bytesRead))
-								.setTotalSizeInBytes(fileToFetch.get().totalSizeInBytes())
+								.setTotalSizeInBytes(totalSizeInBytes)
 								.build();
+							// no re-arm of the Armeria deadline here: `awaitWritable` above already granted
+							// this message its window - see `GrpcOutboundGate#grantNextMessageWindow`. The
+							// deadline has to roll on a stream, because gating on readiness ties this
+							// handler's lifetime to how fast the *client* consumes, and a healthy download
+							// of a large file over a slow link outlives any fixed budget.
 							responseObserver.onNext(response);
 						}
+						// the final chunk's window is the only one still standing - give the half-close,
+						// and whatever is still queued behind it, a full budget of their own
+						outboundGate.grantCompletionWindow();
 						responseObserver.onCompleted();
 					} catch (IOException e) {
 						throw new UnexpectedIOException(
@@ -801,21 +805,240 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 	}
 
 	/**
-	 * No-op implementation of StreamObserver. Used in case the proper observer could not be created.
+	 * Piece of file work that may fail with an {@link IOException}.
 	 */
-	private static class NoopStreamObserver<V> implements StreamObserver<V> {
+	@FunctionalInterface
+	private interface UploadStep {
+
+		void run() throws IOException;
+
+	}
+
+	/**
+	 * Receives an uploaded catalog backup, writes it to a temporary file and submits the restoration
+	 * task once the client half-closes.
+	 *
+	 * All three observer callbacks are invoked on the Armeria event loop, and none of them may block
+	 * there - a 690 MB restore is thousands of blocking write syscalls, and the event loop is shared
+	 * by every other connection the server is serving. Every step that touches the file system is
+	 * therefore appended to {@link #uploadChain}, a single {@link CompletableFuture} chain per call:
+	 * it hands the work to a worker thread while keeping the chunks strictly ordered, which is the one
+	 * property a corrupted ZIP would be the symptom of losing.
+	 *
+	 * The chain is also what makes ordering independent of the executor's scheduling. Routing the
+	 * whole handler to Armeria's blocking task executor (the `@Blocking` annotation) would be a
+	 * one-line alternative, but `AbstractServerCall` dispatches each message as a separate task onto a
+	 * *shared* pool, so ordering would rest on the undocumented assumption that no second message is
+	 * ever dispatched before the first task returns. Here ordering is explicit.
+	 *
+	 * **The chain and the demand protocol are redundant, deliberately.** `disableAutoRequest()` plus a
+	 * `request(1)` issued from inside each *completed* write step already means at most one chunk is in
+	 * flight, which orders the writes on its own and additionally withholds half-close until the last
+	 * write has landed. Removing either mechanism alone therefore changes nothing observable - measured,
+	 * not assumed: `LongRunningGrpcRestoreCatalogUploadTest#shouldRestoreCatalogUploadedThroughClientStreamingRpc`
+	 * stays green against both single-mechanism counterfactuals. Do not read that as licence to delete
+	 * one. Neither is covered by a test that fails when it goes, so the redundancy is the only thing
+	 * standing between a plausible-looking simplification and a silently corrupted archive.
+	 */
+	private final class RestoreCatalogUploadObserver implements StreamObserver<GrpcRestoreCatalogRequest> {
+		/**
+		 * Size of the write buffer wrapped around the temporary file. Writes larger than the buffer
+		 * bypass it, so this only matters for clients that upload in small chunks - which the previous
+		 * unbuffered stream turned into one syscall each.
+		 */
+		private static final int UPLOAD_BUFFER_SIZE = 65_536;
+
+		private final ServerCallStreamObserver<GrpcRestoreCatalogResponse> responseObserver;
+		private final ServiceRequestContext serviceContext;
+		private final Executor uploadExecutor;
+		/**
+		 * The call's configured request timeout, captured once at construction - i.e. before the first
+		 * chunk, and therefore before any re-arm has rewritten the stored budget. Re-reading it from the
+		 * context per chunk instead would compound it; see
+		 * {@link GrpcTimeoutUtil#captureRequestTimeoutMillis(ServiceRequestContext)}.
+		 */
+		private final long configuredRequestTimeoutMillis;
+		private final AtomicLong bytesRead = new AtomicLong(0);
+		/**
+		 * Guards the single terminal response - the client must be told the outcome exactly once, no
+		 * matter which of the failure paths gets there first.
+		 */
+		private final AtomicBoolean terminated = new AtomicBoolean();
+		/**
+		 * Serialises every file operation of this call. Mutated only from the observer callbacks,
+		 * which gRPC delivers serially on the event loop.
+		 */
+		private CompletableFuture<Void> uploadChain = CompletableFuture.completedFuture(null);
+		/**
+		 * Written on the event loop, read from the worker running the chain - the chain's own
+		 * completion machinery orders the two, `volatile` states that intent rather than relying on it.
+		 */
+		private volatile String catalogNameToRestore;
+		private volatile Path backupFilePath;
+		@Nullable private volatile OutputStream outputStream;
+
+		RestoreCatalogUploadObserver(
+			@Nonnull ServerCallStreamObserver<GrpcRestoreCatalogResponse> responseObserver,
+			@Nonnull ServiceRequestContext serviceContext,
+			@Nonnull Executor uploadExecutor,
+			long streamingRequestTimeoutInMillis
+		) {
+			this.responseObserver = responseObserver;
+			this.serviceContext = serviceContext;
+			this.uploadExecutor = uploadExecutor;
+			this.configuredRequestTimeoutMillis = GrpcTimeoutUtil.resolveStreamingBudgetMillis(
+				serviceContext, streamingRequestTimeoutInMillis
+			);
+		}
 
 		@Override
-		public void onNext(V value) {
+		public void onNext(GrpcRestoreCatalogRequest request) {
+			this.catalogNameToRestore = request.getCatalogName();
+			final ByteString backupFile = request.getBackupFile();
+			appendToChain(
+				() -> {
+					openBackupFileIfNeeded();
+					backupFile.writeTo(this.outputStream);
+					this.bytesRead.addAndGet(backupFile.size());
+					GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(
+						this.serviceContext, this.configuredRequestTimeoutMillis
+					);
+					// Only now may the client send the next chunk - raising demand from inside the
+					// *completed* write step is what keeps at most one chunk in flight and therefore
+					// what orders the writes. Safe to call straight from this worker: Armeria's
+					// `StreamingServerCall.request(int)` marshals onto the call's event loop itself
+					// when the caller is not already on it, so the upstream subscription it touches
+					// stays event-loop-confined without help from here.
+					this.responseObserver.request(1);
+				}
+			);
 		}
 
 		@Override
 		public void onError(Throwable t) {
+			// the client aborted mid-upload - let whatever is already in flight finish before the
+			// partial file is closed and discarded, so no worker is writing into a closed stream
+			this.uploadChain.whenCompleteAsync(
+				(ignored, throwable) -> {
+					closeOutputStream();
+					deleteFileIfExists(this.backupFilePath, "restore");
+					if (this.terminated.compareAndSet(false, true)) {
+						sendErrorToClient(t, this.responseObserver);
+					}
+				},
+				this.uploadExecutor
+			);
 		}
 
 		@Override
 		public void onCompleted() {
+			appendToChain(this::submitRestoration);
 		}
+
+		/**
+		 * Appends a file operation to this call's chain. A step that fails reports the failure to the
+		 * client once and then poisons the rest of the chain, so nothing downstream - the restoration
+		 * submission above all - ever runs against a half-written file.
+		 *
+		 * @param step the operation to append
+		 */
+		private void appendToChain(@Nonnull UploadStep step) {
+			this.uploadChain = this.uploadChain.thenRunAsync(
+				() -> {
+					try {
+						step.run();
+					} catch (Exception ex) {
+						failUpload(ex);
+						throw ex instanceof RuntimeException runtimeException ?
+							runtimeException :
+							new UnexpectedIOException(
+								"Failed to store the uploaded backup file: " + ex.getMessage(),
+								"Failed to store the uploaded backup file.",
+								ex
+							);
+					}
+				},
+				this.uploadExecutor
+			);
+		}
+
+		/**
+		 * Creates the temporary file on first use. Deferred to the first chunk on purpose: creating it
+		 * eagerly would put `mkdirs` and `createTempFile` back on the event loop, which is exactly what
+		 * this observer exists to avoid.
+		 */
+		private void openBackupFileIfNeeded() throws IOException {
+			if (this.outputStream != null) {
+				return;
+			}
+			final Path workDirectory = EvitaManagementService.this.evita.getConfiguration()
+				.transaction().transactionWorkDirectory();
+			if (!workDirectory.toFile().exists()) {
+				Assert.isTrue(
+					workDirectory.toFile().mkdirs(), "Failed to create work directory for catalog restore."
+				);
+			}
+			this.backupFilePath = Files.createTempFile(workDirectory, "catalog_backup_for_restore-", ".zip");
+			this.outputStream = new BufferedOutputStream(
+				Files.newOutputStream(this.backupFilePath, StandardOpenOption.APPEND), UPLOAD_BUFFER_SIZE
+			);
+		}
+
+		/**
+		 * Finalises the upload and hands the assembled file to the restoration task.
+		 */
+		private void submitRestoration() throws IOException {
+			Assert.isPremiseValid(this.catalogNameToRestore != null, "Catalog name to restore must be provided.");
+			Assert.isPremiseValid(this.backupFilePath != null, "No backup file contents were uploaded.");
+			final OutputStream theOutputStream = this.outputStream;
+			Assert.isPremiseValid(theOutputStream != null, "Output stream has already been closed.");
+			theOutputStream.close();
+			this.outputStream = null;
+			final Task<?, Void> restorationTask = EvitaManagementService.this.management.restoreCatalog(
+				this.catalogNameToRestore,
+				Files.size(this.backupFilePath),
+				Files.newInputStream(this.backupFilePath, StandardOpenOption.READ)
+			);
+			if (this.terminated.compareAndSet(false, true)) {
+				this.responseObserver.onNext(
+					GrpcRestoreCatalogResponse.newBuilder()
+						.setTask(toGrpcTaskStatus(restorationTask.getStatus()))
+						.setRead(this.bytesRead.get())
+						.build()
+				);
+				this.responseObserver.onCompleted();
+			}
+		}
+
+		/**
+		 * Reports a failed upload to the client and discards the partial file. Idempotent.
+		 *
+		 * @param exception the failure to report
+		 */
+		private void failUpload(@Nonnull Throwable exception) {
+			closeOutputStream();
+			deleteFileIfExists(this.backupFilePath, "restore");
+			if (this.terminated.compareAndSet(false, true)) {
+				sendErrorToClient(exception, this.responseObserver);
+			}
+		}
+
+		/**
+		 * Closes the temporary file, tolerating both "never opened" and "already closed".
+		 */
+		private void closeOutputStream() {
+			final OutputStream stream = this.outputStream;
+			if (stream == null) {
+				return;
+			}
+			this.outputStream = null;
+			try {
+				stream.close();
+			} catch (IOException e) {
+				log.error("Failed to close output stream for backup file: {}", this.backupFilePath, e);
+			}
+		}
+
 	}
 
 }

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaSessionService.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaSessionService.java
@@ -96,6 +96,7 @@ import io.evitadb.externalApi.grpc.services.converter.WriteAheadLogVersionDescri
 import io.evitadb.externalApi.grpc.services.interceptors.GlobalExceptionHandlerInterceptor;
 import io.evitadb.externalApi.grpc.services.interceptors.ServerSessionInterceptor;
 import io.evitadb.externalApi.grpc.services.subscriber.ChangeCatalogCaptureSubscriber;
+import io.evitadb.externalApi.grpc.utils.GrpcOutboundGate;
 import io.evitadb.externalApi.grpc.utils.GrpcTimeoutUtil;
 import io.evitadb.externalApi.grpc.utils.QueryUtil;
 import io.evitadb.externalApi.grpc.utils.QueryWithParameters;
@@ -121,6 +122,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -609,7 +611,19 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 		}
 	}
 
-	public EvitaSessionService(@Nonnull Evita evita, @Nonnull HeaderOptions headers) {
+	/**
+	 * How long a streamed response may make no progress before it is abandoned -
+	 * `api.endpoints.gRPC.streamingRequestTimeoutInMillis`.
+	 * Handed to every {@link GrpcOutboundGate} this service attaches.
+	 */
+	private final long streamingRequestTimeoutInMillis;
+
+	public EvitaSessionService(
+		@Nonnull Evita evita,
+		@Nonnull HeaderOptions headers,
+		long streamingRequestTimeoutInMillis
+	) {
+		this.streamingRequestTimeoutInMillis = streamingRequestTimeoutInMillis;
 		this.evita = evita;
 		this.trackSourceQueries = evita.getConfiguration().server().trafficRecording().sourceQueryTrackingEnabled();
 		this.tracingContext = ExternalApiTracingContextProvider.getContext(Metadata.class, headers);
@@ -767,6 +781,19 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 		StreamObserver<GrpcGoLiveAndCloseWithProgressResponse> responseObserver
 	) {
 		final ServiceRequestContext serviceContext = ServiceRequestContext.current();
+		// resolved before the first progress tick, so that every re-arm below restates the same budget
+		// rather than compounding it. This is a stream, so it gets the streaming budget rather than the
+		// call's whole-request one - a go-live phase that reports no progress for longer than
+		// `api.requestTimeoutInMillis` would otherwise kill the stream mid-flight.
+		final long configuredRequestTimeoutMillis = GrpcTimeoutUtil.resolveStreamingBudgetMillis(
+			serviceContext, this.streamingRequestTimeoutInMillis
+		);
+		// Armed once here, not only from inside the progress callback: the first tick is separated from
+		// this point by the executor hand-off *and* by however long go-live takes to report any progress
+		// at all, and none of that is covered by a re-arm that has not happened yet. Without this the
+		// whole-request budget still bounds the run-up to the first tick - which is exactly the window a
+		// go-live is least able to promise anything about.
+		GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, configuredRequestTimeoutMillis);
 		executeWithClientContext(
 			session -> {
 				if (session == null) {
@@ -788,7 +815,9 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 									responseObserver.onNext(response);
 									this.lastUpdate = System.currentTimeMillis();
 								}
-								GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, serviceContext.requestTimeoutMillis());
+								GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(
+									serviceContext, configuredRequestTimeoutMillis
+								);
 							}
 						}
 					);
@@ -903,7 +932,8 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 						.setTaskStatus(status)
 						.build(),
 					responseObserver,
-					serviceContext
+					serviceContext,
+					this.streamingRequestTimeoutInMillis
 				);
 			},
 			this.evita.getRequestExecutor(),
@@ -936,7 +966,8 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 						.setTaskStatus(status)
 						.build(),
 					responseObserver,
-					serviceContext
+					serviceContext,
+					this.streamingRequestTimeoutInMillis
 				);
 			},
 			this.evita.getRequestExecutor(),
@@ -954,14 +985,28 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 	 * @param responseBuilder  function to build the gRPC response from a task status
 	 * @param responseObserver observer to stream responses to
 	 * @param serviceContext   Armeria service context for timeout management
+	 * @param streamingRequestTimeoutInMillis
+	 *                         `api.endpoints.gRPC.streamingRequestTimeoutInMillis` - the budget each
+	 *                         re-arm restates. Passed in rather than read here because this helper is
+	 *                         static; the poll below happens to refresh the deadline every second
+	 *                         regardless of whether anything was sent, so the whole-request budget would
+	 *                         also survive today - but that is an accident of the poll interval, not a
+	 *                         property anyone should have to preserve.
 	 * @param <T>              the gRPC response type
 	 */
 	private static <T> void streamBackupProgress(
 		@Nonnull Task<?, FileForFetch> backupTask,
 		@Nonnull Function<GrpcTaskStatus, T> responseBuilder,
 		@Nonnull StreamObserver<T> responseObserver,
-		@Nonnull ServiceRequestContext serviceContext
+		@Nonnull ServiceRequestContext serviceContext,
+		long streamingRequestTimeoutInMillis
 	) {
+		// resolved before the first message, so that every re-arm below restates the same budget rather
+		// than compounding it, and from the streaming budget because this is a stream - see
+		// `GrpcTimeoutUtil#resolveStreamingBudgetMillis`
+		final long configuredRequestTimeoutMillis = GrpcTimeoutUtil.resolveStreamingBudgetMillis(
+			serviceContext, streamingRequestTimeoutInMillis
+		);
 		// send initial status
 		responseObserver.onNext(
 			responseBuilder.apply(toGrpcTaskStatus(backupTask.getStatus()))
@@ -981,7 +1026,7 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 						responseBuilder.apply(toGrpcTaskStatus(backupTask.getStatus()))
 					);
 				}
-				GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, serviceContext.requestTimeoutMillis());
+				GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, configuredRequestTimeoutMillis);
 			} catch (ExecutionException e) {
 				// task failed
 				GlobalExceptionHandlerInterceptor.sendErrorToClient(
@@ -2418,6 +2463,7 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 	private void streamMutationsHistory(
 		@Nonnull GetMutationsHistoryRequest request,
 		@Nonnull StreamObserver<GetMutationsHistoryResponse> responseObserver,
+		@Nonnull String methodName,
 		@Nonnull BiFunction<EvitaInternalSessionContract, ChangeCatalogCaptureRequest, Stream<ChangeCatalogCapture>> mutationsHistoryStream
 	) {
 		final ServerCallStreamObserver<GetMutationsHistoryResponse> serverCallStreamObserver =
@@ -2425,16 +2471,23 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 
 		final AtomicReference<Stream<ChangeCatalogCapture>> mutationsHistoryStreamRef = new AtomicReference<>();
 
-		// avoid returning error when client cancels the stream
-		serverCallStreamObserver.setOnCancelHandler(
+		// the gate paces the loop below to the client's consumption rate; it owns the call's cancel
+		// handler (gRPC keeps only the last one registered), so the stream cleanup that used to be
+		// registered here is handed to it. Both must happen synchronously, before this method returns.
+		final GrpcOutboundGate outboundGate = GrpcOutboundGate.attach(
+			serverCallStreamObserver,
+			// the caller's own RPC name - this helper backs both the forward and the reversed variant,
+			// and a stall must name the one the client actually invoked
+			methodName,
+			// avoid returning error when client cancels the stream
 			() -> {
 				log.info("Client cancelled the mutation history request.");
 				ofNullable(mutationsHistoryStreamRef.get())
 					.ifPresent(BaseStream::close);
-			}
+			},
+			this.streamingRequestTimeoutInMillis
 		);
 
-		final ServiceRequestContext serviceContext = ServiceRequestContext.current();
 		executeWithClientContext(
 			session -> {
 				try (
@@ -2445,19 +2498,29 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 					mutationsHistoryStreamRef.set(capturedMutations);
 					final SemVer clientVersion = ServerSessionInterceptor.getClientVersion().orElse(null);
 
-					capturedMutations.forEach(
-						cdcEvent -> {
-							final GetMutationsHistoryResponse.Builder builder = GetMutationsHistoryResponse
-								.newBuilder();
-							final GrpcChangeCatalogCapture event = ChangeCaptureConverter
-								.toGrpcChangeCatalogCapture(cdcEvent, clientVersion);
-							// we send mutations one by one, but we may want to send them in batches in the future
-							builder.addChangeCapture(event);
-							responseObserver.onNext(builder.build());
-							GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, serviceContext.requestTimeoutMillis());
+					// pulled through an iterator rather than `forEach` so the loop can stop early when
+					// the client disappears - the captures are produced lazily, so abandoning it here
+					// also stops the underlying WAL reads
+					final Iterator<ChangeCatalogCapture> captureIterator = capturedMutations.iterator();
+					while (captureIterator.hasNext()) {
+						if (!outboundGate.awaitWritable()) {
+							log.debug("Client of `{}` disconnected, abandoning stream.", methodName);
+							return;
 						}
-					);
+						final GetMutationsHistoryResponse.Builder builder = GetMutationsHistoryResponse
+							.newBuilder();
+						final GrpcChangeCatalogCapture event = ChangeCaptureConverter
+							.toGrpcChangeCatalogCapture(captureIterator.next(), clientVersion);
+						// we send mutations one by one, but we may want to send them in batches in the future
+						builder.addChangeCapture(event);
+						// the Armeria deadline is re-armed by `awaitWritable` above, per granted message -
+						// see `GrpcOutboundGate#grantNextMessageWindow`
+						responseObserver.onNext(builder.build());
+					}
 				}
+				// the final capture's window is the only one still standing - give the half-close a
+				// full budget of its own
+				outboundGate.grantCompletionWindow();
 				responseObserver.onCompleted();
 			},
 			this.evita.getRequestExecutor(),
@@ -2478,7 +2541,10 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 	public void getMutationsHistory(
 		GetMutationsHistoryRequest request, StreamObserver<GetMutationsHistoryResponse> responseObserver
 	) {
-		streamMutationsHistory(request, responseObserver, EvitaInternalSessionContract::getMutationsHistoryReversed);
+		streamMutationsHistory(
+			request, responseObserver, "getMutationsHistory",
+			EvitaInternalSessionContract::getMutationsHistoryReversed
+		);
 	}
 
 	/**
@@ -2493,7 +2559,10 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 	public void getMutationsHistoryForward(
 		GetMutationsHistoryRequest request, StreamObserver<GetMutationsHistoryResponse> responseObserver
 	) {
-		streamMutationsHistory(request, responseObserver, EvitaInternalSessionContract::getMutationsHistoryForward);
+		streamMutationsHistory(
+			request, responseObserver, "getMutationsHistoryForward",
+			EvitaInternalSessionContract::getMutationsHistoryForward
+		);
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaTrafficRecordingService.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaTrafficRecordingService.java
@@ -24,7 +24,6 @@
 package io.evitadb.externalApi.grpc.services;
 
 
-import com.linecorp.armeria.server.ServiceRequestContext;
 import io.evitadb.api.file.FileForFetch;
 import io.evitadb.api.requestResponse.trafficRecording.TrafficRecording;
 import io.evitadb.api.requestResponse.trafficRecording.TrafficRecordingCaptureRequest;
@@ -36,7 +35,7 @@ import io.evitadb.core.traffic.TrafficRecordingSettings;
 import io.evitadb.externalApi.configuration.HeaderOptions;
 import io.evitadb.externalApi.grpc.generated.*;
 import io.evitadb.externalApi.grpc.services.converter.TrafficCaptureConverter;
-import io.evitadb.externalApi.grpc.utils.GrpcTimeoutUtil;
+import io.evitadb.externalApi.grpc.utils.GrpcOutboundGate;
 import io.evitadb.externalApi.trace.ExternalApiTracingContextProvider;
 import io.evitadb.externalApi.utils.ExternalApiTracingContext;
 import io.grpc.Metadata;
@@ -47,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import java.time.Duration;
+import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.BaseStream;
 import java.util.stream.Stream;
@@ -73,7 +73,19 @@ public class EvitaTrafficRecordingService extends GrpcEvitaTrafficRecordingServi
 	 */
 	@Nonnull private final ExternalApiTracingContext<Metadata> tracingContext;
 
-	public EvitaTrafficRecordingService(@Nonnull Evita evita, @Nonnull HeaderOptions headerOptions) {
+	/**
+	 * How long a streamed response may make no progress before it is abandoned -
+	 * `api.endpoints.gRPC.streamingRequestTimeoutInMillis`.
+	 * Handed to every {@link GrpcOutboundGate} this service attaches.
+	 */
+	private final long streamingRequestTimeoutInMillis;
+
+	public EvitaTrafficRecordingService(
+		@Nonnull Evita evita,
+		@Nonnull HeaderOptions headerOptions,
+		long streamingRequestTimeoutInMillis
+	) {
+		this.streamingRequestTimeoutInMillis = streamingRequestTimeoutInMillis;
 		this.evita = evita;
 		this.tracingContext = ExternalApiTracingContextProvider.getContext(Metadata.class, headerOptions);
 	}
@@ -146,40 +158,56 @@ public class EvitaTrafficRecordingService extends GrpcEvitaTrafficRecordingServi
 	 */
 	@Override
 	public void getTrafficRecordingHistory(GetTrafficHistoryRequest request, StreamObserver<GetTrafficHistoryResponse> responseObserver) {
-		ServerCallStreamObserver<GetTrafficHistoryResponse> serverCallStreamObserver =
+		final ServerCallStreamObserver<GetTrafficHistoryResponse> serverCallStreamObserver =
 			(ServerCallStreamObserver<GetTrafficHistoryResponse>) responseObserver;
 
 		final AtomicReference<Stream<TrafficRecording>> trafficHistoryStreamRef = new AtomicReference<>();
 
-		// avoid returning error when client cancels the stream
-		serverCallStreamObserver.setOnCancelHandler(
+		// the gate paces the loop below to the client's consumption rate; it owns the call's cancel
+		// handler (gRPC keeps only the last one registered), so the stream cleanup that used to be
+		// registered here is handed to it. Both must happen synchronously, before this method returns.
+		final GrpcOutboundGate outboundGate = GrpcOutboundGate.attach(
+			serverCallStreamObserver,
+			"getTrafficRecordingHistory",
+			// avoid returning error when client cancels the stream
 			() -> {
 				log.info("Client cancelled the traffic history request.");
 				ofNullable(trafficHistoryStreamRef.get())
 					.ifPresent(BaseStream::close);
-			}
+			},
+			this.streamingRequestTimeoutInMillis
 		);
 
-		final ServiceRequestContext serviceContext = ServiceRequestContext.current();
 		executeWithClientContext(
 			session -> {
 				final TrafficRecordingCaptureRequest captureRequest = TrafficCaptureConverter.toTrafficRecordingCaptureRequest(request);
-				final Stream<TrafficRecording> trafficHistoryStream = session.getRecordings(captureRequest);
-				trafficHistoryStreamRef.set(trafficHistoryStream);
+				try (final Stream<TrafficRecording> trafficHistoryStream = session.getRecordings(captureRequest)) {
+					trafficHistoryStreamRef.set(trafficHistoryStream);
 
-				trafficHistoryStream.forEach(
-					trafficRecording -> {
+					// pulled through an iterator rather than `forEach` so the loop can stop early when
+					// the client disappears - the records are read lazily, so abandoning it here also
+					// stops the underlying traffic-log reads
+					final Iterator<TrafficRecording> recordingIterator = trafficHistoryStream.iterator();
+					while (recordingIterator.hasNext()) {
+						if (!outboundGate.awaitWritable()) {
+							log.debug("Client of `getTrafficRecordingHistory` disconnected, abandoning stream.");
+							return;
+						}
 						final GetTrafficHistoryResponse.Builder builder = GetTrafficHistoryResponse.newBuilder();
-						final GrpcTrafficRecord event = TrafficCaptureConverter.toGrpcGrpcTrafficRecord(trafficRecording, captureRequest.content());
+						final GrpcTrafficRecord event = TrafficCaptureConverter.toGrpcGrpcTrafficRecord(
+							recordingIterator.next(), captureRequest.content()
+						);
 						// we send mutations one by one, but we may want to send them in batches in the future
 						builder.addTrafficRecord(event);
+						// the Armeria deadline is re-armed by `awaitWritable` above, per granted message -
+						// see `GrpcOutboundGate#grantNextMessageWindow`
 						responseObserver.onNext(builder.build());
-
-						GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, serviceContext.requestTimeoutMillis());
 					}
-				);
+				}
+				// the final record's window is the only one still standing - give the half-close a full
+				// budget of its own
+				outboundGate.grantCompletionWindow();
 				responseObserver.onCompleted();
-				trafficHistoryStream.close();
 			},
 			this.evita.getRequestExecutor(),
 			responseObserver,

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/interceptors/GlobalExceptionHandlerInterceptor.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/interceptors/GlobalExceptionHandlerInterceptor.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.common.stream.ClosedStreamException;
 import io.evitadb.exception.EvitaInternalError;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.externalApi.grpc.exception.ClosedGrpcStreamException;
+import io.evitadb.externalApi.grpc.exception.StalledGrpcStreamException;
 import io.evitadb.utils.ExceptionUtils;
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
@@ -89,6 +90,16 @@ public class GlobalExceptionHandlerInterceptor implements ServerInterceptor {
 
 			rpcStatus = com.google.rpc.Status.newBuilder()
 				.setCode(Code.CANCELLED.value())
+				.build();
+		} else if (exception instanceof StalledGrpcStreamException stalledStream) {
+			// the client kept the stream open but stopped reading it - a network/consumer condition
+			// rather than a server fault, so it is logged at WARN and given a status the client can
+			// actually distinguish from a server error
+			log.warn("Abandoning stalled gRPC response stream: {}", stalledStream.getMessage());
+
+			rpcStatus = com.google.rpc.Status.newBuilder()
+				.setCode(Code.DEADLINE_EXCEEDED.value())
+				.setMessage(stalledStream.getErrorCode() + ": " + stalledStream.getPublicMessage())
 				.build();
 		} else if (exception instanceof EvitaInvalidUsageException invalidUsageException) {
 			if (log.isDebugEnabled()) {
@@ -183,8 +194,23 @@ public class GlobalExceptionHandlerInterceptor implements ServerInterceptor {
 			}
 		}
 
+		/**
+		 * Closes the call with a status derived from the escaping exception.
+		 *
+		 * The guard is deliberately {@link ServerCall#isCancelled()} and not {@link ServerCall#isReady()}:
+		 * readiness answers "can the transport accept another message right now", which is false whenever
+		 * a message is still in flight — a state that has nothing to do with whether the call can still be
+		 * closed. It only ever read as an open/closed test because the decorator underneath returned an
+		 * unconditional `true` (see `ObservabilityInterceptor`); once readiness became real, using it here
+		 * would silently swallow the error status for any RPC that had already sent data, leaving the
+		 * client hanging on a stream that is never closed. A cancelled call, on the other hand, is genuinely
+		 * past closing — the client is gone and gRPC has already terminated the stream.
+		 *
+		 * @param exception  the exception that escaped the service method
+		 * @param serverCall the call to close
+		 */
 		private void handleException(@Nonnull RuntimeException exception, @Nonnull ServerCall<T, R> serverCall) {
-			if (serverCall.isReady()) {
+			if (!serverCall.isCancelled()) {
 				final com.google.rpc.Status rpcStatus = createErrorStatus(exception);
 
 				final StatusRuntimeException statusRuntimeException = StatusProto.toStatusRuntimeException(rpcStatus);

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/interceptors/ObservabilityInterceptor.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/interceptors/ObservabilityInterceptor.java
@@ -29,6 +29,7 @@ import io.evitadb.externalApi.grpc.metric.event.AbstractProcedureCalledEvent;
 import io.evitadb.externalApi.grpc.metric.event.AbstractProcedureCalledEvent.InitiatorType;
 import io.evitadb.externalApi.grpc.metric.event.EvitaProcedureCalledEvent;
 import io.evitadb.externalApi.grpc.metric.event.SessionProcedureCalledEvent;
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -100,27 +101,32 @@ public class ObservabilityInterceptor implements ServerInterceptor {
 
 	/**
 	 * Observability server call that logs access log messages and fires gRPC procedure called event.
+	 *
+	 * It must extend {@link SimpleForwardingServerCall} rather than {@link ServerCall} directly: several
+	 * {@link ServerCall} methods are non-abstract and carry defaults that silently disagree with the
+	 * transport. {@link ServerCall#isReady()} is the dangerous one — it returns an unconditional `true`,
+	 * so a hand-rolled decorator that forgets to override it reports every transport as writable and
+	 * disables any {@code isReady()}-driven flow control in the service method underneath it. This is
+	 * the only {@link ServerCall} decorator in evitaDB's interceptor chain - the other two wrap the
+	 * *listener* - so it is what a service's {@code ServerCallStreamObserver} actually queries, and
+	 * what {@code GlobalExceptionHandlerInterceptor} sees when it decides whether it may still close a
+	 * failing call. {@link ServerCall#setOnReadyThreshold(int)}, {@link ServerCall#getAttributes()},
+	 * {@link ServerCall#getAuthority()}, {@link ServerCall#getSecurityLevel()},
+	 * {@link ServerCall#setCompression(String)} and {@link ServerCall#setMessageCompression(boolean)}
+	 * have the same problem in a less visible way. Forwarding by default and overriding only what
+	 * genuinely adds behaviour keeps the decorator correct as gRPC adds methods.
+	 *
+	 * Guarded by `ObservabilityInterceptorReadinessTest`.
 	 */
-	private static class ObservabilityServerCall<M, R> extends ServerCall<M, R> {
-		private final ServerCall<M, R> serverCall;
+	private static class ObservabilityServerCall<M, R> extends SimpleForwardingServerCall<M, R> {
 		private final AbstractProcedureCalledEvent event;
 
 		protected ObservabilityServerCall(
 			@Nonnull ServerCall<M, R> serverCall,
 			@Nonnull AbstractProcedureCalledEvent event
 		) {
-			this.serverCall = serverCall;
+			super(serverCall);
 			this.event = event;
-		}
-
-		@Override
-		public void request(int numMessages) {
-			this.serverCall.request(numMessages);
-		}
-
-		@Override
-		public void sendHeaders(Metadata headers) {
-			this.serverCall.sendHeaders(headers);
 		}
 
 		@Override
@@ -128,23 +134,13 @@ public class ObservabilityInterceptor implements ServerInterceptor {
 			if (this.event.streamsResponses()) {
 				this.event.setInitiator(InitiatorType.SERVER);
 			}
-			this.serverCall.sendMessage(message);
+			super.sendMessage(message);
 		}
 
 		@Override
 		public void close(Status status, Metadata trailers) {
 			this.event.finish().commit();
-			this.serverCall.close(status, trailers);
-		}
-
-		@Override
-		public boolean isCancelled() {
-			return this.serverCall.isCancelled();
-		}
-
-		@Override
-		public MethodDescriptor<M, R> getMethodDescriptor() {
-			return this.serverCall.getMethodDescriptor();
+			super.close(status, trailers);
 		}
 
 	}

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/AbstractChangeCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/AbstractChangeCaptureSubscriber.java
@@ -166,7 +166,9 @@ public abstract class AbstractChangeCaptureSubscriber<CAPTURE, RESPONSE>
 		this.responseObserver = responseObserver;
 		this.versionSupplier = versionSupplier;
 		this.serviceContext = serviceContext;
-		this.responseTimeoutMillis = this.serviceContext.requestTimeoutMillis();
+		// captured once, before the first capture is delivered - re-reading it per message would compound
+		// the budget instead of restating it, see `GrpcTimeoutUtil#captureRequestTimeoutMillis`
+		this.responseTimeoutMillis = GrpcTimeoutUtil.captureRequestTimeoutMillis(this.serviceContext);
 		final long idleTimeoutMillis = this.serviceContext.config().server().config().idleTimeoutMillis();
 		this.heartBeatDelay = resolveHeartBeatDelay(this.responseTimeoutMillis, idleTimeoutMillis);
 		this.heartBeatTask = new DelayedAsyncTask(

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils/GrpcOutboundGate.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils/GrpcOutboundGate.java
@@ -1,0 +1,407 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc.utils;
+
+import com.linecorp.armeria.server.ServiceRequestContext;
+import io.evitadb.externalApi.grpc.exception.StalledGrpcStreamException;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.netty.channel.EventLoop;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Back-pressure gate for server-streaming gRPC methods that produce messages faster than the client
+ * consumes them.
+ *
+ * gRPC-Java's send path never blocks. `StreamObserver.onNext` marshals the message and hands it to
+ * Armeria's outbound {@code StreamMessage}, whose queue has an initial capacity but **no bound** — its
+ * `tryWrite` refuses a message only once the stream is closed, never because it is full. A producer
+ * that ignores this materialises the whole payload in memory (as pooled, off-heap Netty buffers,
+ * roughly twice the payload in reserved arena space) and eventually kills the RPC with a bare
+ * `UNKNOWN` when the allocator gives up. Transport readiness is the only back-pressure signal there
+ * is, and this class is what makes it usable from a straight-line producing loop:
+ *
+ * ```java
+ * final GrpcOutboundGate gate = GrpcOutboundGate.attach(serverCallObserver, methodName);
+ * executeWithClientContext(
+ *     () -> {
+ *         while ((bytesRead = inputStream.read(buffer)) != -1) {
+ *             if (!gate.awaitWritable()) {
+ *                 return;                     // client is gone — abandon without completing
+ *             }
+ *             responseObserver.onNext(chunk);
+ *         }
+ *         responseObserver.onCompleted();
+ *     },
+ *     ...
+ * );
+ * ```
+ *
+ * **`attach` must be called synchronously from the service method, before it returns.** gRPC's
+ * {@code ServerCallStreamObserverImpl} freezes handler registration the moment the service method
+ * returns and throws {@link IllegalStateException} for any later {@code setOnReadyHandler} /
+ * {@code setOnCancelHandler} — which is exactly what would happen if the gate were built inside the
+ * worker task that {@code executeWithClientContext} submits. Only the producing loop belongs on the
+ * worker; the gate is wired up before it.
+ *
+ * The gate parks the producing worker thread rather than driving the loop from the on-ready callback.
+ * The callback runs on the Armeria event loop, so a callback-driven pump would have to bounce every
+ * chunk back onto a worker anyway; parking keeps the loop's `try`-with-resources, tracing scope and
+ * error handling in one straight-line method, and pins no thread that the RPC did not already own for
+ * its whole duration. What it does change is *how long* that thread is held — bounded by
+ * {@link #DEFAULT_STALL_TIMEOUT_MILLIS} so that a client which stops reading without hanging up cannot
+ * hold a request-executor thread forever.
+ *
+ * With Armeria, readiness means `pendingMessages == 0`, so a gated loop keeps exactly one message in
+ * flight. Callers streaming large payloads should size their chunks accordingly — every chunk costs an
+ * event-loop round trip.
+ *
+ * The one configuration the gate cannot help is an engine built with a direct (synchronous) executor,
+ * where the "worker" the service method hands off to *is* the transport event loop. Waiting there would
+ * deadlock rather than throttle, so the gate detects it, warns once and lets the producer run ungated -
+ * see {@link #awaitWritable()}. That is a test-only configuration; a networked `EvitaServer` always runs
+ * on real thread pools.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Slf4j
+public final class GrpcOutboundGate {
+
+	/**
+	 * How long the producer waits for the client to consume a single outstanding message before it
+	 * gives up on it. This is a "the peer is alive but has stopped reading" backstop, not a transfer
+	 * deadline: the wait restarts from zero every time the transport consumes anything, so even a very
+	 * slow but progressing client never reaches it.
+	 *
+	 * Mirrors `GrpcOptions.DEFAULT_STREAMING_REQUEST_TIMEOUT_IN_MILLIS` - a deployment configures it as
+	 * `api.endpoints.gRPC.streamingRequestTimeoutInMillis`, and this constant is only the fallback for
+	 * callers that have no configuration in hand (the two- and three-argument `attach` overloads, used by
+	 * tests and by the example above).
+	 */
+	public static final long DEFAULT_STALL_TIMEOUT_MILLIS = 300_000L;
+
+	/**
+	 * How much longer than the stall timeout the Armeria request deadline is re-armed for.
+	 *
+	 * The two mechanisms that can end a stalled stream - this gate's own wait and Armeria's request
+	 * timeout - are driven from the same budget, but they do not start their clocks at the same instant:
+	 * the deadline is re-armed when a message is *granted*, the gate begins waiting only after that
+	 * message has been written. Armed identically, Armeria would therefore always fire first and the
+	 * gate's stall detection would be unreachable - the client would get a bare `RST_STREAM` instead of
+	 * `DEADLINE_EXCEEDED` naming the stalled method. The grace hands the race to the gate deliberately,
+	 * leaving Armeria as the backstop for a producer that never reaches the gate at all.
+	 */
+	private static final long STALL_DETECTION_GRACE_MILLIS = 5_000L;
+
+	private final ServerCallStreamObserver<?> responseObserver;
+	private final String methodName;
+	private final long stallTimeoutMillis;
+	/**
+	 * The call's Armeria context, captured at attach time (`null` outside a request context, i.e. in
+	 * unit tests driving the gate against a mock observer).
+	 */
+	private final ServiceRequestContext serviceContext;
+	/**
+	 * The budget each re-arm restates, in milliseconds, or `<= 0` when the call has no request timeout
+	 * at all (an explicit `grpc-timeout: 0`, or a deployment that disabled it).
+	 *
+	 * This is the *streaming* budget - {@link #stallTimeoutMillis} plus
+	 * {@link #STALL_DETECTION_GRACE_MILLIS} - not the call's own `requestTimeout`. Re-arming to the
+	 * latter is what made a 1 MiB chunk require a ~4 Mbit/s link before the client's own deadline
+	 * mattered: `requestTimeout` is a whole-request budget sized for unary calls (1 s in code, 2 s
+	 * shipped), and a gated stream needs one message to drain inside it. The distinction is the same one
+	 * `EvitaClientChannel.TimeoutTier` draws on the driver side.
+	 */
+	private final long streamBudgetMillis;
+	/**
+	 * The event loop this call is bound to, captured at attach time (`null` outside a request
+	 * context). Waiting on readiness *from* that loop would be a self-deadlock - see
+	 * {@link #awaitWritable()}.
+	 */
+	private final EventLoop callEventLoop;
+	private final ReentrantLock lock = new ReentrantLock();
+	private final Condition transportStateChanged = this.lock.newCondition();
+
+	/**
+	 * Set from the transport lifecycle callbacks. Volatile so the fast path can read it without
+	 * taking the lock.
+	 */
+	private volatile boolean transportTerminated;
+	/**
+	 * Ensures the "producer runs on the event loop" warning is emitted once per call rather than once
+	 * per message.
+	 */
+	private final AtomicBoolean eventLoopProducerReported = new AtomicBoolean();
+
+	/**
+	 * Attaches a gate to the passed server-call observer using {@link #DEFAULT_STALL_TIMEOUT_MILLIS}.
+	 *
+	 * @param responseObserver observer of the server-streaming call to gate
+	 * @param methodName       name of the gated RPC, used in log and error messages
+	 * @return the attached gate
+	 */
+	@Nonnull
+	public static GrpcOutboundGate attach(
+		@Nonnull ServerCallStreamObserver<?> responseObserver,
+		@Nonnull String methodName
+	) {
+		return attach(responseObserver, methodName, null, DEFAULT_STALL_TIMEOUT_MILLIS);
+	}
+
+	/**
+	 * Attaches a gate to the passed server-call observer using {@link #DEFAULT_STALL_TIMEOUT_MILLIS},
+	 * chaining an additional action onto client-initiated cancellation.
+	 *
+	 * @param responseObserver observer of the server-streaming call to gate
+	 * @param methodName       name of the gated RPC, used in log and error messages
+	 * @param onCancel         action to run when the client cancels the call - typically releasing a
+	 *                         resource the producing loop holds. The gate owns the call's cancel
+	 *                         handler (gRPC allows only one, last registration wins), so any cleanup
+	 *                         the service method used to register itself must be passed in here
+	 * @return the attached gate
+	 */
+	@Nonnull
+	public static GrpcOutboundGate attach(
+		@Nonnull ServerCallStreamObserver<?> responseObserver,
+		@Nonnull String methodName,
+		@Nullable Runnable onCancel
+	) {
+		return attach(responseObserver, methodName, onCancel, DEFAULT_STALL_TIMEOUT_MILLIS);
+	}
+
+	/**
+	 * Attaches a gate to the passed server-call observer.
+	 *
+	 * @param responseObserver   observer of the server-streaming call to gate
+	 * @param methodName         name of the gated RPC, used in log and error messages
+	 * @param onCancel           action to run when the client cancels the call, or `null` for none
+	 * @param stallTimeoutMillis how long to wait for the client to consume a single message before
+	 *                           abandoning the stream with {@link StalledGrpcStreamException}
+	 * @return the attached gate
+	 */
+	@Nonnull
+	public static GrpcOutboundGate attach(
+		@Nonnull ServerCallStreamObserver<?> responseObserver,
+		@Nonnull String methodName,
+		@Nullable Runnable onCancel,
+		long stallTimeoutMillis
+	) {
+		final GrpcOutboundGate gate = new GrpcOutboundGate(responseObserver, methodName, stallTimeoutMillis);
+		responseObserver.setOnReadyHandler(gate::signalTransportStateChanged);
+		// both terminal transport edges wake the producer: onCancel for client-initiated termination
+		// (RST_STREAM, deadline, dead connection), onClose for server-initiated close - an interceptor
+		// closing the call, or our own onError/onCompleted reaching the client. Without the latter a
+		// producer waiting on readiness would sit out the full stall timeout after an unrelated
+		// failure closed the call underneath it.
+		responseObserver.setOnCancelHandler(
+			() -> {
+				gate.markTransportTerminated();
+				if (onCancel != null) {
+					onCancel.run();
+				}
+			}
+		);
+		responseObserver.setOnCloseHandler(gate::markTransportTerminated);
+		return gate;
+	}
+
+	private GrpcOutboundGate(
+		@Nonnull ServerCallStreamObserver<?> responseObserver,
+		@Nonnull String methodName,
+		long stallTimeoutMillis
+	) {
+		this.responseObserver = responseObserver;
+		this.methodName = methodName;
+		this.stallTimeoutMillis = stallTimeoutMillis;
+		this.serviceContext = ServiceRequestContext.currentOrNull();
+		this.callEventLoop = this.serviceContext == null ? null : this.serviceContext.eventLoop();
+		// Whether the call has a deadline at all is still the caller's decision - an explicit
+		// `grpc-timeout: 0` disables it and must stay disabled. What the deadline is re-armed *to*,
+		// however, is the streaming budget rather than the call's own request timeout. Read here rather
+		// than in the loop because `attach` runs synchronously from the service method, before any
+		// message and therefore before any re-arm has rewritten the stored value - see
+		// `GrpcTimeoutUtil#captureRequestTimeoutMillis` for why that matters.
+		this.streamBudgetMillis = this.serviceContext == null ?
+			0L :
+			GrpcTimeoutUtil.resolveStreamingBudgetMillis(
+				this.serviceContext, stallTimeoutMillis + STALL_DETECTION_GRACE_MILLIS
+			);
+	}
+
+	/**
+	 * Blocks the calling thread until the transport can accept another message.
+	 *
+	 * The cancellation check comes first and stays first, in every branch including the ungated
+	 * event-loop one. Attaching a gate registers a cancel handler, and gRPC stops throwing `CANCELLED`
+	 * from `onNext` as soon as one exists - so this method is the only thing left that can stop a
+	 * producing loop from reading its whole source and pushing it into a dead call. Reordering these
+	 * checks silently reintroduces that.
+	 *
+	 * @return true when it is safe to push the next message; false when the RPC is over and the caller
+	 *         must abandon the stream **without** calling `onCompleted` or `onError` - the transport is
+	 *         already terminated and both would be no-ops at best
+	 * @throws StalledGrpcStreamException when the client kept the stream open but consumed nothing
+	 *                                    within the stall timeout
+	 */
+	public boolean awaitWritable() {
+		// cancellation is checked first and unconditionally, before readiness is ever consulted:
+		// Armeria increments its pending-message counter in `sendMessage` and only decrements it once
+		// the payload is genuinely consumed, which never happens for a cancelled call because
+		// `doSendMessage` returns early. The counter is therefore never unwound and `isReady()` answers
+		// false forever - so a gate that trusted readiness here would park the producing worker for the
+		// entire stall timeout every single time a client simply pressed cancel.
+		if (isTransportGone()) {
+			return false;
+		}
+		if (this.responseObserver.isReady()) {
+			return grantNextMessageWindow();
+		}
+		if (this.callEventLoop != null && this.callEventLoop.inEventLoop()) {
+			// The producing loop is running on the very event loop that has to drain the outbound
+			// queue, so waiting here would block the only thread able to make readiness true again -
+			// a guaranteed self-deadlock rather than back-pressure. This happens when the service
+			// method's hand-off collapses into a direct (synchronous) executor, which evitaDB does
+			// for embedded test runs (`Evita(..., directExecutor = true)`); a networked server always
+			// uses real thread pools and never lands here. Proceed ungated, which is exactly the
+			// behaviour that configuration had before the gate existed.
+			if (this.eventLoopProducerReported.compareAndSet(false, true)) {
+				log.warn(
+					"`{}` is producing on the transport event loop, so outbound back-pressure cannot be " +
+						"applied - the response is buffered without bound. This is expected only for an " +
+						"embedded engine configured with a direct executor.",
+					this.methodName
+				);
+			}
+			return grantNextMessageWindow();
+		}
+		this.lock.lock();
+		try {
+			// re-check under the lock: the on-ready callback signals while holding it, and Armeria
+			// decrements the pending counter *before* invoking the callback, so a readiness edge that
+			// lands between the fast path above and the wait below cannot be missed
+			long remainingNanos = TimeUnit.MILLISECONDS.toNanos(this.stallTimeoutMillis);
+			while (!this.responseObserver.isReady()) {
+				if (isTransportGone()) {
+					return false;
+				}
+				if (remainingNanos <= 0L) {
+					throw new StalledGrpcStreamException(this.methodName, this.stallTimeoutMillis);
+				}
+				remainingNanos = this.transportStateChanged.awaitNanos(remainingNanos);
+			}
+			return grantNextMessageWindow();
+		} catch (InterruptedException ex) {
+			// the request executor cancels its tasks when the Armeria context is cancelled, so an
+			// interrupt here means the call is being torn down - treat it exactly like a dead transport
+			Thread.currentThread().interrupt();
+			log.debug("Producer of `{}` interrupted while waiting for the client to consume.", this.methodName);
+			return false;
+		} finally {
+			this.lock.unlock();
+		}
+	}
+
+	/**
+	 * Re-arms the deadline one last time, for the terminal `onCompleted` and whatever is still queued
+	 * behind it.
+	 *
+	 * Needed because {@link #awaitWritable()} grants a window *before* each message, so the final message
+	 * of a stream is the one write no subsequent grant covers. Without this call the deadline stays
+	 * frozen at the last grant while the transport is still draining the residual and the half-close is
+	 * yet to land - and the residual is precisely what a slow client is slowest at. Gating bounds it to
+	 * roughly one flow-control window, not to zero.
+	 *
+	 * Call it immediately before `onCompleted()`, and only on the success path - a producer abandoning a
+	 * dead call has nothing left to protect.
+	 */
+	public void grantCompletionWindow() {
+		grantNextMessageWindow();
+	}
+
+	/**
+	 * Re-arms the call's Armeria request timeout and reports that the producer may send.
+	 *
+	 * This is the reason the gate touches deadlines at all. Armeria's request timeout measures the whole
+	 * request, and gating a producer on readiness ties that request's lifetime to how fast the *client*
+	 * consumes - so a healthy download of a large file over a slow link outlives any fixed budget, and
+	 * without a re-arm the entire transfer has to fit inside one (1-2 s for a client that sends no
+	 * `grpc-timeout`). What the deadline has to mean on a stream is "time without progress", and every
+	 * grant of the gate is exactly one unit of progress.
+	 *
+	 * Doing it here rather than in each producing loop is deliberate: the re-arm was hand-written at six
+	 * call sites and `fetchFile` - the one streaming the largest payloads - was missing it entirely, which
+	 * is the failure mode a per-call-site convention has. A gated method now cannot forget, because the
+	 * grant and the re-arm are the same act.
+	 *
+	 * Safe off the event loop: Armeria's `DefaultCancellationScheduler` guards `setTimeoutNanos` with a
+	 * lock and re-schedules through `EventExecutor.schedule`.
+	 *
+	 * @return always `true` - written as a return so the callers read as a single decision
+	 */
+	private boolean grantNextMessageWindow() {
+		if (this.serviceContext != null) {
+			GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(this.serviceContext, this.streamBudgetMillis);
+		}
+		return true;
+	}
+
+	/**
+	 * Tells whether the RPC is already over, from either transport lifecycle callback or from gRPC's
+	 * own cancellation flag - the latter covers a cancellation that races us before the callback runs.
+	 *
+	 * @return true when nothing more can usefully be written to this call
+	 */
+	private boolean isTransportGone() {
+		return this.transportTerminated || this.responseObserver.isCancelled();
+	}
+
+	/**
+	 * Records that the call is over and wakes a producer waiting on readiness. Runs on the Armeria
+	 * event loop, so it must stay non-blocking.
+	 */
+	private void markTransportTerminated() {
+		this.transportTerminated = true;
+		signalTransportStateChanged();
+	}
+
+	/**
+	 * Wakes a producer waiting on readiness. Runs on the Armeria event loop, so it must stay
+	 * non-blocking - the lock is only ever held for the duration of a state re-check.
+	 */
+	private void signalTransportStateChanged() {
+		this.lock.lock();
+		try {
+			this.transportStateChanged.signalAll();
+		} finally {
+			this.lock.unlock();
+		}
+	}
+
+}

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils/GrpcTimeoutUtil.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils/GrpcTimeoutUtil.java
@@ -40,12 +40,81 @@ import java.time.Duration;
 public class GrpcTimeoutUtil {
 
 	/**
+	 * Reads the call's configured request timeout, to be captured **once before** a streaming loop and
+	 * then passed to every {@link #reArmRequestTimeoutIfEnabled(ServiceRequestContext, long)} inside it.
+	 *
+	 * Calling {@link ServiceRequestContext#requestTimeoutMillis()} from inside the loop instead is the
+	 * trap this method exists to close, and it is not a theoretical one - six call sites had it. That
+	 * getter does **not** return the configured budget, nor the time remaining: Armeria stores the
+	 * timeout relative to the request's start, and {@link TimeoutMode#SET_FROM_NOW} writes
+	 * `elapsed + newTimeout` into that field (`DefaultCancellationScheduler#setTimeoutNanosFromNow0`),
+	 * which `requestTimeoutMillis()` returns verbatim. Feeding it back into the next re-arm therefore
+	 * *ratchets*: a 2 s budget re-armed every 100 ms becomes 2.1 s, then 2.3 s, then 2.6 s, growing
+	 * without bound. The deadline stops being a rolling stall window and becomes an ever-receding
+	 * horizon that a genuinely stalled client never reaches. (The accessor that does mean "time left" is
+	 * `remainingTimeoutNanos()`, which is *also* not what a re-arm wants.)
+	 *
+	 * Capturing before the loop is what makes the value the configured one - at that point no re-arm has
+	 * happened yet, so the stored budget is still the request's own.
+	 *
+	 * @param serviceContext Armeria service context of the call whose budget should be captured
+	 * @return the configured request timeout in milliseconds, or `<= 0` when the timeout is disabled
+	 */
+	public static long captureRequestTimeoutMillis(@Nonnull ServiceRequestContext serviceContext) {
+		return serviceContext.requestTimeoutMillis();
+	}
+
+	/**
+	 * Resolves the budget a **streaming** call should re-arm to, capturing it once before the first
+	 * message in the same way - and for the same reason - as
+	 * {@link #captureRequestTimeoutMillis(ServiceRequestContext)}.
+	 *
+	 * Whether a call has a deadline at all stays the caller's decision: a client that asked for none, or
+	 * for `grpc-timeout: 0`, keeps none, and this returns `0` so the re-arm is skipped. What the deadline
+	 * is re-armed *to*, however, is the deployment's streaming budget rather than the call's own
+	 * `requestTimeout`. Those are different quantities and conflating them is a category error:
+	 * `requestTimeout` bounds a whole request, which suits a unary call, whereas a stream needs a bound
+	 * on *silence*. Re-arming a stream to the whole-request budget imposes a minimum viable link speed -
+	 * at `fetchFile`'s 1 MB chunk and the shipped 2 s, roughly 4 Mbit/s sustained - on transfers that are
+	 * otherwise progressing perfectly well.
+	 *
+	 * This substitution is safe precisely because a gRPC deadline is enforced by the **client**: Armeria's
+	 * client maps `withDeadlineAfter` onto its own response timeout and grpc-java runs a deadline timer, so
+	 * a client that asked for 500 ms still sees its call end at 500 ms. What lengthening the server's copy
+	 * changes is only how long a *live but silent* peer can pin a server worker - the capacity trade
+	 * recorded against `GrpcOutboundGate`.
+	 *
+	 * @param serviceContext              Armeria service context of the streaming call
+	 * @param streamingRequestTimeoutMillis the deployment's streaming budget, from the API configuration
+	 * @return the budget to pass to every subsequent
+	 *         {@link #reArmRequestTimeoutIfEnabled(ServiceRequestContext, long)}, or `0` when this call
+	 *         has no request timeout to re-arm
+	 */
+	public static long resolveStreamingBudgetMillis(
+		@Nonnull ServiceRequestContext serviceContext,
+		long streamingRequestTimeoutMillis
+	) {
+		return captureRequestTimeoutMillis(serviceContext) <= 0 ? 0L : streamingRequestTimeoutMillis;
+	}
+
+	/**
 	 * Re-arms the Armeria request timeout to `requestTimeoutMillis` from now, unless the timeout is
-	 * disabled (`requestTimeoutMillis <= 0`). A disabled request timeout is the normal state for a
-	 * gRPC call without a client-supplied deadline (e.g. `useClientTimeoutHeader(true)` with no
-	 * `grpc-timeout` header, or an open-ended CDC subscription) — Armeria treats `0` as "disabled"
-	 * everywhere else, but {@link TimeoutMode#SET_FROM_NOW} uniquely rejects a zero/negative duration
-	 * with an {@link IllegalArgumentException}, so re-arming must be skipped in that case.
+	 * disabled (`requestTimeoutMillis <= 0`). Armeria treats `0` as "disabled" everywhere else, but
+	 * {@link TimeoutMode#SET_FROM_NOW} uniquely rejects a zero/negative duration with an
+	 * {@link IllegalArgumentException}, so re-arming must be skipped in that case.
+	 *
+	 * A disabled timeout is *not* the default here, and it is worth being precise because the opposite
+	 * is easy to assume. With `useClientTimeoutHeader(true)`, `FramedGrpcService` overrides the context's
+	 * timeout **only when the request actually carries a `grpc-timeout` header**; absent one it leaves
+	 * the server's own `api.requestTimeoutInMillis` in force (1 s code default, 2 s in the shipped
+	 * configuration). So a client that sets no deadline at all - a browser over gRPC-Web, most obviously -
+	 * gets the *shortest* budget of anyone, which is exactly why the re-arm cannot be treated as an
+	 * optimisation for well-behaved clients. A genuinely disabled timeout arises from an explicit
+	 * `grpc-timeout: 0` or from configuration.
+	 *
+	 * The budget passed here must come from {@link #captureRequestTimeoutMillis(ServiceRequestContext)}
+	 * called *before* the loop - never from `serviceContext.requestTimeoutMillis()` read inside it. See
+	 * that method for why the difference is not cosmetic.
 	 *
 	 * @param serviceContext       Armeria service context whose request timeout should be re-armed
 	 * @param requestTimeoutMillis the timeout to re-arm to, in milliseconds (`<= 0` means disabled)

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/module-info.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/module-info.java
@@ -57,6 +57,8 @@ module evita.external.api.grpc {
 	requires evita.external.api.grpc.shared;
 
 	requires io.netty.handler;
+	// io.netty.channel.EventLoop - GrpcOutboundGate has to recognise the transport's own thread
+	requires io.netty.transport;
 	requires io.grpc.services;
 	requires io.grpc;
 	requires io.grpc.protobuf;

--- a/evita_server/src/main/resources/evita-configuration.yaml
+++ b/evita_server/src/main/resources/evita-configuration.yaml
@@ -147,6 +147,7 @@ api:
       tlsMode: ${api.endpoints.gRPC.tlsMode:null}
       keepAlive: ${api.endpoints.gRPC.keepAlive:null}
       exposeDocsService: ${api.endpoints.gRPC.exposeDocsService:false}
+      streamingRequestTimeoutInMillis: ${api.endpoints.gRPC.streamingRequestTimeoutInMillis:300K}
       mTLS:
         enabled: ${api.endpoints.gRPC.mTLS.enabled:null}
         allowedClientCertificatePaths: ${api.endpoints.gRPC.mTLS.allowedClientCertificatesPaths:null}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadWriteTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadWriteTest.java
@@ -87,6 +87,7 @@ import io.evitadb.driver.config.ClientTlsOptions;
 import io.evitadb.driver.config.ClientTimeoutOptions;
 import io.evitadb.driver.config.EvitaClientConfiguration;
 import io.evitadb.exception.EvitaInvalidUsageException;
+import io.evitadb.exception.UnexpectedIOException;
 import io.evitadb.externalApi.configuration.ApiOptions;
 import io.evitadb.externalApi.configuration.HostDefinition;
 import io.evitadb.externalApi.grpc.GrpcProvider;
@@ -1557,6 +1558,97 @@ class EvitaClientReadWriteTest implements TestConstants, EvitaTestSupport {
 				}
 			)
 		);
+	}
+
+	/**
+	 * A chunked unary upload that stops half way must not leave its archive on the server.
+	 *
+	 * Nothing else would ever collect it: the temporary file is not reserved by
+	 * `FileManagementService`, no sweeper walks the work directory, and the restore step that deletes
+	 * it only runs for an upload that completed. There is also no half-close for the server to notice
+	 * the client's absence by - every chunk is its own request - so the cleanup hangs off the
+	 * restoration task's future instead, and the driver cancels that task on its way out.
+	 *
+	 * The assertion is deliberately "the work directory is exactly as it was", rather than a check on
+	 * one file name: it catches an archive left behind under any name, including one this test does not
+	 * know how to predict.
+	 */
+	@Test
+	@UseDataSet(value = EVITA_CLIENT_DATA_SET, destroyAfterTest = true)
+	void shouldDiscardTheArchiveOfAnAbandonedChunkedRestoreUpload(
+		EvitaClient evitaClient,
+		Evita evita
+	) throws ExecutionException, InterruptedException, TimeoutException {
+		final EvitaManagementContract management = evitaClient.management();
+		final FileForFetch fileForFetch = management
+			.backupCatalog(TEST_CATALOG, null, null, true)
+			.get(3, TimeUnit.MINUTES);
+
+		final Path workDirectory = evita.getConfiguration().storage().workDirectory();
+		final Set<String> filesBefore = listWorkDirectory(workDirectory);
+
+		// announce far more than will ever be sent, so the server keeps the task waiting for the rest of
+		// an upload that is about to die - which is the state the archive would otherwise be stranded in
+		final long announcedSize = fileForFetch.totalSizeInBytes() * 2;
+		assertThrows(
+			UnexpectedIOException.class,
+			() -> management.restoreCatalog(
+				TEST_CATALOG + "_abandoned",
+				announcedSize,
+				new FailAfterFirstChunkInputStream(management.fetchFile(fileForFetch.fileId()))
+			),
+			"An upload whose source dies part way through must surface as a failure, not a silent stall."
+		);
+
+		assertEquals(
+			filesBefore, listWorkDirectory(workDirectory),
+			"The abandoned upload's archive must be gone - the restoration task's completion hook owns " +
+				"it, and nothing else in the server would ever delete it."
+		);
+	}
+
+	/**
+	 * Lists the work directory by name, so a test can assert that an upload left nothing behind.
+	 *
+	 * @param workDirectory the engine's work directory
+	 * @return names of the files currently in it, never null
+	 */
+	@Nonnull
+	private static Set<String> listWorkDirectory(@Nonnull Path workDirectory) {
+		final String[] names = workDirectory.toFile().list();
+		return names == null ? Set.of() : Set.of(names);
+	}
+
+	/**
+	 * Input stream that yields one chunk and then fails, standing in for a source that dies mid-upload -
+	 * a disconnected volume, a truncated pipe, a killed producer.
+	 */
+	private static final class FailAfterFirstChunkInputStream extends InputStream {
+		private final InputStream delegate;
+		private boolean firstChunkDelivered;
+
+		FailAfterFirstChunkInputStream(@Nonnull InputStream delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public int read() throws IOException {
+			throw new IOException("Single-byte reads are not used by the chunked upload loop.");
+		}
+
+		@Override
+		public int read(@Nonnull byte[] buffer, int off, int len) throws IOException {
+			if (this.firstChunkDelivered) {
+				throw new IOException("Backup source went away mid-upload.");
+			}
+			this.firstChunkDelivered = true;
+			return this.delegate.read(buffer, off, len);
+		}
+
+		@Override
+		public void close() throws IOException {
+			this.delegate.close();
+		}
 	}
 
 	@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/services/RestoreCatalogUploadObserverTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/services/RestoreCatalogUploadObserverTest.java
@@ -1,0 +1,422 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc.services;
+
+import com.google.protobuf.ByteString;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import io.evitadb.core.management.EvitaManagement;
+import io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogRequest;
+import io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogResponse;
+import io.evitadb.externalApi.grpc.services.EvitaManagementService.RestoreCatalogUploadObserver;
+import io.grpc.stub.ServerCallStreamObserver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.STREAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Pins down what happens to a half-uploaded catalog archive when the request pool refuses the work that
+ * would have written the next chunk.
+ *
+ * The upload's temporary file has no owner other than this observer: `createTempFile` does not reserve it,
+ * nothing sweeps the work directory, and the restore step that would delete it never runs for an upload
+ * that stopped half way. A hand-off the pool rejects therefore has to end the call, not merely lose the
+ * step - otherwise the archive stays on disk for the lifetime of the process.
+ *
+ * **The rejection has to be timed to land while the chain is still running.** A pool that refuses the
+ * *first* hand-off is a much weaker test: `CompletableFuture#thenRunAsync` throws on the calling thread in
+ * that case, so even the original code surfaced something. The failure that hangs a client is the other
+ * one - a rejection while a previous step is in flight, which the old code lost inside
+ * `CompletableFuture#postComplete` on an unrelated worker. {@link RejectAfterFirstExecutor} reproduces
+ * exactly that, and {@link #shouldDiscardThePartialArchiveWhenTheUploadPoolRejectsALaterChunk()} is the
+ * test that separates a real fix from one that still leaks.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("A rejected upload hand-off must discard the partial archive")
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(STREAM)
+class RestoreCatalogUploadObserverTest {
+	/**
+	 * Streaming budget handed to the observer. Never reached - no test here waits on a timeout - it only
+	 * has to be a positive number so the re-arm path is exercised rather than skipped.
+	 */
+	private static final long STREAMING_BUDGET_MILLIS = 300_000L;
+	/**
+	 * How long a latch may wait before the test is declared broken. Generous on purpose: it is a
+	 * *positive* wait, so it only ever elapses when the code under test has genuinely failed to progress.
+	 */
+	private static final long LATCH_TIMEOUT_SECONDS = 30L;
+	/**
+	 * How long the one *negative* assertion here waits before concluding nothing happened. Deliberately
+	 * short: a negative wait pays its full duration on every green run, and lengthening it would not make
+	 * the assertion any stronger - only slower.
+	 */
+	private static final long NEGATIVE_WAIT_MILLIS = 250L;
+
+	/**
+	 * Executor that accepts a fixed number of hand-offs and rejects every one after them, the way the
+	 * bounded request pool does once its queue fills (`EvitaRejectingExecutorHandler` throws).
+	 *
+	 * Accepted work runs on a single background thread, so a step is genuinely in flight - and the chain
+	 * genuinely incomplete - when the next hand-off is refused.
+	 */
+	private static final class RejectAfterFirstExecutor implements Executor {
+		private final ExecutorService delegate = Executors.newSingleThreadExecutor();
+		private final AtomicInteger accepted = new AtomicInteger();
+		/**
+		 * Counted down once the first accepted task has finished. Lets a test wait for the write to land
+		 * rather than poll the directory for it.
+		 */
+		private final CountDownLatch firstTaskCompleted = new CountDownLatch(1);
+		private final int acceptLimit;
+
+		RejectAfterFirstExecutor(int acceptLimit) {
+			this.acceptLimit = acceptLimit;
+		}
+
+		@Override
+		public void execute(@Nonnull Runnable command) {
+			if (this.accepted.incrementAndGet() > this.acceptLimit) {
+				throw new RejectedExecutionException("Evita executor queue full.");
+			}
+			this.delegate.execute(
+				() -> {
+					try {
+						command.run();
+					} finally {
+						this.firstTaskCompleted.countDown();
+					}
+				}
+			);
+		}
+
+		/**
+		 * Waits for the first accepted task to finish.
+		 *
+		 * @return true when it finished within {@link #LATCH_TIMEOUT_SECONDS}
+		 */
+		boolean awaitFirstTask() throws InterruptedException {
+			return this.firstTaskCompleted.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+		}
+
+		void shutdown() {
+			this.delegate.shutdownNow();
+		}
+	}
+
+	/**
+	 * Captures the terminal outcome the client would observe, so a test can tell "the call ended with an
+	 * error" from "the call never ended at all".
+	 */
+	private static final class RecordingResponseObserver extends ServerCallStreamObserver<GrpcRestoreCatalogResponse> {
+		private final CountDownLatch terminated = new CountDownLatch(1);
+		private final List<Throwable> errors = new ArrayList<>(2);
+		private final AtomicInteger requested = new AtomicInteger();
+
+		@Override
+		public void onNext(GrpcRestoreCatalogResponse value) {
+			// a successful upload is not what any test here drives
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			this.errors.add(t);
+			this.terminated.countDown();
+		}
+
+		@Override
+		public void onCompleted() {
+			this.terminated.countDown();
+		}
+
+		@Override
+		public void request(int count) {
+			this.requested.addAndGet(count);
+		}
+
+		@Override
+		public boolean isReady() {
+			return true;
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return false;
+		}
+
+		@Override
+		public void setOnCancelHandler(Runnable onCancelHandler) {
+			// not exercised
+		}
+
+		@Override
+		public void setCompression(String compression) {
+			// not exercised
+		}
+
+		@Override
+		public void disableAutoRequest() {
+			// not exercised
+		}
+
+		@Override
+		public void disableAutoInboundFlowControl() {
+			// not exercised
+		}
+
+		@Override
+		public void setOnReadyHandler(Runnable onReadyHandler) {
+			// not exercised
+		}
+
+		@Override
+		public void setMessageCompression(boolean enable) {
+			// not exercised
+		}
+
+		boolean awaitTermination() throws InterruptedException {
+			return this.terminated.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+		}
+
+		boolean awaitTerminationBriefly() throws InterruptedException {
+			return this.terminated.await(NEGATIVE_WAIT_MILLIS, TimeUnit.MILLISECONDS);
+		}
+	}
+
+	/**
+	 * Builds an observer writing into the given directory, driven by the given executor.
+	 *
+	 * @param workDirectory   directory the assembled archive is written into
+	 * @param responseObserver observer capturing the terminal outcome
+	 * @param uploadExecutor  executor the file work is handed to
+	 * @return the observer under test
+	 */
+	@Nonnull
+	private static RestoreCatalogUploadObserver observerFor(
+		@Nonnull Path workDirectory,
+		@Nonnull RecordingResponseObserver responseObserver,
+		@Nonnull Executor uploadExecutor
+	) {
+		return new RestoreCatalogUploadObserver(
+			responseObserver,
+			ServiceRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/test")).build(),
+			workDirectory,
+			mock(EvitaManagement.class),
+			uploadExecutor,
+			STREAMING_BUDGET_MILLIS
+		);
+	}
+
+	/**
+	 * Builds one upload chunk carrying the given payload.
+	 *
+	 * @param payload bytes the chunk carries
+	 * @return the request message
+	 */
+	@Nonnull
+	private static GrpcRestoreCatalogRequest chunkOf(@Nonnull byte[] payload) {
+		return GrpcRestoreCatalogRequest.newBuilder()
+			.setCatalogName("testCatalog")
+			.setBackupFile(ByteString.copyFrom(payload))
+			.build();
+	}
+
+	/**
+	 * Lists the archives the observer has left in the work directory.
+	 *
+	 * @param workDirectory directory to inspect
+	 * @return the archive files present, never null
+	 */
+	@Nonnull
+	private static File[] archivesIn(@Nonnull Path workDirectory) {
+		final File[] files = workDirectory.toFile().listFiles(
+			(dir, name) -> name.startsWith("catalog_backup_for_restore-")
+		);
+		return files == null ? new File[0] : files;
+	}
+
+	@Test
+	@DisplayName("A rejected later chunk ends the call and leaves no archive behind")
+	void shouldDiscardThePartialArchiveWhenTheUploadPoolRejectsALaterChunk(@TempDir Path workDirectory)
+		throws InterruptedException {
+		final RecordingResponseObserver responseObserver = new RecordingResponseObserver();
+		// the first chunk's write is accepted and runs; every hand-off after it is refused
+		final RejectAfterFirstExecutor uploadExecutor = new RejectAfterFirstExecutor(1);
+		try {
+			final RestoreCatalogUploadObserver observer = observerFor(
+				workDirectory, responseObserver, uploadExecutor
+			);
+
+			observer.onNext(chunkOf(new byte[]{1, 2, 3, 4}));
+			observer.onNext(chunkOf(new byte[]{5, 6, 7, 8}));
+
+			assertTrue(
+				responseObserver.awaitTermination(),
+				"A rejected hand-off must terminate the call - the client is otherwise left waiting for a " +
+					"chunk that will never be written, until its own deadline expires."
+			);
+			assertEquals(
+				1, responseObserver.errors.size(),
+				"The client must be told exactly once why the upload ended."
+			);
+			assertNotNull(responseObserver.errors.get(0));
+
+			// the point of the whole exercise: nothing may be left on disk
+			assertEquals(
+				0, archivesIn(workDirectory).length,
+				"The partial archive must be discarded when the pool refuses the work that would have " +
+					"extended it - nothing else ever deletes it."
+			);
+
+			// The chain must stay poisoned. A rejection that leaves it healthy lets this chunk through to
+			// `openBackupFileIfNeeded`, which finds a closed stream and reopens the file in APPEND mode -
+			// recreating on disk exactly the archive that was just deleted.
+			observer.onNext(chunkOf(new byte[]{9, 10, 11, 12}));
+			assertEquals(
+				0, archivesIn(workDirectory).length,
+				"A chunk arriving after a failed upload must not recreate the archive."
+			);
+		} finally {
+			uploadExecutor.shutdown();
+		}
+	}
+
+	@Test
+	@DisplayName("A rejected first chunk also ends the call and leaves nothing behind")
+	void shouldDiscardThePartialArchiveWhenTheUploadPoolRejectsTheFirstChunk(@TempDir Path workDirectory)
+		throws InterruptedException {
+		final RecordingResponseObserver responseObserver = new RecordingResponseObserver();
+		// nothing is accepted at all - the pool is already saturated when the upload starts
+		final RejectAfterFirstExecutor uploadExecutor = new RejectAfterFirstExecutor(0);
+		try {
+			final RestoreCatalogUploadObserver observer = observerFor(
+				workDirectory, responseObserver, uploadExecutor
+			);
+
+			observer.onNext(chunkOf(new byte[]{1, 2, 3, 4}));
+
+			assertTrue(responseObserver.awaitTermination(), "A rejected hand-off must terminate the call.");
+			assertEquals(
+				0, archivesIn(workDirectory).length,
+				"A rejection before the file is even opened must leave the work directory untouched."
+			);
+		} finally {
+			uploadExecutor.shutdown();
+		}
+	}
+
+	@Test
+	@DisplayName("A client abort discards the archive even when the pool refuses the cleanup")
+	void shouldDiscardThePartialArchiveWhenTheCleanupHandOffIsRejected(@TempDir Path workDirectory)
+		throws InterruptedException {
+		final RecordingResponseObserver responseObserver = new RecordingResponseObserver();
+		// the first chunk lands, then the client aborts and the pool refuses to run the cleanup
+		final RejectAfterFirstExecutor uploadExecutor = new RejectAfterFirstExecutor(1);
+		try {
+			final RestoreCatalogUploadObserver observer = observerFor(
+				workDirectory, responseObserver, uploadExecutor
+			);
+
+			observer.onNext(chunkOf(new byte[]{1, 2, 3, 4}));
+			// let the accepted write land, so there is a real archive for the abort to discard
+			assertTrue(
+				uploadExecutor.awaitFirstTask(),
+				"The accepted first chunk should have been written before the abort is driven."
+			);
+			assertEquals(
+				1, archivesIn(workDirectory).length,
+				"The accepted first chunk should have created the archive this test is about to abort."
+			);
+
+			observer.onError(new RuntimeException("client went away"));
+
+			assertTrue(
+				responseObserver.awaitTermination(),
+				"An aborted upload must still terminate the call."
+			);
+			assertEquals(
+				0, archivesIn(workDirectory).length,
+				"Cleanup refused by the pool must fall back to the calling thread rather than be dropped."
+			);
+		} finally {
+			uploadExecutor.shutdown();
+		}
+	}
+
+	@Test
+	@DisplayName("An upload the pool never refuses leaves the archive in place for the restore step")
+	void shouldKeepTheArchiveWhileTheUploadIsProgressing(@TempDir Path workDirectory) throws InterruptedException {
+		final RecordingResponseObserver responseObserver = new RecordingResponseObserver();
+		// a pool that accepts everything - the control case, so the assertions above cannot pass merely
+		// because the observer discards the archive on any code path at all
+		final RejectAfterFirstExecutor uploadExecutor = new RejectAfterFirstExecutor(Integer.MAX_VALUE);
+		try {
+			final RestoreCatalogUploadObserver observer = observerFor(
+				workDirectory, responseObserver, uploadExecutor
+			);
+
+			observer.onNext(chunkOf(new byte[]{1, 2, 3, 4}));
+
+			assertTrue(uploadExecutor.awaitFirstTask(), "An accepted chunk must be written to the archive.");
+			assertEquals(
+				1, archivesIn(workDirectory).length,
+				"An upload that is progressing normally must keep its archive - it is what the restore " +
+					"step will read."
+			);
+			assertFalse(
+				responseObserver.awaitTerminationBriefly(),
+				"An upload that is progressing normally must not be terminated."
+			);
+		} finally {
+			uploadExecutor.shutdown();
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/services/interceptors/ObservabilityInterceptorReadinessTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/services/interceptors/ObservabilityInterceptorReadinessTest.java
@@ -1,0 +1,163 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc.services.interceptors;
+
+import io.evitadb.externalApi.grpc.generated.EvitaManagementServiceGrpc;
+import io.evitadb.externalApi.grpc.generated.GrpcFetchFileRequest;
+import io.evitadb.externalApi.grpc.generated.GrpcFetchFileResponse;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the transport-readiness signal that {@link ObservabilityInterceptor} sits on top of.
+ *
+ * The interceptor wraps every {@link ServerCall} in its own decorator before handing it to the
+ * service implementation. {@link ServerCall#isReady()} is **not** abstract - `io.grpc.ServerCall`
+ * ships a default implementation that unconditionally returns `true`. A decorator that forgets to
+ * delegate it therefore does not merely lose an optimisation: it reports "the transport can accept
+ * more data" forever, which silently defeats any flow-control loop written against
+ * `ServerCallStreamObserver.isReady()` in a streaming service method (most notably
+ * `EvitaManagementService.fetchFile`, which streams whole backup/export files).
+ *
+ * The failure mode is invisible on a fast consumer and only shows up as unbounded outbound
+ * buffering - and eventually a heap blow-up - when the consumer is slower than the producer, so it
+ * needs a unit-level guard rather than an end-to-end one. The complementary end-to-end evidence
+ * lives in `LongRunningGrpcFetchFileBackpressureTest` in the long-running module.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("gRPC observability interceptor must preserve the transport readiness signal")
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(OBSERVABILITY)
+class ObservabilityInterceptorReadinessTest {
+
+	/**
+	 * Runs the interceptor against a delegate call and returns the decorated call the interceptor
+	 * handed down to the service implementation.
+	 *
+	 * @param delegate the call the interceptor is asked to decorate
+	 * @return the decorated call as seen by the service implementation
+	 */
+	@Nonnull
+	private static ServerCall<GrpcFetchFileRequest, GrpcFetchFileResponse> intercept(
+		@Nonnull ServerCall<GrpcFetchFileRequest, GrpcFetchFileResponse> delegate
+	) {
+		final AtomicReference<ServerCall<GrpcFetchFileRequest, GrpcFetchFileResponse>> decorated =
+			new AtomicReference<>();
+		final ServerCallHandler<GrpcFetchFileRequest, GrpcFetchFileResponse> handler =
+			(call, headers) -> {
+				decorated.set(call);
+				return new Listener<>() {
+				};
+			};
+		new ObservabilityInterceptor().interceptCall(delegate, new Metadata(), handler);
+		final ServerCall<GrpcFetchFileRequest, GrpcFetchFileResponse> result = decorated.get();
+		assertNotNull(result, "Interceptor did not start the downstream call.");
+		return result;
+	}
+
+	@Test
+	@DisplayName("isReady() of the decorated call reflects a transport that cannot accept more data")
+	void shouldPropagateNotReadyTransportStateToServiceImplementation() {
+		final MockServerCall delegate = new MockServerCall(false);
+		assertFalse(
+			intercept(delegate).isReady(),
+			"ObservabilityInterceptor reported the transport as ready while the underlying call is not - " +
+				"any isReady()-driven flow control in a streaming service method is silently disabled."
+		);
+	}
+
+	@Test
+	@DisplayName("isReady() of the decorated call reflects a transport that can accept more data")
+	void shouldPropagateReadyTransportStateToServiceImplementation() {
+		final MockServerCall delegate = new MockServerCall(true);
+		assertTrue(
+			intercept(delegate).isReady(),
+			"ObservabilityInterceptor reported the transport as not ready while the underlying call is."
+		);
+	}
+
+	/**
+	 * Minimal {@link ServerCall} stub whose only interesting property is the readiness flag it was
+	 * constructed with - everything else is a no-op, because the interceptor is not expected to
+	 * touch it during `interceptCall`.
+	 */
+	private static class MockServerCall extends ServerCall<GrpcFetchFileRequest, GrpcFetchFileResponse> {
+		private final boolean ready;
+
+		MockServerCall(boolean ready) {
+			this.ready = ready;
+		}
+
+		@Override
+		public void request(int numMessages) {
+		}
+
+		@Override
+		public void sendHeaders(Metadata headers) {
+		}
+
+		@Override
+		public void sendMessage(GrpcFetchFileResponse message) {
+		}
+
+		@Override
+		public boolean isReady() {
+			return this.ready;
+		}
+
+		@Override
+		public void close(Status status, Metadata trailers) {
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return false;
+		}
+
+		@Override
+		public MethodDescriptor<GrpcFetchFileRequest, GrpcFetchFileResponse> getMethodDescriptor() {
+			return EvitaManagementServiceGrpc.getFetchFileMethod();
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/utils/GrpcOutboundGateTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/utils/GrpcOutboundGateTest.java
@@ -1,0 +1,420 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc.utils;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.common.util.TimeoutMode;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import io.evitadb.externalApi.grpc.exception.StalledGrpcStreamException;
+import io.grpc.stub.ServerCallStreamObserver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.STREAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Deterministic guard for {@link GrpcOutboundGate}, the back-pressure gate every server-streaming RPC
+ * paces itself with.
+ *
+ * This is the *only* fast-loop coverage the gate has, and that is a deliberate consequence of how the
+ * engine is wired for tests: the default test engine collapses the request pool into a direct executor,
+ * so a service method's hand-off lands back on the transport event loop, where the gate detects the
+ * self-deadlock and runs ungated on purpose. Every functional test that streams therefore takes the
+ * *ungated* branch, and the gated one is only reached by an end-to-end test that opts into real thread
+ * pools - which lives in the long-running module behind `@Tag(SLOW)`. Driving the gate directly against
+ * a fake observer is what keeps its contract checked on every build.
+ *
+ * The behaviours pinned here are the ones whose absence is invisible until production:
+ *
+ * - waiting must wake on the on-ready callback, or a slow client hangs forever rather than being paced;
+ * - cancellation must be answered **without parking**. Armeria increments its pending-message counter
+ *   in `sendMessage` and only unwinds it when the payload is genuinely consumed, which never happens
+ *   for a cancelled call - so readiness stays false forever, and a gate that consulted it first would
+ *   pin a request-executor thread for the full stall timeout on every client that simply pressed
+ *   cancel;
+ * - a client that keeps the stream open but stops reading must eventually be abandoned, or that same
+ *   thread is pinned indefinitely with no transport event ever coming to release it.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("gRPC outbound gate paces a producer against transport readiness")
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(STREAM)
+class GrpcOutboundGateTest {
+	/**
+	 * Stall timeout used wherever the test must prove the gate does *not* run into it. Long enough that
+	 * reaching it is unmistakably a failure rather than a slow machine.
+	 */
+	private static final long GENEROUS_STALL_TIMEOUT_MILLIS = 60_000L;
+	/**
+	 * Smallest grace beyond the stall timeout the gate's deadline re-arm must leave. Set below the
+	 * gate's actual `STALL_DETECTION_GRACE_MILLIS` on purpose - the test pins that a grace *exists*,
+	 * which is what stops the gate losing the stall race to Armeria, without freezing its value.
+	 */
+	private static final long MINIMUM_EXPECTED_GRACE_MILLIS = 4_000L;
+
+	/**
+	 * Starts a daemon thread that calls {@link GrpcOutboundGate#awaitWritable()} and records what came
+	 * back - a returned verdict, or the exception it threw.
+	 *
+	 * @param gate     gate to wait on
+	 * @param verdict  receives `TRUE`/`FALSE` as returned by the gate
+	 * @param failure  receives the exception, if the call threw one
+	 * @param finished counted down once the call has returned or thrown
+	 * @return the started thread, so the caller can join it
+	 */
+	@Nonnull
+	private static Thread awaitInBackground(
+		@Nonnull GrpcOutboundGate gate,
+		@Nonnull AtomicReference<Boolean> verdict,
+		@Nonnull AtomicReference<Throwable> failure,
+		@Nonnull CountDownLatch finished
+	) {
+		final Thread producer = new Thread(
+			() -> {
+				try {
+					verdict.set(gate.awaitWritable());
+				} catch (Throwable t) {
+					failure.set(t);
+				} finally {
+					finished.countDown();
+				}
+			},
+			"grpc-outbound-gate-test-producer"
+		);
+		producer.setDaemon(true);
+		producer.start();
+		return producer;
+	}
+
+	@Test
+	@DisplayName("Granting a message re-arms the call deadline to the stall budget, not the call's own")
+	void shouldReArmTheCallDeadlineToTheStallBudgetOnEveryGrant() {
+		final long callTimeoutMillis = 1_000L;
+		final long stallTimeoutMillis = 30_000L;
+		final ServiceRequestContext serviceContext = ServiceRequestContext
+			.builder(HttpRequest.of(HttpMethod.POST, "/test"))
+			.build();
+		serviceContext.setRequestTimeout(TimeoutMode.SET_FROM_START, Duration.ofMillis(callTimeoutMillis));
+
+		final FakeServerCallObserver observer = new FakeServerCallObserver(true);
+		// the gate reads the context at attach time, exactly as a service method would
+		try (final SafeCloseable ignored = serviceContext.push()) {
+			final GrpcOutboundGate gate = GrpcOutboundGate.attach(observer, "testMethod", null, stallTimeoutMillis);
+			assertTrue(gate.awaitWritable(), "A ready transport must grant immediately.");
+		}
+
+		// The horizon must be the *streaming* budget, not the 1 s the call arrived with. Asserted as a
+		// lower bound because Armeria stores the timeout relative to request start, so elapsed time only
+		// pushes it further out - see `GrpcTimeoutUtilTest`.
+		assertTrue(
+			serviceContext.requestTimeoutMillis() >= stallTimeoutMillis,
+			"A granted message must be re-armed to at least the stall budget, but the horizon was " +
+				serviceContext.requestTimeoutMillis() + " ms against a " + stallTimeoutMillis +
+				" ms stall timeout. Re-arming from the call's own budget is the defect this guards."
+		);
+		// ...and beyond it by a *material* margin, so the gate's own stall detection wins the race and the
+		// client gets DEADLINE_EXCEEDED naming the method rather than a bare RST_STREAM.
+		//
+		// The margin is asserted rather than a bare `>` for a reason worth stating: Armeria stores the
+		// timeout relative to request start, so even with the grace deleted the horizon would read
+		// `elapsed + stall` and clear a strict `>` on elapsed time alone. That assertion would have passed
+		// against the very regression this test exists to catch. `MINIMUM_EXPECTED_GRACE_MILLIS` is
+		// deliberately below the gate's actual 5 s so the test pins the *existence* of a grace without
+		// pinning its exact value.
+		assertTrue(
+			serviceContext.requestTimeoutMillis() >= stallTimeoutMillis + MINIMUM_EXPECTED_GRACE_MILLIS,
+			"The deadline must sit materially beyond the stall timeout so the gate detects the stall " +
+				"first, but the horizon was " + serviceContext.requestTimeoutMillis() + " ms against a " +
+				stallTimeoutMillis + " ms stall timeout."
+		);
+	}
+
+	@Test
+	@DisplayName("A call that arrived without a deadline is not given one by the gate")
+	void shouldLeaveADisabledDeadlineDisabled() {
+		final ServiceRequestContext serviceContext = ServiceRequestContext
+			.builder(HttpRequest.of(HttpMethod.POST, "/test"))
+			.build();
+		serviceContext.clearRequestTimeout();
+
+		final FakeServerCallObserver observer = new FakeServerCallObserver(true);
+		try (final SafeCloseable ignored = serviceContext.push()) {
+			final GrpcOutboundGate gate = GrpcOutboundGate.attach(observer, "testMethod", null, 30_000L);
+			assertTrue(gate.awaitWritable(), "A ready transport must grant immediately.");
+		}
+
+		// an open-ended stream that deliberately asked for no deadline must not acquire one here
+		assertEquals(
+			0L, serviceContext.requestTimeoutMillis(),
+			"Granting a message must not arm a deadline the caller declined."
+		);
+	}
+
+	@Test
+	@DisplayName("A ready transport lets the producer straight through")
+	void shouldNotWaitWhenTransportIsReady() {
+		final FakeServerCallObserver observer = new FakeServerCallObserver(true);
+		final GrpcOutboundGate gate = GrpcOutboundGate.attach(observer, "testMethod");
+
+		assertTimeoutPreemptively(
+			Duration.ofSeconds(5),
+			() -> assertTrue(gate.awaitWritable(), "A ready transport must not make the producer wait.")
+		);
+	}
+
+	@Test
+	@DisplayName("The producer waits while the transport is busy and resumes on the on-ready callback")
+	void shouldWaitUntilTransportSignalsReadiness() throws InterruptedException {
+		final FakeServerCallObserver observer = new FakeServerCallObserver(false);
+		final GrpcOutboundGate gate = GrpcOutboundGate.attach(observer, "testMethod");
+		final AtomicReference<Boolean> verdict = new AtomicReference<>();
+		final AtomicReference<Throwable> failure = new AtomicReference<>();
+		final CountDownLatch finished = new CountDownLatch(1);
+		final Thread producer = awaitInBackground(gate, verdict, failure, finished);
+
+		// negative wait - a busy machine can only make the gate wait longer, never release early, so a
+		// short window cannot produce a false failure here
+		assertFalse(
+			finished.await(250, TimeUnit.MILLISECONDS),
+			"Producer sailed past a transport that cannot accept another message."
+		);
+
+		observer.becomeReady();
+
+		assertTrue(finished.await(30, TimeUnit.SECONDS), "Producer never woke up after the transport drained.");
+		producer.join();
+		assertNull(failure.get(), "Producer failed unexpectedly.");
+		assertEquals(Boolean.TRUE, verdict.get(), "Producer must be cleared to send once the transport is ready.");
+	}
+
+	@Test
+	@DisplayName("A cancelled call is answered immediately, without ever parking the producer")
+	void shouldRefuseImmediatelyWhenCallIsAlreadyCancelled() {
+		// not ready *and* cancelled - which is exactly the state Armeria leaves a cancelled call in,
+		// because the pending-message counter it increments in `sendMessage` is never unwound
+		final FakeServerCallObserver observer = new FakeServerCallObserver(false);
+		final GrpcOutboundGate gate = GrpcOutboundGate.attach(
+			observer, "testMethod", null, GENEROUS_STALL_TIMEOUT_MILLIS
+		);
+		observer.cancel();
+
+		assertTimeoutPreemptively(
+			Duration.ofSeconds(5),
+			() -> assertFalse(
+				gate.awaitWritable(),
+				"Gate must report a cancelled call as unwritable rather than waiting for a readiness " +
+					"signal that can never arrive."
+			)
+		);
+	}
+
+	@Test
+	@DisplayName("Cancellation releases a producer that is already waiting, and runs the chained cleanup")
+	void shouldReleaseWaitingProducerOnCancellation() throws InterruptedException {
+		final FakeServerCallObserver observer = new FakeServerCallObserver(false);
+		final AtomicBoolean cleanedUp = new AtomicBoolean();
+		final GrpcOutboundGate gate = GrpcOutboundGate.attach(
+			observer, "testMethod", () -> cleanedUp.set(true), GENEROUS_STALL_TIMEOUT_MILLIS
+		);
+		final AtomicReference<Boolean> verdict = new AtomicReference<>();
+		final AtomicReference<Throwable> failure = new AtomicReference<>();
+		final CountDownLatch finished = new CountDownLatch(1);
+		final Thread producer = awaitInBackground(gate, verdict, failure, finished);
+
+		assertFalse(finished.await(250, TimeUnit.MILLISECONDS), "Producer did not wait for a busy transport.");
+
+		observer.cancel();
+
+		assertTrue(finished.await(30, TimeUnit.SECONDS), "Cancelling the call did not release the producer.");
+		producer.join();
+		assertNull(failure.get(), "Producer failed unexpectedly.");
+		assertEquals(Boolean.FALSE, verdict.get(), "A cancelled call must be reported as unwritable.");
+		assertTrue(
+			cleanedUp.get(),
+			"The gate owns the call's cancel handler, so the cleanup handed to it must still run."
+		);
+	}
+
+	@Test
+	@DisplayName("Closing the call releases a producer that is already waiting")
+	void shouldReleaseWaitingProducerWhenCallCloses() throws InterruptedException {
+		final FakeServerCallObserver observer = new FakeServerCallObserver(false);
+		final GrpcOutboundGate gate = GrpcOutboundGate.attach(
+			observer, "testMethod", null, GENEROUS_STALL_TIMEOUT_MILLIS
+		);
+		final AtomicReference<Boolean> verdict = new AtomicReference<>();
+		final AtomicReference<Throwable> failure = new AtomicReference<>();
+		final CountDownLatch finished = new CountDownLatch(1);
+		final Thread producer = awaitInBackground(gate, verdict, failure, finished);
+
+		assertFalse(finished.await(250, TimeUnit.MILLISECONDS), "Producer did not wait for a busy transport.");
+
+		// a close the producer did not initiate - an interceptor failing the call, or the server
+		// shutting the stream down underneath it
+		observer.close();
+
+		assertTrue(finished.await(30, TimeUnit.SECONDS), "Closing the call did not release the producer.");
+		producer.join();
+		assertNull(failure.get(), "Producer failed unexpectedly.");
+		assertEquals(Boolean.FALSE, verdict.get(), "A closed call must be reported as unwritable.");
+	}
+
+	@Test
+	@DisplayName("A client that holds the stream open but stops reading is abandoned")
+	void shouldAbandonStreamWhenClientStopsConsuming() {
+		final FakeServerCallObserver observer = new FakeServerCallObserver(false);
+		// the transport never becomes ready and the client never hangs up - the only way out is the
+		// stall timeout, which is what stops a vanished client from pinning a worker thread forever
+		final GrpcOutboundGate gate = GrpcOutboundGate.attach(observer, "testMethod", null, 200L);
+
+		assertThrows(
+			StalledGrpcStreamException.class,
+			gate::awaitWritable,
+			"A stream nobody is reading must be abandoned once the stall timeout elapses."
+		);
+	}
+
+	/**
+	 * Stand-in for gRPC's `ServerCallStreamObserverImpl` that exposes the two transport transitions the
+	 * gate reacts to - readiness and termination - as ordinary method calls.
+	 *
+	 * It deliberately mirrors gRPC's own dispatch order: {@link #cancel()} sets the cancellation flag
+	 * *before* running the handler, which is what lets the test distinguish "the gate saw the flag"
+	 * from "the gate was woken by the callback".
+	 */
+	private static class FakeServerCallObserver extends ServerCallStreamObserver<Object> {
+		private final AtomicBoolean ready;
+		private final AtomicBoolean cancelled = new AtomicBoolean();
+		private Runnable onReadyHandler;
+		private Runnable onCancelHandler;
+		private Runnable onCloseHandler;
+
+		FakeServerCallObserver(boolean ready) {
+			this.ready = new AtomicBoolean(ready);
+		}
+
+		/**
+		 * Simulates the transport draining its queue.
+		 */
+		void becomeReady() {
+			this.ready.set(true);
+			if (this.onReadyHandler != null) {
+				this.onReadyHandler.run();
+			}
+		}
+
+		/**
+		 * Simulates a client-initiated cancellation.
+		 */
+		void cancel() {
+			this.cancelled.set(true);
+			if (this.onCancelHandler != null) {
+				this.onCancelHandler.run();
+			}
+		}
+
+		/**
+		 * Simulates a server-initiated close of the call.
+		 */
+		void close() {
+			if (this.onCloseHandler != null) {
+				this.onCloseHandler.run();
+			}
+		}
+
+		@Override
+		public boolean isReady() {
+			return this.ready.get();
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return this.cancelled.get();
+		}
+
+		@Override
+		public void setOnReadyHandler(Runnable onReadyHandler) {
+			this.onReadyHandler = onReadyHandler;
+		}
+
+		@Override
+		public void setOnCancelHandler(Runnable onCancelHandler) {
+			this.onCancelHandler = onCancelHandler;
+		}
+
+		@Override
+		public void setOnCloseHandler(Runnable onCloseHandler) {
+			this.onCloseHandler = onCloseHandler;
+		}
+
+		@Override
+		public void setCompression(String compression) {
+		}
+
+		@Override
+		public void setMessageCompression(boolean enable) {
+		}
+
+		@Override
+		public void disableAutoInboundFlowControl() {
+		}
+
+		@Override
+		public void request(int count) {
+		}
+
+		@Override
+		public void onNext(Object value) {
+		}
+
+		@Override
+		public void onError(Throwable t) {
+		}
+
+		@Override
+		public void onCompleted() {
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/utils/GrpcTimeoutUtilTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/utils/GrpcTimeoutUtilTest.java
@@ -1,0 +1,224 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc.utils;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.util.TimeoutMode;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.time.Duration;
+
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.STREAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins down how a streaming call's Armeria deadline must be rolled forward, and - more importantly -
+ * how it must **not** be.
+ *
+ * Every long-lived producer in this module re-arms the request timeout per message, because Armeria's
+ * request timeout bounds the whole request while a stream needs a bound on *silence*. The subtlety that
+ * cost six call sites is where the budget for that re-arm comes from.
+ * {@link ServiceRequestContext#requestTimeoutMillis()} reads like "the configured timeout" and is not:
+ * Armeria stores the timeout relative to the request's start, and {@link TimeoutMode#SET_FROM_NOW}
+ * writes `elapsed + newTimeout` into that same field. Reading it back inside the loop therefore feeds
+ * each re-arm a budget that already contains every previous one.
+ *
+ * The second test below is a **characterisation test of Armeria**, deliberately. The fix depends on that
+ * behaviour, it is not part of Armeria's documented contract, and an upgrade could change it - in which
+ * case this test fails and says so, instead of the ratchet quietly coming back.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Streaming request timeouts must be re-armed from a captured budget")
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(STREAM)
+class GrpcTimeoutUtilTest {
+	/**
+	 * Budget each context under test starts with. Small enough to keep the test quick, large enough that
+	 * the two strategies below separate by far more than scheduling noise.
+	 */
+	private static final long CONFIGURED_TIMEOUT_MILLIS = 1_000L;
+	/**
+	 * Pause between successive re-arms. This is a *detection widener*, not a poll: the compounding the
+	 * test is looking for is proportional to elapsed time, so a slower machine makes the two strategies
+	 * diverge **further**. It cannot produce a false failure.
+	 */
+	private static final long REARM_SPACING_MILLIS = 120L;
+	/**
+	 * How many times each strategy re-arms. Three is enough for the ratchet to overtake the correct
+	 * strategy by more than a spacing interval, while keeping the whole test under a second.
+	 */
+	private static final int REARM_COUNT = 3;
+	/**
+	 * Stand-in for `api.endpoints.gRPC.streamingRequestTimeoutInMillis`. Deliberately unlike
+	 * {@link #CONFIGURED_TIMEOUT_MILLIS} so a test cannot pass by the two being confused.
+	 */
+	private static final long STREAMING_BUDGET_MILLIS = 300_000L;
+	/**
+	 * Tolerance absorbing millisecond truncation and the gap between the last re-arm and the reading. Far
+	 * smaller than the ~360 ms by which a compounding implementation overshoots, so it costs the
+	 * assertion no teeth.
+	 */
+	private static final long CLOCK_SLACK_MILLIS = 50L;
+
+	/**
+	 * Builds a service request context carrying a configured request timeout, the way a real gRPC call
+	 * with a `grpc-timeout` header arrives.
+	 *
+	 * @return context whose request timeout is {@link #CONFIGURED_TIMEOUT_MILLIS}
+	 */
+	@Nonnull
+	private static ServiceRequestContext contextWithConfiguredTimeout() {
+		final ServiceRequestContext serviceContext = ServiceRequestContext
+			.builder(HttpRequest.of(HttpMethod.POST, "/test"))
+			.build();
+		// SET_FROM_START is how a budget is established, as opposed to rolled forward
+		serviceContext.setRequestTimeout(
+			TimeoutMode.SET_FROM_START, Duration.ofMillis(CONFIGURED_TIMEOUT_MILLIS)
+		);
+		return serviceContext;
+	}
+
+	@Test
+	@DisplayName("Capturing before the first message yields the configured budget")
+	void shouldCaptureConfiguredRequestTimeout() {
+		final ServiceRequestContext serviceContext = contextWithConfiguredTimeout();
+
+		assertEquals(
+			CONFIGURED_TIMEOUT_MILLIS,
+			GrpcTimeoutUtil.captureRequestTimeoutMillis(serviceContext),
+			"Captured before any re-arm, the budget must be the one the call was configured with."
+		);
+	}
+
+	@Test
+	@DisplayName("A disabled request timeout is left disabled rather than rejected")
+	void shouldSkipReArmingWhenRequestTimeoutIsDisabled() {
+		// no timeout configured at all - the normal state for a client that sends no `grpc-timeout`
+		final ServiceRequestContext serviceContext = ServiceRequestContext
+			.builder(HttpRequest.of(HttpMethod.POST, "/test"))
+			.build();
+		serviceContext.clearRequestTimeout();
+
+		final long captured = GrpcTimeoutUtil.captureRequestTimeoutMillis(serviceContext);
+		assertEquals(0L, captured, "A disabled request timeout must read as zero.");
+
+		// `SET_FROM_NOW` is the one timeout mode that rejects a zero duration outright, so re-arming has
+		// to be skipped rather than attempted - this call must not throw
+		GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, captured);
+
+		assertEquals(
+			0L, serviceContext.requestTimeoutMillis(),
+			"Re-arming a disabled timeout must leave it disabled."
+		);
+	}
+
+	@Test
+	@DisplayName("A streaming call is budgeted from the streaming timeout, not the call's own request timeout")
+	void shouldResolveStreamingBudgetIndependentlyOfTheCallsOwnTimeout() {
+		final ServiceRequestContext serviceContext = contextWithConfiguredTimeout();
+
+		// The call asked for 1 s; a stream gets the deployment's streaming budget instead. Substituting
+		// is safe because a gRPC deadline is enforced by the *client* - the caller still sees its own
+		// deadline honoured, and only a live-but-silent peer occupies the server for longer.
+		assertEquals(
+			STREAMING_BUDGET_MILLIS,
+			GrpcTimeoutUtil.resolveStreamingBudgetMillis(serviceContext, STREAMING_BUDGET_MILLIS),
+			"A call that has a deadline must be re-armed from the streaming budget, not its own."
+		);
+	}
+
+	@Test
+	@DisplayName("A call with no deadline is not given one by the streaming budget")
+	void shouldLeaveADisabledTimeoutDisabledWhenResolvingTheStreamingBudget() {
+		final ServiceRequestContext serviceContext = ServiceRequestContext
+			.builder(HttpRequest.of(HttpMethod.POST, "/test"))
+			.build();
+		serviceContext.clearRequestTimeout();
+
+		// Whether a call has a deadline stays the caller's decision; only its *value* is substituted.
+		// Returning the budget here would silently impose a 5-minute deadline on an open-ended stream
+		// (a CDC subscription, say) that deliberately asked for none.
+		assertEquals(
+			0L,
+			GrpcTimeoutUtil.resolveStreamingBudgetMillis(serviceContext, STREAMING_BUDGET_MILLIS),
+			"A deliberately disabled deadline must stay disabled."
+		);
+	}
+
+	@Test
+	@DisplayName("Re-arming from a captured budget holds the horizon; re-reading the context ratchets it")
+	void shouldNotCompoundTheBudgetWhenReArmingFromCapturedValue() throws InterruptedException {
+		// the stopwatch starts before the contexts do: each context's own clock begins when it is built,
+		// so measuring from here keeps `elapsedMillis` an upper bound on the scheduler's notion of elapsed
+		final long startNanos = System.nanoTime();
+		final ServiceRequestContext capturedContext = contextWithConfiguredTimeout();
+		final ServiceRequestContext ratchetingContext = contextWithConfiguredTimeout();
+		// captured once, before the first re-arm - this is what every producing loop must do
+		final long capturedBudget = GrpcTimeoutUtil.captureRequestTimeoutMillis(capturedContext);
+
+		for (int i = 0; i < REARM_COUNT; i++) {
+			Thread.sleep(REARM_SPACING_MILLIS);
+			GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(capturedContext, capturedBudget);
+			// the mistake, reproduced side by side: the budget is read back from the context, so it
+			// already contains everything the previous re-arms added to it
+			GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(
+				ratchetingContext, ratchetingContext.requestTimeoutMillis()
+			);
+		}
+		final long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+
+		final long capturedHorizon = capturedContext.requestTimeoutMillis();
+		final long ratchetingHorizon = ratchetingContext.requestTimeoutMillis();
+
+		// Re-armed from a constant, the deadline sits one budget past the last message - which is exactly
+		// what "the client has `timeout` to send the next one" means. Stated relative to the measured
+		// elapsed time so a loaded machine cannot fail it.
+		assertTrue(
+			capturedHorizon <= elapsedMillis + CONFIGURED_TIMEOUT_MILLIS + CLOCK_SLACK_MILLIS,
+			"Re-arming from a captured budget must leave the horizon at last-message + budget, but it " +
+				"was " + capturedHorizon + " ms after " + elapsedMillis + " ms elapsed."
+		);
+
+		// Re-armed from the context, each step adds the elapsed time to a budget that already included
+		// it. The gap grows with every message, so a stalled client is never caught.
+		assertTrue(
+			ratchetingHorizon > capturedHorizon + REARM_SPACING_MILLIS,
+			"Reading the budget back from the context must be shown to compound it - the ratcheting " +
+				"horizon was " + ratchetingHorizon + " ms against " + capturedHorizon + " ms for the " +
+				"captured one. If these now agree, Armeria changed `requestTimeoutMillis()` semantics " +
+				"and `GrpcTimeoutUtil#captureRequestTimeoutMillis` needs revisiting."
+		);
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/ExceptionUtilsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/ExceptionUtilsTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -271,6 +272,80 @@ class ExceptionUtilsTest {
 			final RuntimeException topLevel = new RuntimeException("top", intermediate);
 
 			assertTrue(ExceptionUtils.causeChainContains(topLevel, IllegalStateException.class));
+		}
+	}
+
+	@Nested
+	@DisplayName("Cause chain instance lookup")
+	class FindInCauseChainTest {
+
+		@Test
+		@DisplayName("should return the matching instance itself, not merely a verdict")
+		void shouldReturnMatchingInstance() {
+			// the point of this method over causeChainContains: callers need state off the instance
+			final IOException rootCause = new IOException("IO error");
+			final RuntimeException topLevel = new RuntimeException("top", rootCause);
+
+			assertSame(rootCause, ExceptionUtils.findInCauseChain(topLevel, IOException.class));
+		}
+
+		@Test
+		@DisplayName("should return the throwable itself when it already matches")
+		void shouldReturnThrowableItselfWhenMatching() {
+			final IOException exception = new IOException("IO error");
+
+			assertSame(exception, ExceptionUtils.findInCauseChain(exception, IOException.class));
+		}
+
+		@Test
+		@DisplayName("should return the outermost match when several are present")
+		void shouldReturnOutermostMatch() {
+			final IllegalStateException rootCause = new IllegalStateException("inner");
+			final IllegalStateException intermediate = new IllegalStateException("outer", rootCause);
+			final RuntimeException topLevel = new RuntimeException("top", intermediate);
+
+			assertSame(intermediate, ExceptionUtils.findInCauseChain(topLevel, IllegalStateException.class));
+		}
+
+		@Test
+		@DisplayName("should return null when the type is absent from the chain")
+		void shouldReturnNullWhenTypeAbsent() {
+			final RuntimeException topLevel = new RuntimeException("top", new IOException("io"));
+
+			assertNull(ExceptionUtils.findInCauseChain(topLevel, CancellationException.class));
+		}
+
+		@Test
+		@DisplayName("should terminate on a two-element circular reference when the type is absent")
+		void shouldTerminateOnCircularReferenceWhenTypeAbsent() {
+			// `A -> B -> A` is the shape a self-reference guard (`current.getCause() == current`)
+			// misses; only the visited-set traversal terminates here
+			final CircularException exception1 = new CircularException("Exception 1");
+			final CircularException exception2 = new CircularException("Exception 2", exception1);
+			exception1.initCause(exception2);
+
+			assertNull(ExceptionUtils.findInCauseChain(exception1, CancellationException.class));
+		}
+
+		@Test
+		@DisplayName("should find the type inside a circular reference chain")
+		void shouldFindTypeInCircularReferenceChain() {
+			final CircularException exception1 = new CircularException("Exception 1");
+			final CircularException exception2 = new CircularException("Exception 2", exception1);
+			exception1.initCause(exception2);
+
+			assertSame(exception1, ExceptionUtils.findInCauseChain(exception1, CircularException.class));
+		}
+
+		@Test
+		@DisplayName("should match a superclass of an exception in the chain")
+		void shouldMatchSuperclassInCauseChain() {
+			// the top level is deliberately *not* a RuntimeException, so the match can only come from
+			// the cause - otherwise this would pass without walking the chain at all
+			final IllegalArgumentException rootCause = new IllegalArgumentException("arg");
+			final IOException topLevel = new IOException("top", rootCause);
+
+			assertSame(rootCause, ExceptionUtils.findInCauseChain(topLevel, RuntimeException.class));
 		}
 	}
 

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningEvitaClientLargeFileDownloadTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningEvitaClientLargeFileDownloadTest.java
@@ -1,0 +1,223 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc;
+
+import io.evitadb.api.file.FileForFetch;
+import io.evitadb.core.Evita;
+import io.evitadb.driver.EvitaClient;
+import io.evitadb.driver.config.ClientTimeoutOptions;
+import io.evitadb.driver.config.ClientTlsOptions;
+import io.evitadb.driver.config.EvitaClientConfiguration;
+import io.evitadb.externalApi.configuration.ApiOptions;
+import io.evitadb.externalApi.configuration.HostDefinition;
+import io.evitadb.externalApi.system.SystemProvider;
+import io.evitadb.server.EvitaServer;
+import io.evitadb.spi.export.model.ExportFileHandle;
+import io.evitadb.test.annotation.DataSet;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import io.evitadb.utils.CertificateUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nonnull;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.CRC32;
+
+import static io.evitadb.test.TestTags.EXPORT;
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static io.evitadb.test.TestTags.SLOW;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Proves the Java driver can download a file bigger than Armeria's default response-length cap.
+ *
+ * Armeria caps a client response at 10 MiB by default, and the cap counts the **whole** HTTP body -
+ * which for a server-streaming call is every message added together, not the largest one. `EvitaClient`
+ * never overrode it, so `management().fetchFile(...)` could not fetch a backup larger than that: it
+ * failed part-way through with a bare `RESOURCE_EXHAUSTED`, indistinguishable from the unbounded-
+ * buffering failure this whole line of work started from. The cap is now lifted on the driver's
+ * streaming and CDC channels and kept on the unary one, where a 10 MiB reply genuinely is anomalous.
+ *
+ * Two existing tests look like they would have caught this and do not, which is why this one exists:
+ *
+ * - `EvitaClientReadWriteTest#shouldBackupAndRestoreCatalogViaDownloadingAndUploadingFileContents`
+ *   downloads through the driver, but backs up a ten-product catalog - about 1 MB, an order of
+ *   magnitude under the cap;
+ * - `LongRunningGrpcFetchFileBackpressureTest` moves 512 MiB, but through its own stub built with
+ *   `maxResponseLength(0)`, so it never exercises the driver's default at all.
+ *
+ * **Calibration.** {@link #FILE_SIZE} is asserted against {@link #ARMERIA_DEFAULT_MAX_RESPONSE_LENGTH}
+ * rather than assumed to exceed it: shrink the file below the cap and this test passes whether the fix
+ * is present or not.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Java driver must download files larger than Armeria's default response-length cap")
+@ExtendWith(EvitaParameterResolver.class)
+@Slf4j
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(MANAGEMENT)
+@Tag(EXPORT)
+@Tag(SLOW)
+public class LongRunningEvitaClientLargeFileDownloadTest {
+	private static final String DATA_SET = "GrpcLargeFileDownload";
+	/**
+	 * Armeria's `ClientOptions.MAX_RESPONSE_LENGTH` default - the ceiling this test exists to cross.
+	 */
+	private static final long ARMERIA_DEFAULT_MAX_RESPONSE_LENGTH = 10L * 1024L * 1024L;
+	/**
+	 * Size of the file to download. Comfortably over the cap, small enough to build and move quickly.
+	 */
+	private static final long FILE_SIZE = 24L * 1024L * 1024L;
+	/**
+	 * Size of the buffer the file is written and read with.
+	 */
+	private static final int BUFFER_SIZE = 65_536;
+
+	/**
+	 * Creates a file of the requested size and publishes it for fetching.
+	 *
+	 * @param evita       engine whose export service the file is stored in
+	 * @param contentsCrc accumulator the written contents are checksummed into
+	 * @return descriptor of the published file
+	 */
+	@Nonnull
+	private static FileForFetch createExportedFile(@Nonnull Evita evita, @Nonnull CRC32 contentsCrc) throws Exception {
+		final byte[] pattern = new byte[BUFFER_SIZE];
+		for (int i = 0; i < pattern.length; i++) {
+			pattern[i] = (byte) (i * 31 + 7);
+		}
+		final ExportFileHandle handle = evita.management().exportService().storeFile(
+			"grpc-large-file-download.bin",
+			"Large file used by the driver download test",
+			"application/octet-stream",
+			"test"
+		);
+		try {
+			final OutputStream outputStream = handle.outputStream();
+			long written = 0L;
+			while (written < FILE_SIZE) {
+				final int toWrite = (int) Math.min(pattern.length, FILE_SIZE - written);
+				outputStream.write(pattern, 0, toWrite);
+				contentsCrc.update(pattern, 0, toWrite);
+				written += toWrite;
+			}
+		} finally {
+			handle.close();
+		}
+		final FileForFetch fileForFetch = handle.fileForFetchFuture().get(60, TimeUnit.SECONDS);
+		assertEquals(FILE_SIZE, fileForFetch.totalSizeInBytes(), "Exported file has an unexpected size.");
+		return fileForFetch;
+	}
+
+	@DataSet(
+		value = DATA_SET, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE},
+		readOnly = false, destroyAfterClass = true,
+		// the download is gated on transport readiness, which only exists when the request executor is a
+		// real pool - see LongRunningGrpcFetchFileBackpressureTest for the full explanation
+		useRealThreadPools = true
+	)
+	static EvitaClient setUp(EvitaServer evitaServer) {
+		final ApiOptions apiOptions = evitaServer.getExternalApiServer().getApiOptions();
+		final HostDefinition grpcHost = apiOptions.getEndpointConfiguration(GrpcProvider.CODE).getHost()[0];
+		final HostDefinition systemHost = apiOptions.getEndpointConfiguration(SystemProvider.CODE).getHost()[0];
+
+		final String serverCertificates = apiOptions.certificate().getFolderPath().toString();
+		final int lastDash = serverCertificates.lastIndexOf('-');
+		assertTrue(lastDash > 0, "Dash not found! Look at the evita-configuration.yml in test resources!");
+		final Path clientCertificates = Path.of(serverCertificates.substring(0, lastDash) + "-client");
+
+		return new EvitaClient(
+			EvitaClientConfiguration.builder()
+				.host(grpcHost.hostAddress())
+				.port(grpcHost.port())
+				.systemApiPort(systemHost.port())
+				.tls(
+					ClientTlsOptions.builder()
+						.mtlsEnabled(false)
+						.certificateFolderPath(clientCertificates)
+						.certificateFileName(Path.of(CertificateUtils.getGeneratedClientCertificateFileName()))
+						.certificateKeyFileName(
+							Path.of(CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName())
+						)
+						.build()
+				)
+				.timeouts(
+					ClientTimeoutOptions.builder()
+						.timeout(10, TimeUnit.MINUTES)
+						.build()
+				)
+				.build()
+		);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET)
+	@DisplayName("Should download a 24 MB file through EvitaClient with its default channel configuration")
+	void shouldDownloadFileLargerThanDefaultResponseLengthCap(Evita evita, EvitaClient evitaClient) throws Exception {
+		assertTrue(
+			FILE_SIZE > ARMERIA_DEFAULT_MAX_RESPONSE_LENGTH,
+			"File is not larger than Armeria's default response-length cap, so this test would pass " +
+				"with or without the fix it exists to guard."
+		);
+
+		final CRC32 expectedCrc = new CRC32();
+		final FileForFetch bigFile = createExportedFile(evita, expectedCrc);
+		try {
+			final CRC32 receivedCrc = new CRC32();
+			long receivedBytes = 0L;
+			// the driver stages the download into a temp file and hands back a stream over it, so this
+			// reads from disk rather than holding 24 MB in memory
+			try (final InputStream inputStream = evitaClient.management().fetchFile(bigFile.fileId())) {
+				final byte[] buffer = new byte[BUFFER_SIZE];
+				int bytesRead;
+				while ((bytesRead = inputStream.read(buffer)) != -1) {
+					receivedCrc.update(buffer, 0, bytesRead);
+					receivedBytes += bytesRead;
+				}
+			}
+
+			log.info("Downloaded {} B through the driver's default channel configuration.", receivedBytes);
+			assertEquals(FILE_SIZE, receivedBytes, "Client did not receive the whole file.");
+			assertEquals(
+				expectedCrc.getValue(), receivedCrc.getValue(),
+				"Downloaded contents differ from the stored file."
+			);
+		} finally {
+			evita.management().deleteFile(bigFile.fileId());
+		}
+	}
+
+}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningGrpcFetchFileBackpressureTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningGrpcFetchFileBackpressureTest.java
@@ -1,0 +1,480 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc;
+
+import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import io.evitadb.api.file.FileForFetch;
+import io.evitadb.core.Evita;
+import io.evitadb.driver.config.EvitaClientConfiguration;
+import io.evitadb.driver.interceptor.ClientSessionInterceptor;
+import io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter;
+import io.evitadb.externalApi.grpc.generated.EvitaManagementServiceGrpc.EvitaManagementServiceStub;
+import io.evitadb.externalApi.grpc.generated.GrpcFetchFileRequest;
+import io.evitadb.externalApi.grpc.generated.GrpcFetchFileResponse;
+import io.evitadb.externalApi.system.SystemProvider;
+import io.evitadb.server.EvitaServer;
+import io.evitadb.spi.export.model.ExportFileHandle;
+import io.evitadb.test.annotation.DataSet;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import io.evitadb.utils.VersionUtils.SemVer;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import io.netty.util.internal.PlatformDependent;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nonnull;
+import java.io.OutputStream;
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.CRC32;
+
+import static io.evitadb.test.TestTags.EXPORT;
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static io.evitadb.test.TestTags.SLOW;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Proves that `EvitaManagementService.fetchFile` bounds the memory it holds on behalf of a client
+ * that stops consuming the stream.
+ *
+ * `fetchFile` streams a file to the client in chunks. Armeria hands every `onNext` straight into the
+ * response `StreamMessage`, whose write queue is unbounded, and reports back-pressure only through
+ * `ServerCallStreamObserver.isReady()` (which, in Armeria, is `pendingMessages == 0`). A handler that
+ * reads the file in a tight loop and never consults readiness therefore converts "slow consumer" into
+ * "the whole file is resident in the server's memory" - the observed production symptom being a large
+ * backup download over a slow tunnel that dies part-way through with a bare `UNKNOWN` status and no
+ * message. `StreamingServerCall.sendMessage` marshals on the Armeria event loop, so the allocation
+ * that finally fails - direct buffer memory, bounded by `MaxDirectMemorySize` rather than `-Xmx` -
+ * fails inside Armeria, whose fallback for an escaping `Throwable` is exactly `UNKNOWN` with no
+ * description (`verboseResponses` is off). Nothing in evitaDB remaps it either:
+ * `executeWithClientContext` catches only `RuntimeException`, and `ObservableRunnable.run` catches
+ * only `Exception`. The handler now paces itself with `GrpcOutboundGate`; this test is what holds it
+ * to that.
+ *
+ * The test reproduces that shape deterministically and without relying on an actual memory
+ * exhaustion (an OOME inside a surefire fork would take the rest of the module down with it):
+ * a manual-flow-control client asks for a handful of messages and then stops requesting, and the
+ * server is given a settle window in which an unbounded handler would drain the whole file into its
+ * outbound queue. The assertion is on retained memory - heap *and* off-heap, because Armeria
+ * marshals each message into a pooled buffer before queueing it - with a wide margin: it is an
+ * order-of-magnitude question, not a precise one.
+ *
+ * **Calibration** (measured against the ungated handler, 512 MB file, `-Xmx5g`): the client
+ * consumed 4 chunks / 256 KB, no thread remained inside `fetchFile` - the streaming loop had run to
+ * completion - and the retained delta was **1035 MB**, against a 64 MB limit: a 16x margin. Almost
+ * none of it was heap (70 MB -> 77 MB); it was Netty direct memory (4 MB -> 1084 MB). The ~2x
+ * amplification over the file size is pooled-arena rounding - a 64 KB payload plus the 5-byte gRPC
+ * frame header lands in the next size class up, so every chunk costs about 128 KB. That is why the
+ * production ceiling is `MaxDirectMemorySize` rather than `-Xmx`, and why a 690 MB download needs
+ * roughly 1.4 GB of direct memory to buffer.
+ *
+ * If this test stops failing when the readiness gating is removed from `fetchFile`, it has gone
+ * decorative - the most likely reason being that `ObservabilityInterceptor` stopped delegating
+ * `ServerCall.isReady()` (the `io.grpc.ServerCall` default returns `true` unconditionally, so a
+ * non-delegating decorator silently disables the gating); that specific trap is guarded separately
+ * and cheaply by `ObservabilityInterceptorReadinessTest` in the functional module.
+ *
+ * The gRPC-Web serialization format is deliberate: it is the framing evitaLab uses, and the one the
+ * production report came from. It shares the framed code path with plain gRPC-proto, so the
+ * buffering behaviour is identical either way.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("gRPC fetchFile must not buffer a whole file for a client that stops consuming")
+@ExtendWith(EvitaParameterResolver.class)
+@Slf4j
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(MANAGEMENT)
+@Tag(EXPORT)
+@Tag(SLOW)
+public class LongRunningGrpcFetchFileBackpressureTest {
+	private static final String DATA_SET = "GrpcFetchFileBackpressure";
+	/**
+	 * Chunk size the server streams with - mirrors `EvitaManagementService.FETCH_FILE_CHUNK_SIZE`.
+	 * Only used to make the log lines and the failure message legible; nothing here depends on the
+	 * server actually using this value.
+	 */
+	private static final int CHUNK_SIZE = 1_048_576;
+	/**
+	 * Size of the file the client asks for. Big enough that "the server buffered all of it" and
+	 * "the server buffered a couple of messages" are separated by three orders of magnitude, small
+	 * enough to be written and read within a long-running test's budget.
+	 */
+	private static final long FILE_SIZE = 512L * 1024L * 1024L;
+	/**
+	 * Number of messages the client consumes before it stops requesting and goes silent.
+	 */
+	private static final int CHUNKS_CONSUMED_BEFORE_STALL = 4;
+	/**
+	 * Upper bound on the memory the server may retain while the client is silent, set from measurements
+	 * on **both** sides rather than from a round fraction of the file:
+	 *
+	 * - gated (this fix): **14.4 MiB** retained, of which **12.0 MiB** was still there after the client
+	 *   drained the stream - i.e. allocator arena growth, not queued messages. Genuine in-flight data
+	 *   was ~2.4 MiB, about two 1 MB chunks, exactly what one message in flight predicts;
+	 * - ungated (the bug): **1035 MiB**, the whole file plus pooled-arena rounding.
+	 *
+	 * 32 MiB sits ~2x above the green measurement - enough headroom for a machine whose Netty arenas
+	 * (which scale with core count) reserve more than this one's - and 32x below the red one. It is
+	 * deliberately *not* the 64 MiB the failing side alone would have justified: that would also pass a
+	 * half-working fix that buffered 50 MB.
+	 *
+	 * **This measurement is JVM-wide, so a shared surefire fork can fail it spuriously.** It samples the
+	 * whole heap and both direct-memory counters, not this call's allocations, so any sibling test
+	 * allocating in the same fork counts against the budget. Running the module's whole `LongRunning*`
+	 * set together does exactly that: the generational fuzz tests push the baseline heap near a gigabyte
+	 * and the "retained" figure to ~3.6 GB, and this assertion fires while the fix is working perfectly.
+	 * Before believing a failure here, read the two diagnostics logged just above it - a thread count of
+	 * `1` inside `fetchFile` with the producer `TIMED_WAITING` **is the gate doing its job**, and points
+	 * at a contaminated fork rather than a regression. Confirm by running this class on its own: the
+	 * same code that "retained 3.6 GB" alongside the fuzz tests retains ~5 MB alone.
+	 *
+	 * Contamination cuts the other way too, and that direction is worse because it is silent: a sibling
+	 * GC between the two samples can make the delta *negative* (observed: -91 MB), which sails past this
+	 * assertion. A negative or implausibly small reading means the baseline was contaminated high, not
+	 * that the gate is working - so it is only evidence when this class runs alone.
+	 */
+	private static final long MAX_TOLERATED_SERVER_BUFFERING = 32L * 1024L * 1024L;
+	/**
+	 * How long the server is given to drain the file into its outbound queue while the client is
+	 * silent. This is a settle window, not a wait for a condition - a slower machine only reads
+	 * *less* of the file within it, so it can never turn a genuine failure into a false pass, and a
+	 * correct server has nothing to do during it at all.
+	 */
+	private static final long SETTLE_WINDOW_MILLIS = 20_000L;
+
+	/**
+	 * Memory the process is holding, split by where it is held.
+	 *
+	 * Both halves are needed: `StreamingServerCall` marshals every message into an `HttpData`
+	 * *eagerly* and queues that, so a message waiting to be written retains a (typically pooled and
+	 * direct) `ByteBuf` rather than the protobuf object it came from. Measuring only the Java heap
+	 * would therefore under-report - possibly to zero - exactly the buffering this test is about.
+	 *
+	 * @param heapBytes       live data on the Java heap
+	 * @param directBytes     off-heap buffer memory, whichever of the two counters sees more of it
+	 * @param nettyDirect     Netty's own direct-memory counter (`-1` when Netty has it disabled)
+	 * @param nioDirect       direct memory visible to the JVM's `BufferPoolMXBean`
+	 */
+	private record MemoryFootprint(long heapBytes, long directBytes, long nettyDirect, long nioDirect) {
+
+		/**
+		 * Returns the total memory retained regardless of where it sits.
+		 */
+		long total() {
+			return this.heapBytes + this.directBytes;
+		}
+
+	}
+
+	/**
+	 * Returns the memory in use after asking the collector to run, so that anything unreachable is
+	 * not counted as retained. Neither `System.gc()` nor the pauses between the rounds are a wait
+	 * for a condition - they only sharpen the measurement.
+	 *
+	 * @return snapshot of retained heap and off-heap memory
+	 */
+	@Nonnull
+	private static MemoryFootprint memoryAfterGc() throws InterruptedException {
+		for (int i = 0; i < 3; i++) {
+			System.gc();
+			Thread.sleep(250L);
+		}
+		final long heap = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+		// Netty's counter covers buffers allocated without a Cleaner (invisible to the JVM's own
+		// bean); the JVM bean covers plain `ByteBuffer.allocateDirect`. Whichever is larger is the
+		// better estimate - summing them would double-count buffers that both of them see.
+		final long nettyDirect = PlatformDependent.usedDirectMemory();
+		final long nioDirect = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)
+			.stream()
+			.filter(it -> "direct".equals(it.getName()))
+			.mapToLong(BufferPoolMXBean::getMemoryUsed)
+			.sum();
+		return new MemoryFootprint(heap, Math.max(Math.max(nettyDirect, 0L), nioDirect), nettyDirect, nioDirect);
+	}
+
+	/**
+	 * Logs whether any thread is currently inside the `fetchFile` streaming loop. Diagnostic only:
+	 * a handler that ignores back-pressure has long since run the loop to completion by the time the
+	 * settle window expires, whereas a gated one is either parked in it or waiting for an on-ready
+	 * callback - which is why this is logged rather than asserted.
+	 */
+	private static void logFetchFileThreadState() {
+		final ThreadInfo[] threads = ManagementFactory.getThreadMXBean().dumpAllThreads(false, false);
+		final long inFetchFile = Arrays.stream(threads)
+			.filter(it -> Arrays.stream(it.getStackTrace())
+				.anyMatch(frame -> frame.getClassName().endsWith("EvitaManagementService") &&
+					frame.getMethodName().contains("fetchFile")))
+			.count();
+		log.info("Threads currently inside EvitaManagementService.fetchFile: {}", inFetchFile);
+		Arrays.stream(threads)
+			.filter(it -> Arrays.stream(it.getStackTrace())
+				.anyMatch(frame -> frame.getClassName().contains("GrpcOutboundGate") ||
+					(frame.getClassName().endsWith("EvitaManagementService") &&
+						frame.getMethodName().contains("fetchFile"))))
+			.forEach(
+				it -> log.info(
+					"Producer thread `{}` is {}:\n\t{}",
+					it.getThreadName(), it.getThreadState(),
+					Arrays.stream(it.getStackTrace()).limit(12).map(StackTraceElement::toString)
+						.reduce((a, b) -> a + "\n\t" + b).orElse("<no stack>")
+				)
+			);
+	}
+
+	/**
+	 * Creates a file of the requested size and publishes it for fetching.
+	 *
+	 * @param evita        engine whose export service the file is stored in
+	 * @param size         size of the file in bytes
+	 * @param contentsCrc  accumulator the written contents are checksummed into
+	 * @return descriptor of the published file
+	 */
+	@Nonnull
+	private static FileForFetch createExportedFile(
+		@Nonnull Evita evita,
+		long size,
+		@Nonnull CRC32 contentsCrc
+	) throws Exception {
+		final byte[] pattern = new byte[CHUNK_SIZE];
+		for (int i = 0; i < pattern.length; i++) {
+			pattern[i] = (byte) (i * 31 + 7);
+		}
+		final ExportFileHandle handle = evita.management().exportService().storeFile(
+			"grpc-fetch-file-backpressure.bin",
+			"Large file used by the fetchFile back-pressure test",
+			"application/octet-stream",
+			"test"
+		);
+		try {
+			final OutputStream outputStream = handle.outputStream();
+			long written = 0L;
+			while (written < size) {
+				final int toWrite = (int) Math.min(pattern.length, size - written);
+				outputStream.write(pattern, 0, toWrite);
+				contentsCrc.update(pattern, 0, toWrite);
+				written += toWrite;
+			}
+		} finally {
+			handle.close();
+		}
+		final FileForFetch fileForFetch = handle.fileForFetchFuture().get(60, TimeUnit.SECONDS);
+		assertEquals(size, fileForFetch.totalSizeInBytes(), "Exported file has an unexpected size.");
+		return fileForFetch;
+	}
+
+	@DataSet(
+		value = DATA_SET, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE},
+		readOnly = false, destroyAfterClass = true,
+		// Mandatory here, not a preference. The default test engine collapses the request pool into a
+		// direct executor, which makes `executeWithClientContext` run the streaming loop on the
+		// transport event loop - the one thread that has to drain the outbound queue. Readiness gating
+		// is impossible there by construction (the gate detects it and deliberately runs ungated), so
+		// without real pools this test would measure the *unbounded* path no matter what the server
+		// does, and could never fail. A networked server always runs on real pools.
+		useRealThreadPools = true
+	)
+	GrpcClientBuilder setUp(EvitaServer evitaServer) {
+		return TestGrpcClientBuilderCreator.getBuilder(
+			new ClientSessionInterceptor(
+				EvitaClientConfiguration.builder().build().clientId(),
+				new SemVer(2025, 4)
+			),
+			evitaServer.getExternalApiServer()
+		);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET)
+	@DisplayName(
+		"Should keep server memory bounded while a client stalls mid-download, " +
+			"and still deliver the file when it resumes"
+	)
+	void shouldNotBufferWholeFileForStalledClient(Evita evita, GrpcClientBuilder clientBuilder) throws Exception {
+		final CRC32 expectedCrc = new CRC32();
+		final FileForFetch bigFile = createExportedFile(evita, FILE_SIZE, expectedCrc);
+		final AtomicReference<ClientCallStreamObserver<GrpcFetchFileRequest>> call = new AtomicReference<>();
+		try {
+			final EvitaManagementServiceStub managementStub = clientBuilder
+				// gRPC-Web framing - the format evitaLab uses and the one the production report came from
+				.serializationFormat(GrpcSerializationFormats.PROTO_WEB)
+				// the client stalls on purpose; neither a response timeout nor the 10 MB default
+				// response-length cap may be what ends the call
+				.responseTimeoutMillis(0)
+				.maxResponseLength(0)
+				.build(EvitaManagementServiceStub.class);
+
+			final CountDownLatch initialChunks = new CountDownLatch(CHUNKS_CONSUMED_BEFORE_STALL);
+			final CountDownLatch terminated = new CountDownLatch(1);
+			final AtomicReference<Throwable> failure = new AtomicReference<>();
+			final AtomicInteger chunksReceived = new AtomicInteger();
+			final AtomicLong bytesReceived = new AtomicLong();
+			final CRC32 receivedCrc = new CRC32();
+
+			final MemoryFootprint memoryBeforeDownload = memoryAfterGc();
+
+			managementStub.fetchFile(
+				GrpcFetchFileRequest.newBuilder()
+					.setFileId(EvitaDataTypesConverter.toGrpcUuid(bigFile.fileId()))
+					.build(),
+				new ClientResponseObserver<GrpcFetchFileRequest, GrpcFetchFileResponse>() {
+
+					@Override
+					public void beforeStart(ClientCallStreamObserver<GrpcFetchFileRequest> requestStream) {
+						// take manual control of the demand - the client asks for a handful of
+						// messages up front and then deliberately goes silent
+						requestStream.disableAutoRequestWithInitial(CHUNKS_CONSUMED_BEFORE_STALL);
+						call.set(requestStream);
+					}
+
+					@Override
+					public void onNext(GrpcFetchFileResponse value) {
+						final byte[] contents = value.getFileContents().toByteArray();
+						receivedCrc.update(contents);
+						bytesReceived.addAndGet(contents.length);
+						chunksReceived.incrementAndGet();
+						initialChunks.countDown();
+					}
+
+					@Override
+					public void onError(Throwable t) {
+						failure.set(t);
+						initialChunks.countDown();
+						terminated.countDown();
+					}
+
+					@Override
+					public void onCompleted() {
+						terminated.countDown();
+					}
+				}
+			);
+
+			final boolean initialChunksDelivered = initialChunks.await(30, TimeUnit.SECONDS);
+			if (!initialChunksDelivered) {
+				// the producer's own state is the only thing that distinguishes "the gate is stuck"
+				// from "the client never asked", and it is gone by the time the assertion is reported
+				logFetchFileThreadState();
+			}
+			assertTrue(
+				initialChunksDelivered,
+				"Server did not deliver the first " + CHUNKS_CONSUMED_BEFORE_STALL + " chunks within 30 " +
+					"seconds - got " + chunksReceived.get() + " (" + bytesReceived.get() + " B), failure: " +
+					failure.get()
+			);
+
+			// give an unbounded server the time it needs to drain the whole file into its outbound queue
+			Thread.sleep(SETTLE_WINDOW_MILLIS);
+
+			final MemoryFootprint memoryWhileStalled = memoryAfterGc();
+			final long retained = memoryWhileStalled.total() - memoryBeforeDownload.total();
+			logFetchFileThreadState();
+			log.info(
+				"Client consumed {} chunks ({} B) of a {} B file; server retained {} B ({} MB). " +
+					"Before: {}; while stalled: {}",
+				chunksReceived.get(), bytesReceived.get(), FILE_SIZE, retained, retained / (1024 * 1024),
+				memoryBeforeDownload, memoryWhileStalled
+			);
+			if (failure.get() instanceof StatusRuntimeException sre) {
+				log.info(
+					"Call already terminated while the client was stalled: status={}, description={}",
+					sre.getStatus().getCode(), sre.getStatus().getDescription()
+				);
+			}
+
+			// preconditions for the measurement to mean anything at all
+			assertNull(
+				failure.get(),
+				"The call must survive a stalled client, but it ended with: " + failure.get()
+			);
+			assertEquals(
+				CHUNKS_CONSUMED_BEFORE_STALL, chunksReceived.get(),
+				"Client received messages it never requested - manual flow control is not in effect, " +
+					"so this run proves nothing about server-side buffering."
+			);
+
+			// The client resumes: the transfer must still complete, intact. This runs *before* the
+			// memory verdict on purpose - asserting the bound here would abort the method on the
+			// currently-unbounded implementation and leave the correctness half of the test never
+			// executed, so it would run for the first time on the day the fix lands and any bug in
+			// it would read as a broken fix.
+			call.get().request(Integer.MAX_VALUE);
+			assertTrue(
+				terminated.await(300, TimeUnit.SECONDS),
+				"Download did not finish within 300 seconds after the client resumed consuming."
+			);
+			assertNull(failure.get(), "Download failed after the client resumed: " + failure.get());
+			assertEquals(FILE_SIZE, bytesReceived.get(), "Client did not receive the whole file.");
+			assertEquals(
+				expectedCrc.getValue(), receivedCrc.getValue(),
+				"Downloaded contents differ from the stored file."
+			);
+
+			// once everything has been drained the queue is empty again - the delta measured here is
+			// the noise floor of the measurement itself (allocator growth, counter drift), and is
+			// what makes the MAX_TOLERATED_SERVER_BUFFERING margin legible rather than arbitrary
+			final MemoryFootprint memoryAfterDrain = memoryAfterGc();
+			log.info(
+				"After the client drained the stream, retained {} B relative to the start; footprint: {}",
+				memoryAfterDrain.total() - memoryBeforeDownload.total(), memoryAfterDrain
+			);
+
+			assertTrue(
+				retained < MAX_TOLERATED_SERVER_BUFFERING,
+				"Server retained " + retained + " B for a client that consumed only " +
+					(long) CHUNKS_CONSUMED_BEFORE_STALL * CHUNK_SIZE + " B - fetchFile is streaming " +
+					"without regard for transport readiness and buffers the whole file (limit " +
+					MAX_TOLERATED_SERVER_BUFFERING + " B)."
+			);
+		} finally {
+			// an assertion that fires mid-download leaves the call - and whatever the server queued
+			// behind it - alive; cancel it so the next test in the fork does not inherit the memory
+			final ClientCallStreamObserver<GrpcFetchFileRequest> pendingCall = call.get();
+			if (pendingCall != null) {
+				pendingCall.cancel("test finished", null);
+			}
+			evita.management().deleteFile(bigFile.fileId());
+		}
+	}
+
+}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningGrpcFetchFileDeadlineTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningGrpcFetchFileDeadlineTest.java
@@ -1,0 +1,364 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc;
+
+import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import io.evitadb.api.file.FileForFetch;
+import io.evitadb.core.Evita;
+import io.evitadb.driver.config.EvitaClientConfiguration;
+import io.evitadb.driver.interceptor.ClientSessionInterceptor;
+import io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter;
+import io.evitadb.externalApi.grpc.generated.EvitaManagementServiceGrpc.EvitaManagementServiceStub;
+import io.evitadb.externalApi.grpc.generated.GrpcFetchFileRequest;
+import io.evitadb.externalApi.grpc.generated.GrpcFetchFileResponse;
+import io.evitadb.externalApi.system.SystemProvider;
+import io.evitadb.server.EvitaServer;
+import io.evitadb.spi.export.model.ExportFileHandle;
+import io.evitadb.test.annotation.DataSet;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import io.evitadb.utils.VersionUtils.SemVer;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nonnull;
+import java.io.OutputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.CRC32;
+
+import static io.evitadb.test.TestTags.EXPORT;
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static io.evitadb.test.TestTags.SLOW;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Proves that a **progressing** download survives a server request deadline far shorter than the
+ * transfer takes - i.e. that the deadline bounds *silence* rather than the length of the exchange.
+ *
+ * This is the invariant `GrpcOutboundGate` re-arms for, and it only became load-bearing once the gate
+ * existed. Before it, `fetchFile` pushed the whole file into Armeria's unbounded outbound queue at disk
+ * speed; afterwards the handler lives exactly as long as the *client* takes to consume, so any fixed
+ * request budget becomes a cap on file size divided by link speed. A 1-2 s budget is not a contrived
+ * setting either - it is what a client sending no `grpc-timeout` at all actually gets, because
+ * Armeria's `FramedGrpcService` overrides the context timeout **only** when the header is present and
+ * otherwise leaves `api.requestTimeoutInMillis` (1 s code default, 2 s shipped) in force. A browser
+ * over gRPC-Web is therefore the *most* exposed client, not the least.
+ *
+ * **Why the test is shaped the way it is.** Three earlier attempts failed to reach the defect at all,
+ * and each trap is easy to fall back into:
+ *
+ * - **The deadline has to be set by the client but enforced only by the server.** `responseTimeoutMillis(0)`
+ *   stops Armeria's client from ending the call on its own - but it also stops it emitting the
+ *   `grpc-timeout` header, so the server silently falls back to its configured budget (10 minutes under
+ *   the test harness) and nothing can ever expire. The header is therefore injected by hand, through a
+ *   {@link ClientInterceptor}, which sets it without arming any client-side clock.
+ * - **Size alone does not make a client slow.** At 8 MB the server produced every chunk in ~6 ms: the
+ *   handler had finished before any deadline could bite, and a "slow" consumer throttled nothing. What
+ *   paces the handler is the gate, and what paces the gate is *demand* - so the client here takes manual
+ *   control of flow control and drip-feeds `request(1)`.
+ * - **The producer must not be on the event loop.** See `useRealThreadPools` on the data set below.
+ *
+ * **Calibration.** With the re-arm removed from {@link io.evitadb.externalApi.grpc.utils.GrpcOutboundGate}
+ * this test fails, the stream dying with `RST_STREAM`/`DEADLINE_EXCEEDED` at roughly
+ * {@link #SERVER_REQUEST_TIMEOUT_MILLIS} - about a fifth of the way in. The measured numbers are quoted
+ * in `documentation/adr/2026-08-24-grpc-streaming-backpressure-readiness-gate.md`.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Slf4j
+@ExtendWith(EvitaParameterResolver.class)
+@DisplayName("gRPC fetchFile must not cap a progressing download at the request deadline")
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(MANAGEMENT)
+@Tag(EXPORT)
+@Tag(SLOW)
+public class LongRunningGrpcFetchFileDeadlineTest {
+	private static final String DATA_SET = "GrpcFetchFileDeadline";
+	/**
+	 * Chunk size the server streams with - mirrors `EvitaManagementService.FETCH_FILE_CHUNK_SIZE`.
+	 */
+	private static final int CHUNK_SIZE = 1_048_576;
+	/**
+	 * Size of the downloaded file. Chosen together with {@link #CONSUMER_PACING_MILLIS} so the transfer
+	 * takes several times {@link #SERVER_REQUEST_TIMEOUT_MILLIS} while no single gap between messages
+	 * comes anywhere near it - the two conditions the test needs to hold simultaneously.
+	 */
+	private static final long FILE_SIZE = 64L * 1024L * 1024L;
+	/**
+	 * Delay the client inserts before asking for each subsequent message. This paces the *server*,
+	 * because the gate advances only on demand. It is not a poll and cannot fail the test spuriously:
+	 * a loaded machine stretches the transfer, which only widens the margin the test asserts.
+	 */
+	private static final long CONSUMER_PACING_MILLIS = 100L;
+	/**
+	 * Request deadline the client asks the server to enforce, in milliseconds. Deliberately far below
+	 * the transfer's duration and far above one message's worth of pacing.
+	 */
+	private static final long SERVER_REQUEST_TIMEOUT_MILLIS = 2_000L;
+	/**
+	 * Upper bound on the whole download. Generous by design - it exists to fail a hang, not to time the
+	 * transfer, and a passing run returns as soon as the stream completes.
+	 */
+	private static final long COMPLETION_TIMEOUT_SECONDS = 120L;
+
+	/**
+	 * gRPC's own header carrying the caller's deadline. Injected by hand rather than by
+	 * `withDeadlineAfter`, so that the deadline exists on the server and nowhere else.
+	 */
+	private static final Metadata.Key<String> GRPC_TIMEOUT = Metadata.Key.of(
+		"grpc-timeout", Metadata.ASCII_STRING_MARSHALLER
+	);
+
+	/**
+	 * Sets `grpc-timeout` on every outgoing call without arming any client-side clock.
+	 *
+	 * The point of the separation is that the test must observe the *server* abandoning a healthy
+	 * transfer. Had the deadline been set through `CallOptions.deadline`, gRPC would enforce it locally
+	 * too and a failure would prove nothing about which side gave up.
+	 */
+	private static final ClientInterceptor SERVER_ONLY_DEADLINE = new ClientInterceptor() {
+
+		@Override
+		public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+			MethodDescriptor<ReqT, RespT> method,
+			CallOptions callOptions,
+			Channel next
+		) {
+			return new SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+
+				@Override
+				public void start(Listener<RespT> responseListener, Metadata headers) {
+					// `m` is the gRPC wire unit for milliseconds
+					headers.put(GRPC_TIMEOUT, SERVER_REQUEST_TIMEOUT_MILLIS + "m");
+					super.start(responseListener, headers);
+				}
+			};
+		}
+	};
+
+	/**
+	 * Creates a file of the requested size and publishes it for fetching.
+	 *
+	 * @param evita       engine whose export service the file is stored in
+	 * @param size        size of the file in bytes
+	 * @param contentsCrc accumulator the written contents are checksummed into
+	 * @return descriptor of the published file
+	 */
+	@Nonnull
+	private static FileForFetch createExportedFile(
+		@Nonnull Evita evita,
+		long size,
+		@Nonnull CRC32 contentsCrc
+	) throws Exception {
+		final byte[] pattern = new byte[CHUNK_SIZE];
+		for (int i = 0; i < pattern.length; i++) {
+			pattern[i] = (byte) (i * 31 + 7);
+		}
+		final ExportFileHandle handle = evita.management().exportService().storeFile(
+			"grpc-fetch-file-deadline.bin",
+			"Large file used by the fetchFile deadline test",
+			"application/octet-stream",
+			"test"
+		);
+		try {
+			final OutputStream outputStream = handle.outputStream();
+			long written = 0L;
+			while (written < size) {
+				final int toWrite = (int) Math.min(pattern.length, size - written);
+				outputStream.write(pattern, 0, toWrite);
+				contentsCrc.update(pattern, 0, toWrite);
+				written += toWrite;
+			}
+		} finally {
+			handle.close();
+		}
+		final FileForFetch fileForFetch = handle.fileForFetchFuture().get(60, TimeUnit.SECONDS);
+		assertEquals(size, fileForFetch.totalSizeInBytes(), "Exported file has an unexpected size.");
+		return fileForFetch;
+	}
+
+	@DataSet(
+		value = DATA_SET, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE},
+		readOnly = false, destroyAfterClass = true,
+		// Mandatory, for the same reason as the back-pressure test: the default test engine collapses
+		// the request pool into a direct executor, which runs the producing loop on the transport event
+		// loop. The gate detects that and deliberately runs ungated, so the handler would again outrun
+		// the client and finish long before any deadline mattered.
+		useRealThreadPools = true
+	)
+	GrpcClientBuilder setUp(EvitaServer evitaServer) {
+		return TestGrpcClientBuilderCreator.getBuilder(
+			new ClientSessionInterceptor(
+				EvitaClientConfiguration.builder().build().clientId(),
+				new SemVer(2025, 4)
+			),
+			evitaServer.getExternalApiServer()
+		);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET)
+	@DisplayName(
+		"Should deliver a whole file to a slow but steady client, though the transfer far outlives " +
+			"the server's request deadline"
+	)
+	void shouldNotEndAProgressingDownloadAtTheRequestDeadline(
+		Evita evita,
+		GrpcClientBuilder clientBuilder
+	) throws Exception {
+		final CRC32 expectedCrc = new CRC32();
+		final FileForFetch bigFile = createExportedFile(evita, FILE_SIZE, expectedCrc);
+
+		final ThreadFactory daemonFactory = runnable -> {
+			final Thread thread = new Thread(runnable, "grpc-fetch-file-deadline-pacer");
+			thread.setDaemon(true);
+			return thread;
+		};
+		final ScheduledExecutorService pacer = Executors.newSingleThreadScheduledExecutor(daemonFactory);
+		try {
+			final EvitaManagementServiceStub managementStub = clientBuilder
+				// gRPC-Web framing - the format evitaLab uses, and the client shape most exposed to this
+				.serializationFormat(GrpcSerializationFormats.PROTO_WEB)
+				// only the server may end this call: no client response timeout, and no response-length
+				// cap that could terminate it for an unrelated reason
+				.responseTimeoutMillis(0)
+				.maxResponseLength(0)
+				.intercept(SERVER_ONLY_DEADLINE)
+				.build(EvitaManagementServiceStub.class);
+
+			final CountDownLatch terminated = new CountDownLatch(1);
+			final AtomicReference<Throwable> failure = new AtomicReference<>();
+			final AtomicInteger chunksReceived = new AtomicInteger();
+			final AtomicLong bytesReceived = new AtomicLong();
+			final CRC32 receivedCrc = new CRC32();
+			final long startNanos = System.nanoTime();
+
+			managementStub.fetchFile(
+				GrpcFetchFileRequest.newBuilder()
+					.setFileId(EvitaDataTypesConverter.toGrpcUuid(bigFile.fileId()))
+					.build(),
+				new ClientResponseObserver<GrpcFetchFileRequest, GrpcFetchFileResponse>() {
+					private ClientCallStreamObserver<GrpcFetchFileRequest> call;
+
+					@Override
+					public void beforeStart(ClientCallStreamObserver<GrpcFetchFileRequest> requestStream) {
+						// one message in flight at a time, so that the pacing below governs the server
+						requestStream.disableAutoRequestWithInitial(1);
+						this.call = requestStream;
+					}
+
+					@Override
+					public void onNext(GrpcFetchFileResponse value) {
+						final byte[] contents = value.getFileContents().toByteArray();
+						receivedCrc.update(contents);
+						bytesReceived.addAndGet(contents.length);
+						chunksReceived.incrementAndGet();
+						// ask for the next message *later*, and from another thread - this callback runs
+						// on the transport event loop, where sleeping would stall the very thread that
+						// has to deliver what we are waiting for
+						pacer.schedule(
+							() -> this.call.request(1), CONSUMER_PACING_MILLIS, TimeUnit.MILLISECONDS
+						);
+					}
+
+					@Override
+					public void onError(Throwable t) {
+						failure.set(t);
+						terminated.countDown();
+					}
+
+					@Override
+					public void onCompleted() {
+						terminated.countDown();
+					}
+				}
+			);
+
+			final boolean completed = terminated.await(COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+			final long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+
+			log.info(
+				"Download of {} B ended after {} ms in {} chunks ({} B received); server deadline was {} ms.",
+				FILE_SIZE, elapsedMillis, chunksReceived.get(), bytesReceived.get(),
+				SERVER_REQUEST_TIMEOUT_MILLIS
+			);
+
+			assertTrue(
+				completed,
+				"The download neither completed nor failed within " + COMPLETION_TIMEOUT_SECONDS +
+					" s - it received " + bytesReceived.get() + " B of " + FILE_SIZE + " B."
+			);
+			assertNull(
+				failure.get(),
+				() -> "A steadily progressing download was terminated after " + elapsedMillis + " ms " +
+					"with " + bytesReceived.get() + " B of " + FILE_SIZE + " B delivered: " +
+					Status.fromThrowable(failure.get()) + ". The request deadline is meant to bound " +
+					"silence, not the length of the transfer - see `GrpcOutboundGate`."
+			);
+
+			// Without this the test could pass on a machine fast enough to finish inside the deadline,
+			// proving nothing at all. It is an assertion about the *scenario*, not about the code.
+			assertTrue(
+				elapsedMillis > 2 * SERVER_REQUEST_TIMEOUT_MILLIS,
+				"The transfer took only " + elapsedMillis + " ms against a " +
+					SERVER_REQUEST_TIMEOUT_MILLIS + " ms deadline, so it never outlived the budget it " +
+					"is supposed to outlive. Raise FILE_SIZE or CONSUMER_PACING_MILLIS."
+			);
+			assertEquals(FILE_SIZE, bytesReceived.get(), "Client did not receive the whole file.");
+			assertEquals(
+				expectedCrc.getValue(), receivedCrc.getValue(),
+				"Downloaded contents differ from what was exported."
+			);
+		} finally {
+			pacer.shutdownNow();
+		}
+	}
+
+}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningGrpcRestoreCatalogUploadTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningGrpcRestoreCatalogUploadTest.java
@@ -1,0 +1,602 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc;
+
+import com.google.protobuf.ByteString;
+import io.evitadb.api.EvitaManagementContract;
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.file.FileForFetch;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
+import io.evitadb.driver.ClientTask;
+import io.evitadb.driver.EvitaClient;
+import io.evitadb.driver.EvitaClientManagement;
+import io.evitadb.driver.interceptor.ClientSessionInterceptor;
+import io.evitadb.driver.config.EvitaClientConfiguration;
+import io.evitadb.externalApi.configuration.ApiOptions;
+import io.evitadb.externalApi.configuration.HostDefinition;
+import io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter;
+import io.evitadb.externalApi.grpc.generated.EvitaManagementServiceGrpc.EvitaManagementServiceStub;
+import io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogRequest;
+import io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogResponse;
+import io.evitadb.externalApi.system.SystemProvider;
+import io.evitadb.server.EvitaServer;
+import io.evitadb.test.annotation.DataSet;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import io.evitadb.utils.CertificateUtils;
+import io.evitadb.utils.VersionUtils.SemVer;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.stub.StreamObserver;
+import io.evitadb.driver.config.ClientTimeoutOptions;
+import io.evitadb.driver.config.ClientTlsOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nonnull;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static io.evitadb.test.TestTags.SLOW;
+import static io.evitadb.test.TestTags.STREAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Proves that a catalog backup survives being uploaded across many messages - over both restore RPCs
+ * evitaDB exposes, because each one is load-bearing for a different reason.
+ *
+ * **`RestoreCatalogUnary`, which the driver uses.** A client-streaming RPC delivers the whole
+ * conversation as a single HTTP request, so the server's `maxRequestLength` - which evitaDB wires to
+ * `api.maxEntitySizeInBytes`, 2 MB by default - bounded the *entire backup*. Anything larger died
+ * part-way through with a bare `RESOURCE_EXHAUSTED`, which made `EvitaClient`'s restore unusable for a
+ * catalog of any real size. The driver now uploads through `RestoreCatalogUnary`, where every chunk is
+ * a request of its own and only the chunk has to fit. {@link #SERVER_REQUEST_LIMIT} is asserted from
+ * below for exactly this reason: shrink the payload under it and the test stops proving anything.
+ *
+ * **The client-streaming `RestoreCatalog`, which third parties still use.** The server no longer
+ * writes to disk inline on the Armeria event loop; each chunk is appended on a per-call
+ * {@link java.util.concurrent.CompletableFuture} chain running on a worker, and the conversation
+ * advances only because each completed write hand-issues demand for the next chunk. Since the driver
+ * was rerouted to the unary RPC, nothing else drives that path across more than one message.
+ * {@link #shouldRestoreCatalogUploadedThroughClientStreamingRpc} is what keeps it covered - read that
+ * method's JavaDoc before trusting it, because it records both what its calibration detected and, more
+ * importantly, what it could not.
+ *
+ * A ZIP is the ideal detector for both - its central directory and per-entry CRCs make reordering or
+ * truncation fail loudly - so the assertion is that the restored catalog opens and holds exactly what
+ * was backed up, payloads compared byte for byte.
+ *
+ * **Why this lives in the long-running module rather than beside the functional backup/restore test.**
+ * The functional round trip
+ * (`EvitaClientReadWriteTest#shouldBackupAndRestoreCatalogViaDownloadingAndUploadingFileContents`)
+ * backs up a ten-product catalog, whose archive fits in a **single** message - so neither the size
+ * ceiling nor the per-chunk hand-off is exercised by it at all. Making the upload span many messages
+ * costs the time to build and archive a payload that large, which is what buys the `@Tag(SLOW)`.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("gRPC catalog restore must carry an upload intact - past the request-body limit, and in order")
+@ExtendWith(EvitaParameterResolver.class)
+@Slf4j
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(MANAGEMENT)
+@Tag(STREAM)
+@Tag(SLOW)
+public class LongRunningGrpcRestoreCatalogUploadTest {
+	private static final String DATA_SET = "GrpcRestoreCatalogUpload";
+	private static final String TEST_CATALOG = "testCatalog";
+	/**
+	 * Second, deliberately small catalog. The client-streaming RPC cannot carry a backup past
+	 * {@link #SERVER_REQUEST_LIMIT} at all - that ceiling is the whole reason the driver left it - so
+	 * the test that keeps that RPC covered needs a payload that fits under it while still spanning
+	 * enough messages to exercise the per-chunk hand-off.
+	 */
+	private static final String TEST_CATALOG_SMALL = "testCatalogSmall";
+	private static final String ENTITY_TYPE = "blob";
+	private static final String ATTRIBUTE_PAYLOAD = "payload";
+	/**
+	 * Number of entities the backed-up catalog holds. Chosen so that the resulting archive lands
+	 * comfortably **over** {@link #SERVER_REQUEST_LIMIT} - the ceiling the upload used to die on.
+	 */
+	private static final int ENTITY_COUNT = 200;
+	/**
+	 * Number of entities {@link #TEST_CATALOG_SMALL} holds. Sized for the opposite constraint: the
+	 * archive must stay under {@link #SERVER_REQUEST_LIMIT} with headroom, yet still take at least
+	 * {@link #MIN_EXPECTED_STREAMED_CHUNKS} messages of {@link #STREAMING_CHUNK_SIZE}.
+	 */
+	private static final int SMALL_ENTITY_COUNT = 20;
+	/**
+	 * Size of each entity's payload attribute. The content is high-entropy on purpose - a compressible
+	 * payload would shrink the archive back to a couple of messages and quietly defeat the test.
+	 */
+	private static final int PAYLOAD_SIZE = 32_768;
+	/**
+	 * Chunk size the driver uploads with (`EvitaClientManagement.RESTORE_CHUNK_SIZE`).
+	 */
+	private static final int CLIENT_CHUNK_SIZE = 524_288;
+	/**
+	 * Largest request body the server accepts: Armeria's `maxRequestLength`, which evitaDB wires to
+	 * `api.maxEntitySizeInBytes` (`ApiOptions.DEFAULT_MAX_ENTITY_SIZE`, 2 MB).
+	 *
+	 * This is what made the *client-streaming* `RestoreCatalog` unusable for a real catalog: the whole
+	 * upload is one request, so the limit bounded the entire backup rather than a chunk, and anything
+	 * larger died part-way through with a bare `RESOURCE_EXHAUSTED`. The limit is deliberate operator
+	 * policy and stays; the driver now uploads through `RestoreCatalogUnary`, where each chunk is a
+	 * request of its own and only the chunk has to fit.
+	 */
+	private static final long SERVER_REQUEST_LIMIT = 2L * 1024L * 1024L;
+	/**
+	 * Lower bound on the number of messages the upload must span for this test to be testing anything
+	 * the functional backup/restore test does not already cover - that one fits in a single message.
+	 */
+	private static final int MIN_EXPECTED_CHUNKS = 8;
+	/**
+	 * Chunk size the client-streaming upload is cut into. Much smaller than {@link #CLIENT_CHUNK_SIZE}
+	 * so that a backup which must stay under {@link #SERVER_REQUEST_LIMIT} still spans many messages -
+	 * roughly 17 at the current fixture size, which leaves room for the archive to shrink before the
+	 * precondition below starts failing on its own.
+	 */
+	private static final int STREAMING_CHUNK_SIZE = 32_768;
+	/**
+	 * Lower bound on the number of messages the client-streaming upload must span. One message would
+	 * leave the chunk-by-chunk hand-off - the thing that test exists for - entirely unexercised.
+	 */
+	private static final int MIN_EXPECTED_STREAMED_CHUNKS = 8;
+	/**
+	 * Fixed seed - the payloads must be reproducible across the two sessions that write and verify them.
+	 */
+	private static final long PAYLOAD_SEED = 0x5EEDL;
+
+	/**
+	 * Builds the payload of the entity with the given primary key. Deterministic, so the verification
+	 * pass can regenerate exactly what the setup wrote.
+	 *
+	 * @param primaryKey primary key of the entity the payload belongs to
+	 * @return payload contents
+	 */
+	@Nonnull
+	private static String payloadOf(int primaryKey) {
+		// a per-entity seed keeps the payloads independent of the order they are generated in
+		final Random random = new Random(PAYLOAD_SEED + primaryKey);
+		final char[] contents = new char[PAYLOAD_SIZE];
+		for (int i = 0; i < contents.length; i++) {
+			// printable, high-entropy, single-byte in UTF-8
+			contents[i] = (char) ('!' + random.nextInt('~' - '!' + 1));
+		}
+		return new String(contents);
+	}
+
+	@DataSet(
+		value = DATA_SET, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE},
+		readOnly = false, destroyAfterClass = true,
+		// Mandatory, not a preference: the default test engine collapses the request pool into a direct
+		// executor, so the upload's hand-off would run inline on the event loop - the very topology this
+		// test exists to verify the absence of. Without it the ordered chain is never scheduled and the
+		// test would pass against the old, event-loop-blocking implementation too.
+		useRealThreadPools = true
+	)
+	static EvitaClient setUp(EvitaServer evitaServer) {
+		final EvitaClient evitaClient = createClient(evitaServer);
+		// `testCatalog` is the one the harness pre-creates; the small one has to be defined by hand
+		fillCatalog(evitaClient, TEST_CATALOG, ENTITY_COUNT);
+		evitaClient.defineCatalog(TEST_CATALOG_SMALL);
+		fillCatalog(evitaClient, TEST_CATALOG_SMALL, SMALL_ENTITY_COUNT);
+		return evitaClient;
+	}
+
+	/**
+	 * Fills the given catalog with `entityCount` entities carrying {@link #payloadOf(int)} payloads and
+	 * takes it live, so it can be backed up.
+	 *
+	 * @param evitaClient client to work through
+	 * @param catalogName catalog to fill
+	 * @param entityCount number of entities to create
+	 */
+	private static void fillCatalog(
+		@Nonnull EvitaClient evitaClient,
+		@Nonnull String catalogName,
+		int entityCount
+	) {
+		evitaClient.updateCatalog(
+			catalogName,
+			session -> {
+				session.defineEntitySchema(ENTITY_TYPE)
+					.withAttribute(ATTRIBUTE_PAYLOAD, String.class, AttributeSchemaEditor::nullable)
+					.updateVia(session);
+				for (int primaryKey = 1; primaryKey <= entityCount; primaryKey++) {
+					session.createNewEntity(ENTITY_TYPE, primaryKey)
+						.setAttribute(ATTRIBUTE_PAYLOAD, payloadOf(primaryKey))
+						.upsertVia(session);
+				}
+				session.goLiveAndClose();
+				return null;
+			}
+		);
+	}
+
+	/**
+	 * Builds a driver client pointed at the running test server.
+	 *
+	 * @param evitaServer the running server
+	 * @return a client connected to it
+	 */
+	@Nonnull
+	private static EvitaClient createClient(@Nonnull EvitaServer evitaServer) {
+		final ApiOptions apiOptions = evitaServer.getExternalApiServer().getApiOptions();
+		final HostDefinition grpcHost = apiOptions.getEndpointConfiguration(GrpcProvider.CODE).getHost()[0];
+		final HostDefinition systemHost = apiOptions.getEndpointConfiguration(SystemProvider.CODE).getHost()[0];
+
+		final String serverCertificates = apiOptions.certificate().getFolderPath().toString();
+		final int lastDash = serverCertificates.lastIndexOf('-');
+		assertTrue(lastDash > 0, "Dash not found! Look at the evita-configuration.yml in test resources!");
+		final Path clientCertificates = Path.of(serverCertificates.substring(0, lastDash) + "-client");
+
+		return new EvitaClient(
+			EvitaClientConfiguration.builder()
+				.host(grpcHost.hostAddress())
+				.port(grpcHost.port())
+				.systemApiPort(systemHost.port())
+				.tls(
+					ClientTlsOptions.builder()
+						.mtlsEnabled(false)
+						.certificateFolderPath(clientCertificates)
+						.certificateFileName(Path.of(CertificateUtils.getGeneratedClientCertificateFileName()))
+						.certificateKeyFileName(
+							Path.of(CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName())
+						)
+						.build()
+				)
+				.timeouts(
+					ClientTimeoutOptions.builder()
+						.timeout(10, TimeUnit.MINUTES)
+						.build()
+				)
+				.build()
+		);
+	}
+
+	/**
+	 * Asserts that a restored catalog holds exactly what was backed up. The entity count alone would
+	 * survive a payload that arrived scrambled or short, so every payload is compared byte for byte -
+	 * that comparison is what actually pins the ordering of the uploaded chunks.
+	 *
+	 * @param evitaClient         client to verify through
+	 * @param restoredCatalogName name the catalog was restored under
+	 * @param entityCount         number of entities the catalog held when it was backed up
+	 */
+	private static void assertCatalogRestoredIntact(
+		@Nonnull EvitaClient evitaClient,
+		@Nonnull String restoredCatalogName,
+		int entityCount
+	) {
+		final Set<String> catalogNames = evitaClient.getCatalogNames();
+		assertTrue(catalogNames.contains(restoredCatalogName), "Restored catalog is not present on the server.");
+		evitaClient.activateCatalog(restoredCatalogName);
+
+		assertEquals(
+			Integer.valueOf(entityCount),
+			evitaClient.queryCatalog(
+				// a block body with an explicit return keeps this off the void-returning overload
+				restoredCatalogName, session -> {
+					return session.getEntityCollectionSize(ENTITY_TYPE);
+				}
+			),
+			"Restored catalog does not hold every entity that was backed up."
+		);
+
+		evitaClient.queryCatalog(
+			restoredCatalogName,
+			(Consumer<EvitaSessionContract>) session -> {
+				for (int primaryKey = 1; primaryKey <= entityCount; primaryKey++) {
+					final int currentKey = primaryKey;
+					final SealedEntity entity = session
+						.getEntity(ENTITY_TYPE, currentKey, attributeContentAll())
+						.orElseThrow(
+							() -> new IllegalStateException(
+								"Entity " + ENTITY_TYPE + " #" + currentKey + " is missing after restore."
+							)
+						);
+					assertEquals(
+						payloadOf(currentKey),
+						entity.getAttribute(ATTRIBUTE_PAYLOAD),
+						"Payload of entity " + currentKey + " differs from the backed-up one."
+					);
+				}
+			}
+		);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET)
+	@DisplayName("Should restore a catalog uploaded across hundreds of messages, byte for byte")
+	void shouldRestoreCatalogUploadedInManyChunks(EvitaClient evitaClient) throws Exception {
+		final EvitaManagementContract management = evitaClient.management();
+		final FileForFetch backup = management.backupCatalog(TEST_CATALOG, null, null, true)
+			.get(10, TimeUnit.MINUTES);
+
+		final long expectedChunks = backup.totalSizeInBytes() / CLIENT_CHUNK_SIZE;
+		log.info(
+			"Backed up {} B, which the driver uploads as roughly {} messages of {} B.",
+			backup.totalSizeInBytes(), expectedChunks, CLIENT_CHUNK_SIZE
+		);
+		assertTrue(
+			expectedChunks >= MIN_EXPECTED_CHUNKS,
+			"Backup is only " + backup.totalSizeInBytes() + " B, i.e. about " + expectedChunks +
+				" upload messages - too few to exercise the chunk-by-chunk hand-off this test guards. " +
+				"Raise ENTITY_COUNT/PAYLOAD_SIZE or lower MIN_EXPECTED_CHUNKS deliberately."
+		);
+		assertTrue(
+			backup.totalSizeInBytes() > SERVER_REQUEST_LIMIT,
+			"Backup is only " + backup.totalSizeInBytes() + " B, under the server's " + SERVER_REQUEST_LIMIT +
+				" B request-body limit - so it would upload happily through the old client-streaming path " +
+				"too, and this test would no longer prove that the ceiling is gone. Grow the payload."
+		);
+
+		final String restoredCatalogName = TEST_CATALOG + "_restored";
+		try (final InputStream inputStream = management.fetchFile(backup.fileId())) {
+			management.restoreCatalog(restoredCatalogName, backup.totalSizeInBytes(), inputStream)
+				.getFutureResult()
+				.get(10, TimeUnit.MINUTES);
+		}
+
+		assertCatalogRestoredIntact(evitaClient, restoredCatalogName, ENTITY_COUNT);
+	}
+
+	/**
+	 * Keeps the **client-streaming** `RestoreCatalog` RPC covered end to end. The driver no longer calls
+	 * it - it was rerouted to `RestoreCatalogUnary` to escape {@link #SERVER_REQUEST_LIMIT} - but it
+	 * stays on the wire for gRPC-Web and third-party clients, and this is the only test that drives
+	 * `RestoreCatalogUploadObserver` across more than one message.
+	 *
+	 * **What it demonstrably guards: the hand-issued demand protocol.** The server uploads with
+	 * `disableAutoRequest()` and re-issues `request(1)` from inside each completed write step, so the
+	 * whole conversation advances only because a worker asks for the next chunk. Delete that
+	 * `eventLoop().execute(() -> request(1))` and the upload stops dead after chunk one: no error, no
+	 * status, the call simply never terminates. Verified - the counterfactual fails here at the 30 s
+	 * latch with "Client-streaming upload never terminated", deterministically.
+	 *
+	 * **What it does *not* prove, despite the byte-for-byte comparison: write ordering.** Two mechanisms
+	 * serialise the writes - the per-call `CompletableFuture` chain and the one-message-at-a-time demand
+	 * above - and they are redundant. Removing the chain from `onCompleted()` alone leaves this test
+	 * green, because demand for the next chunk is issued from inside the *completed* write step, so
+	 * half-close cannot reach `submitRestoration` before the last write has landed. Removing **both**,
+	 * with a 2 ms widener inside the write step, also left it green - the writes still arrived in order
+	 * (measured at nine chunks, before {@link #STREAMING_CHUNK_SIZE} was halved to widen the margin on
+	 * the precondition above). That is a failure to detect, not evidence of safety - a race that does
+	 * not manifest is not a race that is absent. Treat the ordering invariant as **unverified by this
+	 * test**, and do not read a green run here as licence to delete either mechanism.
+	 *
+	 * @param evitaClient driver client, used for the backup, the download and the verification
+	 * @param evitaServer running server, needed to build a raw stub that speaks the streaming RPC
+	 */
+	@Test
+	@UseDataSet(DATA_SET)
+	@DisplayName("Should restore a catalog uploaded through the client-streaming RPC, byte for byte")
+	void shouldRestoreCatalogUploadedThroughClientStreamingRpc(
+		EvitaClient evitaClient,
+		EvitaServer evitaServer
+	) throws Exception {
+		final EvitaManagementContract management = evitaClient.management();
+		final FileForFetch backup = management.backupCatalog(TEST_CATALOG_SMALL, null, null, true)
+			.get(10, TimeUnit.MINUTES);
+
+		final byte[] backupContents;
+		try (final InputStream inputStream = management.fetchFile(backup.fileId())) {
+			backupContents = inputStream.readAllBytes();
+		}
+		final int expectedChunks = (backupContents.length + STREAMING_CHUNK_SIZE - 1) / STREAMING_CHUNK_SIZE;
+		log.info(
+			"Backed up {} B, uploaded through the client-streaming RPC as {} messages of {} B.",
+			backupContents.length, expectedChunks, STREAMING_CHUNK_SIZE
+		);
+		assertTrue(
+			expectedChunks >= MIN_EXPECTED_STREAMED_CHUNKS,
+			"Backup is only " + backupContents.length + " B, i.e. " + expectedChunks + " upload messages - " +
+				"too few to exercise the per-chunk hand-off this test guards. Lower STREAMING_CHUNK_SIZE: " +
+				"this bound and the SERVER_REQUEST_LIMIT one below hold the fixture from opposite sides, so " +
+				"growing SMALL_ENTITY_COUNT to satisfy this one walks straight into that one."
+		);
+		assertTrue(
+			backupContents.length < SERVER_REQUEST_LIMIT,
+			"Backup is " + backupContents.length + " B, at or over the server's " + SERVER_REQUEST_LIMIT +
+				" B request-body limit. A client-streaming upload is one request, so this would be rejected " +
+				"outright and the failure would read as a regression of the ordered chain rather than an " +
+				"oversized fixture. Shrink SMALL_ENTITY_COUNT."
+		);
+
+		final EvitaManagementServiceStub managementStub = TestGrpcClientBuilderCreator.getBuilder(
+				new ClientSessionInterceptor(
+					EvitaClientConfiguration.builder().build().clientId(),
+					new SemVer(2025, 4)
+				),
+				evitaServer.getExternalApiServer()
+			)
+			.build(EvitaManagementServiceStub.class);
+
+		final String restoredCatalogName = TEST_CATALOG_SMALL + "_streamRestored";
+		final CountDownLatch uploadFinished = new CountDownLatch(1);
+		final AtomicReference<GrpcRestoreCatalogResponse> uploadResponse = new AtomicReference<>();
+		final AtomicReference<Throwable> uploadFailure = new AtomicReference<>();
+		final StreamObserver<GrpcRestoreCatalogRequest> requestObserver = managementStub.restoreCatalog(
+			new StreamObserver<>() {
+				@Override
+				public void onNext(GrpcRestoreCatalogResponse value) {
+					uploadResponse.set(value);
+				}
+
+				@Override
+				public void onError(Throwable t) {
+					uploadFailure.set(t);
+					uploadFinished.countDown();
+				}
+
+				@Override
+				public void onCompleted() {
+					uploadFinished.countDown();
+				}
+			}
+		);
+
+		int chunksSent = 0;
+		for (int offset = 0; offset < backupContents.length; offset += STREAMING_CHUNK_SIZE) {
+			final int length = Math.min(STREAMING_CHUNK_SIZE, backupContents.length - offset);
+			requestObserver.onNext(
+				GrpcRestoreCatalogRequest.newBuilder()
+					.setCatalogName(restoredCatalogName)
+					.setBackupFile(ByteString.copyFrom(backupContents, offset, length))
+					.build()
+			);
+			chunksSent++;
+		}
+		requestObserver.onCompleted();
+
+		// positive wait - a latch sized generously, so a loaded box cannot fail it spuriously
+		assertTrue(uploadFinished.await(30, TimeUnit.SECONDS), "Client-streaming upload never terminated.");
+		// nothing else covers this path, so its failure message is the whole diagnostic - a bare
+		// Throwable concatenation would read "failed: null" for a status carrying no message
+		assertNull(
+			uploadFailure.get(),
+			() -> "Client-streaming upload failed: " + Status.fromThrowable(uploadFailure.get())
+		);
+
+		final GrpcRestoreCatalogResponse response = uploadResponse.get();
+		assertNotNull(response, "Server completed the upload without handing back a restoration task.");
+		// the server's own byte accounting - independent of ZIP integrity, and the first thing to check
+		// when the chain drops a chunk, because it localises the loss to the upload rather than the restore
+		assertEquals(
+			backupContents.length, response.getRead(),
+			"Server accounted for a different number of bytes than the " + chunksSent + " messages carried."
+		);
+
+		// the restoration task runs asynchronously on the server; the driver's own task tracker turns it
+		// into a real future, which is what keeps this off a sleep-poll loop
+		final ClientTask<?, ?> restorationTask = ((EvitaClientManagement) management)
+			.createTask(EvitaDataTypesConverter.toTaskStatus(response.getTask()));
+		restorationTask.getFutureResult().get(10, TimeUnit.MINUTES);
+
+		assertCatalogRestoredIntact(evitaClient, restoredCatalogName, SMALL_ENTITY_COUNT);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET)
+	@DisplayName("Should tell a client that still streams an oversized upload which limit it hit")
+	void shouldExplainWhyAnOversizedStreamingUploadIsRejected(EvitaServer evitaServer) throws Exception {
+		// the driver no longer uses the client-streaming RPC, but it stays on the wire for gRPC-Web and
+		// third-party clients - and for them the server's request-body limit is still a hard ceiling.
+		// What must not happen is what used to: a bare RESOURCE_EXHAUSTED with no description, which a
+		// client cannot distinguish from any other resource failure.
+		final EvitaManagementServiceStub managementStub = TestGrpcClientBuilderCreator.getBuilder(
+				new ClientSessionInterceptor(
+					EvitaClientConfiguration.builder().build().clientId(),
+					new SemVer(2025, 4)
+				),
+				evitaServer.getExternalApiServer()
+			)
+			.build(EvitaManagementServiceStub.class);
+
+		final CountDownLatch terminated = new CountDownLatch(1);
+		final AtomicReference<Throwable> failure = new AtomicReference<>();
+		final StreamObserver<GrpcRestoreCatalogRequest> requestObserver = managementStub.restoreCatalog(
+			new StreamObserver<>() {
+				@Override
+				public void onNext(GrpcRestoreCatalogResponse value) {
+				}
+
+				@Override
+				public void onError(Throwable t) {
+					failure.set(t);
+					terminated.countDown();
+				}
+
+				@Override
+				public void onCompleted() {
+					terminated.countDown();
+				}
+			}
+		);
+
+		final byte[] chunk = new byte[65_536];
+		long sent = 0L;
+		try {
+			// push past the server's request-body limit; the exact overshoot does not matter
+			while (sent <= SERVER_REQUEST_LIMIT) {
+				requestObserver.onNext(
+					GrpcRestoreCatalogRequest.newBuilder()
+						.setCatalogName(TEST_CATALOG + "_oversized")
+						.setBackupFile(ByteString.copyFrom(chunk))
+						.build()
+				);
+				sent += chunk.length;
+			}
+			requestObserver.onCompleted();
+		} catch (RuntimeException ex) {
+			// the server may abort the call while we are still pushing - that is the condition under
+			// test, not a failure of it
+			log.debug("Upload aborted by the server after {} B.", sent);
+		}
+
+		assertTrue(terminated.await(30, TimeUnit.SECONDS), "Oversized upload never terminated.");
+		final Throwable serverFailure = failure.get();
+		assertNotNull(serverFailure, "Server accepted an upload larger than its own request-body limit.");
+
+		final Status status = Status.fromThrowable(serverFailure);
+		assertEquals(
+			Code.RESOURCE_EXHAUSTED, status.getCode(),
+			"Oversized upload should be reported as RESOURCE_EXHAUSTED, got: " + status
+		);
+		final String description = status.getDescription();
+		assertNotNull(
+			description,
+			"Oversized upload was rejected with a bare status and no description - the client cannot tell " +
+				"a configured limit from any other resource failure."
+		);
+		assertTrue(
+			description.contains("maxEntitySizeInBytes"),
+			"Rejection should name the limit that was hit, was: " + description
+		);
+		assertTrue(
+			description.contains("RestoreCatalogUnary"),
+			"Rejection should point at the RPC that has no such ceiling, was: " + description
+		);
+	}
+
+}


### PR DESCRIPTION
Closes #1441

Server-streaming RPCs pushed messages into Armeria's unbounded outbound queue as fast as they could produce them. `tryWrite` refuses a message only once the stream is closed, never because it is full, so a client slower than the producer made the server materialise the whole payload — as pooled *direct* buffers, roughly 2x the payload once arena reservation is counted. `setOnReadyHandler` appeared **zero** times across all 20 server-streaming RPCs.

Producers now pace themselves against `ServerCallStreamObserver.isReady()` through a shared `GrpcOutboundGate`, which parks the producing worker until the transport drains.

### What gating exposed

Tying a handler's lifetime to the client's consumption rate made two timeout defects real:

**The per-message re-arm was compounding.** `ServiceRequestContext.requestTimeoutMillis()` looks like "the configured timeout" and is neither that nor the time remaining — Armeria stores the timeout relative to request *start*, and `SET_FROM_NOW` writes `elapsed + newTimeout` into that same field (`DefaultCancellationScheduler#setTimeoutNanosFromNow0`, 1.40.0). Six sites fed that getter back into the next re-arm, so a 2 s budget became 2.1 s, then 2.3 s, then 2.6 s, growing without bound. The rolling stall window the design rests on had become an ever-receding horizon a stalled client never reaches — invisible, because it only ever made calls *survive*.

**`requestTimeoutInMillis` is the wrong shape for a stream.** It bounds a whole request, which suits a unary call. A download's duration is a function of file size and link speed, so a whole-request budget is a cap on what can be transferred at all. New `api.endpoints.gRPC.streamingRequestTimeoutInMillis` (default `300K`) bounds *silence* instead and doubles as the gate's stall timeout, so both mechanisms that can end a stalled stream agree on when one is dead.

**The driver had no timeout tiers.** `EvitaClientManagement` took `ClientTimeoutOptions.timeout` — the unary 5 s budget — for everything including `fetchFile`, so a default-configured `EvitaClient` could not download anything taking longer than 5 s. Every test missed it because harness clients set `.timeout(10, MINUTES)`. `EvitaClientChannel.TimeoutTier` now travels with the channel and is paired with each stub at construction, the same seam that already makes "streaming stub on the retrying channel" not compile (#1388).

### Also in this line of work

- `restoreCatalog` moved its blocking file IO off the event loop onto an ordered chain with explicit inbound demand; the driver uploads through `RestoreCatalogUnary` so `api.maxEntitySizeInBytes` no longer caps a whole backup.
- `ObservabilityServerCall` now extends `SimpleForwardingServerCall` — it previously answered `isReady()` `true` forever, which would have silently no-op'd any readiness loop written against it.
- `ExceptionUtils.findInCauseChain` replaces a hand-rolled walker that guarded only self-referencing causes and would spin forever on `A -> B -> A`.

### Verification

| | result |
|---|---|
| 512 MiB to a stalled client | **1035 MiB → ~15 MB** retained (heap + both direct counters) |
| 64 MiB download, 2000 ms server deadline | completes in **6.7 s**; **dies at 2.1 s** with the re-arm removed |
| Re-arm compounding | pinned by `GrpcTimeoutUtilTest` — both strategies run side by side on real contexts |
| Gate stall-race grace | calibrated by zeroing it: horizon read 30124 ms vs a 30000 ms stall timeout |
| Suites | 80/80 targeted functional, 5/5 long-running streaming, full reactor build green |

Reasoning, rejected options and the two paths deliberately left on the whole-request budget are recorded in `documentation/adr/2026-08-24-grpc-streaming-backpressure-readiness-gate.md`.

### Known and unconfirmed

A production report of *sibling* RPCs failing during a download is discussed in the ADR's Consequences. The leading explanation is bandwidth saturation of the shared connection rather than HTTP/2 window exhaustion, but it is recorded as **unconfirmed** — the failed calls' status codes would distinguish the mechanisms.
