### PR TITLE
fix: unify the 2026.2.5 hotfix into a single release-triggering merge

### DIFF
--- a/documentation/adr/2026-08-05-streaming-calls-must-not-be-retry-decorated.md
+++ b/documentation/adr/2026-08-05-streaming-calls-must-not-be-retry-decorated.md
@@ -1,7 +1,7 @@
 ---
 title: Never decorate a streaming gRPC channel with RetryingClient
 date: 2026-08-05
-updated: 2026-08-05 09:45
+updated: 2026-08-24 14:20
 status: accepted
 kind: fix
 issues: [1388]
@@ -9,7 +9,7 @@ prs: [1389]
 areas: [evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver]
 supersedes: []
 superseded-by: []
-relates: [2026-08-03-driver-connection-resilience, 2026-08-04-client-pool-fail-fast-and-cdc-channel-isolation]
+relates: [2026-08-03-driver-connection-resilience, 2026-08-04-client-pool-fail-fast-and-cdc-channel-isolation, 2026-08-24-grpc-streaming-backpressure-readiness-gate]
 ---
 
 # Never decorate a streaming gRPC channel with RetryingClient
@@ -238,6 +238,9 @@ through the rewired stubs.
   *Consequences*.
 - `2026-08-04-client-pool-fail-fast-and-cdc-channel-isolation` — the CDC channel/event-loop isolation this
   builder split sits alongside; both landed in PR #1389, which two agents staged together.
+- `2026-08-24-grpc-streaming-backpressure-readiness-gate` — the server-side half of the same call sites:
+  this record says the driver must not retry a stream, that one says the server must pace it against
+  transport readiness rather than pushing at disk speed.
 
 ## Timeline
 

--- a/documentation/adr/2026-08-24-grpc-streaming-backpressure-readiness-gate.md
+++ b/documentation/adr/2026-08-24-grpc-streaming-backpressure-readiness-gate.md
@@ -1,0 +1,480 @@
+---
+title: Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers
+date: 2026-08-24
+updated: 2026-08-24 19:40
+status: accepted
+kind: fix
+issues: [1441]
+prs: []
+areas:
+  - evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils
+  - evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services
+  - evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/interceptors
+  - evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver
+supersedes: []
+superseded-by: []
+relates: [2026-08-05-streaming-calls-must-not-be-retry-decorated]
+---
+
+# Pace gRPC server-streaming producers with a readiness gate that parks the worker
+
+Server-streaming RPCs used to push messages into Armeria's outbound queue as fast as they could
+produce them, without ever asking whether the transport could take another one. The queue is
+unbounded, so a client slower than the producer made the server materialise the entire payload in
+memory. `fetchFile` was the acute case: a 690 MB backup download over a slow tunnel died part-way
+through with a bare `UNKNOWN`. Producers now pace themselves against `ServerCallStreamObserver.isReady()`
+through a shared helper, `GrpcOutboundGate`, which parks the producing worker until the transport
+drains. `restoreCatalog`, the upload counterpart, moved its blocking file IO off the event loop and
+replaced the throttle it lost in the process with explicit inbound demand. Two size caps found along
+the way — both pre-existing, both making a large transfer fail with a status that explained nothing —
+were fixed on the driver side in the same line of work.
+
+## Why
+
+gRPC-Java's send path never blocks — a fact that is easy to get wrong, because grpc-go and the
+gRPC C++ sync API *do* block on the flow-control window. `StreamObserver.onNext` marshals the message
+and hands it to Armeria's `StreamMessage`, whose `tryWrite` refuses a message only once the stream is
+closed, never because it is full. `isReady()` is the only back-pressure signal there is, and nothing
+in the module consulted it: `setOnReadyHandler` appeared **zero** times across all 20 server-streaming
+RPCs.
+
+The cost is paid off-heap and is worse than the payload. Because marshalling is eager, the queued
+objects are pooled Netty buffers: a 512 MiB file measured **1035 MiB** of retained direct memory,
+about 2x the payload once pooled-arena reservation is counted. The ceiling such a download hits is
+therefore `-XX:MaxDirectMemorySize`, not `-Xmx`, and the failure surfaces as `UNKNOWN` with no message
+because the allocation that finally fails does so inside Armeria, whose fallback for an escaping
+`Throwable` is exactly that.
+
+Two constraints made the fix non-obvious, and both are the reason this record exists rather than a
+commit message:
+
+- **`ServerCall.isReady()` is not abstract.** It ships a default returning an unconditional `true`.
+  `ObservabilityInterceptor` decorated the call without extending `ForwardingServerCall`, so it
+  answered `true` forever — any readiness-driven loop written against it would have been a silent
+  no-op. Nothing about the service method reveals this.
+- **The producing loop's thread is not guaranteed to be a worker.** `executeWithClientContext` hands
+  off to `Evita.getRequestExecutor()`, which for an engine built with `directExecutor = true` is an
+  `ImmediateExecutorService` that runs the task inline — on the transport event loop.
+
+### Previous state
+
+`fetchFile` read the file in 64 KB chunks in a tight `while` loop, calling `onNext` per chunk with no
+gating (`EvitaManagementService.java:721-727` before this change). `getMutationsHistory` and
+`getTrafficRecordingHistory` had the same shape via `Stream.forEach`. This was invisible for as long
+as every consumer kept up, which is the normal case on a LAN.
+
+`restoreCatalog` performed `Files.createTempFile`, a per-chunk `writeTo` against an **unbuffered**
+stream, and `close`/`Files.size`/`newInputStream` directly on the event loop. It was never throttled
+deliberately: gRPC auto-requests the next message only after `onMessage` returns, so the inline
+blocking write *was* the throttle — accidentally, and at the price of thousands of blocking write
+syscalls on a thread shared with every other connection.
+
+## Options considered
+
+### Option A — park the producing worker on a readiness gate (chosen)
+
+A small shared helper attached synchronously in the service method; the producing loop calls
+`awaitWritable()` before each `onNext` and stops when it returns `false`.
+
+- **Pros:** keeps the loop's straight-line shape, so try-with-resources, tracing scope and error
+  handling stay in one method. Pins no thread the RPC did not already own for its whole duration.
+  One helper covers every call site.
+- **Cons:** holds a request-executor thread for the duration of a slow download rather than for the
+  duration of a fast disk read. Needs a stall timeout so a client that stops reading without hanging
+  up cannot pin that thread forever.
+
+### Option B — drive the loop from the on-ready callback (declined)
+
+Turn each producer into a pump re-entered by `setOnReadyHandler`, holding the source and buffer as
+call state.
+
+- **Pros:** parks no thread at all; the natural shape for a purely async server.
+- **Rejected because:** the on-ready callback runs on the Armeria event loop, so the pump would have
+  to bounce every chunk back to a worker anyway — and then needs its own serialization guard to stop
+  two callbacks from pumping concurrently. That buys back the thread at the cost of turning three
+  straight-line loops into three hand-written state machines, each with its own resource-lifetime and
+  tracing-context problem. Worth revisiting only if request-executor exhaustion from slow downloads
+  is ever actually observed.
+
+### Option C — annotate the handlers `@Blocking` (declined, for `restoreCatalog`)
+
+Armeria supports the annotation per method and it would route the handler and its listener callbacks
+to `evita.getServiceExecutor()` in one line.
+
+- **Pros:** one-line change; no explicit flow control to maintain.
+- **Rejected because:** `AbstractServerCall` dispatches each message as
+  `blockingExecutor.execute(() -> invokeOnMessage(...))` onto a **shared pool**, so per-call ordering
+  would rest on an undocumented implicit invariant — that auto-request never lets a second message be
+  dispatched before the first returns. If that ever fails, the symptom is a silently corrupted catalog
+  ZIP, discovered at restore time. Revisit only if Armeria documents the ordering guarantee.
+
+## Decision
+
+**Chosen: Option A**, with Option C explicitly rejected for the upload path in favour of an explicit
+ordered chain.
+
+The deciding driver was that a slow download already owns its worker thread for the whole transfer;
+gating changes how *long* it is held, not whether. That is a bounded, measurable cost, and it is
+bounded further by a stall timeout. Option B's cost — three bespoke state machines whose failure modes
+are resource leaks and lost tracing context — is unbounded in review effort and lands on every future
+streaming RPC someone adds.
+
+Option B wins the day request-executor exhaustion from concurrent slow downloads is observed in
+production. That is the trigger for an ADR superseding this one.
+
+## Key technical details
+
+- **`GrpcOutboundGate.attach(...)` must be called synchronously in the service method, before it
+  returns.** gRPC's `ServerCallStreamObserverImpl` freezes handler registration the moment the service
+  method returns and throws for any later `setOnReadyHandler`/`setOnCancelHandler`. Only the loop
+  belongs on the worker. The codebase already documents the same constraint for cancel handlers in
+  `AbstractChangeCaptureSubscriber`.
+- **The gate owns the call's cancel handler.** gRPC keeps only the last one registered, so cleanup
+  that service methods used to register themselves (closing the underlying `Stream`) is passed into
+  `attach(...)` instead.
+- **`awaitWritable()` checks cancellation *before* readiness, in every branch.** Armeria increments
+  its pending-message counter in `sendMessage` and only unwinds it once the payload is genuinely
+  consumed, which never happens for a cancelled call — so readiness stays false forever. A gate that
+  consulted readiness first would pin a worker for the full stall timeout every time a client pressed
+  cancel. Registering a cancel handler also stops gRPC throwing `CANCELLED` from `onNext`, so this
+  check is the only thing left that stops a producing loop from reading its whole source into a dead
+  call.
+- **Producing on the event loop is detected and degrades to ungated**, with one warning per call.
+  Waiting there is a self-deadlock, not back-pressure: the parked thread is the only one that could
+  make readiness true again. This is reachable only for an engine built with `directExecutor = true`
+  (embedded test runs); `EvitaServer` always uses real pools. The consequence for tests is in
+  *Verification* below.
+- **`fetchFile`'s chunk size is 1 MB, and that is load-bearing, not cosmetic.** Armeria's readiness
+  is `pendingMessages == 0`, so a gated loop keeps exactly one message in flight and every chunk costs
+  an event-loop round trip; at the original 64 KB a large backup would have been over ten thousand
+  sequential round trips and slower than the unbounded loop for clients that keep up. The ceiling is
+  the receiver's maximum inbound message size — 4 MB in gRPC-Java, unlimited in Armeria's client.
+- **`ObservabilityServerCall` now extends `SimpleForwardingServerCall`.** Forwarding by default is the
+  invariant: `isReady`, `setOnReadyThreshold`, `getAttributes`, `getAuthority`, `getSecurityLevel`,
+  `setCompression` and `setMessageCompression` all have non-abstract defaults that silently disagree
+  with the transport.
+- **Repairing readiness broke a hidden dependency on it.**
+  `GlobalExceptionHandlerInterceptor.handleException` guarded its `close(...)` with
+  `if (serverCall.isReady())`. That only ever read as an open/closed test because readiness was
+  hard-wired to `true`; once real, it would have swallowed the error status for any RPC that had
+  already sent data, leaving the client on a stream that is never closed. It now guards on
+  `isCancelled()`.
+- **`restoreCatalog` serialises its file work on one `CompletableFuture` chain per call**, and issues
+  `request(1)` only once each chunk is on disk (`disableAutoRequest()` in the service method).
+  The `request(1)` is dispatched back onto the event loop: Armeria's `StreamingServerCall` keeps its
+  upstream subscription in a plain, non-volatile field, so raising demand from an arbitrary thread
+  relies on a happens-before its own code does not promise. Chunk ordering is the invariant here; its
+  loss is a corrupted ZIP, not an exception.
+- **The driver's streaming channels no longer carry a total-response-length cap.** Armeria defaults
+  `maxResponseLength` to 10 MiB and counts the *whole* HTTP body, which for a server-streaming call is
+  every message added together. `EvitaClient` never overrode it, so `fetchFile` could not download a
+  backup larger than 10 MiB at all — it died part-way through with `RESOURCE_EXHAUSTED`. This is a
+  pre-existing defect independent of the buffering one, found because the new upload test needed a
+  14 MB backup. The cap is lifted on the streaming and CDC channels and **kept on the unary channel**,
+  where a 10 MiB reply genuinely is anomalous. Lifting it globally was rejected: it would remove the
+  only guard against a runaway unary response, and unary replies have no other bound.
+- **The driver uploads a catalog restore through `RestoreCatalogUnary`, not the client-streaming RPC.**
+  A client-streaming upload is a *single* HTTP request, so `maxRequestLength` — which evitaDB wires to
+  `api.maxEntitySizeInBytes`, 2 MB by default (`ExternalApiServer.java:617`) — bounded the **whole
+  backup** rather than a chunk. Any real-sized catalog therefore died part-way through the upload with
+  a bare `RESOURCE_EXHAUSTED`, making `EvitaClient`'s restore unusable. `RestoreCatalogUnary` (on the
+  wire since 2024-09) sends each chunk as its own request, so only the chunk has to fit; the server
+  accumulates them into one temp file keyed by the `fileId` it returns and submits the restoration task
+  when the accumulated size reaches the announced total. Raising `maxEntitySizeInBytes` instead was
+  rejected — it is a deliberate operator guard that applies to REST and GraphQL too, and overriding a
+  security setting to make one RPC work is the wrong trade. Chunk size is 512 KB, which must stay under
+  whatever the operator configures; nothing client-side can discover that value.
+- **The upload stub is built on the *streaming* channel even though the call is unary.** The unary
+  channel carries the retry decorator, and with `retry` enabled that rule set replays on timeouts and
+  on 503/504/UNKNOWN. Replaying an append would add the chunk twice. The server catches the overshoot,
+  so the damage is a spurious failure rather than a corrupt catalog — but appends are not idempotent
+  and have no business on a channel that replays.
+- **An oversized request now says which limit it hit.** `GrpcProviderRegistrar` maps Armeria's
+  `ContentTooLargeException` to `RESOURCE_EXHAUSTED` *with a description* naming
+  `api.maxEntitySizeInBytes` and pointing at `RestoreCatalogUnary`. The driver no longer needs it, but
+  gRPC-Web and third-party clients still use the streaming RPC and previously got a bare status
+  indistinguishable from any other resource failure.
+- **A stalled stream is abandoned with `DEADLINE_EXCEEDED`, not `UNKNOWN`.**
+  `StalledGrpcStreamException` is mapped explicitly in `GlobalExceptionHandlerInterceptor` and logged
+  at WARN — it is a client/network condition, not a server fault.
+
+## Verification
+
+- `LongRunningGrpcFetchFileBackpressureTest` (long-running module, `useRealThreadPools = true`) —
+  512 MiB file, gRPC-Web framing, a manual-flow-control client that takes 4 chunks and stops.
+  Retained memory (heap **plus** Netty and NIO direct counters, which is the whole point — heap alone
+  moved 6.2 MiB and would have reported the bug as absent):
+  **1035 MiB before the fix, 14.4 MiB after**, of which 12.0 MiB was still present after the client
+  drained the stream, i.e. allocator arena growth rather than queued messages. Genuine in-flight data
+  ~2.4 MiB, about two chunks. The thread-state line flipped from `0` threads inside `fetchFile` (the
+  loop had run to completion) to `1` (parked in the gate). The client then resumes and the whole file
+  arrives with a matching CRC32.
+- `LongRunningGrpcFetchFileDeadlineTest` (long-running module, `useRealThreadPools = true`) — 64 MiB
+  to a client that drip-feeds `request(1)` every 100 ms, with a 2000 ms server deadline injected as a
+  `grpc-timeout` header by a `ClientInterceptor` so it binds on the server and nowhere else.
+  **Completes in 6819 ms with the re-arm, dies at 2144 ms after 19 chunks without it.** The test asserts
+  the scenario as well as the outcome — a machine fast enough to finish inside the deadline fails the
+  precondition rather than passing vacuously.
+- `GrpcTimeoutUtilTest` (functional module) — three cases pinning how a streaming deadline is rolled
+  forward. The load-bearing one runs both strategies **side by side on two real
+  `ServiceRequestContext`s**: three re-arms 120 ms apart from a captured budget leave the horizon at
+  1364 ms (last message + the configured 1000 ms), while re-reading `requestTimeoutMillis()` each time
+  leaves it at ~1720 ms and climbing. The counterfactual is therefore inside the test rather than
+  reachable only by reverting the fix. It is deliberately a **characterisation test of Armeria**: the
+  compounding is not part of its documented contract, so an upgrade that changes it fails here loudly
+  instead of silently restoring the ratchet. The `Thread.sleep` between re-arms is a detection widener —
+  a loaded machine makes the two strategies diverge further, never less.
+- `GrpcOutboundGateTest` (functional module) — six deterministic cases against a fake observer:
+  pass-through when ready, wake on the on-ready callback, refuse a cancelled call **without parking**,
+  release a waiting producer on cancel and on close, and abandon a stream nobody reads.
+- `ObservabilityInterceptorReadinessTest` (functional module) — pins the forwarding of `isReady()`.
+- `EvitaClientReadWriteTest#shouldBackupAndRestoreCatalogViaDownloadingAndUploadingFileContents` —
+  end-to-end backup → `fetchFile` → streaming `restoreCatalog` → restored catalog queried for a
+  matching entity count. Its dataset already carries `useRealThreadPools = true`, so it exercises the
+  gated download and the ordered upload chain for real, not the collapsed topology. What it does *not*
+  exercise is the multi-message path: its ten-product catalog archives into a single 64 KB message.
+- `LongRunningGrpcRestoreCatalogUploadTest` — three cases. (1) A **5.47 MB** backup (2.6x the 2 MB
+  request-body limit that used to be the ceiling) uploaded across ~10 unary chunks, restored, and every
+  one of its 200 entities' 32 KB payloads compared byte for byte against what was backed up; it asserts
+  its own size against that limit from below, so shrinking the payload can no longer hide the ceiling
+  being gone. (2) A **549 KB** backup of a second, deliberately small catalog pushed through the raw
+  client-streaming RPC in ~17 messages and verified the same way — the only end-to-end coverage of
+  `RestoreCatalogUploadObserver`; it asserts its size against the limit from *above*, the mirror of
+  case (1), because that RPC is one request and would otherwise fail as oversize rather than as a
+  regression. Calibrated: deleting the per-write `request(1)` stalls the upload and fails its 30 s latch
+  deterministically. (3) A client that still uses the client-streaming RPC pushing past the limit,
+  asserting the rejection carries a description naming `maxEntitySizeInBytes` and `RestoreCatalogUnary`
+  rather than a bare status. Writing case (1) is what surfaced the driver's 10 MiB response cap.
+- `LongRunningEvitaClientLargeFileDownloadTest` — 24 MiB fetched through `EvitaClient` with its
+  **default** channel configuration, CRC32 verified. This is the only test that covers the
+  response-cap fix: the functional round trip downloads ~1 MB, and
+  `LongRunningGrpcFetchFileBackpressureTest` moves 512 MiB through its own stub built with
+  `maxResponseLength(0)`, so neither exercises the driver default. It asserts its own file size against
+  the 10 MiB cap so it cannot be shrunk below the thing it guards.
+- Regression: 648 tests across `driver | (grpc & external_api)`, green.
+
+**The default test engine cannot exercise the gate.** `EvitaParameterResolver` builds the engine with
+`directExecutor = !useRealThreadPools`, so `executeWithClientContext` runs inline on the event loop and
+every functional test takes the ungated branch. A test that means to cover back-pressure must say
+`@DataSet(..., useRealThreadPools = true)` and say why; without it the test measures the unbounded
+path no matter what the server does, and can never fail.
+
+## Consequences & open follow-ups
+
+- A slow download now holds a request-executor thread for the duration of the transfer (bounded by
+  `GrpcOutboundGate.DEFAULT_STALL_TIMEOUT_MILLIS`, 5 minutes of *zero* progress). The pool is
+  `availableProcessors() * 4` by default. If concurrent slow downloads ever exhaust it, that is the
+  trigger for Option B.
+- **CDC demand gating was deliberately not done.** Both shared publishers are pull-based, so
+  withholding demand is lossless for engine mutations — it only moves a subscriber from the ring
+  buffer to the WAL. But `DefaultChangeCaptureSubscription.deliverImmediate` **silently drops** host
+  events when `requested == 0`, so gating would widen a microsecond drop window to however long the
+  client lags. It is blocked on a second defect anyway: a subscriber whose WAL pointer has been purged
+  (`walFileCountKept`, default 8) gets `findWalIndexFor == -1`, a nonexistent file, a null supplier and
+  an empty stream — no error, no advance, re-requesting the same pointer forever. Filed as **#1446**
+  (milestone 2026.3); it has to land before CDC gating does.
+- **The ungated producer plausibly starved *sibling* RPCs on the same connection, not just memory.**
+  Reported from production: while a backup download was in flight, unrelated gRPC calls issued by other
+  browser threads failed. Memory exhaustion does not explain that on its own. Three mechanisms do, and
+  gating addresses all three — but the ordering below matters, because the first draft of this bullet
+  led with the least likely one.
+
+  1. **Bandwidth saturation of the shared connection (leading explanation).** The ungated loop pushed
+     the whole file into Armeria's unbounded queue at disk speed, so the link ran at capacity for the
+     duration. A sibling call's handful of bytes queues behind that backlog, and only has
+     `api.requestTimeoutInMillis` — 2 s shipped — before it is killed. No flow-control subtlety
+     required; a saturated tunnel is sufficient.
+  2. **Event-loop saturation.** Marshalling happens in `doSendMessage` on the event loop, and Armeria
+     pins a connection to one. A 690 MB file at the old 64 KB chunk size meant ~10,500 marshal tasks
+     queued onto the one thread that also serves every other call on that connection.
+  3. **HTTP/2 connection-window exhaustion (least likely — see the correction below).**
+
+  Gating addresses all three structurally rather than incidentally: readiness in Armeria is
+  `pendingMessages == 0`, so a gated producer never writes more than one message ahead of what the
+  transport has actually consumed. The backlog, the marshal-task flood and the window pressure all
+  disappear together.
+
+  **Correction to an earlier revision of this record, which had the flow-control argument wrong in two
+  ways.** It cited Armeria's `http2InitialConnectionWindowSize` / `http2InitialStreamWindowSize`
+  defaults (1 MiB) as the operative numbers: those are what the evitaDB server advertises for *inbound*
+  (client→server) data and play no part in bounding server→client writes. It is indeed the **client's**
+  advertised windows that bound what the server may write — for Chrome, roughly 6 MiB per stream against
+  a session window raised to ~15 MiB. And the starvation step needs a condition the earlier text
+  asserted without stating: one stream can only exhaust the *connection* window if the client returns
+  connection-level credit as the application consumes. Browsers deliberately do the opposite — session
+  credit is returned as data lands in per-stream buffers, and only stream-level credit tracks the
+  consumer, precisely to stop one stream starving the others. Under that policy a stalled download pins
+  at most its own stream window and siblings keep flowing, so "no other stream can send a byte" is
+  unlikely for a browser client. It remains plausible for a non-browser peer with a naive
+  window-management policy.
+
+  **Not confirmed**, and worth confirming before it is treated as closed: the failed siblings' statuses
+  would distinguish the mechanisms — `DEADLINE_EXCEEDED`/cancellation points at saturation or window
+  starvation plus the request timeout, a bare `UNKNOWN` with no description at direct-memory exhaustion
+  (the signature recorded above), and if evitaLab was on HTTP/1.1 gRPC-Web the cause would instead be the
+  browser's ~6-connection-per-origin pool, which gating does not address.
+- **Which streaming paths got the new budget, and the two that deliberately did not.**
+  `api.endpoints.gRPC.streamingRequestTimeoutInMillis` is resolved once per call through
+  `GrpcTimeoutUtil.resolveStreamingBudgetMillis`, which returns `0` when the call carries no deadline so
+  that "the caller asked for none" survives the substitution. Five sites use it: `GrpcOutboundGate` (all
+  three gated server-streaming loops), the client-streaming `RestoreCatalogUploadObserver`,
+  `goLiveAndCloseWithProgress`, and `streamBackupProgress`. The last of those was already safe by
+  accident — its 1 s poll re-arms whether or not anything was sent — but safety resting on a poll
+  interval is not a property anyone should have to preserve.
+
+  Two sites were left on the whole-request budget, and neither is an oversight:
+
+  - **`RestoreCatalogUnary` — cannot be widened from the handler.** Armeria's `UnaryServerCall`
+    aggregates the request body and deframes only in the aggregation callback, so the handler runs
+    strictly *after* full body receipt: by the time our code could re-arm anything, the window it would
+    need to widen is already spent. The consequence is a real floor on uploads — the driver's 512 KB
+    chunk against the shipped 2 s budget needs roughly **2.1 Mbit/s** upstream — and the escape hatch, if
+    slow-uplink restores ever matter, is an HTTP-level decorator on that route extending the context
+    timeout at request start, before aggregation. Not built, because no report has yet demanded it.
+  - **CDC (`AbstractChangeCaptureSubscriber`) — the budget is load-bearing elsewhere.** It feeds
+    `resolveHeartBeatDelay`, which is `clamp(min(requestTimeout, idleTimeout) − 5 s, 1 s, 5 min)`.
+    Substituting 300 s does **not** break it — the 60 s idle timeout caps the result at 55 s, which still
+    keeps both the deadline and the idle timeout alive — but it coarsens liveness detection from the
+    clamped 1 s floor to 55 s, a ~55x change made for a subsystem that never exhibited the symptom. CDC
+    demand gating is blocked on **#1446** regardless; whoever does that work should revisit this
+    together with the heartbeat, rather than change one clock in isolation now.
+
+    (An earlier revision of this reasoning claimed ~150x and implied the substitution would break the
+    heartbeat outright. Both were wrong — the arithmetic above is what the code actually computes.)
+- **Gating trades unbounded memory for a parked request-executor thread.** The gate parks the producing
+  worker rather than driving the loop from the on-ready callback, so a download now holds one pool
+  thread for its whole duration instead of returning immediately. `K` concurrent slow downloads hold `K`
+  threads, bounded only by `api.endpoints.gRPC.streamingRequestTimeoutInMillis`. This is a deliberate trade — the
+  callback-driven pump gRPC-Java intends would avoid it but turns each producing loop into a state
+  machine, losing its try-with-resources, tracing scope and error handling — but it is a capacity
+  consideration that did not exist before, and a deployment serving many concurrent large downloads
+  should size the request executor with it in mind.
+
+  Note what the streaming budget does **not** lengthen: a gRPC deadline is enforced by the *client*
+  (Armeria's client maps `withDeadlineAfter` onto its own response timeout, and grpc-java runs a deadline
+  timer), so a client that asked for 500 ms still sees its call end at 500 ms and the resulting cancel
+  releases the parked worker promptly. What the server-side substitution changes is only how long a
+  **live but silent** peer can pin a worker. That is why re-arming to the streaming budget rather than
+  the client's own `grpc-timeout` is safe rather than an override of the caller's intent.
+- **Gating put `fetchFile` under the request deadline, which exposed that the per-message re-arm was
+  wrong everywhere.** Before the gate the loop drained into Armeria's outbound queue at disk speed and
+  returned, so the request timeout never bound it. Now the handler lives as long as the client takes to
+  consume — and `fetchFile` was the only streaming producer in the module not re-arming the deadline at
+  all. Adding the re-arm there is what surfaced the deeper defect: **the other five sites were re-arming
+  from a budget that compounds.**
+
+  `serviceContext.requestTimeoutMillis()` reads like "the configured timeout" and is neither that nor
+  the time remaining. Armeria stores the timeout **relative to the request's start**, and
+  `SET_FROM_NOW` writes `elapsed + newTimeout` into that same field
+  (`DefaultCancellationScheduler#setTimeoutNanosFromNow0`, 1.40.0), which the getter returns verbatim.
+  Feeding it back into the next re-arm therefore *ratchets*: a 2 s budget re-armed every 100 ms becomes
+  2.1 s, then 2.3 s, then 2.6 s, growing without bound. The rolling stall window the whole design rests
+  on had quietly become an ever-receding horizon that a genuinely stalled client never reaches — the
+  opposite failure from the one being chased, and invisible because it only ever makes calls *survive*.
+
+  Fixed by capturing the budget once, before the first message, via the new
+  `GrpcTimeoutUtil.captureRequestTimeoutMillis`. All eight sites now do this;
+  `AbstractChangeCaptureSubscriber` already did, which is why CDC never showed the symptom.
+
+  **The re-arm is now the gate's job, not the call site's.** `GrpcOutboundGate` captures the budget at
+  `attach()` — by construction "before the loop" — and re-arms on every `awaitWritable()` that grants a
+  send, on all three of its return paths (a fast-path-only re-arm would leave a *fast* client's transfer
+  un-armed, which is the original bug with extra steps). The hand-written re-arms in the three gated
+  loops are gone; the ungated producers keep theirs, corrected. This is the structural half: a new gated
+  streaming method cannot forget, because the grant and the re-arm are the same act.
+
+  One asymmetry this introduced, and why `grantCompletionWindow()` exists: a grant happens *before* each
+  message, whereas the deleted hand-written re-arms happened *after*. So moving the re-arm into the gate
+  silently orphaned the **last** message of every stream — the deadline would stay frozen at the final
+  grant while the half-close and the residual queue were still in flight, and the residual is exactly
+  what a slow client is slowest at. The three gated loops now call `grantCompletionWindow()` immediately
+  before `onCompleted()`. Anyone adding a gated producer must do the same; the loop-shaped alternative
+  (grant *after* the write) was rejected because it would leave the first message un-armed instead.
+
+  **Re-measured against the corrected code**, with `LongRunningGrpcFetchFileDeadlineTest`: 64 MiB in
+  64 chunks to a client that drip-feeds `request(1)` every 100 ms, server armed to 2000 ms by an
+  injected `grpc-timeout`.
+
+  | | outcome |
+  |---|---|
+  | with the re-arm | **completes in 6819 ms**, all 64 chunks, CRC matches |
+  | re-arm removed | **dies at 2144 ms**, 19 chunks, `RST_STREAM: INTERNAL_ERROR` |
+
+  So the deadline now bounds silence rather than the transfer: 3.4× the budget elapses without the call
+  being touched. The earlier "8696 ms with the re-arm" figure was measured against the *ratcheting*
+  version and is not comparable — since the ratchet only ever extends the deadline, whatever ended that
+  run was not the request timeout. It is not worth chasing: the scenario is now covered by a test that
+  passes for the right reason and fails at the budget when the guard is removed.
+
+  The earlier note in this record that a client sending no `grpc-timeout` leaves the server timeout
+  *disabled* was **wrong**, and the correction matters. Armeria's `FramedGrpcService` overrides the
+  context timeout only when the header is present; absent it the server's own
+  `api.requestTimeoutInMillis` stays in force — 1 s in code, 2 s in the shipped configuration. A client
+  that sets no deadline therefore gets the *shortest* budget of anyone, which makes the re-arm load-
+  bearing for exactly the clients least able to compensate. What the earlier test actually hit was
+  `responseTimeoutMillis(0)` suppressing the header Armeria would otherwise have derived from the
+  deadline, leaving the harness's 10-minute server budget in force.
+- **The driver's management facade had no notion of timeout tiers, and now does.**
+  `EvitaClientManagement` took `ClientTimeoutOptions.timeout` — the **unary, whole-call** budget, 5 s by
+  default — for every call it made, including `fetchFile`. So a default-configured `EvitaClient` could
+  not fetch a file that took longer than 5 s whatever the server did, and every test missed it because
+  the harness and each test build clients with `.timeout(10, MINUTES)`. `EvitaClientSession` had the
+  two-tier regime all along; the facade was simply never given it.
+
+  Rather than fix the call site, the tier is now carried by `EvitaClientChannel.TimeoutTier` and paired
+  with each stub at construction, where the channel is in scope — the same seam that already makes
+  "streaming stub off the retrying channel" not compile (#1388). A management method cannot pick a tier,
+  and therefore cannot pick the wrong one. `EvitaClient.resolveTimeout` keeps an explicit
+  `executeWithExtendedTimeout` override winning over both tiers, since that API's whole purpose is to
+  name a duration for the work inside it.
+
+  `fetchFile` needed all three of its caps addressed, not one: the gRPC deadline (now `PER_MESSAGE`), a
+  missing per-message `setResponseTimeout` re-arm in `onNext`, and `downloadFuture.get(timeout)` — an
+  independent whole-download budget on the calling thread, now a stall-based wait recomputed from the
+  last message. A plain unbounded `get()` was rejected: it would hang forever on a stream that never
+  produces a terminal event, and a spurious timeout is recoverable where a parked application thread is
+  not.
+- **`GrpcFetchFileRequest` still cannot resume.** It carries only `fileId`, so any retry restarts at
+  byte 0. An additive `optional int64 offset = 2` is wire-compatible both ways, but *silently* so — an
+  old server ignores it and streams from byte 0 with no error — so it needs an echo field on the
+  response for the client to confirm the offset was honoured.
+- **The client-streaming `RestoreCatalog` is covered again, but not for the invariant we assumed.**
+  Rerouting the driver to `RestoreCatalogUnary` had left nothing driving the ordered chain end to end.
+  `LongRunningGrpcRestoreCatalogUploadTest#shouldRestoreCatalogUploadedThroughClientStreamingRpc` closes
+  that: a 549 KB backup — deliberately *under* `SERVER_REQUEST_LIMIT`, since a client-streaming upload
+  is one request — pushed through the raw `EvitaManagementServiceStub` in ~17 messages, restored, and
+  every payload compared byte for byte. The await that made this awkward turned out to be a non-problem:
+  `EvitaClientManagement.createTask(TaskStatus)` is public, so the test converts the response's
+  `GrpcTaskStatus` and gets a real `ClientTaskTracker`-backed future — no sleep-polling.
+
+  **What calibrating it actually found is worth more than the test.** The intended counterfactual —
+  unchaining `submitRestoration` from `onCompleted` — *does not fail*. Demand for chunk N+1 is issued
+  from inside the **completed** write step for chunk N, so the demand protocol both orders the writes
+  and withholds half-close until the last one has landed. The chain and `disableAutoRequest()` +
+  `request(1)` are **redundant**, and removing either alone is unobservable. Removing *both*, with a
+  2 ms widener in the write step, also stayed green at nine chunks — a failure to detect, not evidence
+  of safety.
+
+  Two things follow. First, the ordering invariant is **still unverified**; what the new test
+  demonstrably guards is the hand-issued demand protocol, whose removal stalls the upload dead and fails
+  the 30 s latch deterministically. Second, the `@Blocking` rejection above is weaker than it reads:
+  with one-message-at-a-time demand, `AbstractServerCall`'s dispatch assumption is no longer the thing
+  ordering rests on. The rejection stands on the remaining ground — an explicit chain over an
+  undocumented scheduling property — but it is no longer the sole guarantee, and the class JavaDoc on
+  `RestoreCatalogUploadObserver` now says so.
+
+  The deprecation option is still open and still deliberate: gRPC-Web uses the unary RPC (the proto says
+  so) and the driver now does too, so the client-streaming variant has **no known first-party client**.
+  Keeping it costs one long-running test; that seems the right trade while third-party clients may exist.
+- The long-running restore counterpart exercises tens of chunks, not thousands. The scale is not
+  covered.
+
+## Related work
+
+- `2026-08-05-streaming-calls-must-not-be-retry-decorated` — same streaming call sites; that record
+  explains why the driver must not retry them, this one why the server must pace them.
+
+## Timeline
+
+- **2026-08-24** — diagnosis confirmed by measurement, issue #1441 filed
+- **2026-08-24** — implemented and verified

--- a/documentation/adr/2026-08-24-grpc-streaming-backpressure-readiness-gate.md
+++ b/documentation/adr/2026-08-24-grpc-streaming-backpressure-readiness-gate.md
@@ -1,11 +1,11 @@
 ---
 title: Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers
 date: 2026-08-24
-updated: 2026-08-24 19:40
+updated: 2026-08-25 05:00
 status: accepted
 kind: fix
 issues: [1441]
-prs: []
+prs: [1450, 1451]
 areas:
   - evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils
   - evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services
@@ -261,6 +261,44 @@ path no matter what the server does, and can never fail.
 
 ## Consequences & open follow-ups
 
+- **A restore upload's temporary archive is owned by whoever created it, and the owner must survive a
+  hand-off the request pool refuses.** Both restore paths assemble the upload into a temporary file that
+  nothing else will ever collect: `FileManagementService.createTempFile` deliberately does *not* reserve
+  the file (that is `createManagedTempFile`), no sweeper walks the work directory, and the restore step
+  that deletes it — `deleteAfterRestore` — only runs for an upload that completed. An upload that stops
+  half way therefore leaves an archive the size of a catalog behind for the lifetime of the process.
+
+  The two paths hang that cleanup on different things, and neither is obvious from the call site:
+  - **Client-streaming** (`RestoreCatalogUploadObserver`) owns the file directly and discards it in
+    `failUpload`. Because the request pool is bounded and *throws* once its queue fills
+    (`EvitaRejectingExecutorHandler`), every hand-off to it has to be made by hand rather than through
+    `thenRunAsync`: a rejection raised while a previous step is in flight surfaces on that worker inside
+    `CompletableFuture#postComplete`, unrelated to the call, and the stage simply never completes.
+    Worse, a rejection raised once the chain is idle throws *before* `uploadChain` is reassigned, leaving
+    the chain looking healthy — so the next chunk reopens the archive that was just deleted. Poisoning
+    the successor stage in both cases is what closes that second hole.
+  - **Chunked unary** (`restoreCatalogUnary`) has no half-close to notice, so the *restoration task's
+    future* carries the cleanup. It completes on every terminal outcome, including the scheduler's
+    ten-minute purge of tasks still waiting for a precondition, which is what catches a client that
+    crashed or lost the network. The driver additionally cancels the task on its way out
+    (`EvitaClientManagement#abandonRestoreUpload`), which only makes the reclaim prompt — it is best
+    effort by construction, since the failure that triggers it may have taken the channel with it.
+
+  Anything that later adds a third upload path inherits this obligation. One invariant is worth stating
+  because nothing enforces it locally: the unary hook is registered on the *first* chunk, while the
+  over-size branch that relies on it can fire on any chunk. It works because `getWaitingTask` hands back
+  the same task instance across requests — a cross-request dependency that a future change to task
+  lookup could quietly break.
+
+  Both halves are verified, and both tests were calibrated against the pre-fix code rather than merely
+  observed to pass:
+  - `RestoreCatalogUploadObserverTest` — three rejection cases, each of which hangs for the full 30 s
+    latch without the fix instead of terminating the call, plus a control case that a progressing upload
+    keeps its archive.
+  - `EvitaClientReadWriteTest#shouldDiscardTheArchiveOfAnAbandonedChunkedRestoreUpload` — drives a real
+    chunked upload whose source dies after the first chunk and asserts the work directory is unchanged.
+    With the task-future hook removed it fails with the archive still present
+    (`[.lock, 69cb300e-….zip]`), which is precisely the leak being fixed.
 - A slow download now holds a request-executor thread for the duration of the transfer (bounded by
   `GrpcOutboundGate.DEFAULT_STALL_TIMEOUT_MILLIS`, 5 minutes of *zero* progress). The pool is
   `availableProcessors() * 4` by default. If concurrent slow downloads ever exhaust it, that is the

--- a/documentation/adr/2026-08-24-price-histogram-per-accessor-granularity.md
+++ b/documentation/adr/2026-08-24-price-histogram-per-accessor-granularity.md
@@ -1,11 +1,11 @@
 ---
 title: Price histogram granularity is decided per accessor, not all-or-nothing across the query
 date: 2026-08-24
-updated: 2026-08-24 13:10
-status: proposed
+updated: 2026-08-24 13:45
+status: accepted
 kind: fix
 issues: [1433]
-prs: []
+prs: [1435, 1436]
 areas: [evita_engine/src/main/java/io/evitadb/core/query/algebra/price, evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram]
 supersedes: []
 superseded-by: []
@@ -214,5 +214,8 @@ list would get simpler.
 - **2026-05-18** — #1159 fix merged (PR #1165); per-inner-record path introduced behind the
   all-or-nothing capability gate
 - **2026-08-24** — mixed-pool defect reported as #1433, reproduced, fixed; record written with the
-  implementation, `status: proposed` until the PR merges (flip to `accepted` and fill `prs:` then —
-  `date:` stays as written)
+  implementation and accepted. The fix ships through two pull requests rather than one: PR #1435 into
+  `release_2026-2`, where the defect was reported, and PR #1436 into `dev`. `release_2026-2` holds ten
+  commits `dev` does not, so #1436 is a cherry-pick onto a branch cut from `dev` rather than a
+  retarget — a retarget would have dragged those ten unrelated commits into the diff. Both were
+  verified independently against their own base, `dev` being 257 commits ahead at the time.

--- a/documentation/adr/2026-08-24-price-histogram-per-accessor-granularity.md
+++ b/documentation/adr/2026-08-24-price-histogram-per-accessor-granularity.md
@@ -1,0 +1,218 @@
+---
+title: Price histogram granularity is decided per accessor, not all-or-nothing across the query
+date: 2026-08-24
+updated: 2026-08-24 13:10
+status: proposed
+kind: fix
+issues: [1433]
+prs: []
+areas: [evita_engine/src/main/java/io/evitadb/core/query/algebra/price, evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram]
+supersedes: []
+superseded-by: []
+relates: []
+---
+
+# Price histogram granularity is decided per accessor, not all-or-nothing across the query
+
+The per-inner-record price histogram shipped in #1159 only engaged when *every*
+`FilteredPriceRecordAccessor` in the query exposed the per-inner-record side-output. Because a
+`filterBy` builds one price branch per `PriceInnerRecordHandling` present in the catalog, and only
+the `LOWEST_PRICE` branch has per-inner-record data points to give, that rule could never be
+satisfied by a candidate pool mixing handling modes — the histogram silently fell back to
+per-entity granularity, which is exactly the symptom #1159 was opened to remove. The capability
+probe is now read per accessor: exposing accessors contribute their per-inner-record records, and
+the unchanged per-entity collector tops up every entity those records did not cover.
+
+## Why
+
+A category listing that contains both simple products (`NONE`) and master/variant products
+(`LOWEST_PRICE`) is the ordinary shape of an e-commerce catalog, not an edge case. In such a pool
+the shipped code capped the histogram's upper bound at the highest *price for sale*, hiding every
+non-cheapest variant price above it — reported on a live 2026.2 deployment as a histogram maximum
+of 5 000 CZK for a pool containing an 8 000 CZK variant.
+
+The constraint that made this non-obvious is that the two halves of the answer are produced by
+completely different machinery. The `LOWEST_PRICE` half arrives as an eagerly-collected array from
+`LowestPriceTerminationFormula`'s side-output; the `NONE`/`SUM` half is produced by an
+entity-driven collector that walks the filter result and asks each accessor for the prices of one
+entity at a time. There is no single call that yields both, so "just merge the accessors" is not
+available as a one-liner.
+
+### Previous state
+
+`FilteredPriceRecords.allAccessorsExposePerInnerRecordHistogram` returned `true` only when the
+collection was non-empty and every member exposed the side-output; `PriceHistogramComputer` used it
+to choose between two whole-query paths. Two independent causes closed that gate on a mixed pool:
+
+- the `SHALLOW` accessor scan descends through `PlainPriceTerminationFormula` (which is not a
+  `FilteredPriceRecordAccessor`) and surfaces the inner `PriceIdToEntityIdTranslateFormula`, which
+  inherits the interface default of `false`;
+- `SelectionFormula` implements the accessor interface unconditionally, so a wrapper the planner
+  inserted above a price-free sub-tree was gathered into the histogram's accessor list and reported
+  `false` on its own.
+
+Either was sufficient. Neither was visible in tests, because the per-inner-record fixtures added in
+#1165 used a homogeneous `LOWEST_PRICE` pool, and the shared assertion helper *dispatched on the
+composition of the pool* — asserting per-entity counts the moment one entity was not
+`LOWEST_PRICE`. The assertion adapted to the engine, so it could not detect the engine getting
+coarser.
+
+## Options considered
+
+### Option A — partition the accessor set, top up the remainder (chosen)
+
+Read `exposesPerInnerRecordHistogramRecords()` per accessor. Merge the exposing accessors'
+side-output, narrow it to the entities the whole filter matched, then run the existing
+`FilteredPriceRecordsCollector` over `baseline \ covered` and concatenate. `SelectionFormula`'s
+probe becomes "any inner accessor exposes" and its histogram records become "only the exposing
+inners' contribution".
+
+- **Pros:** each half keeps running through the code path that already has passing assertions
+  behind it; double counting is impossible by construction rather than by argument, which is what
+  makes it hold on the prefetch plan too (there a `SelectionFormula`'s per-entity alternative would
+  happily answer for a `LOWEST_PRICE` entity, but it is never asked — that entity is not in the
+  remainder); no accessor is asked for a shape it does not have.
+- **Cons:** the histogram now computes the relaxed baseline bitmap on the per-inner-record path,
+  which it previously skipped; one extra `contains` per per-inner-record price.
+
+### Option B — stop the `SHALLOW` scan at the termination formula (declined)
+
+The issue's own prescription: fix the accessor collection so each handling branch contributes its
+*termination* formula rather than the raw translate formula underneath it — by making
+`PlainPriceTerminationFormula` a `FilteredPriceRecordAccessor`.
+
+- **Pros:** attacks the surfaced-wrong-node problem at its origin; the accessor list would then read
+  as one entry per handling branch, which is easier to reason about.
+- **Rejected because:** `PlainPriceTerminationFormula` owns no price records at all — it is the
+  no-price-filter variant that deliberately postpones resolving the entity price, and it delegates
+  straight to `getDelegate().compute()`. Stopping the scan there yields *zero* contribution from the
+  `NONE` branch, so those entities would vanish from the histogram entirely — worse than the bug.
+  Making it a real accessor means giving it a record store and a resolution step it exists to avoid.
+  Revisit if `PlainPriceTerminationFormula` ever has to resolve entity prices for another reason.
+
+### Option C — give `PriceIdToEntityIdTranslateFormula` the capability (declined)
+
+Let the node the `SHALLOW` scan actually surfaces answer `true`, so the merge covers every branch.
+
+- **Pros:** a one-line change at the exact node the scan returns; no partitioning logic anywhere.
+- **Rejected because:** it returns one raw record per translated price id (`SortingForm.NOT_SORTED`),
+  not per-entity winners. Merging those inflates the buckets — an entity present in two queried
+  price lists would contribute twice. The per-entity view for that branch only exists after the
+  entity-driven collector has picked the winner, which is precisely what Option A keeps doing.
+
+## Decision
+
+**Chosen: Option A.** The driver is that the two halves are genuinely different computations and
+the correct answer is their union, not a choice between them. Options B and C both try to make one
+mechanism serve both, and each breaks on the same fact: the `NONE` branch's per-entity winner is not
+materialised anywhere until the collector selects it.
+
+Option B becomes worth revisiting only if `PlainPriceTerminationFormula` gains eager price
+resolution for an unrelated reason — at that point it could contribute directly and the accessor
+list would get simpler.
+
+## Key technical details
+
+- **Entry point:** `PriceHistogramComputer.getPriceRecords()` partitions via
+  `FilteredPriceRecords.collectPerInnerRecordHistogramAccessors(...)`; the two-pass assembly lives
+  in `collectPerInnerRecordHistogramRecords(List)`.
+- **Invariant — the probe is per accessor.** `exposesPerInnerRecordHistogramRecords()` returning
+  `false` forfeits *that accessor's* contribution and nothing else. Any future reader that ANDs the
+  probe across a collection reintroduces this bug. `SelectionFormula` follows the same rule with
+  "any inner exposes".
+- **The `SHALLOW` scan still surfaces `PriceIdToEntityIdTranslateFormula`, and that is now inert —
+  not a leftover.** It keeps answering `false`, but a `false` no longer closes the gate for anyone
+  else, and the branch it stands for is picked up by the entity-driven remainder pass. Nothing needs
+  to change at the scan; see Option B for why stopping it earlier would be a regression.
+- **The side-output is not narrowed at its source.** `LowestPriceTerminationFormula` fills its
+  funnel from its own delegate — the price sub-tree — so it covers entities that the non-price parts
+  of the query (`entityPrimaryKeyInSet`, attribute filters, hierarchy constraints) exclude. The
+  computer narrows it to the baseline; removing that narrowing turns a 10-data-point histogram into a
+  108-data-point one on the fixture named below. This latent over-count predates this change and was
+  simply unreachable while the whole path was gated off for anything but price-only queries.
+- **The remainder pass must not reuse `priceRecordsLookupResult`.** That result comes from
+  `FilteredPricesSorter`, built over the full accessor set and the full filter result, so it already
+  contains a per-entity record for every `LOWEST_PRICE` entity that pass 1 expanded.
+- **`covered` is built with incremental `PersistentRoaringBitmap.add`, not
+  `RoaringBitmapBackedBitmap.buildWriter()`.** The constant-memory writer materialises a container
+  when the high bits change and so assumes ascending input; concatenating several accessors'
+  side-outputs restarts at each accessor's lowest entity primary key.
+
+## Verification
+
+- `CombinedPriceEntityByPriceFilteringFunctionalTest` (mixed `NONE`/`LOWEST_PRICE`/`SUM` pool) — the
+  four `shouldReturnPriceHistogram*` tests are the reproduction. Restoring the all-or-nothing gate on
+  the fixed code reproduces every one of them: `expected 78 but was 70` (twice), `58/52`, and `8/6` on
+  the prefetch variant. After the fix all four pass.
+- **The prefetch variant needs *both* halves of the gate restored to reproduce.** Reverting only
+  `PriceHistogramComputer` leaves it green, because on a prefetched plan the single top-level accessor
+  is the `SelectionFormula` wrapper — the all-or-nothing decision was being taken *inside* it, by its
+  own all-true probe over the inners. That is what makes the wrapper change load-bearing rather than
+  cosmetic, and it is worth knowing before concluding a future gate change is covered.
+- `FindFirstPriceEntityByPriceFilteringFunctionalTest`, new test
+  `shouldLimitPerInnerRecordHistogramToEntitiesMatchedByNonPriceConstraint` — pins the narrowing with
+  an `entityPrimaryKeyInSet` handle over a pure `LOWEST_PRICE` fixture. Counterfactual check: with the
+  narrowing removed it reports `expected 10 but was 108`, and the mixed prefetch test `expected 8 but
+  was 39`.
+- `SelectionFormulaHistogramCapabilityTest` — the capability probe now asserts "any", plus a new
+  *Accessor set partitioning* group covering the price-free wrapper and the surfaced translate
+  formula.
+- **Both named reproductions are covered, and the coverage is asserted rather than measured.** The
+  `CombinedPrice...` fixture carries all three handlings in every pool the histogram tests query, so
+  the `LOWEST_PRICE + SUM` mix the issue names is exercised and not merely assumed.
+  `assertPoolMixesInnerRecordHandling` pins that for the index-plan pools, and the prefetch test pins
+  two properties of the six entities it selects: that they span every handling the dataset offers, and
+  — wherever the dataset has `LOWEST_PRICE` — that at least one of them is a *multi*-inner-record
+  master. **The second guard is not redundant with the first.** An intermediate version of the picker
+  produced a perfectly balanced `{NONE=2, LOWEST_PRICE=2, SUM=2}` pool whose masters all happened to
+  carry a single variant; per-entity and per-inner-record granularity return identical numbers for
+  such a pool, and the deliberately regressed engine passed against it. Handling diversity is not
+  granularity diversity, and only the latter can detect this bug.
+- **Cross-plan and cached-payload agreement.** `VERIFY_ALTERNATIVE_INDEX_RESULTS` and
+  `VERIFY_POSSIBLE_CACHING_TREES` are now enabled on the per-inner-record tests; they had been
+  omitted since #1159 because the old all-or-nothing gate could flip between rebuilt plans and the
+  verifier raised `InconsistentResultsException`. The caching verifier substitutes
+  `FlattenedFormulaWithFilteredPricesForHistogram` for the flagged LP, which is what gives the cached
+  form of the hybrid path its coverage.
+- Full sweep `-Dgroups="price | histogram | cache"`: 1609 tests, 0 failures, 4 skipped (1607 before
+  the two prefetch overrides were enabled).
+
+## Consequences & open follow-ups
+
+- The shared assertion helper `EntityByPriceFilteringFunctionalTest.assertHistogramIntegrity` no
+  longer dispatches on the pool's composition — it derives the expectation from each entity's own
+  handling, so a future regression to coarser granularity fails the test instead of changing which
+  branch it takes. `assertHistogramIntegrityPerEntity` was deleted; the per-inner-record helper
+  remains for the pure-`LOWEST_PRICE` call sites.
+- **The prefetch histogram test's fixture is now derived, not hard-coded.**
+  `shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch` used to pick its six
+  entities with per-price-list `getPriceForSale` comparisons and assert a literal
+  `assertEquals(3, result.getTotalRecordCount())`. That only models `NONE` handling, which is why the
+  `FindFirst` and `Sum` overrides had silently been left without `@Test` — enabling them failed on the
+  fixture's own precondition, not on anything the test was written to check. Selection now goes
+  through `PricesContract.hasPriceInInterval`, the model's own per-handling reading of `priceBetween`,
+  and the expected count is the size of the group it selected. Both overrides now carry `@Test` and
+  pass. The lesson generalises: a fixture predicate that hand-rolls price semantics per price list is
+  only valid for the `NONE` dataset, and the suite has a subclass per handling mode.
+  **What changed is the predicate, not the constants.** The `[50, 150]` band and the two
+  `assertEquals(3, ...)` group sizes are still hard-coded in the base method and inherited by all four
+  datasets; they hold on every one of them today, but a data-generator change that shifts the price
+  distribution can still starve a group. The difference is the failure mode: it would now be an honest
+  "this dataset cannot supply six suitable entities", not a precondition that was wrong by
+  construction for three datasets out of four. Deriving the band from the dataset is the next step if
+  that ever bites.
+- `shouldReturnProductsHavingPriceInCurrencyAndPriceListInIntervalWithTaxOrderByPriceAscendingWithoutExplicitAnd`
+  is the one remaining `@Test`-less override in the price hierarchy (in both the `FindFirst` and `Sum`
+  subclasses). It is an ordering test, not a histogram one, so it is out of scope here — but it is the
+  same class of gap and worth the same treatment.
+- `SUM` still contributes one data point per entity, per the #1159 specification table. Nothing in
+  this change makes that assumption load-bearing anywhere new — a future `SUM` per-inner-record
+  requirement only has to flip its termination formula's probe to `true`.
+
+## Timeline
+
+- **2026-05-18** — #1159 fix merged (PR #1165); per-inner-record path introduced behind the
+  all-or-nothing capability gate
+- **2026-08-24** — mixed-pool defect reported as #1433, reproduced, fixed; record written with the
+  implementation, `status: proposed` until the PR merges (flip to `accepted` and fill `prs:` then —
+  `date:` stays as written)

--- a/documentation/adr/2026-08-24-refresh-provisional-representative-key.md
+++ b/documentation/adr/2026-08-24-refresh-provisional-representative-key.md
@@ -1,0 +1,211 @@
+---
+title: Refresh a reference's representative key whenever its built state is replaced
+date: 2026-08-24
+updated: 2026-08-24 13:20
+status: accepted
+kind: fix
+issues: [1438]
+prs: [1442, 1443]
+areas: [evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure]
+supersedes: []
+superseded-by: []
+relates: []
+---
+
+# Refresh a reference's representative key whenever its built state is replaced
+
+`InitialReferencesBuilder.createReference` registers a brand new — and therefore still empty —
+reference in its `BuilderReferenceBundle` and only afterwards hands the key back so the caller can
+populate the attributes. The key it registers is derived from the *default* representative values,
+normally `[null]`, and nothing refreshed it once the caller filled the attributes in. Every
+replacement of a reference's built state now re-keys it in the bundle, so a provisional key never
+outlives the state it was derived from. The same work fixes the reference counter the bundle keeps
+alongside those keys, which double-counted in two places.
+
+## Why
+
+An `EvitaIncrementalIndexJob` in production failed with
+
+```
+InvalidMutationException: Cannot add duplicate reference `media` with the same representative
+attributes [null] as it would be indistinguishable from existing reference with internal id -7!
+```
+
+on the **third** duplicate of one business key. Two duplicates always worked; the third never did.
+The client was driving entity proxies, and every `getOrCreate`-style reference method in
+`SetReferenceMethodClassifier` routes to `createReference`, runs the caller's consumer and only then
+propagates the builder back — precisely the create-then-populate order that leaves a stale key
+behind.
+
+The loud rejection was only half of it. Because the bundle never learned the real representative
+values, two references that genuinely *were* indistinguishable were silently accepted into the
+entity instead of being refused: duplicate detection was not merely over-strict on the third
+reference, it was also blind on the second. That half never raised an exception and would have
+written indistinguishable references into an entity.
+
+### Previous state
+
+`createReference` registers into the bundle at creation time; `addOrReplaceReferenceMutations` — the
+path the proxy commits through — only refreshed the reference *collection* and never touched the
+bundle. So:
+
+- reference #1 registers under the generic key and is fine (a lone reference carries no attribute
+  values in its key);
+- reference #2 triggers `convertToDuplicateReference`, which re-derives **its predecessor's** key
+  from that predecessor's already-built state — self-healing #1, but registering #2 itself under
+  `[null]`;
+- reference #3 computes `[null]` too, collides with #2's stale slot, and is rejected.
+
+The `[null]` slot was vacated by accident until `b8400f922` (2026-07-25, first released in
+v2026.2.0): `upsertDuplicateReference` used to remove `previousRRK` unconditionally, including when
+it was the key just written. That commit correctly guarded the removal, which is why the failure
+first appears in 2026.2 even though the missing refresh dates back to v2025.7.0. Empirically:
+v2025.7.0 pass, v2026.1.20 pass, v2026.2.0 fail, `a7c9b78ba` fail.
+
+`ExistingReferencesBuilder` was never affected, and the reason is structural rather than lucky: its
+`addOrReplaceReferenceMutations` passes the **populated** builder to `replaceChangeSet` →
+`upsertWithDuplicateReferenceConversion`, so it re-registers on every commit and the stale-key window
+never opens. `InitialReferencesBuilder` was the only commit path that skipped bundle re-registration
+entirely.
+
+## Options considered
+
+### Option A — refresh the key at the collection choke point (chosen)
+
+Add `BuilderReferenceBundle.refreshRepresentativeKey`, which recomputes a registered reference's
+representative key from its current state, and call it from
+`InitialReferencesBuilder.addOrReplaceReferenceInternal` — the single private method every path that
+replaces a reference's built state funnels through.
+
+- **Pros:** fixes both known entry points (the proxy's `addOrReplaceReferenceMutations` and
+  `mutateReference(ReferenceAttributeMutation)`) and any future one, because it sits at the choke
+  point rather than at a call site. Runs before the collection is touched, so a rejected re-key
+  leaves the builder unchanged.
+- **Cons:** one more method on a class that already carries several near-synonymous upsert paths;
+  the choke point runs on every reference replacement, including the many where it is a no-op.
+
+### Option B — revert the `previousRRK` guard added by `b8400f922` (declined)
+
+Bisection points straight at `b8400f922`, and its guard is the line that stopped vacating `[null]`.
+
+- **Pros:** one-line change; restores the last known-good behaviour on this exact scenario.
+- **Cons:** the unconditional removal it would restore deletes the key the method has just written.
+- **Rejected because:** that guard fixes a real, separate defect — without it a reference is dropped
+  from `repRefKeysToInternalPk` while left in `internalPkToRepRefKeys`, and an indistinguishable twin
+  takes over the vacated slot. Reverting trades the loud third-duplicate rejection for silent
+  reference loss. The vacating was never the design; it was a side effect of a bug that happened to
+  cancel this one out. **Revisit if** the guard is ever shown to be unnecessary — but the refresh in
+  Option A still has to exist, because the guard is not what keys references correctly.
+
+### Option C — do not register in `createReference` until the reference is populated (declined)
+
+Let `createReference` hand back a key without touching the bundle, and register once the caller
+commits the populated builder.
+
+- **Pros:** removes the provisional key entirely rather than repairing it; no re-keying needed.
+- **Cons:** opens a window in which a reference exists in the collection but not in the bundle.
+- **Rejected because:** `convertToDuplicateReference` asserts the *generic* slot is already present
+  when the second reference for a business key arrives, and `getReference(key)` has to resolve
+  between create and populate — the proxy calls it immediately. Both would need redesigning, and a
+  caller that creates a reference and never commits it would leave the two structures permanently out
+  of step. **Revisit if** the bundle ever becomes derived at build time (as `ExistingReferencesBuilder`'s
+  effectively is) rather than maintained incrementally.
+
+### Option D — call the existing `upsertDuplicateReference` from the choke point (declined)
+
+Mirror `ExistingReferencesBuilder` and re-register through the existing upsert; it already drops the
+stale `previousRRK` when it differs, so it *does* re-key correctly.
+
+- **Pros:** no new method; makes the two builders symmetric.
+- **Cons:** it is an insert-or-update that presumes the caller intends registration, and the choke
+  point cannot promise that.
+- **Rejected because:** all three of its preconditions are false at the choke point. It asserts
+  `representativeAttributeDefinition != null`, so it throws for every bundle not in duplicate mode —
+  which is most of them. It registers references it has not seen, but the choke point also runs
+  *inside* `createReference` **before** the bundle registration, so it would register the reference
+  twice and corrupt the create flow. And it would promote a lone reference held under a generic key
+  into an attribute-bearing key, which is wrong while it is still the only one. The choke point needs
+  a *no-op-unless-already-keyed-with-attributes* operation; upsert is the opposite by construction.
+  (The counter inflation that first argued against this option was a real bug and is fixed here —
+  it is no longer a reason, but the three preconditions are structural and remain.)
+
+## Decision
+
+**Chosen: Option A.** It is the only option that keys references from the state they actually have at
+the moment that state becomes current, which is the invariant the bundle needs and none of the others
+establish. B restores a symptom-level accident, C requires redesigning two contracts to remove a key
+that is cheap to refresh, and D is the right *shape* but wrong preconditions.
+
+## Key technical details
+
+- `BuilderReferenceBundle.refreshRepresentativeKey(ReferenceContract)` — recomputes the key, claims the new
+  slot with `putIfAbsent` **before** releasing the old one so a collision is a no-op on the bundle,
+  and throws `InvalidMutationException` when the new key belongs to a different internal primary key.
+- It is a no-op when the bundle never entered duplicate mode (`representativeAttributeDefinition ==
+  null`), or when the reference is registered under a generic key
+  (`representativeAttributeValues().length == 0`) — generic keys carry no attribute values and cannot
+  go stale. Those two guards are the whole reason it is not just `upsertDuplicateReference`; see
+  Option D before merging them.
+- `InitialReferencesBuilder.addOrReplaceReferenceInternal` calls it *before* mutating the collection.
+  The ordering is load-bearing: it is what makes a rejected re-key leave the builder untouched.
+- `RepresentativeReferenceKey` normalizes its `ReferenceKey` to `(referenceName, primaryKey)`, so keys
+  from different internal primary keys compare equal — that is what makes collision detection work at
+  all, and what makes the `putIfAbsent` check meaningful.
+- **`usedReferenceKeys` counts references per business key, and both writers over-counted.**
+  `upsertDuplicateReference` bumped on every call, so a builder that re-registers a reference on each
+  commit counted the same reference repeatedly; `convertToDuplicateReference` bumped for the incoming
+  reference and then called `upsertDuplicateReference`, which bumped for it again. The bump is now
+  gated on `previousRRK == null` — an internal primary key the bundle has not seen before — and
+  `convertToDuplicateReference`'s own bump is gone, since the call that closes it does the counting.
+  Its unreachable `cardinality == null ? 2` fallback went with it: the method asserts the generic slot
+  is present, and that slot is only ever written by `upsertNonDuplicateReference`, which sets the count
+  to 1.
+- The exception message in `upsertDuplicateReference` reported `internalPk` — the *incoming*
+  reference — where it meant `previousValue`, the existing one. The production trace's "internal id
+  -7" was the reference being added, not the one it collided with, which sent the investigation after
+  the wrong reference. Now reports `previousValue`.
+
+## Verification
+
+`CreateReferenceDuplicateBookkeepingTest` — 9 tests, all green; **5 fail without the fix**:
+
+- `shouldAcceptThreeDuplicatesCreatedViaCreateReference` and
+  `shouldAcceptManyDuplicatesCreatedViaCreateReference` (6 duplicates) reproduce the production
+  failure verbatim — `Cannot add duplicate reference ... [null] ...`.
+- `shouldThrowExceptionWhenDuplicatesShareRepresentativeAttributes` pins the other half: without the
+  fix **nothing is thrown** and two identical references are accepted.
+- `shouldRefreshRepresentativeKeyWhenAttributeMutationIsApplied` and
+  `shouldThrowExceptionWhenAttributeMutationCollidesWithSibling` cover
+  `mutateReference(ReferenceAttributeMutation)`, the second entry point the choke point fixes.
+- `shouldAcceptThreeDuplicatesCreatedViaSetOrUpdateReference` is the control: the
+  populate-then-register path was always healthy and stays so.
+- The two `ExistingReferencesBuilder` tests pass with *and* without the fix, confirming that path's
+  structural immunity rather than assuming it.
+
+`BuilderReferenceBundleTest` — 23 tests, all green; the 3 new counting tests
+(`shouldStopReportingReferenceKeyOnceAllDuplicatesAreRemoved`,
+`shouldNotCountRepeatedUpsertsOfTheSameDuplicateReference`,
+`shouldNotCountReKeyingOfAnAlreadyRegisteredDuplicateReference`) fail without the counting fix, each
+on `containsReferenceKey` still answering `true` after every reference under the key was removed.
+`count()` was correct throughout — it reads `internalPkToRepRefKeys`, not the counter — which is what
+localised the bug to `usedReferenceKeys`.
+
+Regression: full `unitAndFunctional` suite, 20 919 tests.
+
+## Consequences & open follow-ups
+
+- The choke point runs on every reference replacement. It is two map lookups and an early return in
+  the overwhelmingly common non-duplicate case, but it is on the write path.
+- `mutateReference(InsertReferenceMutation)` adds a reference to the collection without registering it
+  in the bundle at all. `refreshRepresentativeKey` cannot help — it only re-keys what is already registered.
+  Not investigated; flagged so the next reader does not mistake this record for a claim that every
+  path is now consistent.
+- `convertToDuplicateReference` still does `internalPkToRepRefKeys.remove(genericInternalPk)` followed
+  by `put(previousRefInternalPk, ...)` on what is provably the same key. Harmless, left alone
+  deliberately: it is on a path this change already touches and shrinking it further would have
+  widened the diff without changing behaviour.
+
+## Timeline
+
+- **2026-08-24** — reported from production, diagnosed live over JDWP, issue #1438 filed
+- **2026-08-24** — fixed, counter defect found and fixed alongside, verified, recorded

--- a/documentation/adr/2026-08-24-refresh-provisional-representative-key.md
+++ b/documentation/adr/2026-08-24-refresh-provisional-representative-key.md
@@ -1,7 +1,7 @@
 ---
 title: Keep the reference bundle in step with the reference collection
 date: 2026-08-24
-updated: 2026-08-24 14:05
+updated: 2026-08-24 15:10
 status: accepted
 kind: fix
 issues: [1438, 1444]
@@ -101,10 +101,15 @@ Bisection points straight at `b8400f922`, and its guard is the line that stopped
   cancel this one out. **Revisit if** the guard is ever shown to be unnecessary — but the refresh in
   Option A still has to exist, because the guard is not what keys references correctly.
 
-### Option C — do not register in `createReference` until the reference is populated (declined)
+### Option C — defer only the *bundle registration* until the reference is populated (declined)
 
-Let `createReference` hand back a key without touching the bundle, and register once the caller
-commits the populated builder.
+Let `createReference` assign the internal primary key and add the reference to the collection exactly
+as it does today, but hold off on the `BuilderReferenceBundle` entry until the caller commits the
+populated builder.
+
+**This option does not touch when the internal primary key is assigned.** That assignment must stay
+eager and is not negotiable — see *The early-PK invariant* below. Only the bundle entry is at stake
+here.
 
 - **Pros:** removes the provisional key entirely rather than repairing it; no re-keying needed.
 - **Cons:** opens a window in which a reference exists in the collection but not in the bundle.
@@ -112,8 +117,20 @@ commits the populated builder.
   when the second reference for a business key arrives, and `getReference(key)` has to resolve
   between create and populate — the proxy calls it immediately. Both would need redesigning, and a
   caller that creates a reference and never commits it would leave the two structures permanently out
-  of step. **Revisit if** the bundle ever becomes derived at build time (as `ExistingReferencesBuilder`'s
+  of step. That last shape is not hypothetical: it is exactly the gap that produced #1444.
+  **Revisit if** the bundle ever becomes derived at build time (as `ExistingReferencesBuilder`'s
   effectively is) rather than maintained incrementally.
+
+#### The early-PK invariant
+
+`createReference` assigns the internal primary key **before** returning, and every alternative here
+preserves that. It is load-bearing for the proxy layer: a proxy can be built on top of an
+*uncommitted* `InitialEntityBuilder`, handed to client code, and that client can read a reference back
+off the uncommitted proxy, modify it and reinsert it. Every one of those steps needs a stable identity
+for a reference that has not been committed yet, and the internal primary key is that identity —
+there is nothing else to key it by. Any future redesign that defers the bundle must still assign the
+key eagerly, or the proxy round-trip loses the ability to address the reference it is holding.
+Covered by `EntityEditorProxyingFunctionalTest` / `EntityPojoProxyingFunctionalTest` (179 tests).
 
 ### Option D — call the existing `upsertDuplicateReference` from the choke point (declined)
 
@@ -171,12 +188,27 @@ that is cheap to refresh, and D is the right *shape* but wrong preconditions.
   `upsertWithDuplicateReferenceConversion` like `createReference` does; the internal id is resolved
   *before* the `Reference` is constructed, so the bundle files it under the very key the collection
   stores.
-- **That registration makes mutation emission order load-bearing.** Registering eagerly means two
-  still-empty references collide on their identical default representative values, so a stream ordered
-  `[Insert A, Insert B, Attr A, Attr B]` would break replay. Real streams interleave per reference —
-  `buildChangeSet()` emits each insert followed by its own attribute mutations, which `toMutation()`'s
-  contract states — and `shouldReplayItsOwnMutationStream` exists to keep that guaranteed rather than
-  incidental. Anyone reordering `buildChangeSet` must read that test first.
+- **That registration makes mutation emission order load-bearing, and the exposure is not only
+  internal.** Registering eagerly means two still-empty references collide on their identical default
+  representative values, so a mutation list ordered `[Insert A, Insert B, Attr A, Attr B]` is rejected
+  even though the two references are distinguishable once their attributes land. Scope, measured
+  rather than assumed:
+  - **The server / gRPC path is unaffected.** `EntityUpsertMutation.mutate(...)` delegates to
+    `Entity.mutateEntity(...)`, which builds its references through its own `mutateReferences(...)`
+    helper and never touches `InitialReferencesBuilder` or the bundle. A client submitting a batched
+    mutation list over gRPC does **not** reach this code — verified by applying that exact batched list
+    through both paths and watching only the builder one throw.
+  - **The exposed surface is the client-side `EntityBuilder.mutate(LocalMutation...)` API**, where a
+    caller hand-orders mutations rather than taking them from `buildChangeSet()`. That is broader than
+    "someone refactors `buildChangeSet`", which is how this note originally read.
+  - Anything derived from `buildChangeSet()` is safe by construction: it emits each insert followed by
+    its own attribute mutations, which `toMutation()`'s contract states, and
+    `shouldReplayItsOwnMutationStream` keeps that guaranteed rather than incidental. Anyone reordering
+    `buildChangeSet` must read that test first.
+
+  The failure is loud (`InvalidMutationException`) rather than silent, so a caller in the exposed shape
+  finds out immediately. Accepted on that basis; making the builder tolerate transient collisions means
+  deferring duplicate validation to `build()`, which is Option C's redesign.
 - The exception message in `upsertDuplicateReference` reported `internalPk` — the *incoming*
   reference — where it meant `previousValue`, the existing one. The production trace's "internal id
   -7" was the reference being added, not the one it collided with, which sent the investigation after

--- a/documentation/adr/2026-08-24-refresh-provisional-representative-key.md
+++ b/documentation/adr/2026-08-24-refresh-provisional-representative-key.md
@@ -1,10 +1,10 @@
 ---
-title: Refresh a reference's representative key whenever its built state is replaced
+title: Keep the reference bundle in step with the reference collection
 date: 2026-08-24
-updated: 2026-08-24 13:20
+updated: 2026-08-24 14:05
 status: accepted
 kind: fix
-issues: [1438]
+issues: [1438, 1444]
 prs: [1442, 1443]
 areas: [evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure]
 supersedes: []
@@ -12,15 +12,19 @@ superseded-by: []
 relates: []
 ---
 
-# Refresh a reference's representative key whenever its built state is replaced
+# Keep the reference bundle in step with the reference collection
 
 `InitialReferencesBuilder.createReference` registers a brand new — and therefore still empty —
 reference in its `BuilderReferenceBundle` and only afterwards hands the key back so the caller can
 populate the attributes. The key it registers is derived from the *default* representative values,
 normally `[null]`, and nothing refreshed it once the caller filled the attributes in. Every
 replacement of a reference's built state now re-keys it in the bundle, so a provisional key never
-outlives the state it was derived from. The same work fixes the reference counter the bundle keeps
-alongside those keys, which double-counted in two places.
+outlives the state it was derived from.
+
+Two further gaps in the same invariant — *the bundle must know about every reference the collection
+holds, under the key that reference currently has* — were found and closed alongside it: references
+inserted through `InsertReferenceMutation` were never registered in the bundle at all (#1444), and the
+reference counter the bundle keeps alongside those keys double-counted in two places.
 
 ## Why
 
@@ -160,6 +164,19 @@ that is cheap to refresh, and D is the right *shape* but wrong preconditions.
   Its unreachable `cardinality == null ? 2` fallback went with it: the method asserts the generic slot
   is present, and that slot is only ever written by `upsertNonDuplicateReference`, which sets the count
   to 1.
+- **`mutateReference(InsertReferenceMutation)` registered nothing in the bundle** (#1444, latent since
+  v2025.8.0 — *not* a 2026.2 regression; `mutateReference` did not exist on the references builder
+  before `8e10a5e9f`). Removal of such a reference failed outright with "is not present in the
+  structure", and duplicate detection never ran for it. It now registers through
+  `upsertWithDuplicateReferenceConversion` like `createReference` does; the internal id is resolved
+  *before* the `Reference` is constructed, so the bundle files it under the very key the collection
+  stores.
+- **That registration makes mutation emission order load-bearing.** Registering eagerly means two
+  still-empty references collide on their identical default representative values, so a stream ordered
+  `[Insert A, Insert B, Attr A, Attr B]` would break replay. Real streams interleave per reference —
+  `buildChangeSet()` emits each insert followed by its own attribute mutations, which `toMutation()`'s
+  contract states — and `shouldReplayItsOwnMutationStream` exists to keep that guaranteed rather than
+  incidental. Anyone reordering `buildChangeSet` must read that test first.
 - The exception message in `upsertDuplicateReference` reported `internalPk` — the *incoming*
   reference — where it meant `previousValue`, the existing one. The production trace's "internal id
   -7" was the reference being added, not the one it collided with, which sent the investigation after
@@ -190,16 +207,33 @@ on `containsReferenceKey` still answering `true` after every reference under the
 `count()` was correct throughout — it reads `internalPkToRepRefKeys`, not the counter — which is what
 localised the bug to `usedReferenceKeys`.
 
-Regression: full `unitAndFunctional` suite, 20 919 tests.
+`InsertReferenceMutationBookkeepingTest` — 5 tests, all green; **3 fail without the fix**, two on
+`GenericEvitaInternalError: ... is not present in the structure!` and one on "expected
+`InvalidMutationException`, nothing was thrown". The other two are guards: distinguishable duplicates
+still accepted, and the mutation-stream round-trip described above. The v2025.8.0 dating was confirmed
+by reproducing the removal crash in a worktree at that tag, not by reading the diff.
+
+Rejecting identical representative attributes on the mutation path is not a new restriction:
+`createReference`, `setOrUpdateReference` and `ExistingReferencesBuilder.createReference` were each
+probed and all three already throw the identical `InvalidMutationException` in that situation. The
+mutation path was the one hole that bypassed the rule.
+
+Regression: full `unitAndFunctional` suite, 20 927 tests.
 
 ## Consequences & open follow-ups
 
 - The choke point runs on every reference replacement. It is two map lookups and an early return in
   the overwhelmingly common non-duplicate case, but it is on the write path.
-- `mutateReference(InsertReferenceMutation)` adds a reference to the collection without registering it
-  in the bundle at all. `refreshRepresentativeKey` cannot help — it only re-keys what is already registered.
-  Not investigated; flagged so the next reader does not mistake this record for a claim that every
-  path is now consistent.
+- The four reference-creation entry points are now consistent, but that is a statement about the paths
+  *examined here*, not a proof that the bundle and the collection can no longer drift. The invariant is
+  maintained by convention at each call site rather than enforced structurally — nothing stops the next
+  new path from adding to the collection and forgetting the bundle, which is exactly how #1444 arose.
+  Deriving the bundle at build time would remove the class of bug entirely; see Option C for why that
+  was out of scope here.
+- A reference whose schema declares duplicating cardinality but **no** representative attributes cannot
+  have duplicates at all — every path rejects the second one, because both derive the same empty key.
+  That predates this work and was left alone; it is a schema-validation question (such a schema is
+  arguably invalid at declaration time) rather than a bookkeeping one.
 - `convertToDuplicateReference` still does `internalPkToRepRefKeys.remove(genericInternalPk)` followed
   by `put(previousRefInternalPk, ...)` on what is provably the same key. Harmless, left alone
   deliberately: it is on a path this change already touches and shrinking it further would have
@@ -209,3 +243,4 @@ Regression: full `unitAndFunctional` suite, 20 919 tests.
 
 - **2026-08-24** — reported from production, diagnosed live over JDWP, issue #1438 filed
 - **2026-08-24** — fixed, counter defect found and fixed alongside, verified, recorded
+- **2026-08-24** — follow-up chased: #1444 filed and closed in the same PRs

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-24 | [Refresh a reference's representative key whenever its built state is replaced](2026-08-24-refresh-provisional-representative-key.md) | fix | accepted | #1438, PR #1442, PR #1443 |
+| 2026-08-24 | [Keep the reference bundle in step with the reference collection](2026-08-24-refresh-provisional-representative-key.md) | fix | accepted | #1438, #1444, PR #1442, PR #1443 |
 | 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-24 | [Refresh a reference's representative key whenever its built state is replaced](2026-08-24-refresh-provisional-representative-key.md) | fix | accepted | #1438, PR #1442, PR #1443 |
 | 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-24 | [Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers](2026-08-24-grpc-streaming-backpressure-readiness-gate.md) | fix | accepted | #1441 |
+| 2026-08-24 | [Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers](2026-08-24-grpc-streaming-backpressure-readiness-gate.md) | fix | accepted | #1441, PR #1450, PR #1451 |
 | 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-24 | [Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers](2026-08-24-grpc-streaming-backpressure-readiness-gate.md) | fix | accepted | #1441 |
 | 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | proposed | #1433 |
+| 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | accepted | #1433, PR #1435, PR #1436 |
 | 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | proposed | #1433 |
 | 2026-08-10 | [LocalDateTime is a first-class schema type, and its UTC-anchored Instant encoding lives in the index normalizer](2026-08-10-stored-value-normalization-split.md) | fix | accepted | #1403, PR #1404, PR #1405 |
 | 2026-08-05 | [Share schema-derived attribute keys and resolve reference schemas once per run instead of per mutation](2026-08-05-schema-handling-write-path-optimizations.md) | optimization | accepted | #1390, PR #1395 |
 | 2026-08-05 | [Never decorate a streaming gRPC channel with RetryingClient](2026-08-05-streaming-calls-must-not-be-retry-decorated.md) | fix | accepted | #1388, PR #1389 |

--- a/documentation/user/en/operate/configure.md
+++ b/documentation/user/en/operate/configure.md
@@ -160,6 +160,7 @@ api:                                              # [see API configuration](#api
       tlsMode: null
       keepAlive: null
       exposeDocsService: false
+      streamingRequestTimeoutInMillis: 300K
       mTLS:
         enabled: null
         allowedClientCertificatePaths: null
@@ -1104,7 +1105,10 @@ This section of the configuration allows you to selectively enable, disable, and
     <dt>requestTimeoutInMillis</dt>
     <dd>
         <p>**Default:** `2K`</p>
-        <p>The amount of time a connection can sit idle without processing a request, before it is closed by the server.</p>
+        <p>The budget for handling a **whole request**, measured from its start until the response has been fully sent.
+            This is the right shape for a unary call, where the work is one bounded round trip. It is the wrong shape
+            for a long-lived streaming response, which is why the gRPC API has a separate
+            [streamingRequestTimeoutInMillis](#grpc-api-configuration).</p>
     </dd> 
     <dt>maxEntitySizeInBytes</dt>
     <dd>
@@ -1386,6 +1390,22 @@ This allows you to set common settings for all endpoints in one place.
         <p>**Default:** `false`</p>
         <p>It enables / disables the gRPC service, which provides documentation for the gRPC API and allows to
         experimentally call any of the services from the web UI and examine its output.</p>
+    </dd>
+    <dt>streamingRequestTimeoutInMillis</dt>
+    <dd>
+        <p>**Default:** `300K`</p>
+        <p>How long a **streaming** RPC may make no progress before the server abandons it. Unlike the shared
+            [requestTimeoutInMillis](#api-configuration) this bounds *silence* rather than total duration: it is
+            re-armed every time a message is handed to the transport, so a slow but steadily progressing transfer never
+            reaches it however long it runs.</p>
+        <p>A whole-request budget cannot serve a stream, because a download's duration is a function of the file's size
+            and the link's speed - neither of which the server knows. Size this against the slowest client you intend to
+            serve: it must comfortably exceed the time a **single message** takes to reach that client. Lowering it
+            towards `requestTimeoutInMillis` reintroduces a minimum viable link speed for large downloads - the file
+            download RPC streams 1 MB chunks, so a 2 s budget would demand roughly 4 Mbit/s sustained.</p>
+        <p>The same value bounds how long a server worker stays parked waiting for a client that has stopped reading, so
+            it is also the point at which such a stream is abandoned with `DEADLINE_EXCEEDED`. A non-positive value
+            falls back to the default.</p>
     </dd>
     <dt>mTls.enabled</dt>
     <dd>

--- a/documentation/user/en/query/requirements/histogram.md
+++ b/documentation/user/en/query/requirements/histogram.md
@@ -318,6 +318,11 @@ handles inner records (`PriceInnerRecordHandling`), because that determines what
 | `SUM`                 | One — the cumulated price of all inner records |
 | `LOWEST_PRICE`        | **One per inner-record id** — the winning price of each variant |
 
+The rule is applied **per entity**, using that entity's own handling. A candidate pool that mixes handling
+modes — a category listing containing both simple products and master/variant products, for instance —
+therefore contributes the union of both rules: every `LOWEST_PRICE` master still expands into one data point
+per variant, while its `NONE` and `SUM` neighbours contribute a single price for sale each.
+
 To demonstrate the use of the histogram, we will use the following example:
 
 <SourceCodeTabs requires="evita_test/evita_documentation_tests/src/test/resources/META-INF/documentation/evitaql-init.java" langSpecificTabOnly>

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/BuilderReferenceBundle.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/BuilderReferenceBundle.java
@@ -254,7 +254,7 @@ class BuilderReferenceBundle {
 					"` with the same representative attributes " + Arrays.toString(
 					rrk.representativeAttributeValues()) +
 					" as it would be indistinguishable from existing reference with internal id " +
-					internalPk + "!"
+					previousValue + "!"
 			);
 		} else {
 			final RepresentativeReferenceKey previousRRK = this.internalPkToRepRefKeys.put(internalPk, rrk);
@@ -268,11 +268,77 @@ class BuilderReferenceBundle {
 					() -> "Inconsistent internal structure!"
 				);
 			}
-			this.usedReferenceKeys.compute(
-				rrk.referenceKey(),
-				(rk, cardinality) -> cardinality == null ? 1 : cardinality + 1
+			// only an internal primary key the bundle has not seen before adds to the number of references
+			// the reference key holds - builders re-register a reference on every commit, and re-registering
+			// or re-keying a reference the bundle already knows must leave the count alone
+			if (previousRRK == null) {
+				this.usedReferenceKeys.compute(
+					rrk.referenceKey(),
+					(rk, cardinality) -> cardinality == null ? 1 : cardinality + 1
+				);
+			}
+		}
+	}
+
+	/**
+	 * Refreshes the representative key the passed reference is registered under, so that the key reflects the
+	 * current state of the reference's representative attributes.
+	 *
+	 * References may be registered in this bundle before their attributes are known:
+	 * {@link InitialReferencesBuilder#createReference(String, int)} registers a brand new - and therefore still empty -
+	 * reference and only afterwards hands the key back so the caller can populate it. The key derived at
+	 * registration time is consequently built from the default (usually {@code null}) representative values, and
+	 * goes stale the moment the caller fills the attributes in. A stale key keeps occupying a slot no reference
+	 * matches anymore, and the next reference registered the very same way is rejected as indistinguishable from
+	 * it.
+	 *
+	 * The method is a no-op when the reference is not registered yet, or when it is registered under a generic
+	 * key - generic keys carry no attribute values and therefore cannot go stale. That tolerance is what
+	 * separates it from {@link #upsertDuplicateReference(ReferenceContract)}, which presumes duplicate mode and
+	 * presumes the caller intends to register: this one is safe to call for every reference on every write.
+	 * It never touches {@link #usedReferenceKeys} either, because re-keying an already registered reference
+	 * does not change how many references its reference key holds.
+	 *
+	 * @param reference the reference whose representative key is to be recomputed, must not be null
+	 * @throws InvalidMutationException when the recomputed key is already occupied by a different reference
+	 */
+	public void refreshRepresentativeKey(@Nonnull ReferenceContract reference) {
+		final ReferenceKey referenceKey = reference.getReferenceKey();
+		if (referenceKey.isUnknownReference() || this.representativeAttributeDefinition == null) {
+			// the bundle never entered duplicate mode - there are no attribute bearing keys to refresh
+			return;
+		}
+		final int internalPk = referenceKey.internalPrimaryKey();
+		final RepresentativeReferenceKey currentRRK = this.internalPkToRepRefKeys.get(internalPk);
+		if (currentRRK == null || currentRRK.representativeAttributeValues().length == 0) {
+			// the reference is either not registered yet, or registered under a generic key
+			return;
+		}
+		final RepresentativeReferenceKey newRRK = new RepresentativeReferenceKey(
+			referenceKey,
+			this.representativeAttributeDefinition.getRepresentativeValues(reference)
+		);
+		if (currentRRK.equals(newRRK)) {
+			// the representative attributes did not change - the registered key is still accurate
+			return;
+		}
+		// claim the new slot first, so that a collision leaves the bundle exactly as it was
+		final Integer collidingPk = this.repRefKeysToInternalPk.putIfAbsent(newRRK, internalPk);
+		if (collidingPk != null && !collidingPk.equals(internalPk)) {
+			// this is a problem - we have two different references with the same representative keys
+			throw new InvalidMutationException(
+				"Cannot update duplicate reference `" + reference.getReferenceName() +
+					"` to representative attributes " + Arrays.toString(newRRK.representativeAttributeValues()) +
+					" as it would be indistinguishable from existing reference with internal id " +
+					collidingPk + "!"
 			);
 		}
+		this.internalPkToRepRefKeys.put(internalPk, newRRK);
+		final Integer removedPk = this.repRefKeysToInternalPk.remove(currentRRK);
+		Assert.isPremiseValid(
+			removedPk == null || removedPk == internalPk,
+			() -> "Inconsistent internal structure!"
+		);
 	}
 
 	/**
@@ -317,10 +383,8 @@ class BuilderReferenceBundle {
 			// zero in the map means that there are duplicates for this generic key
 			this.repRefKeysToInternalPk.put(genericRRK, 0);
 			this.repRefKeysToInternalPk.put(newRRK, previousRefInternalPk);
-			this.usedReferenceKeys.compute(
-				genericRRK.referenceKey(),
-				(rk, cardinality) -> cardinality == null ? 2 : cardinality + 1
-			);
+			// the previous reference is only re-keyed here, so it stays counted exactly once; the incoming
+			// one is counted by the upsertDuplicateReference call that closes this method
 			this.internalPkToRepRefKeys.remove(genericInternalPk);
 			this.internalPkToRepRefKeys.put(previousRefInternalPk, newRRK);
 			// now we can add the new duplicate reference

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/InitialReferencesBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/InitialReferencesBuilder.java
@@ -1210,6 +1210,12 @@ public class InitialReferencesBuilder implements ReferencesBuilder {
 	 * If the reference is added for the first time, it is stored. In case of a duplicate, the reference is marked
 	 * with a special indicator for duplicate references.
 	 *
+	 * Every replacement also refreshes the representative key the reference is registered under in its
+	 * {@link BuilderReferenceBundle}. References created through {@link #createReference(String, int)} are
+	 * registered while still empty and are populated only afterwards, so without this refresh the bundle would keep
+	 * them filed under their initial - all defaults, usually {@code null} - representative values forever, and the
+	 * next reference created the same way would be rejected as indistinguishable from that stale entry.
+	 *
 	 * @param reference the reference to be added; must not be null
 	 */
 	private void addOrReplaceReferenceInternal(@Nonnull ReferenceContract reference) {
@@ -1218,6 +1224,15 @@ public class InitialReferencesBuilder implements ReferencesBuilder {
 			this.references = new LinkedHashMap<>(16);
 		}
 		final ReferenceContract referenceWithAssignedInternalId = getReference(reference);
+		// re-key before the collection is touched, so that a genuine collision leaves the builder untouched
+		if (this.referenceBundles != null) {
+			final BuilderReferenceBundle referenceBundle = this.referenceBundles.get(
+				referenceWithAssignedInternalId.getReferenceName()
+			);
+			if (referenceBundle != null) {
+				referenceBundle.refreshRepresentativeKey(referenceWithAssignedInternalId);
+			}
+		}
 		this.references.compute(
 			referenceWithAssignedInternalId.getReferenceKey(),
 			(key, existingValue) -> {

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/InitialReferencesBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/InitialReferencesBuilder.java
@@ -969,17 +969,28 @@ public class InitialReferencesBuilder implements ReferencesBuilder {
     @Override
     public ReferencesBuilder mutateReference(@Nonnull ReferenceMutation<?> referenceMutation) {
         if (referenceMutation instanceof InsertReferenceMutation lm) {
-            final String referenceName = referenceMutation.getReferenceKey().referenceName();
+            final ReferenceKey mutationKey = referenceMutation.getReferenceKey();
+            final String referenceName = mutationKey.referenceName();
             final ReferenceSchemaContract referenceSchema = getReferenceSchemaOrCreateImplicit(
                 referenceName, lm.getReferencedEntityType(), lm.getReferenceCardinality()
             );
-            this.addOrReplaceReferenceInternal(
-                new Reference(
-                    this.entitySchema,
-                    referenceSchema,
-                    referenceMutation.getReferenceKey(),
-                    null
-                )
+            // the internal id is resolved up front rather than inside addOrReplaceReferenceInternal, because the
+            // reference has to be registered in the bundle under the very key the collection stores it with
+            final ReferenceKey referenceKey = mutationKey.isUnknownReference() ?
+                new ReferenceKey(referenceName, mutationKey.primaryKey(), getNextReferenceInternalId()) :
+                mutationKey;
+            final Reference newReference = new Reference(
+                this.entitySchema,
+                referenceSchema,
+                referenceKey,
+                null
+            );
+            this.addOrReplaceReferenceInternal(newReference);
+            // a reference the bundle never learned about cannot be removed (removeNonDuplicateReference fails on
+            // "not present in the structure") and cannot take part in duplicate detection at all
+            getReferenceBundleForUpdate(referenceName, 8).upsertWithDuplicateReferenceConversion(
+                newReference,
+                rk -> this.getReference(rk).orElseThrow()
             );
         } else if (referenceMutation instanceof SetReferenceGroupMutation lm) {
             final ReferenceContract existingReference = this.getReference(lm.getReferenceKey())

--- a/evita_common/src/main/java/io/evitadb/utils/ExceptionUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/ExceptionUtils.java
@@ -25,6 +25,7 @@ package io.evitadb.utils;
 
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
@@ -79,15 +80,39 @@ public class ExceptionUtils {
 		@Nonnull Throwable throwable,
 		@Nonnull Class<? extends Throwable> exceptionType
 	) {
+		return findInCauseChain(throwable, exceptionType) != null;
+	}
+
+	/**
+	 * Returns the first throwable in the causal chain that matches the specified exception type - the
+	 * instance itself rather than a mere yes/no, so the caller can read state off it (a configured
+	 * limit, a status code, a file name) when building a diagnostic.
+	 *
+	 * Prefer this over an ad-hoc `while (current != null) current = current.getCause()` loop at the
+	 * call site: the traversal handles circular references, which a naive loop turns into an infinite
+	 * one. Guarding only against a self-referencing cause (`current.getCause() == current`) is *not*
+	 * enough - a two-element cycle `A -> B -> A` passes that check and spins forever.
+	 *
+	 * @param throwable the throwable to evaluate, must not be null
+	 * @param exceptionType the class of the exception type to look for, must not be null
+	 * @return the first matching throwable in the causal chain, or null when the chain holds none
+	 * @param <T> the exception type being looked for
+	 */
+	@Nullable
+	public static <T extends Throwable> T findInCauseChain(
+		@Nonnull Throwable throwable,
+		@Nonnull Class<T> exceptionType
+	) {
 		final Set<Throwable> visited = new HashSet<>();
 		Throwable current = throwable;
+		// `visited.add` returning false means the chain has looped back on itself - stop rather than spin
 		while (current != null && visited.add(current)) {
 			if (exceptionType.isInstance(current)) {
-				return true;
+				return exceptionType.cast(current);
 			}
 			current = current.getCause();
 		}
-		return false;
+		return null;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/SelectionFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/SelectionFormula.java
@@ -258,18 +258,26 @@ public class SelectionFormula extends AbstractFormula implements ChildrenDepende
 
 	/**
 	 * Propagates the histogram side-output capability from inner accessors so {@link PriceHistogramComputer}'s
-	 * bypass continues to fire even when prefetch wiring (`PriceInPriceListsTranslator`) inserts a
-	 * {@link SelectionFormula} between the histogram and the histogram-aware
+	 * per-inner-record path continues to fire even when prefetch wiring (`PriceInPriceListsTranslator`) inserts
+	 * a {@link SelectionFormula} between the histogram and the histogram-aware
 	 * `io.evitadb.core.query.algebra.price.termination.LowestPriceTerminationFormula`. A naive
-	 * top-level-only probe would miss wrapped LPs and incorrectly disable the bypass.
+	 * top-level-only probe would miss wrapped LPs and incorrectly disable the per-inner-record granularity.
 	 *
-	 * Semantics are "all-true": this wrapper exposes the side-output only if **every** inner accessor
-	 * does. The histogram producer collects the accessor list from a `withoutUserFilter` view of the
-	 * filtering tree, so wrappers above un-flagged inner LPs (e.g. price-between LPs under
-	 * `UserFilterFormula`) never end up in the histogram accessor list in the first place.
+	 * Semantics are "any-true": this wrapper exposes the side-output when **at least one** inner accessor
+	 * does. A single `SelectionFormula` is inserted above the whole price filter container, so in a catalog
+	 * mixing {@link io.evitadb.api.requestResponse.data.PriceInnerRecordHandling} values its inner accessor
+	 * set legitimately contains both the flagged `LOWEST_PRICE` termination formula and the non-exposing
+	 * `NONE`/`SUM` branches. Under the previous "all-true" rule that mix silently dropped the histogram back
+	 * to per-entity granularity (issue #1433). {@link #getFilteredPriceRecordsForHistogram} therefore returns
+	 * only the *exposing* inners' contribution, and the histogram producer routes every entity not covered by
+	 * it through the per-entity collector.
 	 *
 	 * **Prefetch parity**: the probe ignores `isPrefetchExecution()` — both alternative plans (index and
-	 * prefetch) must return the same histogram or `VERIFY_ALTERNATIVE_INDEX_RESULTS` fails. The cost of
+	 * prefetch) must return the same histogram. `QueryPlanner.verifyConsistentResultsInAllPlans` executes
+	 * the query under the bitmap-favouring *and* the prefetch-favouring policy and compares the whole
+	 * `EvitaResponse`, extra results included, so a divergence raises `InconsistentResultsException` — but
+	 * only when a query enables `VERIFY_ALTERNATIVE_INDEX_RESULTS` **and** `PREFER_PREFETCHING` together.
+	 * The cost of
 	 * running the inner LP's `computeInternal()` on the prefetch path to populate the side-output is
 	 * accepted because histogram queries are inherently expensive; the alternative is silently wrong
 	 * histograms whenever prefetch is enabled.
@@ -284,22 +292,26 @@ public class SelectionFormula extends AbstractFormula implements ChildrenDepende
 
 	/**
 	 * One-shot computation backing {@link #exposesPerInnerRecordHistogramRecords()}. Delegates to the
-	 * shared {@link FilteredPriceRecords#allAccessorsExposePerInnerRecordHistogram(Collection)} probe
-	 * so the "all-or-nothing" rule cannot drift between the wrapper and the histogram producer. An
-	 * empty inner-accessor set returns `false` because there is no histogram-aware LP to forward to.
+	 * shared {@link FilteredPriceRecords#anyAccessorExposesPerInnerRecordHistogram(Collection)} probe
+	 * so the rule cannot drift between the wrapper and the histogram producer. An empty inner-accessor
+	 * set returns `false` because there is no histogram-aware LP to forward to — notably, a wrapper
+	 * inserted above a price-free sub-tree must not claim a capability it has no records for.
 	 *
-	 * @return `true` iff every inner {@link FilteredPriceRecordAccessor} exposes the per-inner-record
-	 *         histogram side-output
+	 * @return `true` iff at least one inner {@link FilteredPriceRecordAccessor} exposes the
+	 *         per-inner-record histogram side-output
 	 */
 	private boolean computeExposesPerInnerRecordHistogramRecords() {
-		return FilteredPriceRecords.allAccessorsExposePerInnerRecordHistogram(findInnerAccessors());
+		return FilteredPriceRecords.anyAccessorExposesPerInnerRecordHistogram(findInnerAccessors());
 	}
 
 	/**
-	 * Walks the delegate's inner accessors and merges their per-inner-record histogram records into a
-	 * single flat array. Called by {@link PriceHistogramComputer} only when
-	 * {@link #exposesPerInnerRecordHistogramRecords()} returned `true`, so every inner accessor is
-	 * guaranteed to populate its side-output without throwing.
+	 * Merges the per-inner-record histogram records of the delegate's **histogram-exposing** inner
+	 * accessors into a single flat array. Non-exposing inner accessors (the `NONE` and `SUM` handling
+	 * branches, which have no per-inner-record data points to contribute) are deliberately skipped: the
+	 * entities they cover are picked up by `PriceHistogramComputer`'s per-entity collector pass over
+	 * whatever the returned records did not cover. Calling
+	 * {@link FilteredPriceRecordAccessor#getFilteredPriceRecordsForHistogram} on them here would either
+	 * trip a flag-off LP's guard or contribute raw per-price-id records that inflate the buckets.
 	 *
 	 * Always delegates to the inner accessors — even on the prefetch path — so both alternative plans
 	 * produce the same histogram (see the JavaDoc on
@@ -309,57 +321,28 @@ public class SelectionFormula extends AbstractFormula implements ChildrenDepende
 	 *
 	 * Behaviour matrix:
 	 *
-	 * - no inner accessors → fall back to {@link #getFilteredPriceRecords(QueryExecutionContext)};
-	 * - any inner accessor missing the capability → fall back to per-entity records (the wrapper
-	 *   honours the default interface contract for non-histogram-aware accessors rather than tripping
-	 *   the merge guard mid-loop on a flag-off LP);
-	 * - single histogram-aware inner accessor → size-1 fast path returns its records directly without
-	 *   the intermediate array and `System.arraycopy` round-trip;
-	 * - two or more histogram-aware inner accessors → the actual concatenation is delegated to
+	 * - no exposing inner accessor → fall back to {@link #getFilteredPriceRecords(QueryExecutionContext)},
+	 *   honouring the default interface contract for non-histogram-aware accessors. Defensive only: the
+	 *   caller probes {@link #exposesPerInnerRecordHistogramRecords()} first;
+	 * - exactly one exposing inner accessor → fast path returns its records directly, without the
+	 *   intermediate array and `System.arraycopy` round-trip;
+	 * - two or more exposing inner accessors → the concatenation is delegated to
 	 *   {@link FilteredPriceRecords#mergePerInnerRecordHistogramRecords(Collection, QueryExecutionContext)}
 	 *   so the algorithm stays in one place.
-	 *
-	 * The capability-mismatch fallbacks differ intentionally between size-1 and size≥2:
-	 *
-	 * - size-1 falls back to the *inner* accessor's per-entity records because the wrapper's view
-	 *   over a single delegate is, by construction, that single delegate's view — there is nothing to
-	 *   merge and routing through the wrapper would just add a no-op `createFromFormulas` round-trip;
-	 * - size≥2 falls back to the *wrapper's* per-entity records because per-inner-record arrays from
-	 *   multiple accessors can overlap on the same entity primary key, and only the wrapper's own
-	 *   `getFilteredPriceRecords` knows how to reduce them (via `createFromFormulas`) into a single
-	 *   coherent per-entity view.
-	 *
-	 * Today both fallbacks are dead in production because the caller (`PriceHistogramComputer`)
-	 * always probes `exposesPerInnerRecordHistogramRecords()` first; the asymmetry is kept as a
-	 * defensive safety net in case that contract ever loosens.
 	 */
 	@Nonnull
 	@Override
 	public FilteredPriceRecords getFilteredPriceRecordsForHistogram(@Nonnull QueryExecutionContext context) {
-		final Collection<FilteredPriceRecordAccessor> innerAccessors = findInnerAccessors();
-		if (innerAccessors.isEmpty()) {
+		final List<FilteredPriceRecordAccessor> exposingAccessors =
+			FilteredPriceRecords.collectPerInnerRecordHistogramAccessors(findInnerAccessors());
+		if (exposingAccessors.isEmpty()) {
 			return getFilteredPriceRecords(context);
 		}
-		if (innerAccessors.size() == 1) {
-			// size-1 fast path — common case where the delegate wraps a single histogram-aware LP; avoids the
-			// intermediate array and `System.arraycopy` round-trip below. Mirror the default interface
-			// contract: when the inner accessor is not histogram-aware, fall back to its per-entity records
-			// rather than trip the LP's histogram-collection guard.
-			final FilteredPriceRecordAccessor inner = innerAccessors.iterator().next();
-			if (!inner.exposesPerInnerRecordHistogramRecords()) {
-				return inner.getFilteredPriceRecords(context);
-			}
-			return inner.getFilteredPriceRecordsForHistogram(context);
-		}
-		if (!exposesPerInnerRecordHistogramRecords()) {
-			// size>=2 capability mismatch — at least one inner accessor lacks the side-output, so entering
-			// the merge loop would trip the flag-off LP's guard. Defer to the wrapper's per-entity output
-			// (which the production planner always initialises with a non-null context) instead. Mirrors
-			// the default interface contract for non-histogram-aware accessors.
-			return getFilteredPriceRecords(context);
+		if (exposingAccessors.size() == 1) {
+			return exposingAccessors.get(0).getFilteredPriceRecordsForHistogram(context);
 		}
 		final PriceRecordContract[] merged = FilteredPriceRecords.mergePerInnerRecordHistogramRecords(
-			innerAccessors, context
+			exposingAccessors, context
 		);
 		if (merged.length == 0) {
 			return FilteredPriceRecords.EMPTY;

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/FilteredPriceRecordAccessor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/FilteredPriceRecordAccessor.java
@@ -87,8 +87,9 @@ public interface FilteredPriceRecordAccessor {
 	}
 
 	/**
-	 * Capability probe used by `PriceHistogramComputer` to decide whether it may bypass the per-entity
-	 * `FilteredPriceRecordsCollector` and read the per-inner-record records directly from each accessor.
+	 * Capability probe used by `PriceHistogramComputer` to partition the accessor set: accessors that
+	 * answer `true` contribute their per-inner-record records directly, everything else is served by the
+	 * per-entity `FilteredPriceRecordsCollector`.
 	 *
 	 * Returns `true` only when {@link #getFilteredPriceRecordsForHistogram(QueryExecutionContext)} is
 	 * guaranteed to expose the per-inner-record histogram side-output for this accessor's scope:
@@ -102,8 +103,15 @@ public interface FilteredPriceRecordAccessor {
 	 * - `FlattenedFormulaWithFilteredPricesForHistogram` (the cached form of the above) always returns
 	 *   `true`.
 	 * - Wrapper accessors (e.g. `SelectionFormula`) propagate the capability from their inner
-	 *   accessors so the histogram bypass continues to fire even when prefetch wiring inserts a
-	 *   wrapper between the histogram and the histogram-aware termination formula.
+	 *   accessors so the per-inner-record granularity survives prefetch wiring inserting a wrapper
+	 *   between the histogram and the histogram-aware termination formula.
+	 *
+	 * **A `false` answer only forfeits this accessor's own contribution.** It must never be read as
+	 * "the whole histogram falls back to per-entity granularity" — the accessors of a single query
+	 * routinely mix answers, because a `filterBy` builds one price branch per
+	 * {@link PriceInnerRecordHandling} present in the catalog and only the `LOWEST_PRICE` branch has
+	 * per-inner-record data points to give. Treating the probe as all-or-nothing is what made the
+	 * histogram silently revert to per-entity granularity for mixed pools (issue #1433).
 	 *
 	 * Implementations that override this method must keep its evaluation allocation-free — the probe
 	 * is called once per accessor during histogram planning, but cumulatively across multi-tenant

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/filteredPriceRecords/FilteredPriceRecords.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/filteredPriceRecords/FilteredPriceRecords.java
@@ -49,6 +49,7 @@ import io.evitadb.roaringbitmap.RoaringBitmapWriter;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -78,27 +79,60 @@ public interface FilteredPriceRecords extends Serializable {
 	FilteredPriceRecords EMPTY = new ResolvedFilteredPriceRecords();
 
 	/**
-	 * Returns `true` when every accessor in the supplied collection exposes the per-inner-record
+	 * Returns `true` when **at least one** accessor in the supplied collection exposes the per-inner-record
 	 * histogram side-output (see {@link FilteredPriceRecordAccessor#exposesPerInnerRecordHistogramRecords()}).
-	 * An empty collection returns `false` because there is no histogram-aware contributor — the
-	 * caller must fall back to its non-histogram path.
+	 * An empty collection returns `false` because there is no histogram-aware contributor at all.
+	 *
+	 * The probe is deliberately *any*, not *all*. A single `filterBy` produces one price branch per
+	 * {@link io.evitadb.api.requestResponse.data.PriceInnerRecordHandling} present in the catalog, and only
+	 * the `LOWEST_PRICE` branch has per-inner-record data points to contribute — `NONE` and `SUM` correctly
+	 * contribute one price for sale per entity. An all-or-nothing rule therefore discarded the whole
+	 * per-inner-record contribution as soon as the candidate pool mixed handling modes (issue #1433);
+	 * callers now merge the exposing accessors' side-output and route the remaining entities through the
+	 * per-entity collector.
 	 *
 	 * Centralises the capability probe so the histogram producer and wrapper formulas like
-	 * `SelectionFormula` cannot drift on the "all-or-nothing" rule.
+	 * `SelectionFormula` cannot drift apart on the rule.
 	 *
 	 * @param accessors accessors to probe
-	 * @return `true` iff the collection is non-empty and every accessor exposes the side-output
+	 * @return `true` iff at least one accessor exposes the side-output
 	 */
-	static boolean allAccessorsExposePerInnerRecordHistogram(@Nonnull Collection<FilteredPriceRecordAccessor> accessors) {
-		if (accessors.isEmpty()) {
-			return false;
-		}
+	static boolean anyAccessorExposesPerInnerRecordHistogram(
+		@Nonnull Collection<FilteredPriceRecordAccessor> accessors
+	) {
 		for (final FilteredPriceRecordAccessor accessor : accessors) {
-			if (!accessor.exposesPerInnerRecordHistogramRecords()) {
-				return false;
+			if (accessor.exposesPerInnerRecordHistogramRecords()) {
+				return true;
 			}
 		}
-		return true;
+		return false;
+	}
+
+	/**
+	 * Returns the subset of `accessors` that expose the per-inner-record histogram side-output, preserving
+	 * the input order. Only these accessors may be passed to
+	 * {@link #mergePerInnerRecordHistogramRecords(Collection, QueryExecutionContext)} — calling the merge on
+	 * a non-exposing accessor would either trip its histogram-collection guard or silently contribute
+	 * per-entity records a second time.
+	 *
+	 * @param accessors accessors to partition
+	 * @return the exposing accessors; an empty list when none of them expose the side-output
+	 */
+	@Nonnull
+	static List<FilteredPriceRecordAccessor> collectPerInnerRecordHistogramAccessors(
+		@Nonnull Collection<FilteredPriceRecordAccessor> accessors
+	) {
+		List<FilteredPriceRecordAccessor> exposing = null;
+		for (final FilteredPriceRecordAccessor accessor : accessors) {
+			if (accessor.exposesPerInnerRecordHistogramRecords()) {
+				// lazily allocated — the common non-histogram query never reaches this branch at all
+				if (exposing == null) {
+					exposing = new ArrayList<>(accessors.size());
+				}
+				exposing.add(accessor);
+			}
+		}
+		return exposing == null ? List.of() : exposing;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/PriceHistogramComputer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/PriceHistogramComputer.java
@@ -44,6 +44,7 @@ import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
 import io.evitadb.index.price.model.priceRecord.PriceRecord;
 import io.evitadb.index.price.model.priceRecord.PriceRecordContract;
+import io.evitadb.roaringbitmap.PersistentRoaringBitmap;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
 import net.openhft.hashing.LongHashFunction;
@@ -54,6 +55,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.ToIntFunction;
@@ -72,11 +74,15 @@ import static java.util.Optional.ofNullable;
  *   histogram cruncher via the existing {@link FilteredPriceRecordsCollector} path.
  * - **`LOWEST_PRICE`**: the filter planner constructs every outer {@link LowestPriceTerminationFormula} in
  *   the filtering tree with its `collectPerInnerRecordPrices` flag enabled, so {@code computeInternal()}
- *   populates a per-inner-record side-output funnel alongside the regular per-entity result. When every
- *   {@link FilteredPriceRecordAccessor} in {@link #filteredPriceRecordAccessors} exposes that side-output
- *   (checked by {@link #allAccessorsExposePerInnerRecordHistogram()}), the
- *   {@link FilteredPriceRecordsCollector} is bypassed and the per-inner-record records are merged directly.
- *   This ensures the histogram reports one bucket data point per inner-record-id rather than one per entity.
+ *   populates a per-inner-record side-output funnel alongside the regular per-entity result. Every
+ *   {@link FilteredPriceRecordAccessor} in {@link #filteredPriceRecordAccessors} that exposes that
+ *   side-output contributes one bucket data point per inner-record-id rather than one per entity.
+ *
+ * The two rules compose rather than exclude each other: a `filterBy` produces one price branch per
+ * handling value present in the catalog, so a candidate pool mixing simple products with master/variant
+ * products is the common case, not an exception. The per-inner-record records are collected first and the
+ * per-entity collector then tops up exactly the entities they did not cover — see
+ * {@link #collectPerInnerRecordHistogramRecords(List)}.
  *
  * The computed result is memoized in {@link #memoizedResult}; the intermediate price records array is memoized in
  * {@link #memoizedPriceRecords}. Both fields are `null` until {@link #compute()} is first invoked.
@@ -442,56 +448,123 @@ public class PriceHistogramComputer implements CacheableEvitaResponseExtraResult
 	 *
 	 * Branching:
 	 *
-	 * - When every accessor in {@link #filteredPriceRecordAccessors} exposes the per-inner-record
+	 * - When **at least one** accessor in {@link #filteredPriceRecordAccessors} exposes the per-inner-record
 	 *   side-output prepared at construction time by {@link LowestPriceTerminationFormula} (or its
-	 *   flattened cache sibling {@link FlattenedFormulaWithFilteredPricesForHistogram}), the
-	 *   {@link FilteredPriceRecordsCollector} is bypassed entirely so the histogram reports one bucket
-	 *   data point per inner record id, not per entity. The {@code PriceHistogramTranslator} collects
+	 *   flattened cache sibling {@link FlattenedFormulaWithFilteredPricesForHistogram}), those accessors
+	 *   contribute one bucket data point per inner record id and every entity they do not cover is topped
+	 *   up from the {@link FilteredPriceRecordsCollector} — see
+	 *   {@link #collectPerInnerRecordHistogramRecords(List)}. The {@code PriceHistogramTranslator} collects
 	 *   this accessor list from a {@code withoutUserFilter} view of the filtering tree so the inner
 	 *   {@link LowestPriceTerminationFormula} produced by {@code priceBetween} (which would otherwise
 	 *   double-count the same entities) does not show up here.
-	 * - Otherwise (`NONE`/`SUM` handling, mixed catalog, or no LOWEST_PRICE LP at all) the existing
-	 *   collector path runs unchanged.
+	 * - Otherwise (pure `NONE`/`SUM` handling, or no LOWEST_PRICE LP at all) the existing collector path
+	 *   runs unchanged.
 	 */
 	private PriceRecordContract[] getPriceRecords() {
 		if (this.memoizedPriceRecords == null) {
-			if (allAccessorsExposePerInnerRecordHistogram()) {
-				this.memoizedPriceRecords = collectPerInnerRecordHistogramRecords();
-			} else {
-				this.memoizedPriceRecords = collectViaPriceRecordsCollector();
-			}
+			final List<FilteredPriceRecordAccessor> histogramAccessors =
+				FilteredPriceRecords.collectPerInnerRecordHistogramAccessors(this.filteredPriceRecordAccessors);
+			this.memoizedPriceRecords = histogramAccessors.isEmpty() ?
+				collectViaPriceRecordsCollector() :
+				collectPerInnerRecordHistogramRecords(histogramAccessors);
 		}
 		return this.memoizedPriceRecords;
 	}
 
 	/**
-	 * Returns `true` when every accessor in {@link #filteredPriceRecordAccessors} exposes a per-inner-record
-	 * histogram side-output (see {@link FilteredPriceRecordAccessor#exposesPerInnerRecordHistogramRecords()}).
+	 * Assembles the histogram baseline from a candidate pool that may mix
+	 * {@link io.evitadb.api.requestResponse.data.PriceInnerRecordHandling} values, in two passes:
 	 *
-	 * The capability probe is virtual rather than `instanceof`-based so wrapper accessors — currently
-	 * `io.evitadb.core.query.algebra.prefetch.SelectionFormula` inserted by `PriceInPriceListsTranslator`
-	 * for prefetch-eligible queries — can propagate the capability from their inner histogram-aware
-	 * `LowestPriceTerminationFormula` without the histogram producer having to know about them.
+	 * 1. the per-inner-record side-output of `histogramAccessors` (the `LOWEST_PRICE` branches) —
+	 *    **narrowed to the entities the query actually matched**. A termination formula's side-output
+	 *    covers everything its own price sub-tree matched and is not intersected with the non-price parts
+	 *    of the query (an `entityPrimaryKeyInSet`, an attribute filter, a hierarchy constraint), so
+	 *    without this narrowing the histogram would describe entities the query excluded;
+	 * 2. the per-entity price for sale of every remaining entity, collected through the unchanged
+	 *    {@link FilteredPriceRecordsCollector}. This covers the `NONE` and `SUM` branches, for which one
+	 *    data point per entity is the correct contribution.
 	 *
-	 * Delegates to {@link FilteredPriceRecords#allAccessorsExposePerInnerRecordHistogram(Collection)}
-	 * so the "all-or-nothing" rule stays in one place.
+	 * The second pass runs over `baseline \ covered` rather than over the whole baseline, which is what
+	 * makes double counting impossible by construction — including on the prefetch plan, where a
+	 * `SelectionFormula`'s per-entity alternative would happily answer for a `LOWEST_PRICE` entity that
+	 * pass 1 already expanded. For the same reason {@link #priceRecordsLookupResult} (computed by
+	 * {@link io.evitadb.core.query.sort.price.FilteredPricesSorter} over the *full* accessor set and the
+	 * *full* result) must not be reused here.
+	 *
+	 * @param histogramAccessors accessors exposing the per-inner-record side-output; never empty
+	 * @return every price record the histogram should bucket
 	 */
-	private boolean allAccessorsExposePerInnerRecordHistogram() {
-		return FilteredPriceRecords.allAccessorsExposePerInnerRecordHistogram(this.filteredPriceRecordAccessors);
+	@Nonnull
+	private PriceRecordContract[] collectPerInnerRecordHistogramRecords(
+		@Nonnull List<FilteredPriceRecordAccessor> histogramAccessors
+	) {
+		final PersistentRoaringBitmap baseline = computeHistogramBaseline();
+		final PriceRecordContract[] perInnerRecordPrices = FilteredPriceRecords.mergePerInnerRecordHistogramRecords(
+			histogramAccessors, this.context
+		);
+
+		// pass 1 — keep only the per-inner-record prices of entities that survived the whole filter, and
+		// remember which entities they already account for. `covered` is built by incremental `add` rather
+		// than through `RoaringBitmapBackedBitmap.buildWriter()`: the constant-memory writer materializes a
+		// container as soon as the high bits change and therefore assumes ascending input, which the
+		// concatenation of several accessors' side-outputs does not provide (each restarts at its own
+		// lowest entity primary key)
+		final PersistentRoaringBitmap covered = new PersistentRoaringBitmap();
+		final PriceRecordContract[] narrowedPrices = new PriceRecordContract[perInnerRecordPrices.length];
+		int narrowedCount = 0;
+		for (final PriceRecordContract priceRecord : perInnerRecordPrices) {
+			final int entityPrimaryKey = priceRecord.entityPrimaryKey();
+			if (baseline.contains(entityPrimaryKey)) {
+				narrowedPrices[narrowedCount++] = priceRecord;
+				covered.add(entityPrimaryKey);
+			}
+		}
+
+		// pass 2 — top up with the per-entity price for sale of everything pass 1 left uncovered
+		final PersistentRoaringBitmap remainder = PersistentRoaringBitmap.andNot(baseline, covered);
+		if (remainder.isEmpty()) {
+			return narrowedCount == narrowedPrices.length ?
+				narrowedPrices : Arrays.copyOf(narrowedPrices, narrowedCount);
+		}
+		final PriceRecordContract[] perEntityPrices = FilteredPriceRecords
+			.collectFilteredPriceRecordsFromPriceRecordAccessors(
+				this.filteredPriceRecordAccessors, remainder, this.context
+			)
+			.getPriceRecords();
+		if (perEntityPrices.length == 0) {
+			return narrowedCount == narrowedPrices.length ?
+				narrowedPrices : Arrays.copyOf(narrowedPrices, narrowedCount);
+		}
+
+		final PriceRecordContract[] merged = new PriceRecordContract[narrowedCount + perEntityPrices.length];
+		System.arraycopy(narrowedPrices, 0, merged, 0, narrowedCount);
+		System.arraycopy(perEntityPrices, 0, merged, narrowedCount, perEntityPrices.length);
+		return merged;
 	}
 
 	/**
-	 * Concatenates per-inner-record histogram price records from every accessor into a single flat
-	 * array. Delegates to
-	 * {@link FilteredPriceRecords#mergePerInnerRecordHistogramRecords(Collection, QueryExecutionContext)}
-	 * so the merge algorithm stays in one place — `SelectionFormula` calls the same helper when it
-	 * has to flatten the side-output of wrapped accessors.
+	 * Returns the entity primary keys the histogram must describe — the filtering result widened by the
+	 * entities the `priceBetween` slider inside `userFilter` filtered out, mirroring the union
+	 * {@link #collectViaPriceRecordsCollector()} produces through
+	 * {@link FilteredPriceRecordsCollector#combineResultWithAndReturnPriceRecords}. The histogram is
+	 * supposed to answer *"what prices would be reachable if the user cleared the price slider"*, so the
+	 * relaxed clone contributes to the baseline even though it never contributes to the query result.
 	 */
 	@Nonnull
-	private PriceRecordContract[] collectPerInnerRecordHistogramRecords() {
-		return FilteredPriceRecords.mergePerInnerRecordHistogramRecords(
-			this.filteredPriceRecordAccessors, this.context
+	private PersistentRoaringBitmap computeHistogramBaseline() {
+		final PersistentRoaringBitmap filteringResult = RoaringBitmapBackedBitmap.getRoaringBitmap(
+			this.filteringFormula.compute()
 		);
+		if (this.filteringFormulaWithFilteredOutRecords == null) {
+			return filteringResult;
+		}
+		final Bitmap pricePredicateFilteredOutEntities = this.filteringFormulaWithFilteredOutRecords.compute();
+		return pricePredicateFilteredOutEntities.isEmpty() ?
+			filteringResult :
+			PersistentRoaringBitmap.or(
+				filteringResult,
+				RoaringBitmapBackedBitmap.getRoaringBitmap(pricePredicateFilteredOutEntities)
+			);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/PriceHistogramComputer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/PriceHistogramComputer.java
@@ -526,6 +526,14 @@ public class PriceHistogramComputer implements CacheableEvitaResponseExtraResult
 			return narrowedCount == narrowedPrices.length ?
 				narrowedPrices : Arrays.copyOf(narrowedPrices, narrowedCount);
 		}
+		// pass 2 deliberately queries **every** accessor, including the ones pass 1 already merged. Subtracting
+		// `histogramAccessors` here looks like a free optimization — a remainder entity is by construction one
+		// their histogram side-output did not cover — but it is wrong: this collector reads
+		// `getFilteredPriceRecords()`, not `getFilteredPriceRecordsForHistogram()`, and for `SelectionFormula`
+		// those two deliberately differ. The wrapper reports the per-inner-record side-output of its *exposing*
+		// inners only, while its regular records cover the whole price container. On a prefetched plan that
+		// wrapper is the single accessor, so excluding it leaves nothing to answer for the NONE/SUM remainder
+		// and those entities drop out of the histogram entirely (verified: 8 data points become 4).
 		final PriceRecordContract[] perEntityPrices = FilteredPriceRecords
 			.collectFilteredPriceRecordsFromPriceRecordAccessors(
 				this.filteredPriceRecordAccessors, remainder, this.context

--- a/evita_engine/src/main/java/io/evitadb/index/array/UnorderedLookupTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/UnorderedLookupTree.java
@@ -1044,7 +1044,7 @@ public class UnorderedLookupTree implements
 		for (final LeafNode leaf : collectLeaves()) {
 			// create-free reset: this runs at flush time after commit() has forbidden new layer creation, and the walk
 			// visits EVERY leaf including collapse survivors this transaction never touched (which carry no layer) - so
-			// it must NOT route through the create-on-write setPageSequence/clearDirty (see LeafNode.forgetPage)
+			// it must not create a layer either (see LeafNode.forgetPage)
 			leaf.forgetPage();
 		}
 	}
@@ -2759,12 +2759,26 @@ public class UnorderedLookupTree implements
 		}
 
 		/**
-		 * Stamps this leaf's logical persistence page sequence, decoupling into the transactional layer when present.
-		 * Structural bookkeeping only — does NOT flag the leaf dirty.
+		 * Stamps this leaf's logical persistence page sequence, writing through an EXISTING transactional layer when
+		 * one is present but NEVER creating one — the same create-free contract as {@link #forgetPage()}, and for the
+		 * same reason. Structural bookkeeping only — does NOT flag the leaf dirty.
+		 *
+		 * This is called from the flush path ({@code PageStreamRegistry.collectChangedPages}), which runs INSIDE the
+		 * commit — {@code TransactionTrunkFinalizer.commitCatalogChanges} flushes the catalog after
+		 * {@link io.evitadb.core.transaction.memory.TransactionalLayerMaintainer#commit} has already forbidden new
+		 * layer creation. The emitter walks EVERY leaf and stamps each one not yet paged, so a leaf the transaction
+		 * never touched (which carries no layer) reaches this method routinely: a create-on-write stamp would trip the
+		 * "already committed" premise on it and abort the commit. That is exactly what happens on the first write to a
+		 * chain index restored from a legacy, non-paged `ChainIndexStoragePart` — every leaf of such a tree is fresh
+		 * (see issue #1437).
+		 *
+		 * Writing the committed baseline field in place is what the merge carries forward anyway: with no layer,
+		 * {@link #createCopyWithMergedTransactionalMemory} returns `this`. When a layer DOES exist the merge takes the
+		 * layer's value, so the stamp must land there — hence the branch rather than an unconditional field write.
 		 */
 		void setPageSequence(int pageSequence) {
 			final LeafNode layer = this.transactionalLayer ?
-				Transaction.getOrCreateTransactionalMemoryLayer(this) : null;
+				Transaction.getTransactionalMemoryLayerIfExists(this) : null;
 			if (layer == null) {
 				this.pageSequence = pageSequence;
 			} else {
@@ -2782,12 +2796,15 @@ public class UnorderedLookupTree implements
 		}
 
 		/**
-		 * Clears this leaf's dirty flag, decoupling into the transactional layer when present. Called by the page emitter
-		 * once the leaf's page has been collected for the current flush.
+		 * Clears this leaf's dirty flag, writing through an EXISTING transactional layer when one is present but NEVER
+		 * creating one. Called by the page emitter once the leaf's page has been collected for the current flush —
+		 * i.e. from the very same post-{@code commit()} flush pass as {@link #setPageSequence(int)}, and therefore
+		 * bound by the same create-free contract (see that method for the full rationale). Symmetric with the
+		 * create-free read path {@link #isDirty()}: the flag is cleared exactly where it was read from.
 		 */
 		void clearDirty() {
 			final LeafNode layer = this.transactionalLayer ?
-				Transaction.getOrCreateTransactionalMemoryLayer(this) : null;
+				Transaction.getTransactionalMemoryLayerIfExists(this) : null;
 			if (layer == null) {
 				this.dirty = false;
 			} else {
@@ -2798,9 +2815,10 @@ public class UnorderedLookupTree implements
 		/**
 		 * Resets this leaf's page bookkeeping — un-assigns the page sequence and clears the dirty flag — as part of a
 		 * `PAGED->SINGLE` collapse (see {@link #forgetPageStream()}). Writes through an EXISTING transactional layer when
-		 * one is present, but NEVER creates one — unlike {@link #setPageSequence(int)} / {@link #clearDirty()}, which route
-		 * through the create-on-write path. This runs at flush time, INSIDE the commit, after
-		 * {@link io.evitadb.core.transaction.memory.TransactionalLayerMaintainer#commit} has forbidden new layer creation;
+		 * one is present, but NEVER creates one — the same create-free contract the rest of the flush-path page
+		 * bookkeeping ({@link #setPageSequence(int)} / {@link #clearDirty()}) obeys. This runs at flush time, INSIDE
+		 * the commit, after {@link io.evitadb.core.transaction.memory.TransactionalLayerMaintainer#commit} has
+		 * forbidden new layer creation;
 		 * because `forgetPageStream` walks EVERY leaf (a collapse survivor can be a leaf this transaction never touched, so
 		 * it carries no layer), a create-on-write reset would trip the "already committed" premise on that untouched leaf.
 		 * A leaf with no layer has no pending diff, so resetting its committed baseline field in place is what the merge

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
@@ -78,6 +78,7 @@ import io.evitadb.api.requestResponse.system.SystemStatus;
 import io.evitadb.driver.cdc.ClientChangeCapturePublisher;
 import io.evitadb.driver.cdc.ClientChangeSystemCaptureProcessor;
 import io.evitadb.driver.config.ClientConnectionOptions;
+import io.evitadb.driver.EvitaClientChannel.TimeoutTier;
 import io.evitadb.driver.config.ClientTimeoutOptions;
 import io.evitadb.driver.config.ClientTlsOptions;
 import io.evitadb.driver.config.EvitaClientConfiguration;
@@ -192,6 +193,12 @@ public class EvitaClient implements EvitaContract {
 	private static final long CDC_CALLBACK_DRAIN_TIMEOUT_MS = 5_000L;
 	/**
 	 * Client call timeout.
+	 *
+	 * The bottom of the stack is the configured {@link ClientTimeoutOptions#timeout()} - the *whole-call*
+	 * tier. Anything above it was pushed by {@link #executeWithExtendedTimeout} and is an explicit
+	 * caller override. Prefer {@link #resolveTimeout(TimeoutTier)} over reading this directly: peeking
+	 * at it hands every call the whole-call budget, which is wrong for a stream and is precisely the bug
+	 * {@link TimeoutTier} was introduced to end.
 	 */
 	final ThreadLocal<LinkedList<Timeout>> timeout;
 	/**
@@ -489,6 +496,9 @@ public class EvitaClient implements EvitaContract {
 	 *                          those paths this value is overwritten anyway. Measured: disabling it changes
 	 *                          nothing (see the ADR's *Verification*). It is kept so that a future call site
 	 *                          which forgets the deadline still gets a sane window rather than 15 s.
+	 * @param streaming         `true` for a channel carrying server-streaming calls, which lifts Armeria's
+	 *                          10 MiB total-response-length cap - see the call site for why that cap is
+	 *                          meaningless on a stream and fatal for large file downloads
 	 * @param connectionOptions connection options providing the client id reported to the server
 	 * @param clientVersion     semantic version of this client, or NULL when it could not be parsed
 	 * @param grpcConfigurator  optional caller-supplied customization applied last, so it can override defaults
@@ -500,6 +510,7 @@ public class EvitaClient implements EvitaContract {
 		@Nonnull ClientFactory clientFactory,
 		@Nullable RetryRule retryRule,
 		@Nullable Duration responseTimeout,
+		boolean streaming,
 		@Nonnull ClientConnectionOptions connectionOptions,
 		@Nullable SemVer clientVersion,
 		@Nullable Consumer<GrpcClientBuilder> grpcConfigurator
@@ -522,6 +533,16 @@ public class EvitaClient implements EvitaContract {
 		}
 		if (responseTimeout != null) {
 			grpcClientBuilder.responseTimeout(responseTimeout);
+		}
+		if (streaming) {
+			// Armeria caps a response at 10 MiB by default, and the cap counts the *entire* HTTP body -
+			// which for a server-streaming call is every message added together, not the largest one.
+			// That is a sane guard on a unary reply and a hard ceiling on a stream: `fetchFile` could not
+			// download a backup larger than 10 MiB at all, dying part-way through with
+			// RESOURCE_EXHAUSTED. A stream's total length is not a meaningful safety bound - what needs
+			// bounding is how much is in flight at once, which is the server's job (see
+			// `GrpcOutboundGate`) - so the cap is lifted here and left in place for unary calls.
+			grpcClientBuilder.maxResponseLength(0);
 		}
 
 		ofNullable(grpcConfigurator).ifPresent(it -> it.accept(grpcClientBuilder));
@@ -797,20 +818,20 @@ public class EvitaClient implements EvitaContract {
 		// response-timeout deadline at call start and caps every stream at 15 s (issue #1388).
 		this.unaryChannel = new EvitaClientChannel.Unary(
 			createGrpcClientBuilder(
-				uri, this.clientFactory, createRetryRule(configuration.retry()), null, connectionOptions,
-				clientVersion, grpcConfigurator
+				uri, this.clientFactory, createRetryRule(configuration.retry()), null, false,
+				connectionOptions, clientVersion, grpcConfigurator
 			)
 		);
 		this.streamingChannel = new EvitaClientChannel.Streaming(
 			createGrpcClientBuilder(
-				uri, this.clientFactory, null, this.streamingTimeout, connectionOptions, clientVersion,
-				grpcConfigurator
+				uri, this.clientFactory, null, this.streamingTimeout, true,
+				connectionOptions, clientVersion, grpcConfigurator
 			)
 		);
 		this.cdcChannel = new EvitaClientChannel.Cdc(
 			createGrpcClientBuilder(
-				uri, this.cdcClientFactory, null, this.streamingTimeout, connectionOptions, clientVersion,
-				grpcConfigurator
+				uri, this.cdcClientFactory, null, this.streamingTimeout, true,
+				connectionOptions, clientVersion, grpcConfigurator
 			)
 		);
 		this.evitaServiceFutureStub = this.unaryChannel.stub(EvitaServiceFutureStub.class);
@@ -1615,6 +1636,27 @@ public class EvitaClient implements EvitaContract {
 		} finally {
 			callTimeouts.pop();
 		}
+	}
+
+	/**
+	 * Resolves the deadline a call of the passed tier runs under.
+	 *
+	 * An explicit {@link #executeWithExtendedTimeout} override wins over both tiers: the caller named a
+	 * duration for the work inside that lambda, and silently substituting a configured default for it -
+	 * in either direction - would defeat the point of the API. Absent an override, the tier decides, so
+	 * that a streaming call is budgeted per message rather than per call.
+	 *
+	 * @param tier which of the configured budgets applies, normally taken from the channel the call's
+	 *             stub was built from
+	 * @return the timeout to deadline the call with
+	 */
+	@Nonnull
+	Timeout resolveTimeout(@Nonnull TimeoutTier tier) {
+		final LinkedList<Timeout> callTimeouts = this.timeout.get();
+		// the stack is seeded with exactly one element, so anything beyond that is a caller override
+		return callTimeouts.size() > 1 ?
+			Objects.requireNonNull(callTimeouts.peek()) :
+			tier.resolve(this.configuration.timeouts());
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientChannel.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientChannel.java
@@ -24,6 +24,7 @@
 package io.evitadb.driver;
 
 import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
+import io.evitadb.driver.config.ClientTimeoutOptions;
 
 import javax.annotation.Nonnull;
 
@@ -64,6 +65,14 @@ public sealed interface EvitaClientChannel {
 	GrpcClientBuilder builder();
 
 	/**
+	 * Which of the two configured budgets a call on this channel is deadlined from.
+	 *
+	 * @return the tier every stub built from this channel must be budgeted with
+	 */
+	@Nonnull
+	TimeoutTier timeoutTier();
+
+	/**
 	 * Builds a stub bound to this channel.
 	 *
 	 * @param stubType the generated gRPC stub class to instantiate
@@ -82,6 +91,12 @@ public sealed interface EvitaClientChannel {
 	 * @param builder the retry-decorated builder bound to the main client factory
 	 */
 	record Unary(@Nonnull GrpcClientBuilder builder) implements EvitaClientChannel {
+
+		@Nonnull
+		@Override
+		public TimeoutTier timeoutTier() {
+			return TimeoutTier.WHOLE_CALL;
+		}
 	}
 
 	/**
@@ -91,6 +106,12 @@ public sealed interface EvitaClientChannel {
 	 * @param builder the undecorated builder bound to the main client factory
 	 */
 	record Streaming(@Nonnull GrpcClientBuilder builder) implements EvitaClientChannel {
+
+		@Nonnull
+		@Override
+		public TimeoutTier timeoutTier() {
+			return TimeoutTier.PER_MESSAGE;
+		}
 	}
 
 	/**
@@ -101,6 +122,52 @@ public sealed interface EvitaClientChannel {
 	 * @param builder the undecorated builder bound to the dedicated CDC client factory
 	 */
 	record Cdc(@Nonnull GrpcClientBuilder builder) implements EvitaClientChannel {
+
+		@Nonnull
+		@Override
+		public TimeoutTier timeoutTier() {
+			return TimeoutTier.PER_MESSAGE;
+		}
+	}
+
+	/**
+	 * Which of {@link ClientTimeoutOptions}' two budgets deadlines a call, and - just as importantly -
+	 * *what the number means*. The two are not interchangeable, and pairing a call with the wrong one is
+	 * the mistake this enum exists to make un-makeable: the tier travels with the channel, so a stub
+	 * cannot be budgeted from a tier its channel does not carry.
+	 *
+	 * The management facade is what motivated it. It had no notion of tiers at all and took the
+	 * whole-call budget for everything, including `fetchFile` - so a default-configured client could not
+	 * download a backup that took longer than {@link ClientTimeoutOptions#timeout()} (5 s), whatever the
+	 * server did. No test caught it, because every harness client raises that value.
+	 */
+	enum TimeoutTier {
+
+		/**
+		 * {@link ClientTimeoutOptions#timeout()} - a budget for the **entire call**, appropriate where the
+		 * work is one bounded round trip. Nothing re-arms it, and nothing should.
+		 */
+		WHOLE_CALL,
+		/**
+		 * {@link ClientTimeoutOptions#streamingTimeout()} - the wait for the **next message**, not the
+		 * length of the exchange. A call budgeted from this tier must re-arm its response timeout on
+		 * every message received, or the rolling deadline silently degenerates into a whole-call one that
+		 * merely happens to be larger.
+		 */
+		PER_MESSAGE;
+
+		/**
+		 * Resolves this tier against the client's configured timeouts.
+		 *
+		 * @param timeouts the client's timeout configuration
+		 * @return the budget calls of this tier are deadlined from
+		 */
+		@Nonnull
+		public Timeout resolve(@Nonnull ClientTimeoutOptions timeouts) {
+			return this == WHOLE_CALL ?
+				new Timeout(timeouts.timeout(), timeouts.timeoutUnit()) :
+				new Timeout(timeouts.streamingTimeout(), timeouts.streamingTimeoutUnit());
+		}
 	}
 
 }

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientManagement.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientManagement.java
@@ -25,9 +25,12 @@ package io.evitadb.driver;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.google.protobuf.Empty;
 import com.google.protobuf.StringValue;
 import io.evitadb.api.CatalogStatistics;
+import io.evitadb.driver.EvitaClientChannel.TimeoutTier;
 import io.evitadb.api.EvitaManagementContract;
 import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.exception.FileForFetchNotFoundException;
@@ -60,7 +63,6 @@ import java.io.Closeable;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -69,15 +71,14 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter.toGrpcUuid;
@@ -89,6 +90,18 @@ import static io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter.toGrp
  */
 @Slf4j
 public class EvitaClientManagement implements EvitaManagementContract, Closeable {
+	/**
+	 * Size of a single chunk uploaded by {@link #restoreCatalog(String, long, InputStream)}.
+	 *
+	 * Each chunk travels as its own unary request, so the binding constraint is the server's
+	 * `maxRequestLength` - evitaDB wires that to `api.maxEntitySizeInBytes`, whose default is 2 MB.
+	 * 512 KB leaves generous room for the protobuf envelope underneath that default while cutting the
+	 * number of round trips eightfold against the 64 KB the client-streaming upload used. Nothing here
+	 * can discover the server's actual setting, so an operator who lowers `maxEntitySizeInBytes` below
+	 * this value has to raise it back above the chunk size.
+	 */
+	private static final int RESTORE_CHUNK_SIZE = 524_288;
+
 	/**
 	 * Evita client used for communication with the server side.
 	 */
@@ -105,6 +118,29 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 	 * Created evita service stub that returns futures.
 	 */
 	private final EvitaManagementServiceFutureStub evitaManagementServiceFutureStub;
+	/**
+	 * Stub used to upload a catalog backup chunk by chunk.
+	 *
+	 * Deliberately built on the **streaming** channel even though `RestoreCatalogUnary` is a unary call.
+	 * The unary channel carries the retry decorator, and with `retry` enabled that rule set replays on
+	 * timeouts and on 503/504/UNKNOWN. Replaying a chunk would append it to the uploaded archive a second
+	 * time - the server notices the overshoot and fails the restore, so the damage is a spurious failure
+	 * rather than a corrupted catalog, but appending is not idempotent and has no business running on a
+	 * channel that replays.
+	 */
+	private final EvitaManagementServiceFutureStub evitaManagementServiceUploadStub;
+	/**
+	 * Deadline tier of {@link #evitaManagementServiceStub}, taken from the channel it was built on.
+	 */
+	private final TimeoutTier streamingStubTier;
+	/**
+	 * Deadline tier of {@link #evitaManagementServiceFutureStub}, taken from the channel it was built on.
+	 */
+	private final TimeoutTier unaryStubTier;
+	/**
+	 * Deadline tier of {@link #evitaManagementServiceUploadStub}, taken from the channel it was built on.
+	 */
+	private final TimeoutTier uploadStubTier;
 
 	/**
 	 * Creates the management facade.
@@ -132,6 +168,12 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 		);
 		this.evitaManagementServiceStub = streamingChannel.stub(EvitaManagementServiceStub.class);
 		this.evitaManagementServiceFutureStub = unaryChannel.stub(EvitaManagementServiceFutureStub.class);
+		this.evitaManagementServiceUploadStub = streamingChannel.stub(EvitaManagementServiceFutureStub.class);
+		// each stub is budgeted from the tier its own channel carries, paired here - the one place where
+		// both are in scope - so that no method below can pick a tier at all, let alone the wrong one
+		this.streamingStubTier = streamingChannel.timeoutTier();
+		this.unaryStubTier = unaryChannel.timeoutTier();
+		this.uploadStubTier = streamingChannel.timeoutTier();
 	}
 
 	@Nonnull
@@ -183,75 +225,69 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 	) throws UnexpectedIOException {
 		this.evitaClient.assertActive();
 
-		return executeWithEvitaBlockingService(
-			evitaService -> {
-				final CompletableFuture<TaskStatus<?, ?>> result = new CompletableFuture<>();
-				final AtomicLong bytesSent = new AtomicLong(0);
-				final AtomicReference<TaskStatus<?, ?>> taskStatus = new AtomicReference<>();
-				final StreamObserver<GrpcRestoreCatalogRequest> requestObserver = evitaService.restoreCatalog(
-					new StreamObserver<>() {
-						final AtomicLong bytesReceived = new AtomicLong(0);
-
-						@Override
-						public void onNext(GrpcRestoreCatalogResponse value) {
-							this.bytesReceived.accumulateAndGet(value.getRead(), Math::max);
-							if (value.hasTask()) {
-								taskStatus.set(EvitaDataTypesConverter.toTaskStatus(value.getTask()));
-							}
-						}
-
-						@Override
-						public void onError(Throwable t) {
-							log.error("Error occurred during catalog restoration: {}", t.getMessage(), t);
-							result.completeExceptionally(t);
-						}
-
-						@Override
-						public void onCompleted() {
-							if (bytesSent.get() == this.bytesReceived.get()) {
-								result.complete(taskStatus.get());
-							} else {
-								result.completeExceptionally(
-									new UnexpectedIOException(
-										"Number of bytes sent and received during catalog restoration does not match (sent " + bytesSent.get() + ", received " + this.bytesReceived.get() + ")!",
-										"Number of bytes sent and received during catalog restoration does not match!"
-									)
-								);
-							}
-						}
-					}
-				);
-
-				// Send data in chunks
-				final ByteBuffer buffer = ByteBuffer.allocate(65_536);
-				try (inputStream) {
-					while (inputStream.available() > 0) {
-						final int read = inputStream.read(buffer.array());
-						if (read == -1) {
-							requestObserver.onCompleted();
-						}
-						buffer.limit(read);
-						requestObserver.onNext(
-							GrpcRestoreCatalogRequest.newBuilder()
-								.setCatalogName(catalogName)
-								.setBackupFile(ByteString.copyFrom(buffer))
-								.build()
-						);
-						buffer.clear();
-						bytesSent.addAndGet(read);
-					}
-
-					requestObserver.onCompleted();
-				} catch (IOException e) {
-					requestObserver.onError(e);
-					throw new RuntimeException(e);
+		// Uploaded through the chunked unary RPC rather than the client-streaming one, deliberately.
+		// A client-streaming upload is a *single* HTTP request, so the server's `maxRequestLength` -
+		// which evitaDB wires to `api.maxEntitySizeInBytes`, 2 MB by default - caps the whole backup;
+		// anything larger died part-way through with a bare RESOURCE_EXHAUSTED, which made the streaming
+		// variant unusable for a catalog of any real size. With the unary variant every chunk is its own
+		// request, so only the chunk has to fit under that limit. The server accumulates the chunks into
+		// one temporary file keyed by the `fileId` it echoes back in the first response, and submits the
+		// restoration task once the accumulated size reaches `totalBytesExpected`.
+		final byte[] buffer = new byte[RESTORE_CHUNK_SIZE];
+		GrpcTaskStatus restorationTask = null;
+		GrpcUuid uploadFileId = null;
+		long bytesSent = 0L;
+		try (inputStream) {
+			int bytesRead;
+			while ((bytesRead = inputStream.read(buffer)) != -1) {
+				final GrpcRestoreCatalogUnaryRequest.Builder requestBuilder = GrpcRestoreCatalogUnaryRequest
+					.newBuilder()
+					.setCatalogName(catalogName)
+					.setTotalSizeInBytes(totalBytesExpected)
+					.setBackupFile(ByteString.copyFrom(buffer, 0, bytesRead));
+				// every chunk but the first names the upload it belongs to
+				if (uploadFileId != null) {
+					requestBuilder.setFileId(uploadFileId);
 				}
-
-				//noinspection unchecked
-				return (Task<?, Void>) this.clientTaskTracker.createTask(
-					Objects.requireNonNull(result.get())
+				final GrpcRestoreCatalogUnaryRequest request = requestBuilder.build();
+				final GrpcRestoreCatalogUnaryResponse response = executeWithEvitaUploadService(
+					evitaService -> evitaService.restoreCatalogUnary(request)
 				);
+				restorationTask = response.getTask();
+				if (uploadFileId == null) {
+					// the response's own `fileId` is the documented handle for the upload - the id on the
+					// task's file descriptor is not populated on the first chunk
+					uploadFileId = response.getFileId();
+				}
+				bytesSent += bytesRead;
 			}
+		} catch (IOException e) {
+			throw new UnexpectedIOException(
+				"Failed to read the backup file being restored: " + e.getMessage(),
+				"Failed to read the backup file being restored.",
+				e
+			);
+		}
+
+		if (restorationTask == null) {
+			throw new UnexpectedIOException(
+				"The backup file being restored contains no data.",
+				"The backup file being restored contains no data."
+			);
+		}
+		// the server submits the restoration task only once the uploaded size reaches the announced one,
+		// so a mismatch here would otherwise hand back a task that is never going to run
+		if (bytesSent != totalBytesExpected) {
+			throw new UnexpectedIOException(
+				"Number of bytes uploaded during catalog restoration does not match the announced size " +
+					"(announced " + totalBytesExpected + ", uploaded " + bytesSent + ")!",
+				"Number of bytes uploaded during catalog restoration does not match the announced size!"
+			);
+		}
+
+		//noinspection unchecked
+		return (Task<?, Void>) this.clientTaskTracker.createTask(
+			EvitaDataTypesConverter.toTaskStatus(restorationTask)
 		);
 	}
 
@@ -414,6 +450,11 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 			// Create a temporary file
 			Path tempFile = Files.createTempFile("downloadedFile", ".tmp");
 			CompletableFuture<Void> downloadFuture = new CompletableFuture<>();
+			// A download is deadlined per message, not per call - see `TimeoutTier#PER_MESSAGE`. Both
+			// clocks below are driven from this one stamp: the transport's response timeout, re-armed in
+			// `onNext`, and the caller's own wait, which is recomputed from it rather than fixed.
+			final Timeout stallTimeout = this.evitaClient.resolveTimeout(this.streamingStubTier);
+			final AtomicLong lastProgressNanos = new AtomicLong(System.nanoTime());
 
 			// Download the file asynchronously
 			executeWithEvitaBlockingService(
@@ -426,6 +467,19 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 								try {
 									// Write chunks to the temporary file
 									Files.write(tempFile, response.getFileContents().toByteArray(), StandardOpenOption.APPEND);
+									lastProgressNanos.set(System.nanoTime());
+									// Roll the transport deadline forward: without this the response
+									// timeout bounds the *whole* download, so a backup simply larger than
+									// the link is fast enough to move in one window can never arrive, no
+									// matter how healthily it is progressing. Same re-arm the session's
+									// streaming observers do.
+									ClientRequestContext.current().setResponseTimeout(
+										TimeoutMode.SET_FROM_NOW,
+										Duration.of(
+											stallTimeout.timeout(),
+											stallTimeout.timeoutUnit().toChronoUnit()
+										)
+									);
 								} catch (IOException e) {
 									onError(e);
 								}
@@ -446,13 +500,14 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 				}
 			);
 
-			// Wait for the download to complete with timeout
-			final Timeout timeout = Objects.requireNonNull(this.evitaClient.timeout.get().peek());
+			// Wait for the download to stop making progress, rather than for it to fit in a fixed budget.
+			// A plain `get(stallTimeout)` here would reintroduce the whole-call cap the tier and the
+			// per-message re-arm above just removed - it would simply cap the download at a larger number.
 			try {
-				downloadFuture.get(timeout.timeout(), timeout.timeoutUnit());
+				awaitDownloadProgress(downloadFuture, lastProgressNanos, stallTimeout);
 			} catch (TimeoutException e) {
 				downloadFuture.cancel(true);
-				throw new EvitaClientTimedOutException(timeout.timeout(), timeout.timeoutUnit());
+				throw new EvitaClientTimedOutException(stallTimeout.timeout(), stallTimeout.timeoutUnit());
 			} catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 				throw new EvitaClientServerCallException("File download interrupted.", e);
@@ -563,6 +618,48 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 	}
 
 	/**
+	 * Waits for a streamed download to finish, giving up only once it has made **no progress** for
+	 * `stallTimeout` - not once it has taken `stallTimeout` in total.
+	 *
+	 * The distinction is the whole point of {@link TimeoutTier#PER_MESSAGE}: a download's duration is a
+	 * function of the file's size and the link's speed, neither of which the client knows, so any fixed
+	 * budget is a guess that a large enough backup will always lose. What can be bounded is silence.
+	 *
+	 * Waiting in recomputed slices, rather than simply blocking forever and trusting the transport to
+	 * fail the future, is deliberate: it keeps a caller-side bound on a hang that never produces a
+	 * terminal event. A spurious timeout is recoverable, a permanently parked application thread is not.
+	 *
+	 * @param downloadFuture    future completed by the stream's terminal event
+	 * @param lastProgressNanos `System.nanoTime()` stamp of the most recently received message, updated
+	 *                          by the observer as the download proceeds
+	 * @param stallTimeout      how long the stream may stay silent before it is considered dead
+	 * @throws TimeoutException     when nothing arrived for the whole `stallTimeout`
+	 * @throws InterruptedException when the waiting thread is interrupted
+	 * @throws ExecutionException   when the download itself failed
+	 */
+	private static void awaitDownloadProgress(
+		@Nonnull CompletableFuture<Void> downloadFuture,
+		@Nonnull AtomicLong lastProgressNanos,
+		@Nonnull Timeout stallTimeout
+	) throws TimeoutException, InterruptedException, ExecutionException {
+		final long stallNanos = stallTimeout.timeoutUnit().toNanos(stallTimeout.timeout());
+		while (true) {
+			final long remainingNanos = stallNanos - (System.nanoTime() - lastProgressNanos.get());
+			if (remainingNanos <= 0L) {
+				throw new TimeoutException();
+			}
+			try {
+				downloadFuture.get(remainingNanos, TimeUnit.NANOSECONDS);
+				return;
+			} catch (TimeoutException e) {
+				// the window elapsed - but a message may have landed while we waited, which moves
+				// `lastProgressNanos` and makes the recomputed window positive again. Only a genuinely
+				// silent stream leaves it non-positive and exits above.
+			}
+		}
+	}
+
+	/**
 	 * Creates a new client task. If the task is not yet completed (finished or failed), it is added to the queue of
 	 * tracked tasks and its status is updated in the background, so that the {@link Task#getFutureResult()} is completed
 	 * when the task is finished.
@@ -588,7 +685,7 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 	private <T> T executeWithEvitaBlockingService(
 		@Nonnull AsyncCallFunction<EvitaManagementServiceStub, T> lambda
 	) {
-		final Timeout timeout = Objects.requireNonNull(this.evitaClient.timeout.get().peek());
+		final Timeout timeout = this.evitaClient.resolveTimeout(this.streamingStubTier);
 		try {
 			return lambda.apply(
 				this.evitaManagementServiceStub.withDeadlineAfter(timeout.timeout(), timeout.timeoutUnit())
@@ -619,9 +716,40 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 	private <T> T executeWithEvitaService(
 		@Nonnull AsyncCallFunction<EvitaManagementServiceFutureStub, ListenableFuture<T>> lambda
 	) {
-		final Timeout timeout = Objects.requireNonNull(this.evitaClient.timeout.get().peek());
+		return executeWithStub(this.evitaManagementServiceFutureStub, this.unaryStubTier, lambda);
+	}
+
+	/**
+	 * Runs a unary call on the non-retrying {@link #evitaManagementServiceUploadStub} - see that field
+	 * for why an append must not travel on a channel that replays.
+	 *
+	 * @param lambda function that holds a logic passed by the caller
+	 * @param <T>    return type of the function
+	 * @return result of the applied function
+	 */
+	private <T> T executeWithEvitaUploadService(
+		@Nonnull AsyncCallFunction<EvitaManagementServiceFutureStub, ListenableFuture<T>> lambda
+	) {
+		return executeWithStub(this.evitaManagementServiceUploadStub, this.uploadStubTier, lambda);
+	}
+
+	/**
+	 * Applies the passed logic on the given stub under the timeout its channel's tier resolves to.
+	 *
+	 * @param stub   stub to issue the call on
+	 * @param tier   deadline tier of that stub, i.e. the one its channel carries
+	 * @param lambda function that holds a logic passed by the caller
+	 * @param <T>    return type of the function
+	 * @return result of the applied function
+	 */
+	private <T> T executeWithStub(
+		@Nonnull EvitaManagementServiceFutureStub stub,
+		@Nonnull TimeoutTier tier,
+		@Nonnull AsyncCallFunction<EvitaManagementServiceFutureStub, ListenableFuture<T>> lambda
+	) {
+		final Timeout timeout = this.evitaClient.resolveTimeout(tier);
 		try {
-			return lambda.apply(this.evitaManagementServiceFutureStub.withDeadlineAfter(timeout.timeout(), timeout.timeoutUnit()))
+			return lambda.apply(stub.withDeadlineAfter(timeout.timeout(), timeout.timeoutUnit()))
 				.get(timeout.timeout(), timeout.timeoutUnit());
 		} catch (ExecutionException e) {
 			throw EvitaClient.transformException(

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientManagement.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientManagement.java
@@ -237,58 +237,95 @@ public class EvitaClientManagement implements EvitaManagementContract, Closeable
 		GrpcTaskStatus restorationTask = null;
 		GrpcUuid uploadFileId = null;
 		long bytesSent = 0L;
-		try (inputStream) {
-			int bytesRead;
-			while ((bytesRead = inputStream.read(buffer)) != -1) {
-				final GrpcRestoreCatalogUnaryRequest.Builder requestBuilder = GrpcRestoreCatalogUnaryRequest
-					.newBuilder()
-					.setCatalogName(catalogName)
-					.setTotalSizeInBytes(totalBytesExpected)
-					.setBackupFile(ByteString.copyFrom(buffer, 0, bytesRead));
-				// every chunk but the first names the upload it belongs to
-				if (uploadFileId != null) {
-					requestBuilder.setFileId(uploadFileId);
+		// flipped only once the upload is the caller's problem rather than ours - every other way out of
+		// this method leaves a half-written archive on the server that nobody has been told to discard
+		boolean handedOver = false;
+		try {
+			try (inputStream) {
+				int bytesRead;
+				while ((bytesRead = inputStream.read(buffer)) != -1) {
+					final GrpcRestoreCatalogUnaryRequest.Builder requestBuilder = GrpcRestoreCatalogUnaryRequest
+						.newBuilder()
+						.setCatalogName(catalogName)
+						.setTotalSizeInBytes(totalBytesExpected)
+						.setBackupFile(ByteString.copyFrom(buffer, 0, bytesRead));
+					// every chunk but the first names the upload it belongs to
+					if (uploadFileId != null) {
+						requestBuilder.setFileId(uploadFileId);
+					}
+					final GrpcRestoreCatalogUnaryRequest request = requestBuilder.build();
+					final GrpcRestoreCatalogUnaryResponse response = executeWithEvitaUploadService(
+						evitaService -> evitaService.restoreCatalogUnary(request)
+					);
+					restorationTask = response.getTask();
+					if (uploadFileId == null) {
+						// the response's own `fileId` is the documented handle for the upload - the id on the
+						// task's file descriptor is not populated on the first chunk
+						uploadFileId = response.getFileId();
+					}
+					bytesSent += bytesRead;
 				}
-				final GrpcRestoreCatalogUnaryRequest request = requestBuilder.build();
-				final GrpcRestoreCatalogUnaryResponse response = executeWithEvitaUploadService(
-					evitaService -> evitaService.restoreCatalogUnary(request)
+			} catch (IOException e) {
+				throw new UnexpectedIOException(
+					"Failed to read the backup file being restored: " + e.getMessage(),
+					"Failed to read the backup file being restored.",
+					e
 				);
-				restorationTask = response.getTask();
-				if (uploadFileId == null) {
-					// the response's own `fileId` is the documented handle for the upload - the id on the
-					// task's file descriptor is not populated on the first chunk
-					uploadFileId = response.getFileId();
-				}
-				bytesSent += bytesRead;
 			}
-		} catch (IOException e) {
-			throw new UnexpectedIOException(
-				"Failed to read the backup file being restored: " + e.getMessage(),
-				"Failed to read the backup file being restored.",
-				e
-			);
-		}
 
-		if (restorationTask == null) {
-			throw new UnexpectedIOException(
-				"The backup file being restored contains no data.",
-				"The backup file being restored contains no data."
-			);
-		}
-		// the server submits the restoration task only once the uploaded size reaches the announced one,
-		// so a mismatch here would otherwise hand back a task that is never going to run
-		if (bytesSent != totalBytesExpected) {
-			throw new UnexpectedIOException(
-				"Number of bytes uploaded during catalog restoration does not match the announced size " +
-					"(announced " + totalBytesExpected + ", uploaded " + bytesSent + ")!",
-				"Number of bytes uploaded during catalog restoration does not match the announced size!"
-			);
-		}
+			if (restorationTask == null) {
+				throw new UnexpectedIOException(
+					"The backup file being restored contains no data.",
+					"The backup file being restored contains no data."
+				);
+			}
+			// the server submits the restoration task only once the uploaded size reaches the announced one,
+			// so a mismatch here would otherwise hand back a task that is never going to run
+			if (bytesSent != totalBytesExpected) {
+				throw new UnexpectedIOException(
+					"Number of bytes uploaded during catalog restoration does not match the announced size " +
+						"(announced " + totalBytesExpected + ", uploaded " + bytesSent + ")!",
+					"Number of bytes uploaded during catalog restoration does not match the announced size!"
+				);
+			}
 
-		//noinspection unchecked
-		return (Task<?, Void>) this.clientTaskTracker.createTask(
-			EvitaDataTypesConverter.toTaskStatus(restorationTask)
-		);
+			handedOver = true;
+			//noinspection unchecked
+			return (Task<?, Void>) this.clientTaskTracker.createTask(
+				EvitaDataTypesConverter.toTaskStatus(restorationTask)
+			);
+		} finally {
+			if (!handedOver && restorationTask != null) {
+				abandonRestoreUpload(restorationTask);
+			}
+		}
+	}
+
+	/**
+	 * Tells the server to discard a restore upload this client has given up on.
+	 *
+	 * Once the first chunk has been accepted the server holds a temporary archive and a task waiting for
+	 * the rest of it, and a chunked unary upload has no half-close for the server to notice its absence
+	 * by. Cancelling the task is the abort signal: the task's completion hook is what deletes the partial
+	 * archive.
+	 *
+	 * Deliberately best effort. The server does not depend on this - the scheduler purges a task left
+	 * waiting for its precondition after ten minutes and the same hook runs then - and the failure that
+	 * brought us here has quite possibly taken the channel with it, so a cancellation that cannot be
+	 * delivered must not replace the original exception with a less informative one. All this buys is
+	 * releasing the disk space now rather than ten minutes from now.
+	 *
+	 * @param restorationTask status of the waiting restoration task, as returned by the last accepted chunk
+	 */
+	private void abandonRestoreUpload(@Nonnull GrpcTaskStatus restorationTask) {
+		try {
+			cancelTask(EvitaDataTypesConverter.toTaskStatus(restorationTask).taskId());
+		} catch (Exception ex) {
+			log.debug(
+				"Failed to abandon an unfinished catalog restore upload - the server will reclaim it when " +
+					"the waiting task is purged: {}", ex.getMessage()
+			);
+		}
 	}
 
 	@Nonnull

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/GrpcProviderRegistrar.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/GrpcProviderRegistrar.java
@@ -23,7 +23,9 @@
 
 package io.evitadb.externalApi.grpc;
 
+import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.grpc.GrpcExceptionHandlerFunction;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.server.cors.CorsService;
@@ -43,6 +45,8 @@ import io.evitadb.externalApi.grpc.services.interceptors.ServerSessionIntercepto
 import io.evitadb.externalApi.http.ExternalApiProvider;
 import io.evitadb.externalApi.http.ExternalApiProviderRegistrar;
 import io.evitadb.externalApi.http.ExternalApiServer;
+import io.evitadb.utils.ExceptionUtils;
+import io.grpc.Status;
 import io.grpc.protobuf.services.ProtoReflectionService;
 
 import javax.annotation.Nonnull;
@@ -53,6 +57,33 @@ import javax.annotation.Nonnull;
  * @author Tomáš Pozler, 2022
  */
 public class GrpcProviderRegistrar implements ExternalApiProviderRegistrar<GrpcOptions> {
+
+	/**
+	 * Turns Armeria's "request body too large" rejection into a status a client can act on.
+	 *
+	 * A client-streaming upload travels as a **single** HTTP request, so `maxRequestLength` - which
+	 * evitaDB wires to `api.maxEntitySizeInBytes` - bounds the whole upload rather than one message.
+	 * `RestoreCatalog` is the RPC that runs into it, and Armeria's default mapping is a bare
+	 * `RESOURCE_EXHAUSTED` with no description, indistinguishable from any other resource failure - the
+	 * client cannot tell that it hit a configured limit, let alone which one or what to do instead.
+	 *
+	 * Returning `null` for anything else hands the exception back to Armeria's default handler.
+	 */
+	private static final GrpcExceptionHandlerFunction OVERSIZED_REQUEST_HANDLER =
+		(ctx, status, cause, metadata) -> {
+			final ContentTooLargeException tooLarge = cause == null ?
+				null : ExceptionUtils.findInCauseChain(cause, ContentTooLargeException.class);
+			return tooLarge == null ?
+				null :
+				Status.RESOURCE_EXHAUSTED
+					.withDescription(
+						"Request body exceeds the server limit of " + tooLarge.maxContentLength() +
+							" B (`api.maxEntitySizeInBytes`). A client-streaming upload is one request, so " +
+							"the limit applies to the whole upload - send a large catalog backup through " +
+							"`RestoreCatalogUnary` instead, where every chunk is a request of its own."
+					)
+					.withCause(tooLarge);
+		};
 
 	@Nonnull
 	@Override
@@ -76,9 +107,15 @@ public class GrpcProviderRegistrar implements ExternalApiProviderRegistrar<GrpcO
 	) {
 		final GrpcServiceBuilder grpcServiceBuilder = GrpcService.builder()
 			.addService(new EvitaService(evita, apiOptions.headers()))
-			.addService(new EvitaManagementService(evita, externalApiServer, apiOptions.headers()))
-			.addService(new EvitaSessionService(evita, apiOptions.headers()))
-			.addService(new EvitaTrafficRecordingService(evita, apiOptions.headers()))
+			.addService(new EvitaManagementService(
+				evita, externalApiServer, apiOptions.headers(), grpcAPIConfig.getStreamingRequestTimeoutInMillis()
+			))
+			.addService(new EvitaSessionService(
+				evita, apiOptions.headers(), grpcAPIConfig.getStreamingRequestTimeoutInMillis()
+			))
+			.addService(new EvitaTrafficRecordingService(
+				evita, apiOptions.headers(), grpcAPIConfig.getStreamingRequestTimeoutInMillis()
+			))
 			.addService(ProtoReflectionService.newInstance())
 			.intercept(new ServerSessionInterceptor(evita))
 			.intercept(new GlobalExceptionHandlerInterceptor())
@@ -86,7 +123,8 @@ public class GrpcProviderRegistrar implements ExternalApiProviderRegistrar<GrpcO
 			.supportedSerializationFormats(GrpcSerializationFormats.values())
 			.enableHttpJsonTranscoding(true)
 			.enableUnframedRequests(true)
-			.useClientTimeoutHeader(true);
+			.useClientTimeoutHeader(true)
+			.exceptionHandler(OVERSIZED_REQUEST_HANDLER.orElse(GrpcExceptionHandlerFunction.of()));
 
 		final CorsServiceBuilder corsBuilder = CorsService.builderForAnyOrigin()
 			.allowRequestMethods(HttpMethod.POST) // Allow POST method.

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/configuration/GrpcOptions.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/configuration/GrpcOptions.java
@@ -49,9 +49,36 @@ public class GrpcOptions extends AbstractApiOptions {
 	 */
 	public static final int DEFAULT_GRPC_PORT = 5555;
 	/**
+	 * Default value of {@link #getStreamingRequestTimeoutInMillis()}.
+	 */
+	public static final long DEFAULT_STREAMING_REQUEST_TIMEOUT_IN_MILLIS = 300_000L;
+	/**
 	 * Allows to expose the Armeria specific docs service on the gRPC API.
 	 */
 	@Getter private final boolean exposeDocsService;
+
+	/**
+	 * How long a **streaming** RPC may make no progress before the server abandons it, in milliseconds.
+	 *
+	 * `api.requestTimeoutInMillis` is a budget for a *whole request*. That is the right shape for a unary
+	 * call, where the work is one bounded round trip, and the wrong shape for a server-streaming one: a
+	 * download's duration is a function of the file's size and the link's speed, neither of which the
+	 * server knows, so any whole-request budget silently becomes a cap on what can be transferred at all.
+	 * This option is the streaming counterpart - it bounds *silence*. It is re-armed every time a message
+	 * is handed to the transport, so a slow but steadily progressing transfer never reaches it however
+	 * long it runs.
+	 *
+	 * The same value bounds how long {@link io.evitadb.externalApi.grpc.utils.GrpcOutboundGate} parks a
+	 * producing worker waiting for a client that has stopped reading, so it is also the point at which
+	 * such a stream is abandoned with `DEADLINE_EXCEEDED`. Size it against the slowest client to be
+	 * served: it must comfortably exceed the time a **single message** takes to reach that client.
+	 * Lowering it towards `requestTimeoutInMillis` reintroduces a minimum viable link speed - `fetchFile`
+	 * streams 1 MB chunks, so a 2 s budget would demand roughly 4 Mbit/s sustained.
+	 *
+	 * This lives here rather than in `ApiOptions` because it is enforced by gRPC-specific machinery. The
+	 * other APIs' long-lived endpoints (the REST and GraphQL WebSocket handlers) do not consume it.
+	 */
+	@Getter private final long streamingRequestTimeoutInMillis;
 
 	/**
 	 * Controls the prefix gRPC API will react on.
@@ -64,12 +91,14 @@ public class GrpcOptions extends AbstractApiOptions {
 		super(true, ":" + DEFAULT_GRPC_PORT);
 		this.exposeDocsService = false;
 		this.prefix = BASE_GRPC_PATH;
+		this.streamingRequestTimeoutInMillis = DEFAULT_STREAMING_REQUEST_TIMEOUT_IN_MILLIS;
 	}
 
 	public GrpcOptions(@Nonnull String host) {
 		super(true, host);
 		this.exposeDocsService = false;
 		this.prefix = BASE_GRPC_PATH;
+		this.streamingRequestTimeoutInMillis = DEFAULT_STREAMING_REQUEST_TIMEOUT_IN_MILLIS;
 	}
 
 	@JsonCreator
@@ -80,11 +109,17 @@ public class GrpcOptions extends AbstractApiOptions {
 	                   @Nullable @JsonProperty("keepAlive") Boolean keepAlive,
 	                   @Nullable @JsonProperty("exposeDocsService") Boolean exposeDocsService,
 	                   @Nullable @JsonProperty("prefix") String prefix,
+	                   @Nullable @JsonProperty("streamingRequestTimeoutInMillis") Long streamingRequestTimeoutInMillis,
 	                   @Nullable @JsonProperty("mTLS") MtlsConfiguration mtlsConfiguration
 	) {
 		super(enabled, host, exposeOn, tlsMode, keepAlive, mtlsConfiguration);
 		this.exposeDocsService = ofNullable(exposeDocsService).orElse(false);
 		this.prefix = ofNullable(prefix).orElse(BASE_GRPC_PATH);
+		// a non-positive value is meaningless for a stall budget and would disable the re-arm entirely,
+		// so it falls back to the default rather than silently reinstating the whole-request budget
+		this.streamingRequestTimeoutInMillis = ofNullable(streamingRequestTimeoutInMillis)
+			.filter(it -> it > 0L)
+			.orElse(DEFAULT_STREAMING_REQUEST_TIMEOUT_IN_MILLIS);
 	}
 
 	@Override

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/exception/StalledGrpcStreamException.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/exception/StalledGrpcStreamException.java
@@ -1,0 +1,58 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc.exception;
+
+import io.evitadb.exception.EvitaInvalidUsageException;
+
+import javax.annotation.Nonnull;
+import java.io.Serial;
+
+/**
+ * Raised when a server-streaming RPC has been waiting for the client to consume already-sent data for
+ * longer than the configured stall timeout, while the connection itself is still alive.
+ *
+ * This is the "the client stopped reading but never hung up" case — a paused SSH/`kubectl port-forward`
+ * tunnel, a suspended browser tab, a consumer blocked on its own downstream. The transport never
+ * cancels, so nothing else would ever end the call: without this exception the producing worker thread
+ * would park indefinitely and the RPC would hang forever from both sides.
+ *
+ * It is a client/network condition rather than a server fault, so it is logged at WARN and translated
+ * to `DEADLINE_EXCEEDED` by
+ * {@link io.evitadb.externalApi.grpc.services.interceptors.GlobalExceptionHandlerInterceptor} — a
+ * status the client can act on, unlike the bare `UNKNOWN` that an exhausted allocator used to produce.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class StalledGrpcStreamException extends EvitaInvalidUsageException {
+	@Serial private static final long serialVersionUID = -3255905625734017402L;
+
+	public StalledGrpcStreamException(@Nonnull String methodName, long stallTimeoutMillis) {
+		super(
+			"Client of `" + methodName + "` has not consumed any data for " + stallTimeoutMillis +
+				" ms while the stream stayed open; abandoning the response stream.",
+			"The client stopped consuming the response stream and the transfer timed out."
+		);
+	}
+
+}

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaManagementService.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaManagementService.java
@@ -85,6 +85,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
@@ -394,6 +395,8 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 		return new RestoreCatalogUploadObserver(
 			serverCallObserver,
 			ServiceRequestContext.current(),
+			this.evita.getConfiguration().transaction().transactionWorkDirectory(),
+			this.management,
 			this.evita.getRequestExecutor(),
 			this.streamingRequestTimeoutInMillis
 		);
@@ -434,6 +437,27 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 							request.getTotalSizeInBytes(),
 							true
 						);
+						// The archive assembled here has no other owner. `createTempFile` deliberately does
+						// not reserve the file (that is `createManagedTempFile`), nothing sweeps the work
+						// directory, and the restore step - which deletes it once it runs, because
+						// `deleteAfterRestore` is set - only runs for an upload that actually completed. An
+						// upload that stops half way would therefore leave an archive the size of a catalog
+						// behind for the lifetime of the process.
+						//
+						// A chunked upload has no half-close to hang that cleanup on, so the task's future
+						// carries it: it completes on every terminal outcome, including the scheduler's purge
+						// of tasks left waiting for a precondition for longer than ten minutes
+						// (`Scheduler#purgeFinishedAndLongWaitingTasks`). That purge is what catches the cases
+						// no protocol-level signal ever reaches us for - a client that was killed, crashed, or
+						// simply lost the network mid-upload.
+						final Path uploadedFilePath = backupFilePath;
+						restorationTask.getFutureResult().whenComplete(
+							(result, exception) -> {
+								if (exception != null) {
+									deleteFileIfExists(uploadedFilePath, "restore");
+								}
+							}
+						);
 						this.management.registerWaitingTask(restorationTask);
 					} else {
 						backupFilePath = this.management.fileManagementService().getTempFile(fileId + ".zip");
@@ -446,9 +470,26 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 						backupFile.writeTo(outputStream);
 					}
 
-					// we've reached the expected size of the file
 					final long actualSize = Files.size(backupFilePath);
-					if (actualSize == request.getTotalSizeInBytes()) {
+
+					// An over-long upload has to be rejected *before* the client is told the chunk was
+					// accepted. Reporting success first and throwing afterwards left the error being written
+					// into an already-completed observer - so the client saw the upload succeed - while the
+					// archive was deleted underneath a task that stayed registered, making the next chunk fail
+					// on `getTempFile`'s existence check instead of on the size that was actually wrong.
+					//
+					// Cancelling the task is what discards the archive: its completion hook owns that file.
+					if (actualSize > totalSizeInBytes) {
+						this.management.cancelTask(restorationTask.getStatus().taskId());
+						throw new UnexpectedIOException(
+							"Backup file size exceeds the expected size.",
+							"Backup file size exceeds the expected size (expected " + totalSizeInBytes +
+								", actual " + actualSize + " Bytes)."
+						);
+					}
+
+					// we've reached the expected size of the file
+					if (actualSize == totalSizeInBytes) {
 						this.management.submitWaitingTask(createRestoreTaskFindPredicate(fileId));
 					}
 
@@ -460,14 +501,6 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 							.build()
 					);
 					responseObserver.onCompleted();
-
-					if (actualSize > totalSizeInBytes) {
-						deleteFileIfExists(backupFilePath, "restore");
-						throw new UnexpectedIOException(
-							"Backup file size exceeds the expected size.",
-							"Backup file size exceeds the expected size (expected " + totalSizeInBytes + ", actual " + actualSize + " Bytes)."
-						);
-					}
 				} catch (IOException e) {
 					throw new UnexpectedIOException(
 						"Failed to store data to the designated file: " + e.getMessage(),
@@ -840,7 +873,7 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 	 * one. Neither is covered by a test that fails when it goes, so the redundancy is the only thing
 	 * standing between a plausible-looking simplification and a silently corrupted archive.
 	 */
-	private final class RestoreCatalogUploadObserver implements StreamObserver<GrpcRestoreCatalogRequest> {
+	static final class RestoreCatalogUploadObserver implements StreamObserver<GrpcRestoreCatalogRequest> {
 		/**
 		 * Size of the write buffer wrapped around the temporary file. Writes larger than the buffer
 		 * bypass it, so this only matters for clients that upload in small chunks - which the previous
@@ -850,6 +883,13 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 
 		private final ServerCallStreamObserver<GrpcRestoreCatalogResponse> responseObserver;
 		private final ServiceRequestContext serviceContext;
+		/**
+		 * Directory the assembled archive is written into. Resolved once at construction rather than per
+		 * chunk - it is a configuration read, and doing it here is what lets this observer be driven from
+		 * a test without an engine behind it.
+		 */
+		private final Path workDirectory;
+		private final EvitaManagement management;
 		private final Executor uploadExecutor;
 		/**
 		 * The call's configured request timeout, captured once at construction - i.e. before the first
@@ -880,11 +920,15 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 		RestoreCatalogUploadObserver(
 			@Nonnull ServerCallStreamObserver<GrpcRestoreCatalogResponse> responseObserver,
 			@Nonnull ServiceRequestContext serviceContext,
+			@Nonnull Path workDirectory,
+			@Nonnull EvitaManagement management,
 			@Nonnull Executor uploadExecutor,
 			long streamingRequestTimeoutInMillis
 		) {
 			this.responseObserver = responseObserver;
 			this.serviceContext = serviceContext;
+			this.workDirectory = workDirectory;
+			this.management = management;
 			this.uploadExecutor = uploadExecutor;
 			this.configuredRequestTimeoutMillis = GrpcTimeoutUtil.resolveStreamingBudgetMillis(
 				serviceContext, streamingRequestTimeoutInMillis
@@ -918,15 +962,8 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 		public void onError(Throwable t) {
 			// the client aborted mid-upload - let whatever is already in flight finish before the
 			// partial file is closed and discarded, so no worker is writing into a closed stream
-			this.uploadChain.whenCompleteAsync(
-				(ignored, throwable) -> {
-					closeOutputStream();
-					deleteFileIfExists(this.backupFilePath, "restore");
-					if (this.terminated.compareAndSet(false, true)) {
-						sendErrorToClient(t, this.responseObserver);
-					}
-				},
-				this.uploadExecutor
+			this.uploadChain.whenComplete(
+				(ignored, throwable) -> handOffCleanupToUploadExecutor(() -> failUpload(t))
 			);
 		}
 
@@ -940,26 +977,94 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 		 * client once and then poisons the rest of the chain, so nothing downstream - the restoration
 		 * submission above all - ever runs against a half-written file.
 		 *
+		 * The hand-off to {@link #uploadExecutor} is made by hand rather than by `thenRunAsync`, because
+		 * the request pool is bounded and rejects work once its queue fills
+		 * (`EvitaRejectingExecutorHandler` throws). Letting `CompletableFuture` schedule the step loses
+		 * that rejection in two different ways, and the second one is worse than a lost error:
+		 *
+		 * - while the previous step is still running, the rejection surfaces on *that* worker, inside
+		 *   `CompletableFuture#postComplete`, with no relation to this call - the stage simply never
+		 *   completes and the client waits out its deadline;
+		 * - once the previous step has completed, `thenRunAsync` throws on the calling thread *before*
+		 *   `this.uploadChain` is reassigned, so the chain is left looking healthy. The next chunk then
+		 *   appends successfully, {@link #openBackupFileIfNeeded()} finds a null stream and reopens the
+		 *   temporary file in `APPEND` mode - leaking a second archive on the very path being handled.
+		 *
+		 * Completing `next` exceptionally in both cases is what keeps the chain poisoned, and therefore
+		 * what stops that reopen.
+		 *
 		 * @param step the operation to append
 		 */
 		private void appendToChain(@Nonnull UploadStep step) {
-			this.uploadChain = this.uploadChain.thenRunAsync(
-				() -> {
-					try {
-						step.run();
-					} catch (Exception ex) {
-						failUpload(ex);
-						throw ex instanceof RuntimeException runtimeException ?
-							runtimeException :
-							new UnexpectedIOException(
-								"Failed to store the uploaded backup file: " + ex.getMessage(),
-								"Failed to store the uploaded backup file.",
-								ex
-							);
+			final CompletableFuture<Void> previous = this.uploadChain;
+			final CompletableFuture<Void> next = new CompletableFuture<>();
+			this.uploadChain = next;
+			// deliberately `whenComplete` and not `whenCompleteAsync`: this stage only *submits* work, so
+			// running it inline (or on whichever worker completed the previous step) costs nothing and,
+			// crucially, cannot itself be rejected
+			previous.whenComplete(
+				(ignored, previousFailure) -> {
+					if (previousFailure != null) {
+						// a poisoned chain stays poisoned - nothing may run against a discarded file
+						next.completeExceptionally(previousFailure);
+						return;
 					}
-				},
-				this.uploadExecutor
+					handOffToUploadExecutor(
+						() -> {
+							try {
+								step.run();
+								next.complete(null);
+							} catch (Exception ex) {
+								failUpload(ex);
+								next.completeExceptionally(ex);
+							}
+						},
+						next
+					);
+				}
 			);
+		}
+
+		/**
+		 * Hands a step to {@link #uploadExecutor}, falling back to running it on the calling thread when
+		 * the pool refuses it.
+		 *
+		 * The fallback puts a `close` and an `unlink` on whichever thread got here - the event loop, in
+		 * the worst case - which is exactly what this observer exists to avoid. It is still the right
+		 * trade: the alternative to a few microseconds of blocking on an already-degraded server is a
+		 * part-uploaded archive, up to the full size of a catalog, left in the work directory for the
+		 * lifetime of the process. Nothing sweeps that directory.
+		 *
+		 * @param step             the work to run on the upload executor
+		 * @param rejectionOutcome poisoned with the rejection when the pool refuses the hand-off, so the
+		 *                         chain cannot continue past a step that never ran
+		 */
+		private void handOffToUploadExecutor(
+			@Nonnull Runnable step,
+			@Nonnull CompletableFuture<Void> rejectionOutcome
+		) {
+			try {
+				this.uploadExecutor.execute(step);
+			} catch (RejectedExecutionException ex) {
+				failUpload(ex);
+				rejectionOutcome.completeExceptionally(ex);
+			}
+		}
+
+		/**
+		 * Hands terminal cleanup to {@link #uploadExecutor}, running it on the calling thread when the
+		 * pool refuses it. Unlike {@link #handOffToUploadExecutor(Runnable, CompletableFuture)} there is
+		 * no stage left to poison - the call is already ending - so the rejection only has to not
+		 * prevent the cleanup from happening at all.
+		 *
+		 * @param cleanup the cleanup to run; idempotent, so running it on either thread is equivalent
+		 */
+		private void handOffCleanupToUploadExecutor(@Nonnull Runnable cleanup) {
+			try {
+				this.uploadExecutor.execute(cleanup);
+			} catch (RejectedExecutionException ex) {
+				cleanup.run();
+			}
 		}
 
 		/**
@@ -971,14 +1076,14 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 			if (this.outputStream != null) {
 				return;
 			}
-			final Path workDirectory = EvitaManagementService.this.evita.getConfiguration()
-				.transaction().transactionWorkDirectory();
-			if (!workDirectory.toFile().exists()) {
+			if (!this.workDirectory.toFile().exists()) {
 				Assert.isTrue(
-					workDirectory.toFile().mkdirs(), "Failed to create work directory for catalog restore."
+					this.workDirectory.toFile().mkdirs(), "Failed to create work directory for catalog restore."
 				);
 			}
-			this.backupFilePath = Files.createTempFile(workDirectory, "catalog_backup_for_restore-", ".zip");
+			this.backupFilePath = Files.createTempFile(
+				this.workDirectory, "catalog_backup_for_restore-", ".zip"
+			);
 			this.outputStream = new BufferedOutputStream(
 				Files.newOutputStream(this.backupFilePath, StandardOpenOption.APPEND), UPLOAD_BUFFER_SIZE
 			);
@@ -994,7 +1099,7 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 			Assert.isPremiseValid(theOutputStream != null, "Output stream has already been closed.");
 			theOutputStream.close();
 			this.outputStream = null;
-			final Task<?, Void> restorationTask = EvitaManagementService.this.management.restoreCatalog(
+			final Task<?, Void> restorationTask = this.management.restoreCatalog(
 				this.catalogNameToRestore,
 				Files.size(this.backupFilePath),
 				Files.newInputStream(this.backupFilePath, StandardOpenOption.READ)

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaManagementService.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaManagementService.java
@@ -53,6 +53,7 @@ import io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter;
 import io.evitadb.externalApi.grpc.generated.*;
 import io.evitadb.externalApi.grpc.generated.GrpcTaskStatusesResponse.Builder;
 import io.evitadb.externalApi.grpc.requestResponse.EvitaEnumConverter;
+import io.evitadb.externalApi.grpc.utils.GrpcOutboundGate;
 import io.evitadb.externalApi.grpc.utils.GrpcTimeoutUtil;
 import io.evitadb.externalApi.http.ExternalApiProvider;
 import io.evitadb.externalApi.http.ExternalApiServer;
@@ -64,11 +65,13 @@ import io.evitadb.utils.ClassifierUtils;
 import io.evitadb.utils.ClassifierUtils.Keyword;
 import io.evitadb.utils.UUIDUtil;
 import io.grpc.Metadata;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -80,6 +83,9 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -102,6 +108,24 @@ import static java.util.Optional.ofNullable;
  */
 @Slf4j
 public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaManagementServiceImplBase {
+	/**
+	 * Size of a single chunk streamed by {@link #fetchFile(GrpcFetchFileRequest, StreamObserver)}.
+	 *
+	 * The value is a direct consequence of the readiness gating that loop performs. Armeria reports a
+	 * server call as ready only while `pendingMessages == 0`, so a gated producer keeps exactly one
+	 * message in flight and every chunk costs a full event-loop round trip - at the original 64 KB that
+	 * is over ten thousand sequential round trips for a large backup, and it would make downloads for
+	 * clients that keep up measurably slower than the unbounded loop it replaces. 1 MB restores the
+	 * throughput while keeping the worst-case in-flight footprint at a couple of megabytes instead of
+	 * the whole file.
+	 *
+	 * The binding ceiling is the receiving side's maximum inbound message size: gRPC-Java defaults to
+	 * 4 MB and Armeria's gRPC client to no limit at all, so 1 MB is safe for every client - and chunk
+	 * size is not part of the wire contract anyway, since `totalSizeInBytes` carries the whole file
+	 * size on every message.
+	 */
+	private static final int FETCH_FILE_CHUNK_SIZE = 1_048_576;
+
 	/**
 	 * Instance of Evita upon which will be executed service calls
 	 */
@@ -146,7 +170,20 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 			fileIdCarrier.fileId().equals(theFileId);
 	}
 
-	public EvitaManagementService(@Nonnull Evita evita, @Nonnull ExternalApiServer externalApiServer, HeaderOptions headers) {
+	/**
+	 * How long a streamed response may make no progress before it is abandoned -
+	 * `api.endpoints.gRPC.streamingRequestTimeoutInMillis`.
+	 * Handed to every {@link GrpcOutboundGate} this service attaches.
+	 */
+	private final long streamingRequestTimeoutInMillis;
+
+	public EvitaManagementService(
+		@Nonnull Evita evita,
+		@Nonnull ExternalApiServer externalApiServer,
+		HeaderOptions headers,
+		long streamingRequestTimeoutInMillis
+	) {
+		this.streamingRequestTimeoutInMillis = streamingRequestTimeoutInMillis;
 		this.evita = evita;
 		this.externalApiServer = externalApiServer;
 		this.management = evita.management();
@@ -340,85 +377,26 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 	 */
 	@Override
 	public StreamObserver<GrpcRestoreCatalogRequest> restoreCatalog(StreamObserver<GrpcRestoreCatalogResponse> responseObserver) {
-		Path backupFilePath = null;
-		try {
-			try {
-				final Path workDirectory = this.evita.getConfiguration().transaction().transactionWorkDirectory();
-				if (!workDirectory.toFile().exists()) {
-					Assert.isTrue(workDirectory.toFile().mkdirs(), "Failed to create work directory for catalog restore.");
-				}
-				backupFilePath = Files.createTempFile(workDirectory, "catalog_backup_for_restore-", ".zip");
-				final Path finalBackupFilePath = backupFilePath;
-				@SuppressWarnings("resource") final OutputStream outputStream = Files.newOutputStream(finalBackupFilePath, StandardOpenOption.APPEND);
-				final AtomicLong bytesRead = new AtomicLong(0);
-				final ServiceRequestContext serviceContext = ServiceRequestContext.current();
+		final ServerCallStreamObserver<GrpcRestoreCatalogResponse> serverCallObserver =
+			(ServerCallStreamObserver<GrpcRestoreCatalogResponse>) responseObserver;
+		// Inbound demand has to become explicit here. gRPC auto-requests the next message only after
+		// `onMessage` returns, so the inline blocking write this method used to perform *was* the
+		// throttle that kept a client from outrunning the disk - an accidental one, paid for by doing
+		// file IO on the Armeria event loop. Moving the write onto a worker removes that side effect,
+		// so the demand it used to provide is now issued by hand: one message at a time, the next one
+		// requested only once the previous chunk is on disk.
+		//
+		// Both calls must happen before this method returns - gRPC freezes the observer immediately
+		// afterwards and rejects any later attempt to change the flow-control mode.
+		serverCallObserver.disableAutoRequest();
+		serverCallObserver.request(1);
 
-				return new StreamObserver<>() {
-					private String catalogNameToRestore;
-
-					@Override
-					public void onNext(GrpcRestoreCatalogRequest request) {
-						this.catalogNameToRestore = request.getCatalogName();
-						try {
-							final ByteString backupFile = request.getBackupFile();
-							backupFile.writeTo(outputStream);
-							bytesRead.addAndGet(backupFile.size());
-							GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, serviceContext.requestTimeoutMillis());
-
-						} catch (IOException e) {
-							throw new UnexpectedIOException(
-								"Failed to write backup file to temporary file.",
-								"Failed to write backup file to temporary file.",
-								e
-							);
-						}
-					}
-
-					@Override
-					public void onError(Throwable t) {
-						try {
-							outputStream.close();
-						} catch (IOException e) {
-							log.error("Failed to close output stream for backup file: {}", finalBackupFilePath, e);
-						} finally {
-							deleteFileIfExists(finalBackupFilePath, "restore");
-							sendErrorToClient(t, responseObserver);
-						}
-					}
-
-					@Override
-					public void onCompleted() {
-						try {
-							outputStream.close();
-							Assert.isPremiseValid(this.catalogNameToRestore != null, "Catalog name to restore must be provided.");
-							final Task<?, Void> restorationTask = EvitaManagementService.this.management.restoreCatalog(
-								this.catalogNameToRestore,
-								Files.size(finalBackupFilePath),
-								Files.newInputStream(finalBackupFilePath, StandardOpenOption.READ)
-							);
-							responseObserver.onNext(
-								GrpcRestoreCatalogResponse.newBuilder()
-									.setTask(toGrpcTaskStatus(restorationTask.getStatus()))
-									.setRead(bytesRead.get())
-									.build()
-							);
-							responseObserver.onCompleted();
-						} catch (Exception e) {
-							deleteFileIfExists(finalBackupFilePath, "restore");
-							sendErrorToClient(e, responseObserver);
-						}
-					}
-				};
-			} catch (IOException e) {
-				sendErrorToClient(e, responseObserver);
-				throw e;
-			}
-		} catch (Exception e) {
-			if (backupFilePath != null) {
-				deleteFileIfExists(backupFilePath, "restore");
-			}
-			return new NoopStreamObserver<>();
-		}
+		return new RestoreCatalogUploadObserver(
+			serverCallObserver,
+			ServiceRequestContext.current(),
+			this.evita.getRequestExecutor(),
+			this.streamingRequestTimeoutInMillis
+		);
 	}
 
 	/**
@@ -700,9 +678,20 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 
 	/**
 	 * Method streams contents of the single file identified by its unique UUID to the client.
+	 *
+	 * The producing loop is gated on transport readiness, so the file is streamed at the speed the
+	 * client actually consumes it. Without the gate the loop pushes the whole file into Armeria's
+	 * unbounded outbound queue at disk speed, which for a large backup over a slow link exhausts the
+	 * direct-memory allocator and kills the RPC with a bare `UNKNOWN` part-way through.
 	 */
 	@Override
 	public void fetchFile(GrpcFetchFileRequest request, StreamObserver<GrpcFetchFileResponse> responseObserver) {
+		// the gate has to be wired up here, on the thread that invoked the service method and before it
+		// returns - gRPC freezes handler registration afterwards, and the loop below runs on a worker
+		final GrpcOutboundGate outboundGate = GrpcOutboundGate.attach(
+			(ServerCallStreamObserver<GrpcFetchFileResponse>) responseObserver,
+			"fetchFile", null, this.streamingRequestTimeoutInMillis
+		);
 		executeWithClientContext(
 			() -> {
 				final UUID fileId = toUuid(request.getFileId());
@@ -710,21 +699,36 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 				if (fileToFetch.isEmpty()) {
 					sendErrorToClient(new FileForFetchNotFoundException(fileId), responseObserver);
 				} else {
+					final long totalSizeInBytes = fileToFetch.get().totalSizeInBytes();
 					try (
 						final InputStream inputStream = this.management.fetchFile(
 							fileId
 						)
 					) {
 						//noinspection CheckForOutOfMemoryOnLargeArrayAllocation
-						byte[] buffer = new byte[65_536];
+						final byte[] buffer = new byte[FETCH_FILE_CHUNK_SIZE];
 						int bytesRead;
 						while ((bytesRead = inputStream.read(buffer)) != -1) {
-							GrpcFetchFileResponse response = GrpcFetchFileResponse.newBuilder()
+							if (!outboundGate.awaitWritable()) {
+								// the client is gone - abandon the transfer without completing the
+								// stream, since completing it would claim a file that never arrived
+								log.debug("Client of `fetchFile` disconnected, abandoning transfer of {}.", fileId);
+								return;
+							}
+							final GrpcFetchFileResponse response = GrpcFetchFileResponse.newBuilder()
 								.setFileContents(ByteString.copyFrom(buffer, 0, bytesRead))
-								.setTotalSizeInBytes(fileToFetch.get().totalSizeInBytes())
+								.setTotalSizeInBytes(totalSizeInBytes)
 								.build();
+							// no re-arm of the Armeria deadline here: `awaitWritable` above already granted
+							// this message its window - see `GrpcOutboundGate#grantNextMessageWindow`. The
+							// deadline has to roll on a stream, because gating on readiness ties this
+							// handler's lifetime to how fast the *client* consumes, and a healthy download
+							// of a large file over a slow link outlives any fixed budget.
 							responseObserver.onNext(response);
 						}
+						// the final chunk's window is the only one still standing - give the half-close,
+						// and whatever is still queued behind it, a full budget of their own
+						outboundGate.grantCompletionWindow();
 						responseObserver.onCompleted();
 					} catch (IOException e) {
 						throw new UnexpectedIOException(
@@ -801,21 +805,240 @@ public class EvitaManagementService extends EvitaManagementServiceGrpc.EvitaMana
 	}
 
 	/**
-	 * No-op implementation of StreamObserver. Used in case the proper observer could not be created.
+	 * Piece of file work that may fail with an {@link IOException}.
 	 */
-	private static class NoopStreamObserver<V> implements StreamObserver<V> {
+	@FunctionalInterface
+	private interface UploadStep {
+
+		void run() throws IOException;
+
+	}
+
+	/**
+	 * Receives an uploaded catalog backup, writes it to a temporary file and submits the restoration
+	 * task once the client half-closes.
+	 *
+	 * All three observer callbacks are invoked on the Armeria event loop, and none of them may block
+	 * there - a 690 MB restore is thousands of blocking write syscalls, and the event loop is shared
+	 * by every other connection the server is serving. Every step that touches the file system is
+	 * therefore appended to {@link #uploadChain}, a single {@link CompletableFuture} chain per call:
+	 * it hands the work to a worker thread while keeping the chunks strictly ordered, which is the one
+	 * property a corrupted ZIP would be the symptom of losing.
+	 *
+	 * The chain is also what makes ordering independent of the executor's scheduling. Routing the
+	 * whole handler to Armeria's blocking task executor (the `@Blocking` annotation) would be a
+	 * one-line alternative, but `AbstractServerCall` dispatches each message as a separate task onto a
+	 * *shared* pool, so ordering would rest on the undocumented assumption that no second message is
+	 * ever dispatched before the first task returns. Here ordering is explicit.
+	 *
+	 * **The chain and the demand protocol are redundant, deliberately.** `disableAutoRequest()` plus a
+	 * `request(1)` issued from inside each *completed* write step already means at most one chunk is in
+	 * flight, which orders the writes on its own and additionally withholds half-close until the last
+	 * write has landed. Removing either mechanism alone therefore changes nothing observable - measured,
+	 * not assumed: `LongRunningGrpcRestoreCatalogUploadTest#shouldRestoreCatalogUploadedThroughClientStreamingRpc`
+	 * stays green against both single-mechanism counterfactuals. Do not read that as licence to delete
+	 * one. Neither is covered by a test that fails when it goes, so the redundancy is the only thing
+	 * standing between a plausible-looking simplification and a silently corrupted archive.
+	 */
+	private final class RestoreCatalogUploadObserver implements StreamObserver<GrpcRestoreCatalogRequest> {
+		/**
+		 * Size of the write buffer wrapped around the temporary file. Writes larger than the buffer
+		 * bypass it, so this only matters for clients that upload in small chunks - which the previous
+		 * unbuffered stream turned into one syscall each.
+		 */
+		private static final int UPLOAD_BUFFER_SIZE = 65_536;
+
+		private final ServerCallStreamObserver<GrpcRestoreCatalogResponse> responseObserver;
+		private final ServiceRequestContext serviceContext;
+		private final Executor uploadExecutor;
+		/**
+		 * The call's configured request timeout, captured once at construction - i.e. before the first
+		 * chunk, and therefore before any re-arm has rewritten the stored budget. Re-reading it from the
+		 * context per chunk instead would compound it; see
+		 * {@link GrpcTimeoutUtil#captureRequestTimeoutMillis(ServiceRequestContext)}.
+		 */
+		private final long configuredRequestTimeoutMillis;
+		private final AtomicLong bytesRead = new AtomicLong(0);
+		/**
+		 * Guards the single terminal response - the client must be told the outcome exactly once, no
+		 * matter which of the failure paths gets there first.
+		 */
+		private final AtomicBoolean terminated = new AtomicBoolean();
+		/**
+		 * Serialises every file operation of this call. Mutated only from the observer callbacks,
+		 * which gRPC delivers serially on the event loop.
+		 */
+		private CompletableFuture<Void> uploadChain = CompletableFuture.completedFuture(null);
+		/**
+		 * Written on the event loop, read from the worker running the chain - the chain's own
+		 * completion machinery orders the two, `volatile` states that intent rather than relying on it.
+		 */
+		private volatile String catalogNameToRestore;
+		private volatile Path backupFilePath;
+		@Nullable private volatile OutputStream outputStream;
+
+		RestoreCatalogUploadObserver(
+			@Nonnull ServerCallStreamObserver<GrpcRestoreCatalogResponse> responseObserver,
+			@Nonnull ServiceRequestContext serviceContext,
+			@Nonnull Executor uploadExecutor,
+			long streamingRequestTimeoutInMillis
+		) {
+			this.responseObserver = responseObserver;
+			this.serviceContext = serviceContext;
+			this.uploadExecutor = uploadExecutor;
+			this.configuredRequestTimeoutMillis = GrpcTimeoutUtil.resolveStreamingBudgetMillis(
+				serviceContext, streamingRequestTimeoutInMillis
+			);
+		}
 
 		@Override
-		public void onNext(V value) {
+		public void onNext(GrpcRestoreCatalogRequest request) {
+			this.catalogNameToRestore = request.getCatalogName();
+			final ByteString backupFile = request.getBackupFile();
+			appendToChain(
+				() -> {
+					openBackupFileIfNeeded();
+					backupFile.writeTo(this.outputStream);
+					this.bytesRead.addAndGet(backupFile.size());
+					GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(
+						this.serviceContext, this.configuredRequestTimeoutMillis
+					);
+					// Only now may the client send the next chunk - raising demand from inside the
+					// *completed* write step is what keeps at most one chunk in flight and therefore
+					// what orders the writes. Safe to call straight from this worker: Armeria's
+					// `StreamingServerCall.request(int)` marshals onto the call's event loop itself
+					// when the caller is not already on it, so the upstream subscription it touches
+					// stays event-loop-confined without help from here.
+					this.responseObserver.request(1);
+				}
+			);
 		}
 
 		@Override
 		public void onError(Throwable t) {
+			// the client aborted mid-upload - let whatever is already in flight finish before the
+			// partial file is closed and discarded, so no worker is writing into a closed stream
+			this.uploadChain.whenCompleteAsync(
+				(ignored, throwable) -> {
+					closeOutputStream();
+					deleteFileIfExists(this.backupFilePath, "restore");
+					if (this.terminated.compareAndSet(false, true)) {
+						sendErrorToClient(t, this.responseObserver);
+					}
+				},
+				this.uploadExecutor
+			);
 		}
 
 		@Override
 		public void onCompleted() {
+			appendToChain(this::submitRestoration);
 		}
+
+		/**
+		 * Appends a file operation to this call's chain. A step that fails reports the failure to the
+		 * client once and then poisons the rest of the chain, so nothing downstream - the restoration
+		 * submission above all - ever runs against a half-written file.
+		 *
+		 * @param step the operation to append
+		 */
+		private void appendToChain(@Nonnull UploadStep step) {
+			this.uploadChain = this.uploadChain.thenRunAsync(
+				() -> {
+					try {
+						step.run();
+					} catch (Exception ex) {
+						failUpload(ex);
+						throw ex instanceof RuntimeException runtimeException ?
+							runtimeException :
+							new UnexpectedIOException(
+								"Failed to store the uploaded backup file: " + ex.getMessage(),
+								"Failed to store the uploaded backup file.",
+								ex
+							);
+					}
+				},
+				this.uploadExecutor
+			);
+		}
+
+		/**
+		 * Creates the temporary file on first use. Deferred to the first chunk on purpose: creating it
+		 * eagerly would put `mkdirs` and `createTempFile` back on the event loop, which is exactly what
+		 * this observer exists to avoid.
+		 */
+		private void openBackupFileIfNeeded() throws IOException {
+			if (this.outputStream != null) {
+				return;
+			}
+			final Path workDirectory = EvitaManagementService.this.evita.getConfiguration()
+				.transaction().transactionWorkDirectory();
+			if (!workDirectory.toFile().exists()) {
+				Assert.isTrue(
+					workDirectory.toFile().mkdirs(), "Failed to create work directory for catalog restore."
+				);
+			}
+			this.backupFilePath = Files.createTempFile(workDirectory, "catalog_backup_for_restore-", ".zip");
+			this.outputStream = new BufferedOutputStream(
+				Files.newOutputStream(this.backupFilePath, StandardOpenOption.APPEND), UPLOAD_BUFFER_SIZE
+			);
+		}
+
+		/**
+		 * Finalises the upload and hands the assembled file to the restoration task.
+		 */
+		private void submitRestoration() throws IOException {
+			Assert.isPremiseValid(this.catalogNameToRestore != null, "Catalog name to restore must be provided.");
+			Assert.isPremiseValid(this.backupFilePath != null, "No backup file contents were uploaded.");
+			final OutputStream theOutputStream = this.outputStream;
+			Assert.isPremiseValid(theOutputStream != null, "Output stream has already been closed.");
+			theOutputStream.close();
+			this.outputStream = null;
+			final Task<?, Void> restorationTask = EvitaManagementService.this.management.restoreCatalog(
+				this.catalogNameToRestore,
+				Files.size(this.backupFilePath),
+				Files.newInputStream(this.backupFilePath, StandardOpenOption.READ)
+			);
+			if (this.terminated.compareAndSet(false, true)) {
+				this.responseObserver.onNext(
+					GrpcRestoreCatalogResponse.newBuilder()
+						.setTask(toGrpcTaskStatus(restorationTask.getStatus()))
+						.setRead(this.bytesRead.get())
+						.build()
+				);
+				this.responseObserver.onCompleted();
+			}
+		}
+
+		/**
+		 * Reports a failed upload to the client and discards the partial file. Idempotent.
+		 *
+		 * @param exception the failure to report
+		 */
+		private void failUpload(@Nonnull Throwable exception) {
+			closeOutputStream();
+			deleteFileIfExists(this.backupFilePath, "restore");
+			if (this.terminated.compareAndSet(false, true)) {
+				sendErrorToClient(exception, this.responseObserver);
+			}
+		}
+
+		/**
+		 * Closes the temporary file, tolerating both "never opened" and "already closed".
+		 */
+		private void closeOutputStream() {
+			final OutputStream stream = this.outputStream;
+			if (stream == null) {
+				return;
+			}
+			this.outputStream = null;
+			try {
+				stream.close();
+			} catch (IOException e) {
+				log.error("Failed to close output stream for backup file: {}", this.backupFilePath, e);
+			}
+		}
+
 	}
 
 }

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaSessionService.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaSessionService.java
@@ -96,6 +96,7 @@ import io.evitadb.externalApi.grpc.services.converter.WriteAheadLogVersionDescri
 import io.evitadb.externalApi.grpc.services.interceptors.GlobalExceptionHandlerInterceptor;
 import io.evitadb.externalApi.grpc.services.interceptors.ServerSessionInterceptor;
 import io.evitadb.externalApi.grpc.services.subscriber.ChangeCatalogCaptureSubscriber;
+import io.evitadb.externalApi.grpc.utils.GrpcOutboundGate;
 import io.evitadb.externalApi.grpc.utils.GrpcTimeoutUtil;
 import io.evitadb.externalApi.grpc.utils.QueryUtil;
 import io.evitadb.externalApi.grpc.utils.QueryWithParameters;
@@ -121,6 +122,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -609,7 +611,19 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 		}
 	}
 
-	public EvitaSessionService(@Nonnull Evita evita, @Nonnull HeaderOptions headers) {
+	/**
+	 * How long a streamed response may make no progress before it is abandoned -
+	 * `api.endpoints.gRPC.streamingRequestTimeoutInMillis`.
+	 * Handed to every {@link GrpcOutboundGate} this service attaches.
+	 */
+	private final long streamingRequestTimeoutInMillis;
+
+	public EvitaSessionService(
+		@Nonnull Evita evita,
+		@Nonnull HeaderOptions headers,
+		long streamingRequestTimeoutInMillis
+	) {
+		this.streamingRequestTimeoutInMillis = streamingRequestTimeoutInMillis;
 		this.evita = evita;
 		this.trackSourceQueries = evita.getConfiguration().server().trafficRecording().sourceQueryTrackingEnabled();
 		this.tracingContext = ExternalApiTracingContextProvider.getContext(Metadata.class, headers);
@@ -767,6 +781,19 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 		StreamObserver<GrpcGoLiveAndCloseWithProgressResponse> responseObserver
 	) {
 		final ServiceRequestContext serviceContext = ServiceRequestContext.current();
+		// resolved before the first progress tick, so that every re-arm below restates the same budget
+		// rather than compounding it. This is a stream, so it gets the streaming budget rather than the
+		// call's whole-request one - a go-live phase that reports no progress for longer than
+		// `api.requestTimeoutInMillis` would otherwise kill the stream mid-flight.
+		final long configuredRequestTimeoutMillis = GrpcTimeoutUtil.resolveStreamingBudgetMillis(
+			serviceContext, this.streamingRequestTimeoutInMillis
+		);
+		// Armed once here, not only from inside the progress callback: the first tick is separated from
+		// this point by the executor hand-off *and* by however long go-live takes to report any progress
+		// at all, and none of that is covered by a re-arm that has not happened yet. Without this the
+		// whole-request budget still bounds the run-up to the first tick - which is exactly the window a
+		// go-live is least able to promise anything about.
+		GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, configuredRequestTimeoutMillis);
 		executeWithClientContext(
 			session -> {
 				if (session == null) {
@@ -788,7 +815,9 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 									responseObserver.onNext(response);
 									this.lastUpdate = System.currentTimeMillis();
 								}
-								GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, serviceContext.requestTimeoutMillis());
+								GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(
+									serviceContext, configuredRequestTimeoutMillis
+								);
 							}
 						}
 					);
@@ -903,7 +932,8 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 						.setTaskStatus(status)
 						.build(),
 					responseObserver,
-					serviceContext
+					serviceContext,
+					this.streamingRequestTimeoutInMillis
 				);
 			},
 			this.evita.getRequestExecutor(),
@@ -936,7 +966,8 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 						.setTaskStatus(status)
 						.build(),
 					responseObserver,
-					serviceContext
+					serviceContext,
+					this.streamingRequestTimeoutInMillis
 				);
 			},
 			this.evita.getRequestExecutor(),
@@ -954,14 +985,28 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 	 * @param responseBuilder  function to build the gRPC response from a task status
 	 * @param responseObserver observer to stream responses to
 	 * @param serviceContext   Armeria service context for timeout management
+	 * @param streamingRequestTimeoutInMillis
+	 *                         `api.endpoints.gRPC.streamingRequestTimeoutInMillis` - the budget each
+	 *                         re-arm restates. Passed in rather than read here because this helper is
+	 *                         static; the poll below happens to refresh the deadline every second
+	 *                         regardless of whether anything was sent, so the whole-request budget would
+	 *                         also survive today - but that is an accident of the poll interval, not a
+	 *                         property anyone should have to preserve.
 	 * @param <T>              the gRPC response type
 	 */
 	private static <T> void streamBackupProgress(
 		@Nonnull Task<?, FileForFetch> backupTask,
 		@Nonnull Function<GrpcTaskStatus, T> responseBuilder,
 		@Nonnull StreamObserver<T> responseObserver,
-		@Nonnull ServiceRequestContext serviceContext
+		@Nonnull ServiceRequestContext serviceContext,
+		long streamingRequestTimeoutInMillis
 	) {
+		// resolved before the first message, so that every re-arm below restates the same budget rather
+		// than compounding it, and from the streaming budget because this is a stream - see
+		// `GrpcTimeoutUtil#resolveStreamingBudgetMillis`
+		final long configuredRequestTimeoutMillis = GrpcTimeoutUtil.resolveStreamingBudgetMillis(
+			serviceContext, streamingRequestTimeoutInMillis
+		);
 		// send initial status
 		responseObserver.onNext(
 			responseBuilder.apply(toGrpcTaskStatus(backupTask.getStatus()))
@@ -981,7 +1026,7 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 						responseBuilder.apply(toGrpcTaskStatus(backupTask.getStatus()))
 					);
 				}
-				GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, serviceContext.requestTimeoutMillis());
+				GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, configuredRequestTimeoutMillis);
 			} catch (ExecutionException e) {
 				// task failed
 				GlobalExceptionHandlerInterceptor.sendErrorToClient(
@@ -2418,6 +2463,7 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 	private void streamMutationsHistory(
 		@Nonnull GetMutationsHistoryRequest request,
 		@Nonnull StreamObserver<GetMutationsHistoryResponse> responseObserver,
+		@Nonnull String methodName,
 		@Nonnull BiFunction<EvitaInternalSessionContract, ChangeCatalogCaptureRequest, Stream<ChangeCatalogCapture>> mutationsHistoryStream
 	) {
 		final ServerCallStreamObserver<GetMutationsHistoryResponse> serverCallStreamObserver =
@@ -2425,16 +2471,23 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 
 		final AtomicReference<Stream<ChangeCatalogCapture>> mutationsHistoryStreamRef = new AtomicReference<>();
 
-		// avoid returning error when client cancels the stream
-		serverCallStreamObserver.setOnCancelHandler(
+		// the gate paces the loop below to the client's consumption rate; it owns the call's cancel
+		// handler (gRPC keeps only the last one registered), so the stream cleanup that used to be
+		// registered here is handed to it. Both must happen synchronously, before this method returns.
+		final GrpcOutboundGate outboundGate = GrpcOutboundGate.attach(
+			serverCallStreamObserver,
+			// the caller's own RPC name - this helper backs both the forward and the reversed variant,
+			// and a stall must name the one the client actually invoked
+			methodName,
+			// avoid returning error when client cancels the stream
 			() -> {
 				log.info("Client cancelled the mutation history request.");
 				ofNullable(mutationsHistoryStreamRef.get())
 					.ifPresent(BaseStream::close);
-			}
+			},
+			this.streamingRequestTimeoutInMillis
 		);
 
-		final ServiceRequestContext serviceContext = ServiceRequestContext.current();
 		executeWithClientContext(
 			session -> {
 				try (
@@ -2445,19 +2498,29 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 					mutationsHistoryStreamRef.set(capturedMutations);
 					final SemVer clientVersion = ServerSessionInterceptor.getClientVersion().orElse(null);
 
-					capturedMutations.forEach(
-						cdcEvent -> {
-							final GetMutationsHistoryResponse.Builder builder = GetMutationsHistoryResponse
-								.newBuilder();
-							final GrpcChangeCatalogCapture event = ChangeCaptureConverter
-								.toGrpcChangeCatalogCapture(cdcEvent, clientVersion);
-							// we send mutations one by one, but we may want to send them in batches in the future
-							builder.addChangeCapture(event);
-							responseObserver.onNext(builder.build());
-							GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, serviceContext.requestTimeoutMillis());
+					// pulled through an iterator rather than `forEach` so the loop can stop early when
+					// the client disappears - the captures are produced lazily, so abandoning it here
+					// also stops the underlying WAL reads
+					final Iterator<ChangeCatalogCapture> captureIterator = capturedMutations.iterator();
+					while (captureIterator.hasNext()) {
+						if (!outboundGate.awaitWritable()) {
+							log.debug("Client of `{}` disconnected, abandoning stream.", methodName);
+							return;
 						}
-					);
+						final GetMutationsHistoryResponse.Builder builder = GetMutationsHistoryResponse
+							.newBuilder();
+						final GrpcChangeCatalogCapture event = ChangeCaptureConverter
+							.toGrpcChangeCatalogCapture(captureIterator.next(), clientVersion);
+						// we send mutations one by one, but we may want to send them in batches in the future
+						builder.addChangeCapture(event);
+						// the Armeria deadline is re-armed by `awaitWritable` above, per granted message -
+						// see `GrpcOutboundGate#grantNextMessageWindow`
+						responseObserver.onNext(builder.build());
+					}
 				}
+				// the final capture's window is the only one still standing - give the half-close a
+				// full budget of its own
+				outboundGate.grantCompletionWindow();
 				responseObserver.onCompleted();
 			},
 			this.evita.getRequestExecutor(),
@@ -2478,7 +2541,10 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 	public void getMutationsHistory(
 		GetMutationsHistoryRequest request, StreamObserver<GetMutationsHistoryResponse> responseObserver
 	) {
-		streamMutationsHistory(request, responseObserver, EvitaInternalSessionContract::getMutationsHistoryReversed);
+		streamMutationsHistory(
+			request, responseObserver, "getMutationsHistory",
+			EvitaInternalSessionContract::getMutationsHistoryReversed
+		);
 	}
 
 	/**
@@ -2493,7 +2559,10 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 	public void getMutationsHistoryForward(
 		GetMutationsHistoryRequest request, StreamObserver<GetMutationsHistoryResponse> responseObserver
 	) {
-		streamMutationsHistory(request, responseObserver, EvitaInternalSessionContract::getMutationsHistoryForward);
+		streamMutationsHistory(
+			request, responseObserver, "getMutationsHistoryForward",
+			EvitaInternalSessionContract::getMutationsHistoryForward
+		);
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaTrafficRecordingService.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaTrafficRecordingService.java
@@ -24,7 +24,6 @@
 package io.evitadb.externalApi.grpc.services;
 
 
-import com.linecorp.armeria.server.ServiceRequestContext;
 import io.evitadb.api.file.FileForFetch;
 import io.evitadb.api.requestResponse.trafficRecording.TrafficRecording;
 import io.evitadb.api.requestResponse.trafficRecording.TrafficRecordingCaptureRequest;
@@ -36,7 +35,7 @@ import io.evitadb.core.traffic.TrafficRecordingSettings;
 import io.evitadb.externalApi.configuration.HeaderOptions;
 import io.evitadb.externalApi.grpc.generated.*;
 import io.evitadb.externalApi.grpc.services.converter.TrafficCaptureConverter;
-import io.evitadb.externalApi.grpc.utils.GrpcTimeoutUtil;
+import io.evitadb.externalApi.grpc.utils.GrpcOutboundGate;
 import io.evitadb.externalApi.trace.ExternalApiTracingContextProvider;
 import io.evitadb.externalApi.utils.ExternalApiTracingContext;
 import io.grpc.Metadata;
@@ -47,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import java.time.Duration;
+import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.BaseStream;
 import java.util.stream.Stream;
@@ -73,7 +73,19 @@ public class EvitaTrafficRecordingService extends GrpcEvitaTrafficRecordingServi
 	 */
 	@Nonnull private final ExternalApiTracingContext<Metadata> tracingContext;
 
-	public EvitaTrafficRecordingService(@Nonnull Evita evita, @Nonnull HeaderOptions headerOptions) {
+	/**
+	 * How long a streamed response may make no progress before it is abandoned -
+	 * `api.endpoints.gRPC.streamingRequestTimeoutInMillis`.
+	 * Handed to every {@link GrpcOutboundGate} this service attaches.
+	 */
+	private final long streamingRequestTimeoutInMillis;
+
+	public EvitaTrafficRecordingService(
+		@Nonnull Evita evita,
+		@Nonnull HeaderOptions headerOptions,
+		long streamingRequestTimeoutInMillis
+	) {
+		this.streamingRequestTimeoutInMillis = streamingRequestTimeoutInMillis;
 		this.evita = evita;
 		this.tracingContext = ExternalApiTracingContextProvider.getContext(Metadata.class, headerOptions);
 	}
@@ -146,40 +158,56 @@ public class EvitaTrafficRecordingService extends GrpcEvitaTrafficRecordingServi
 	 */
 	@Override
 	public void getTrafficRecordingHistory(GetTrafficHistoryRequest request, StreamObserver<GetTrafficHistoryResponse> responseObserver) {
-		ServerCallStreamObserver<GetTrafficHistoryResponse> serverCallStreamObserver =
+		final ServerCallStreamObserver<GetTrafficHistoryResponse> serverCallStreamObserver =
 			(ServerCallStreamObserver<GetTrafficHistoryResponse>) responseObserver;
 
 		final AtomicReference<Stream<TrafficRecording>> trafficHistoryStreamRef = new AtomicReference<>();
 
-		// avoid returning error when client cancels the stream
-		serverCallStreamObserver.setOnCancelHandler(
+		// the gate paces the loop below to the client's consumption rate; it owns the call's cancel
+		// handler (gRPC keeps only the last one registered), so the stream cleanup that used to be
+		// registered here is handed to it. Both must happen synchronously, before this method returns.
+		final GrpcOutboundGate outboundGate = GrpcOutboundGate.attach(
+			serverCallStreamObserver,
+			"getTrafficRecordingHistory",
+			// avoid returning error when client cancels the stream
 			() -> {
 				log.info("Client cancelled the traffic history request.");
 				ofNullable(trafficHistoryStreamRef.get())
 					.ifPresent(BaseStream::close);
-			}
+			},
+			this.streamingRequestTimeoutInMillis
 		);
 
-		final ServiceRequestContext serviceContext = ServiceRequestContext.current();
 		executeWithClientContext(
 			session -> {
 				final TrafficRecordingCaptureRequest captureRequest = TrafficCaptureConverter.toTrafficRecordingCaptureRequest(request);
-				final Stream<TrafficRecording> trafficHistoryStream = session.getRecordings(captureRequest);
-				trafficHistoryStreamRef.set(trafficHistoryStream);
+				try (final Stream<TrafficRecording> trafficHistoryStream = session.getRecordings(captureRequest)) {
+					trafficHistoryStreamRef.set(trafficHistoryStream);
 
-				trafficHistoryStream.forEach(
-					trafficRecording -> {
+					// pulled through an iterator rather than `forEach` so the loop can stop early when
+					// the client disappears - the records are read lazily, so abandoning it here also
+					// stops the underlying traffic-log reads
+					final Iterator<TrafficRecording> recordingIterator = trafficHistoryStream.iterator();
+					while (recordingIterator.hasNext()) {
+						if (!outboundGate.awaitWritable()) {
+							log.debug("Client of `getTrafficRecordingHistory` disconnected, abandoning stream.");
+							return;
+						}
 						final GetTrafficHistoryResponse.Builder builder = GetTrafficHistoryResponse.newBuilder();
-						final GrpcTrafficRecord event = TrafficCaptureConverter.toGrpcGrpcTrafficRecord(trafficRecording, captureRequest.content());
+						final GrpcTrafficRecord event = TrafficCaptureConverter.toGrpcGrpcTrafficRecord(
+							recordingIterator.next(), captureRequest.content()
+						);
 						// we send mutations one by one, but we may want to send them in batches in the future
 						builder.addTrafficRecord(event);
+						// the Armeria deadline is re-armed by `awaitWritable` above, per granted message -
+						// see `GrpcOutboundGate#grantNextMessageWindow`
 						responseObserver.onNext(builder.build());
-
-						GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, serviceContext.requestTimeoutMillis());
 					}
-				);
+				}
+				// the final record's window is the only one still standing - give the half-close a full
+				// budget of its own
+				outboundGate.grantCompletionWindow();
 				responseObserver.onCompleted();
-				trafficHistoryStream.close();
 			},
 			this.evita.getRequestExecutor(),
 			responseObserver,

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/interceptors/GlobalExceptionHandlerInterceptor.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/interceptors/GlobalExceptionHandlerInterceptor.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.common.stream.ClosedStreamException;
 import io.evitadb.exception.EvitaInternalError;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.externalApi.grpc.exception.ClosedGrpcStreamException;
+import io.evitadb.externalApi.grpc.exception.StalledGrpcStreamException;
 import io.evitadb.utils.ExceptionUtils;
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
@@ -89,6 +90,16 @@ public class GlobalExceptionHandlerInterceptor implements ServerInterceptor {
 
 			rpcStatus = com.google.rpc.Status.newBuilder()
 				.setCode(Code.CANCELLED.value())
+				.build();
+		} else if (exception instanceof StalledGrpcStreamException stalledStream) {
+			// the client kept the stream open but stopped reading it - a network/consumer condition
+			// rather than a server fault, so it is logged at WARN and given a status the client can
+			// actually distinguish from a server error
+			log.warn("Abandoning stalled gRPC response stream: {}", stalledStream.getMessage());
+
+			rpcStatus = com.google.rpc.Status.newBuilder()
+				.setCode(Code.DEADLINE_EXCEEDED.value())
+				.setMessage(stalledStream.getErrorCode() + ": " + stalledStream.getPublicMessage())
 				.build();
 		} else if (exception instanceof EvitaInvalidUsageException invalidUsageException) {
 			if (log.isDebugEnabled()) {
@@ -183,8 +194,23 @@ public class GlobalExceptionHandlerInterceptor implements ServerInterceptor {
 			}
 		}
 
+		/**
+		 * Closes the call with a status derived from the escaping exception.
+		 *
+		 * The guard is deliberately {@link ServerCall#isCancelled()} and not {@link ServerCall#isReady()}:
+		 * readiness answers "can the transport accept another message right now", which is false whenever
+		 * a message is still in flight — a state that has nothing to do with whether the call can still be
+		 * closed. It only ever read as an open/closed test because the decorator underneath returned an
+		 * unconditional `true` (see `ObservabilityInterceptor`); once readiness became real, using it here
+		 * would silently swallow the error status for any RPC that had already sent data, leaving the
+		 * client hanging on a stream that is never closed. A cancelled call, on the other hand, is genuinely
+		 * past closing — the client is gone and gRPC has already terminated the stream.
+		 *
+		 * @param exception  the exception that escaped the service method
+		 * @param serverCall the call to close
+		 */
 		private void handleException(@Nonnull RuntimeException exception, @Nonnull ServerCall<T, R> serverCall) {
-			if (serverCall.isReady()) {
+			if (!serverCall.isCancelled()) {
 				final com.google.rpc.Status rpcStatus = createErrorStatus(exception);
 
 				final StatusRuntimeException statusRuntimeException = StatusProto.toStatusRuntimeException(rpcStatus);

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/interceptors/ObservabilityInterceptor.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/interceptors/ObservabilityInterceptor.java
@@ -29,6 +29,7 @@ import io.evitadb.externalApi.grpc.metric.event.AbstractProcedureCalledEvent;
 import io.evitadb.externalApi.grpc.metric.event.AbstractProcedureCalledEvent.InitiatorType;
 import io.evitadb.externalApi.grpc.metric.event.EvitaProcedureCalledEvent;
 import io.evitadb.externalApi.grpc.metric.event.SessionProcedureCalledEvent;
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -100,27 +101,32 @@ public class ObservabilityInterceptor implements ServerInterceptor {
 
 	/**
 	 * Observability server call that logs access log messages and fires gRPC procedure called event.
+	 *
+	 * It must extend {@link SimpleForwardingServerCall} rather than {@link ServerCall} directly: several
+	 * {@link ServerCall} methods are non-abstract and carry defaults that silently disagree with the
+	 * transport. {@link ServerCall#isReady()} is the dangerous one — it returns an unconditional `true`,
+	 * so a hand-rolled decorator that forgets to override it reports every transport as writable and
+	 * disables any {@code isReady()}-driven flow control in the service method underneath it. This is
+	 * the only {@link ServerCall} decorator in evitaDB's interceptor chain - the other two wrap the
+	 * *listener* - so it is what a service's {@code ServerCallStreamObserver} actually queries, and
+	 * what {@code GlobalExceptionHandlerInterceptor} sees when it decides whether it may still close a
+	 * failing call. {@link ServerCall#setOnReadyThreshold(int)}, {@link ServerCall#getAttributes()},
+	 * {@link ServerCall#getAuthority()}, {@link ServerCall#getSecurityLevel()},
+	 * {@link ServerCall#setCompression(String)} and {@link ServerCall#setMessageCompression(boolean)}
+	 * have the same problem in a less visible way. Forwarding by default and overriding only what
+	 * genuinely adds behaviour keeps the decorator correct as gRPC adds methods.
+	 *
+	 * Guarded by `ObservabilityInterceptorReadinessTest`.
 	 */
-	private static class ObservabilityServerCall<M, R> extends ServerCall<M, R> {
-		private final ServerCall<M, R> serverCall;
+	private static class ObservabilityServerCall<M, R> extends SimpleForwardingServerCall<M, R> {
 		private final AbstractProcedureCalledEvent event;
 
 		protected ObservabilityServerCall(
 			@Nonnull ServerCall<M, R> serverCall,
 			@Nonnull AbstractProcedureCalledEvent event
 		) {
-			this.serverCall = serverCall;
+			super(serverCall);
 			this.event = event;
-		}
-
-		@Override
-		public void request(int numMessages) {
-			this.serverCall.request(numMessages);
-		}
-
-		@Override
-		public void sendHeaders(Metadata headers) {
-			this.serverCall.sendHeaders(headers);
 		}
 
 		@Override
@@ -128,23 +134,13 @@ public class ObservabilityInterceptor implements ServerInterceptor {
 			if (this.event.streamsResponses()) {
 				this.event.setInitiator(InitiatorType.SERVER);
 			}
-			this.serverCall.sendMessage(message);
+			super.sendMessage(message);
 		}
 
 		@Override
 		public void close(Status status, Metadata trailers) {
 			this.event.finish().commit();
-			this.serverCall.close(status, trailers);
-		}
-
-		@Override
-		public boolean isCancelled() {
-			return this.serverCall.isCancelled();
-		}
-
-		@Override
-		public MethodDescriptor<M, R> getMethodDescriptor() {
-			return this.serverCall.getMethodDescriptor();
+			super.close(status, trailers);
 		}
 
 	}

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/AbstractChangeCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/AbstractChangeCaptureSubscriber.java
@@ -166,7 +166,9 @@ public abstract class AbstractChangeCaptureSubscriber<CAPTURE, RESPONSE>
 		this.responseObserver = responseObserver;
 		this.versionSupplier = versionSupplier;
 		this.serviceContext = serviceContext;
-		this.responseTimeoutMillis = this.serviceContext.requestTimeoutMillis();
+		// captured once, before the first capture is delivered - re-reading it per message would compound
+		// the budget instead of restating it, see `GrpcTimeoutUtil#captureRequestTimeoutMillis`
+		this.responseTimeoutMillis = GrpcTimeoutUtil.captureRequestTimeoutMillis(this.serviceContext);
 		final long idleTimeoutMillis = this.serviceContext.config().server().config().idleTimeoutMillis();
 		this.heartBeatDelay = resolveHeartBeatDelay(this.responseTimeoutMillis, idleTimeoutMillis);
 		this.heartBeatTask = new DelayedAsyncTask(

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils/GrpcOutboundGate.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils/GrpcOutboundGate.java
@@ -1,0 +1,407 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc.utils;
+
+import com.linecorp.armeria.server.ServiceRequestContext;
+import io.evitadb.externalApi.grpc.exception.StalledGrpcStreamException;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.netty.channel.EventLoop;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Back-pressure gate for server-streaming gRPC methods that produce messages faster than the client
+ * consumes them.
+ *
+ * gRPC-Java's send path never blocks. `StreamObserver.onNext` marshals the message and hands it to
+ * Armeria's outbound {@code StreamMessage}, whose queue has an initial capacity but **no bound** — its
+ * `tryWrite` refuses a message only once the stream is closed, never because it is full. A producer
+ * that ignores this materialises the whole payload in memory (as pooled, off-heap Netty buffers,
+ * roughly twice the payload in reserved arena space) and eventually kills the RPC with a bare
+ * `UNKNOWN` when the allocator gives up. Transport readiness is the only back-pressure signal there
+ * is, and this class is what makes it usable from a straight-line producing loop:
+ *
+ * ```java
+ * final GrpcOutboundGate gate = GrpcOutboundGate.attach(serverCallObserver, methodName);
+ * executeWithClientContext(
+ *     () -> {
+ *         while ((bytesRead = inputStream.read(buffer)) != -1) {
+ *             if (!gate.awaitWritable()) {
+ *                 return;                     // client is gone — abandon without completing
+ *             }
+ *             responseObserver.onNext(chunk);
+ *         }
+ *         responseObserver.onCompleted();
+ *     },
+ *     ...
+ * );
+ * ```
+ *
+ * **`attach` must be called synchronously from the service method, before it returns.** gRPC's
+ * {@code ServerCallStreamObserverImpl} freezes handler registration the moment the service method
+ * returns and throws {@link IllegalStateException} for any later {@code setOnReadyHandler} /
+ * {@code setOnCancelHandler} — which is exactly what would happen if the gate were built inside the
+ * worker task that {@code executeWithClientContext} submits. Only the producing loop belongs on the
+ * worker; the gate is wired up before it.
+ *
+ * The gate parks the producing worker thread rather than driving the loop from the on-ready callback.
+ * The callback runs on the Armeria event loop, so a callback-driven pump would have to bounce every
+ * chunk back onto a worker anyway; parking keeps the loop's `try`-with-resources, tracing scope and
+ * error handling in one straight-line method, and pins no thread that the RPC did not already own for
+ * its whole duration. What it does change is *how long* that thread is held — bounded by
+ * {@link #DEFAULT_STALL_TIMEOUT_MILLIS} so that a client which stops reading without hanging up cannot
+ * hold a request-executor thread forever.
+ *
+ * With Armeria, readiness means `pendingMessages == 0`, so a gated loop keeps exactly one message in
+ * flight. Callers streaming large payloads should size their chunks accordingly — every chunk costs an
+ * event-loop round trip.
+ *
+ * The one configuration the gate cannot help is an engine built with a direct (synchronous) executor,
+ * where the "worker" the service method hands off to *is* the transport event loop. Waiting there would
+ * deadlock rather than throttle, so the gate detects it, warns once and lets the producer run ungated -
+ * see {@link #awaitWritable()}. That is a test-only configuration; a networked `EvitaServer` always runs
+ * on real thread pools.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Slf4j
+public final class GrpcOutboundGate {
+
+	/**
+	 * How long the producer waits for the client to consume a single outstanding message before it
+	 * gives up on it. This is a "the peer is alive but has stopped reading" backstop, not a transfer
+	 * deadline: the wait restarts from zero every time the transport consumes anything, so even a very
+	 * slow but progressing client never reaches it.
+	 *
+	 * Mirrors `GrpcOptions.DEFAULT_STREAMING_REQUEST_TIMEOUT_IN_MILLIS` - a deployment configures it as
+	 * `api.endpoints.gRPC.streamingRequestTimeoutInMillis`, and this constant is only the fallback for
+	 * callers that have no configuration in hand (the two- and three-argument `attach` overloads, used by
+	 * tests and by the example above).
+	 */
+	public static final long DEFAULT_STALL_TIMEOUT_MILLIS = 300_000L;
+
+	/**
+	 * How much longer than the stall timeout the Armeria request deadline is re-armed for.
+	 *
+	 * The two mechanisms that can end a stalled stream - this gate's own wait and Armeria's request
+	 * timeout - are driven from the same budget, but they do not start their clocks at the same instant:
+	 * the deadline is re-armed when a message is *granted*, the gate begins waiting only after that
+	 * message has been written. Armed identically, Armeria would therefore always fire first and the
+	 * gate's stall detection would be unreachable - the client would get a bare `RST_STREAM` instead of
+	 * `DEADLINE_EXCEEDED` naming the stalled method. The grace hands the race to the gate deliberately,
+	 * leaving Armeria as the backstop for a producer that never reaches the gate at all.
+	 */
+	private static final long STALL_DETECTION_GRACE_MILLIS = 5_000L;
+
+	private final ServerCallStreamObserver<?> responseObserver;
+	private final String methodName;
+	private final long stallTimeoutMillis;
+	/**
+	 * The call's Armeria context, captured at attach time (`null` outside a request context, i.e. in
+	 * unit tests driving the gate against a mock observer).
+	 */
+	private final ServiceRequestContext serviceContext;
+	/**
+	 * The budget each re-arm restates, in milliseconds, or `<= 0` when the call has no request timeout
+	 * at all (an explicit `grpc-timeout: 0`, or a deployment that disabled it).
+	 *
+	 * This is the *streaming* budget - {@link #stallTimeoutMillis} plus
+	 * {@link #STALL_DETECTION_GRACE_MILLIS} - not the call's own `requestTimeout`. Re-arming to the
+	 * latter is what made a 1 MiB chunk require a ~4 Mbit/s link before the client's own deadline
+	 * mattered: `requestTimeout` is a whole-request budget sized for unary calls (1 s in code, 2 s
+	 * shipped), and a gated stream needs one message to drain inside it. The distinction is the same one
+	 * `EvitaClientChannel.TimeoutTier` draws on the driver side.
+	 */
+	private final long streamBudgetMillis;
+	/**
+	 * The event loop this call is bound to, captured at attach time (`null` outside a request
+	 * context). Waiting on readiness *from* that loop would be a self-deadlock - see
+	 * {@link #awaitWritable()}.
+	 */
+	private final EventLoop callEventLoop;
+	private final ReentrantLock lock = new ReentrantLock();
+	private final Condition transportStateChanged = this.lock.newCondition();
+
+	/**
+	 * Set from the transport lifecycle callbacks. Volatile so the fast path can read it without
+	 * taking the lock.
+	 */
+	private volatile boolean transportTerminated;
+	/**
+	 * Ensures the "producer runs on the event loop" warning is emitted once per call rather than once
+	 * per message.
+	 */
+	private final AtomicBoolean eventLoopProducerReported = new AtomicBoolean();
+
+	/**
+	 * Attaches a gate to the passed server-call observer using {@link #DEFAULT_STALL_TIMEOUT_MILLIS}.
+	 *
+	 * @param responseObserver observer of the server-streaming call to gate
+	 * @param methodName       name of the gated RPC, used in log and error messages
+	 * @return the attached gate
+	 */
+	@Nonnull
+	public static GrpcOutboundGate attach(
+		@Nonnull ServerCallStreamObserver<?> responseObserver,
+		@Nonnull String methodName
+	) {
+		return attach(responseObserver, methodName, null, DEFAULT_STALL_TIMEOUT_MILLIS);
+	}
+
+	/**
+	 * Attaches a gate to the passed server-call observer using {@link #DEFAULT_STALL_TIMEOUT_MILLIS},
+	 * chaining an additional action onto client-initiated cancellation.
+	 *
+	 * @param responseObserver observer of the server-streaming call to gate
+	 * @param methodName       name of the gated RPC, used in log and error messages
+	 * @param onCancel         action to run when the client cancels the call - typically releasing a
+	 *                         resource the producing loop holds. The gate owns the call's cancel
+	 *                         handler (gRPC allows only one, last registration wins), so any cleanup
+	 *                         the service method used to register itself must be passed in here
+	 * @return the attached gate
+	 */
+	@Nonnull
+	public static GrpcOutboundGate attach(
+		@Nonnull ServerCallStreamObserver<?> responseObserver,
+		@Nonnull String methodName,
+		@Nullable Runnable onCancel
+	) {
+		return attach(responseObserver, methodName, onCancel, DEFAULT_STALL_TIMEOUT_MILLIS);
+	}
+
+	/**
+	 * Attaches a gate to the passed server-call observer.
+	 *
+	 * @param responseObserver   observer of the server-streaming call to gate
+	 * @param methodName         name of the gated RPC, used in log and error messages
+	 * @param onCancel           action to run when the client cancels the call, or `null` for none
+	 * @param stallTimeoutMillis how long to wait for the client to consume a single message before
+	 *                           abandoning the stream with {@link StalledGrpcStreamException}
+	 * @return the attached gate
+	 */
+	@Nonnull
+	public static GrpcOutboundGate attach(
+		@Nonnull ServerCallStreamObserver<?> responseObserver,
+		@Nonnull String methodName,
+		@Nullable Runnable onCancel,
+		long stallTimeoutMillis
+	) {
+		final GrpcOutboundGate gate = new GrpcOutboundGate(responseObserver, methodName, stallTimeoutMillis);
+		responseObserver.setOnReadyHandler(gate::signalTransportStateChanged);
+		// both terminal transport edges wake the producer: onCancel for client-initiated termination
+		// (RST_STREAM, deadline, dead connection), onClose for server-initiated close - an interceptor
+		// closing the call, or our own onError/onCompleted reaching the client. Without the latter a
+		// producer waiting on readiness would sit out the full stall timeout after an unrelated
+		// failure closed the call underneath it.
+		responseObserver.setOnCancelHandler(
+			() -> {
+				gate.markTransportTerminated();
+				if (onCancel != null) {
+					onCancel.run();
+				}
+			}
+		);
+		responseObserver.setOnCloseHandler(gate::markTransportTerminated);
+		return gate;
+	}
+
+	private GrpcOutboundGate(
+		@Nonnull ServerCallStreamObserver<?> responseObserver,
+		@Nonnull String methodName,
+		long stallTimeoutMillis
+	) {
+		this.responseObserver = responseObserver;
+		this.methodName = methodName;
+		this.stallTimeoutMillis = stallTimeoutMillis;
+		this.serviceContext = ServiceRequestContext.currentOrNull();
+		this.callEventLoop = this.serviceContext == null ? null : this.serviceContext.eventLoop();
+		// Whether the call has a deadline at all is still the caller's decision - an explicit
+		// `grpc-timeout: 0` disables it and must stay disabled. What the deadline is re-armed *to*,
+		// however, is the streaming budget rather than the call's own request timeout. Read here rather
+		// than in the loop because `attach` runs synchronously from the service method, before any
+		// message and therefore before any re-arm has rewritten the stored value - see
+		// `GrpcTimeoutUtil#captureRequestTimeoutMillis` for why that matters.
+		this.streamBudgetMillis = this.serviceContext == null ?
+			0L :
+			GrpcTimeoutUtil.resolveStreamingBudgetMillis(
+				this.serviceContext, stallTimeoutMillis + STALL_DETECTION_GRACE_MILLIS
+			);
+	}
+
+	/**
+	 * Blocks the calling thread until the transport can accept another message.
+	 *
+	 * The cancellation check comes first and stays first, in every branch including the ungated
+	 * event-loop one. Attaching a gate registers a cancel handler, and gRPC stops throwing `CANCELLED`
+	 * from `onNext` as soon as one exists - so this method is the only thing left that can stop a
+	 * producing loop from reading its whole source and pushing it into a dead call. Reordering these
+	 * checks silently reintroduces that.
+	 *
+	 * @return true when it is safe to push the next message; false when the RPC is over and the caller
+	 *         must abandon the stream **without** calling `onCompleted` or `onError` - the transport is
+	 *         already terminated and both would be no-ops at best
+	 * @throws StalledGrpcStreamException when the client kept the stream open but consumed nothing
+	 *                                    within the stall timeout
+	 */
+	public boolean awaitWritable() {
+		// cancellation is checked first and unconditionally, before readiness is ever consulted:
+		// Armeria increments its pending-message counter in `sendMessage` and only decrements it once
+		// the payload is genuinely consumed, which never happens for a cancelled call because
+		// `doSendMessage` returns early. The counter is therefore never unwound and `isReady()` answers
+		// false forever - so a gate that trusted readiness here would park the producing worker for the
+		// entire stall timeout every single time a client simply pressed cancel.
+		if (isTransportGone()) {
+			return false;
+		}
+		if (this.responseObserver.isReady()) {
+			return grantNextMessageWindow();
+		}
+		if (this.callEventLoop != null && this.callEventLoop.inEventLoop()) {
+			// The producing loop is running on the very event loop that has to drain the outbound
+			// queue, so waiting here would block the only thread able to make readiness true again -
+			// a guaranteed self-deadlock rather than back-pressure. This happens when the service
+			// method's hand-off collapses into a direct (synchronous) executor, which evitaDB does
+			// for embedded test runs (`Evita(..., directExecutor = true)`); a networked server always
+			// uses real thread pools and never lands here. Proceed ungated, which is exactly the
+			// behaviour that configuration had before the gate existed.
+			if (this.eventLoopProducerReported.compareAndSet(false, true)) {
+				log.warn(
+					"`{}` is producing on the transport event loop, so outbound back-pressure cannot be " +
+						"applied - the response is buffered without bound. This is expected only for an " +
+						"embedded engine configured with a direct executor.",
+					this.methodName
+				);
+			}
+			return grantNextMessageWindow();
+		}
+		this.lock.lock();
+		try {
+			// re-check under the lock: the on-ready callback signals while holding it, and Armeria
+			// decrements the pending counter *before* invoking the callback, so a readiness edge that
+			// lands between the fast path above and the wait below cannot be missed
+			long remainingNanos = TimeUnit.MILLISECONDS.toNanos(this.stallTimeoutMillis);
+			while (!this.responseObserver.isReady()) {
+				if (isTransportGone()) {
+					return false;
+				}
+				if (remainingNanos <= 0L) {
+					throw new StalledGrpcStreamException(this.methodName, this.stallTimeoutMillis);
+				}
+				remainingNanos = this.transportStateChanged.awaitNanos(remainingNanos);
+			}
+			return grantNextMessageWindow();
+		} catch (InterruptedException ex) {
+			// the request executor cancels its tasks when the Armeria context is cancelled, so an
+			// interrupt here means the call is being torn down - treat it exactly like a dead transport
+			Thread.currentThread().interrupt();
+			log.debug("Producer of `{}` interrupted while waiting for the client to consume.", this.methodName);
+			return false;
+		} finally {
+			this.lock.unlock();
+		}
+	}
+
+	/**
+	 * Re-arms the deadline one last time, for the terminal `onCompleted` and whatever is still queued
+	 * behind it.
+	 *
+	 * Needed because {@link #awaitWritable()} grants a window *before* each message, so the final message
+	 * of a stream is the one write no subsequent grant covers. Without this call the deadline stays
+	 * frozen at the last grant while the transport is still draining the residual and the half-close is
+	 * yet to land - and the residual is precisely what a slow client is slowest at. Gating bounds it to
+	 * roughly one flow-control window, not to zero.
+	 *
+	 * Call it immediately before `onCompleted()`, and only on the success path - a producer abandoning a
+	 * dead call has nothing left to protect.
+	 */
+	public void grantCompletionWindow() {
+		grantNextMessageWindow();
+	}
+
+	/**
+	 * Re-arms the call's Armeria request timeout and reports that the producer may send.
+	 *
+	 * This is the reason the gate touches deadlines at all. Armeria's request timeout measures the whole
+	 * request, and gating a producer on readiness ties that request's lifetime to how fast the *client*
+	 * consumes - so a healthy download of a large file over a slow link outlives any fixed budget, and
+	 * without a re-arm the entire transfer has to fit inside one (1-2 s for a client that sends no
+	 * `grpc-timeout`). What the deadline has to mean on a stream is "time without progress", and every
+	 * grant of the gate is exactly one unit of progress.
+	 *
+	 * Doing it here rather than in each producing loop is deliberate: the re-arm was hand-written at six
+	 * call sites and `fetchFile` - the one streaming the largest payloads - was missing it entirely, which
+	 * is the failure mode a per-call-site convention has. A gated method now cannot forget, because the
+	 * grant and the re-arm are the same act.
+	 *
+	 * Safe off the event loop: Armeria's `DefaultCancellationScheduler` guards `setTimeoutNanos` with a
+	 * lock and re-schedules through `EventExecutor.schedule`.
+	 *
+	 * @return always `true` - written as a return so the callers read as a single decision
+	 */
+	private boolean grantNextMessageWindow() {
+		if (this.serviceContext != null) {
+			GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(this.serviceContext, this.streamBudgetMillis);
+		}
+		return true;
+	}
+
+	/**
+	 * Tells whether the RPC is already over, from either transport lifecycle callback or from gRPC's
+	 * own cancellation flag - the latter covers a cancellation that races us before the callback runs.
+	 *
+	 * @return true when nothing more can usefully be written to this call
+	 */
+	private boolean isTransportGone() {
+		return this.transportTerminated || this.responseObserver.isCancelled();
+	}
+
+	/**
+	 * Records that the call is over and wakes a producer waiting on readiness. Runs on the Armeria
+	 * event loop, so it must stay non-blocking.
+	 */
+	private void markTransportTerminated() {
+		this.transportTerminated = true;
+		signalTransportStateChanged();
+	}
+
+	/**
+	 * Wakes a producer waiting on readiness. Runs on the Armeria event loop, so it must stay
+	 * non-blocking - the lock is only ever held for the duration of a state re-check.
+	 */
+	private void signalTransportStateChanged() {
+		this.lock.lock();
+		try {
+			this.transportStateChanged.signalAll();
+		} finally {
+			this.lock.unlock();
+		}
+	}
+
+}

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils/GrpcTimeoutUtil.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils/GrpcTimeoutUtil.java
@@ -40,12 +40,81 @@ import java.time.Duration;
 public class GrpcTimeoutUtil {
 
 	/**
+	 * Reads the call's configured request timeout, to be captured **once before** a streaming loop and
+	 * then passed to every {@link #reArmRequestTimeoutIfEnabled(ServiceRequestContext, long)} inside it.
+	 *
+	 * Calling {@link ServiceRequestContext#requestTimeoutMillis()} from inside the loop instead is the
+	 * trap this method exists to close, and it is not a theoretical one - six call sites had it. That
+	 * getter does **not** return the configured budget, nor the time remaining: Armeria stores the
+	 * timeout relative to the request's start, and {@link TimeoutMode#SET_FROM_NOW} writes
+	 * `elapsed + newTimeout` into that field (`DefaultCancellationScheduler#setTimeoutNanosFromNow0`),
+	 * which `requestTimeoutMillis()` returns verbatim. Feeding it back into the next re-arm therefore
+	 * *ratchets*: a 2 s budget re-armed every 100 ms becomes 2.1 s, then 2.3 s, then 2.6 s, growing
+	 * without bound. The deadline stops being a rolling stall window and becomes an ever-receding
+	 * horizon that a genuinely stalled client never reaches. (The accessor that does mean "time left" is
+	 * `remainingTimeoutNanos()`, which is *also* not what a re-arm wants.)
+	 *
+	 * Capturing before the loop is what makes the value the configured one - at that point no re-arm has
+	 * happened yet, so the stored budget is still the request's own.
+	 *
+	 * @param serviceContext Armeria service context of the call whose budget should be captured
+	 * @return the configured request timeout in milliseconds, or `<= 0` when the timeout is disabled
+	 */
+	public static long captureRequestTimeoutMillis(@Nonnull ServiceRequestContext serviceContext) {
+		return serviceContext.requestTimeoutMillis();
+	}
+
+	/**
+	 * Resolves the budget a **streaming** call should re-arm to, capturing it once before the first
+	 * message in the same way - and for the same reason - as
+	 * {@link #captureRequestTimeoutMillis(ServiceRequestContext)}.
+	 *
+	 * Whether a call has a deadline at all stays the caller's decision: a client that asked for none, or
+	 * for `grpc-timeout: 0`, keeps none, and this returns `0` so the re-arm is skipped. What the deadline
+	 * is re-armed *to*, however, is the deployment's streaming budget rather than the call's own
+	 * `requestTimeout`. Those are different quantities and conflating them is a category error:
+	 * `requestTimeout` bounds a whole request, which suits a unary call, whereas a stream needs a bound
+	 * on *silence*. Re-arming a stream to the whole-request budget imposes a minimum viable link speed -
+	 * at `fetchFile`'s 1 MB chunk and the shipped 2 s, roughly 4 Mbit/s sustained - on transfers that are
+	 * otherwise progressing perfectly well.
+	 *
+	 * This substitution is safe precisely because a gRPC deadline is enforced by the **client**: Armeria's
+	 * client maps `withDeadlineAfter` onto its own response timeout and grpc-java runs a deadline timer, so
+	 * a client that asked for 500 ms still sees its call end at 500 ms. What lengthening the server's copy
+	 * changes is only how long a *live but silent* peer can pin a server worker - the capacity trade
+	 * recorded against `GrpcOutboundGate`.
+	 *
+	 * @param serviceContext              Armeria service context of the streaming call
+	 * @param streamingRequestTimeoutMillis the deployment's streaming budget, from the API configuration
+	 * @return the budget to pass to every subsequent
+	 *         {@link #reArmRequestTimeoutIfEnabled(ServiceRequestContext, long)}, or `0` when this call
+	 *         has no request timeout to re-arm
+	 */
+	public static long resolveStreamingBudgetMillis(
+		@Nonnull ServiceRequestContext serviceContext,
+		long streamingRequestTimeoutMillis
+	) {
+		return captureRequestTimeoutMillis(serviceContext) <= 0 ? 0L : streamingRequestTimeoutMillis;
+	}
+
+	/**
 	 * Re-arms the Armeria request timeout to `requestTimeoutMillis` from now, unless the timeout is
-	 * disabled (`requestTimeoutMillis <= 0`). A disabled request timeout is the normal state for a
-	 * gRPC call without a client-supplied deadline (e.g. `useClientTimeoutHeader(true)` with no
-	 * `grpc-timeout` header, or an open-ended CDC subscription) — Armeria treats `0` as "disabled"
-	 * everywhere else, but {@link TimeoutMode#SET_FROM_NOW} uniquely rejects a zero/negative duration
-	 * with an {@link IllegalArgumentException}, so re-arming must be skipped in that case.
+	 * disabled (`requestTimeoutMillis <= 0`). Armeria treats `0` as "disabled" everywhere else, but
+	 * {@link TimeoutMode#SET_FROM_NOW} uniquely rejects a zero/negative duration with an
+	 * {@link IllegalArgumentException}, so re-arming must be skipped in that case.
+	 *
+	 * A disabled timeout is *not* the default here, and it is worth being precise because the opposite
+	 * is easy to assume. With `useClientTimeoutHeader(true)`, `FramedGrpcService` overrides the context's
+	 * timeout **only when the request actually carries a `grpc-timeout` header**; absent one it leaves
+	 * the server's own `api.requestTimeoutInMillis` in force (1 s code default, 2 s in the shipped
+	 * configuration). So a client that sets no deadline at all - a browser over gRPC-Web, most obviously -
+	 * gets the *shortest* budget of anyone, which is exactly why the re-arm cannot be treated as an
+	 * optimisation for well-behaved clients. A genuinely disabled timeout arises from an explicit
+	 * `grpc-timeout: 0` or from configuration.
+	 *
+	 * The budget passed here must come from {@link #captureRequestTimeoutMillis(ServiceRequestContext)}
+	 * called *before* the loop - never from `serviceContext.requestTimeoutMillis()` read inside it. See
+	 * that method for why the difference is not cosmetic.
 	 *
 	 * @param serviceContext       Armeria service context whose request timeout should be re-armed
 	 * @param requestTimeoutMillis the timeout to re-arm to, in milliseconds (`<= 0` means disabled)

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/module-info.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/module-info.java
@@ -57,6 +57,8 @@ module evita.external.api.grpc {
 	requires evita.external.api.grpc.shared;
 
 	requires io.netty.handler;
+	// io.netty.channel.EventLoop - GrpcOutboundGate has to recognise the transport's own thread
+	requires io.netty.transport;
 	requires io.grpc.services;
 	requires io.grpc;
 	requires io.grpc.protobuf;

--- a/evita_server/src/main/resources/evita-configuration.yaml
+++ b/evita_server/src/main/resources/evita-configuration.yaml
@@ -147,6 +147,7 @@ api:
       tlsMode: ${api.endpoints.gRPC.tlsMode:null}
       keepAlive: ${api.endpoints.gRPC.keepAlive:null}
       exposeDocsService: ${api.endpoints.gRPC.exposeDocsService:false}
+      streamingRequestTimeoutInMillis: ${api.endpoints.gRPC.streamingRequestTimeoutInMillis:300K}
       mTLS:
         enabled: ${api.endpoints.gRPC.mTLS.enabled:null}
         allowedClientCertificatePaths: ${api.endpoints.gRPC.mTLS.allowedClientCertificatesPaths:null}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/CombinedPriceEntityByPriceFilteringFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/CombinedPriceEntityByPriceFilteringFunctionalTest.java
@@ -267,6 +267,9 @@ public class CombinedPriceEntityByPriceFilteringFunctionalTest extends EntityByP
 	@Test
 	@Override
 	void shouldReturnPriceHistogram(Evita evita, List<SealedEntity> originalProductEntities) {
+		// #1433 regression: the histogram must keep per-inner-record granularity for the LOWEST_PRICE
+		// masters even though NONE and SUM neighbours share the candidate pool
+		assertPoolMixesInnerRecordHandling(originalProductEntities);
 		super.shouldReturnPriceHistogram(evita, originalProductEntities);
 	}
 
@@ -275,6 +278,9 @@ public class CombinedPriceEntityByPriceFilteringFunctionalTest extends EntityByP
 	@Test
 	@Override
 	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilter(Evita evita, List<SealedEntity> originalProductEntities) {
+		// #1433 regression: the histogram must keep per-inner-record granularity for the LOWEST_PRICE
+		// masters even though NONE and SUM neighbours share the candidate pool
+		assertPoolMixesInnerRecordHandling(originalProductEntities);
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilter(evita, originalProductEntities);
 	}
 
@@ -283,6 +289,9 @@ public class CombinedPriceEntityByPriceFilteringFunctionalTest extends EntityByP
 	@Test
 	@Override
 	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterAndValidity(Evita evita, List<SealedEntity> originalProductEntities) {
+		// #1433 regression: the histogram must keep per-inner-record granularity for the LOWEST_PRICE
+		// masters even though NONE and SUM neighbours share the candidate pool
+		assertPoolMixesInnerRecordHandling(originalProductEntities);
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterAndValidity(evita, originalProductEntities);
 	}
 
@@ -291,6 +300,9 @@ public class CombinedPriceEntityByPriceFilteringFunctionalTest extends EntityByP
 	@Test
 	@Override
 	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
+		// #1433 regression: the histogram must keep per-inner-record granularity for the LOWEST_PRICE
+		// masters even though NONE and SUM neighbours share the candidate pool
+		assertPoolMixesInnerRecordHandling(originalProductEntities);
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(evita, originalProductEntities);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/EntityByPriceFilteringFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/EntityByPriceFilteringFunctionalTest.java
@@ -64,6 +64,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Currency;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,6 @@ import static io.evitadb.test.TestConstants.TEST_CATALOG;
 import static io.evitadb.test.generator.DataGenerator.*;
 import static io.evitadb.utils.AssertionUtils.assertSortedResultEquals;
 import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.summingInt;
 import static org.junit.jupiter.api.Assertions.*;
 import static io.evitadb.test.TestTags.CONTRACT;
 import static io.evitadb.test.TestTags.FILTER;
@@ -113,12 +113,18 @@ public class EntityByPriceFilteringFunctionalTest {
 	/**
 	 * Verifies histogram integrity against source entities.
 	 *
-	 * Auto-detects the engine path used to build the histogram and dispatches to the matching assertion
-	 * helper. When **every** filtered entity has `LOWEST_PRICE` inner-record handling the engine activates
-	 * the per-inner-record histogram bypass — each inner-record-id contributes one bucket data point. In
-	 * any other case (pure `NONE`, pure `SUM`, or a mixed catalog that contains at least one
-	 * non-LOWEST_PRICE accessor) the engine falls back to the per-entity histogram path, so each entity
-	 * contributes exactly one bucket data point.
+	 * The expected bucket population is derived **per entity from its own
+	 * {@link PriceInnerRecordHandling}** — the granularity contract the histogram promises regardless of
+	 * how homogeneous the candidate pool happens to be:
+	 *
+	 * - `LOWEST_PRICE` entities contribute one data point per inner-record-id (every variant price the
+	 *   pool can reach), not just the winning price for sale;
+	 * - `NONE` and `SUM` entities contribute exactly one data point — their price for sale.
+	 *
+	 * A pool that mixes handling modes therefore expects the union of both rules. This is deliberately
+	 * **not** derived from which engine path fired: an assertion that adapts to the engine cannot detect
+	 * the engine silently dropping to a coarser granularity, which is exactly the defect reported in
+	 * issue #1433.
 	 */
 	protected static void assertHistogramIntegrity(
 		@Nonnull EvitaResponse<SealedEntity> result,
@@ -127,66 +133,188 @@ public class EntityByPriceFilteringFunctionalTest {
 		@Nullable BigDecimal to,
 		@Nullable OffsetDateTime validIn
 	) {
-		// detect whether the engine fired the per-inner-record bypass: requires every accessor to be a
-		// histogram-aware LOWEST_PRICE termination formula, which in practice maps to "every filtered
-		// entity uses LOWEST_PRICE handling"
-		boolean allLowestPrice = !filteredProducts.isEmpty();
-		for (final SealedEntity entity : filteredProducts) {
-			if (entity.getPriceInnerRecordHandling() != PriceInnerRecordHandling.LOWEST_PRICE) {
-				allLowestPrice = false;
-				break;
-			}
-		}
-		if (allLowestPrice) {
-			assertHistogramIntegrityPerInnerRecord(result, filteredProducts, from, to, validIn);
-		} else {
-			assertHistogramIntegrityPerEntity(result, filteredProducts, from, to, validIn);
-		}
+		final PriceHistogram priceHistogram = result.getExtraResult(PriceHistogram.class);
+		assertNotNull(priceHistogram);
+
+		assertHistogramMatchesDataPoints(
+			priceHistogram,
+			collectExpectedHistogramDataPoints(filteredProducts, validIn),
+			from, to,
+			"Histogram data points must follow each entity's own price inner record handling — one per " +
+				"inner-record-id for LOWEST_PRICE entities, one per entity for NONE/SUM entities"
+		);
 	}
 
 	/**
-	 * Verifies histogram integrity against source entities for the per-entity histogram path.
+	 * Asserts the fixture really mixes {@link PriceInnerRecordHandling} values — the precondition the
+	 * mixed-pool histogram assertions exist to exercise (issue #1433). Without it a change to the data
+	 * generator could homogenise the catalog and every mixed-pool test would keep passing while covering
+	 * nothing, which is how the original defect stayed invisible.
 	 *
-	 * The histogram reports one bucket data point per filtered entity — the entity's selling price (the
-	 * winner across the queried price-list priority). Used for pure `NONE` and pure `SUM` handling
-	 * catalogs as well as for mixed catalogs where the engine cannot fire the per-inner-record bypass.
+	 * @param products the whole fixture the histogram queries draw their candidate pools from
 	 */
-	protected static void assertHistogramIntegrityPerEntity(
-		@Nonnull EvitaResponse<SealedEntity> result,
-		@Nonnull List<SealedEntity> filteredProducts,
-		@Nullable BigDecimal from,
-		@Nullable BigDecimal to,
+	protected static void assertPoolMixesInnerRecordHandling(@Nonnull List<SealedEntity> products) {
+		final Set<PriceInnerRecordHandling> handlings = collectInnerRecordHandlings(products);
+		assertTrue(
+			handlings.containsAll(
+				List.of(
+					PriceInnerRecordHandling.NONE,
+					PriceInnerRecordHandling.LOWEST_PRICE,
+					PriceInnerRecordHandling.SUM
+				)
+			),
+			"Mixed-pool histogram tests require a fixture carrying NONE, LOWEST_PRICE and SUM entities " +
+				"(both the LOWEST_PRICE + NONE and the LOWEST_PRICE + SUM combinations reproduce #1433), " +
+				"but the fixture only carries: " + handlings
+		);
+	}
+
+	/**
+	 * Collects the distinct {@link PriceInnerRecordHandling} values present among the passed entities.
+	 */
+	@Nonnull
+	private static Set<PriceInnerRecordHandling> collectInnerRecordHandlings(@Nonnull List<SealedEntity> entities) {
+		final Set<PriceInnerRecordHandling> handlings = EnumSet.noneOf(PriceInnerRecordHandling.class);
+		for (final SealedEntity entity : entities) {
+			handlings.add(entity.getPriceInnerRecordHandling());
+		}
+		return handlings;
+	}
+
+	/**
+	 * Picks up to `count` entities satisfying the predicate, spreading the selection over as many distinct
+	 * {@link PriceInnerRecordHandling} values as the candidates offer and preferring, within each of them,
+	 * the entity contributing the most histogram data points.
+	 *
+	 * Both halves matter for the prefetch histogram tests, which query a handful of entities by primary key:
+	 *
+	 * - without the **spread**, a plain "first N matches" pick can land on a homogeneous subset of an
+	 *   otherwise mixed catalog, and the mixed-pool granularity contract of issue #1433 stops being covered;
+	 * - without the **contribution preference**, the pick can satisfy the spread with single-variant
+	 *   `LOWEST_PRICE` masters, for which per-entity and per-inner-record granularity return the same
+	 *   numbers — a pool that is mixed by handling but cannot tell the two granularities apart. That is not
+	 *   a hypothetical: the balanced-but-toothless `{NONE=2, LOWEST_PRICE=2, SUM=2}` pool is exactly what
+	 *   this method produced before the ordering was added, and the regressed engine passed against it.
+	 *
+	 * @param candidates entities to pick from, in the order they should be preferred among equals
+	 * @param predicate  condition every picked entity has to satisfy
+	 * @param validIn    moment the prices must be valid in, or `null` when validity is not constrained
+	 * @param count      maximum number of entities to pick
+	 * @return the picked entities — fewer than `count` when the candidates cannot supply enough matches
+	 */
+	@Nonnull
+	private static List<SealedEntity> pickSpreadingInnerRecordHandling(
+		@Nonnull List<SealedEntity> candidates,
+		@Nonnull Predicate<SealedEntity> predicate,
+		@Nullable OffsetDateTime validIn,
+		int count
+	) {
+		// stable sort — entities contributing more data points first, encounter order preserved among equals
+		final List<SealedEntity> matching = candidates.stream()
+			.filter(predicate)
+			.sorted(
+				Comparator.comparingInt(
+					(SealedEntity it) -> collectExpectedHistogramDataPoints(List.of(it), validIn).size()
+				).reversed()
+			)
+			.toList();
+		final boolean[] alreadyPicked = new boolean[matching.size()];
+		final List<SealedEntity> picked = new ArrayList<>(count);
+
+		// first pass — take one entity per distinct price inner record handling
+		final Set<PriceInnerRecordHandling> covered = EnumSet.noneOf(PriceInnerRecordHandling.class);
+		for (int i = 0; i < matching.size() && picked.size() < count; i++) {
+			final SealedEntity candidate = matching.get(i);
+			if (covered.add(candidate.getPriceInnerRecordHandling())) {
+				picked.add(candidate);
+				alreadyPicked[i] = true;
+			}
+		}
+
+		// second pass — fill the remaining slots with whatever is left
+		for (int i = 0; i < matching.size() && picked.size() < count; i++) {
+			if (!alreadyPicked[i]) {
+				picked.add(matching.get(i));
+			}
+		}
+
+		return picked;
+	}
+
+	/**
+	 * Expands the passed entities into the price values the histogram is expected to bucket, applying the
+	 * granularity rule of each entity's own {@link PriceInnerRecordHandling}. Entities that resolve to no
+	 * price in the queried scope are skipped — they contribute nothing to the engine's funnel either.
+	 *
+	 * @param entities entities that survived the filter (the histogram's candidate pool)
+	 * @param validIn  moment the prices must be valid in, or `null` when validity is not constrained
+	 * @return every price value expected to appear as a histogram data point, in no particular order
+	 */
+	@Nonnull
+	private static List<BigDecimal> collectExpectedHistogramDataPoints(
+		@Nonnull List<SealedEntity> entities,
 		@Nullable OffsetDateTime validIn
 	) {
-		final PriceHistogram priceHistogram = result.getExtraResult(PriceHistogram.class);
-		assertNotNull(priceHistogram);
+		// capacity hint of `entities.size() * 2` reflects the typical mixed catalog shape — LOWEST_PRICE
+		// masters carry ~2 inner records, the remaining handling modes contribute a single point each
+		final List<BigDecimal> expanded = new ArrayList<>(entities.size() * 2);
+		for (final SealedEntity entity : entities) {
+			if (entity.getPriceInnerRecordHandling() == PriceInnerRecordHandling.LOWEST_PRICE) {
+				final List<PriceContract> allPricesForSale = entity.getAllPricesForSale(
+					CURRENCY_EUR, validIn, PRICE_LIST_VIP, PRICE_LIST_BASIC
+				);
+				for (final PriceContract price : allPricesForSale) {
+					expanded.add(price.priceWithTax());
+				}
+			} else {
+				entity.getPriceForSale(CURRENCY_EUR, validIn, PRICE_LIST_VIP, PRICE_LIST_BASIC)
+					.map(PriceContract::priceWithTax)
+					.ifPresent(expanded::add);
+			}
+		}
+		return expanded;
+	}
+
+	/**
+	 * Shared assertion core for every histogram integrity check — verifies the overall count, the min/max
+	 * span, the per-bucket occurrences and the `requested` flag against a pre-computed list of expected
+	 * data points. Keeping the assertions in one place stops the per-entity, per-inner-record and mixed
+	 * expectations from drifting apart on everything except how they expand entities into prices.
+	 *
+	 * @param priceHistogram histogram returned by the engine
+	 * @param expectedPrices price values expected to populate the histogram
+	 * @param from           lower bound of the user's price slider, or `null` when unconstrained
+	 * @param to             upper bound of the user's price slider, or `null` when unconstrained
+	 * @param countMessage   explanation attached to the overall-count assertion
+	 */
+	private static void assertHistogramMatchesDataPoints(
+		@Nonnull PriceHistogram priceHistogram,
+		@Nonnull List<BigDecimal> expectedPrices,
+		@Nullable BigDecimal from,
+		@Nullable BigDecimal to,
+		@Nonnull String countMessage
+	) {
 		assertTrue(priceHistogram.getBuckets().length <= 20);
 
-		assertEquals(filteredProducts.size(), priceHistogram.getOverallCount());
-		final List<BigDecimal> pricesForSale = filteredProducts
-			.stream()
-			.map(it -> it.getPriceForSale(CURRENCY_EUR, validIn, PRICE_LIST_VIP, PRICE_LIST_BASIC))
-			.filter(Optional::isPresent)
-			.map(Optional::get)
-			.map(PriceContract::priceWithTax)
-			.toList();
+		assertEquals(expectedPrices.size(), priceHistogram.getOverallCount(), countMessage);
+		assertEquals(
+			expectedPrices.stream().min(Comparator.naturalOrder()).orElse(BigDecimal.ZERO),
+			priceHistogram.getMin()
+		);
+		assertEquals(
+			expectedPrices.stream().max(Comparator.naturalOrder()).orElse(BigDecimal.ZERO),
+			priceHistogram.getMax()
+		);
 
-		assertEquals(pricesForSale.stream().min(Comparator.naturalOrder()).orElse(BigDecimal.ZERO), priceHistogram.getMin());
-		assertEquals(pricesForSale.stream().max(Comparator.naturalOrder()).orElse(BigDecimal.ZERO), priceHistogram.getMax());
-
-		// verify bucket occurrences
-		final Map<Integer, Integer> expectedOccurrences = filteredProducts
-			.stream()
-			.collect(
-				Collectors.groupingBy(
-					it -> findIndexInHistogram(it, priceHistogram, validIn),
-					summingInt(entity -> 1)
-				)
-			);
+		// verify bucket occurrences — one data point per expected price
+		final Map<Integer, Integer> expectedOccurrences = new HashMap<>(expectedPrices.size());
+		for (final BigDecimal price : expectedPrices) {
+			expectedOccurrences.merge(findIndexInHistogramByPrice(price, priceHistogram), 1, Integer::sum);
+		}
 
 		final Bucket[] buckets = priceHistogram.getBuckets();
 		for (int i = 0; i < buckets.length; i++) {
-			final Bucket bucket = priceHistogram.getBuckets()[i];
+			final Bucket bucket = buckets[i];
 			if (from == null && to == null) {
 				assertTrue(bucket.requested());
 			} else if (
@@ -221,79 +349,28 @@ public class EntityByPriceFilteringFunctionalTest {
 	) {
 		final PriceHistogram priceHistogram = result.getExtraResult(PriceHistogram.class);
 		assertNotNull(priceHistogram);
-		assertTrue(priceHistogram.getBuckets().length <= 20);
 
 		// expand each entity into its per-inner-record winning prices
-		final List<PriceContract> expandedPrices = collectPerInnerRecordPricesForSale(filteredProducts, validIn);
+		final List<BigDecimal> expandedPrices = new ArrayList<>(filteredProducts.size() * 2);
+		for (final SealedEntity entity : filteredProducts) {
+			final List<PriceContract> allPricesForSale = entity.getAllPricesForSale(
+				CURRENCY_EUR, validIn, PRICE_LIST_VIP, PRICE_LIST_BASIC
+			);
+			for (final PriceContract price : allPricesForSale) {
+				expandedPrices.add(price.priceWithTax());
+			}
+		}
 
-		assertEquals(
-			expandedPrices.size(), priceHistogram.getOverallCount(),
+		assertHistogramMatchesDataPoints(
+			priceHistogram, expandedPrices, from, to,
 			"Per-inner-record histogram overall count must equal the total number of distinct " +
 				"inner-record prices across all LOWEST_PRICE entities"
 		);
-
-		final BigDecimal expectedMin = expandedPrices.stream()
-			.map(PriceContract::priceWithTax)
-			.min(Comparator.naturalOrder())
-			.orElse(BigDecimal.ZERO);
-		final BigDecimal expectedMax = expandedPrices.stream()
-			.map(PriceContract::priceWithTax)
-			.max(Comparator.naturalOrder())
-			.orElse(BigDecimal.ZERO);
-		assertEquals(expectedMin, priceHistogram.getMin());
-		assertEquals(expectedMax, priceHistogram.getMax());
-
-		// verify bucket occurrences — one data point per per-inner-record price
-		final Map<Integer, Integer> expectedOccurrences = new HashMap<>(expandedPrices.size());
-		for (final PriceContract price : expandedPrices) {
-			final int bucketIndex = findIndexInHistogramByPrice(price.priceWithTax(), priceHistogram);
-			expectedOccurrences.merge(bucketIndex, 1, Integer::sum);
-		}
-
-		final Bucket[] buckets = priceHistogram.getBuckets();
-		for (int i = 0; i < buckets.length; i++) {
-			final Bucket bucket = buckets[i];
-			if (from == null && to == null) {
-				assertTrue(bucket.requested());
-			} else if (
-				(from == null || from.compareTo(bucket.threshold()) <= 0) &&
-					(to == null || to.compareTo(bucket.threshold()) >= 0)) {
-				assertTrue(bucket.requested());
-			} else {
-				assertFalse(bucket.requested());
-			}
-			assertEquals(
-				ofNullable(expectedOccurrences.get(i)).orElse(0),
-				bucket.occurrences()
-			);
-		}
 	}
 
 	/**
-	 * Collects per-inner-record selling prices from all passed entities using the same priority rule the
-	 * engine applies (`getAllPricesForSale` for LOWEST_PRICE entities returns one winner per inner record
-	 * id). Entities that resolve to no candidates in scope are silently skipped — they would not appear in
-	 * the engine's histogram funnel either.
-	 */
-	@Nonnull
-	private static List<PriceContract> collectPerInnerRecordPricesForSale(
-		@Nonnull List<SealedEntity> entities,
-		@Nullable OffsetDateTime validIn
-	) {
-		// capacity hint of `entities.size() * 2` reflects the typical LOWEST_PRICE catalog shape — most
-		// entities have ~2 inner records; under-shoots are cheap (ArrayList grows by ~50%), over-shoots are
-		// wasted memory only for the duration of the assertion
-		final List<PriceContract> expanded = new ArrayList<>(entities.size() * 2);
-		for (final SealedEntity entity : entities) {
-			expanded.addAll(entity.getAllPricesForSale(CURRENCY_EUR, validIn, PRICE_LIST_VIP, PRICE_LIST_BASIC));
-		}
-		return expanded;
-	}
-
-	/**
-	 * Locates the histogram bucket index for an arbitrary price value. Mirrors the logic of
-	 * `findIndexInHistogram` but works against a pre-computed price (used when expanding LOWEST_PRICE
-	 * entities into multiple data points — one per inner record id).
+	 * Locates the histogram bucket index for an arbitrary price value — the bucket whose threshold is the
+	 * greatest one still not exceeding the price.
 	 */
 	private static int findIndexInHistogramByPrice(@Nonnull BigDecimal price, @Nonnull HistogramContract histogram) {
 		final Bucket[] buckets = histogram.getBuckets();
@@ -364,25 +441,6 @@ public class EntityByPriceFilteringFunctionalTest {
 			}
 		}
 		fail("There is product that contains price from price lists: " + Arrays.stream(priceLists).map(Object::toString).collect(Collectors.joining(", ")));
-	}
-
-	/**
-	 * Finds appropriate index in the histogram according to histogram thresholds.
-	 */
-	private static int findIndexInHistogram(SealedEntity entity, HistogramContract histogram, OffsetDateTime validIn) {
-		final BigDecimal entityPrice = entity.getPriceForSale(CURRENCY_EUR, validIn, PRICE_LIST_VIP, PRICE_LIST_BASIC)
-			.orElseThrow()
-			.priceWithTax();
-		final Bucket[] buckets = histogram.getBuckets();
-		for (int i = buckets.length - 1; i >= 0; i--) {
-			final Bucket bucket = buckets[i];
-			final int priceCompared = entityPrice.compareTo(bucket.threshold());
-			if (priceCompared >= 0) {
-				return i;
-			}
-		}
-		fail("Histogram span doesn't match current entity price: " + entityPrice);
-		return -1;
 	}
 
 	/**
@@ -1875,29 +1933,65 @@ public class EntityByPriceFilteringFunctionalTest {
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
-				final Predicate<PriceContract> betweenPredicate = it -> it.priceWithTax().compareTo(from) >= 0 && it.priceWithTax().compareTo(to) <= 0;
-				final List<SealedEntity> filteredProducts = Stream.concat(
-					originalProductEntities
-						.stream()
-						.filter(
-							sealedEntity ->
-								sealedEntity.getPriceForSale(CURRENCY_EUR, null, PRICE_LIST_VIP).map(betweenPredicate::test).orElse(false) ||
-									sealedEntity.getPriceForSale(CURRENCY_EUR, null, PRICE_LIST_BASIC).map(betweenPredicate::test).orElse(false)
-						)
-						.limit(3),
-					originalProductEntities
-						.stream()
-						.filter(
-							sealedEntity ->
-							{
-								final Optional<PriceContract> vipPrice = sealedEntity.getPriceForSale(CURRENCY_EUR, null, PRICE_LIST_VIP);
-								final Optional<PriceContract> basicPrice = sealedEntity.getPriceForSale(CURRENCY_EUR, null, PRICE_LIST_BASIC);
-								return (vipPrice.isPresent() && vipPrice.map(it -> !betweenPredicate.test(it)).orElse(true)) &&
-									(basicPrice.map(it -> !betweenPredicate.test(it)).orElse(true));
-							}
-						)
-						.limit(3)
-				).collect(Collectors.toList());
+				// both pool membership and price-between matching are derived from the model contract rather
+				// than hand-rolled per price list — `hasPriceInInterval` applies the very rule the engine does
+				// for each handling mode (price for sale for NONE/SUM, any inner-record price for LOWEST_PRICE),
+				// which is what makes this fixture valid for every subclass' dataset and not just the NONE one
+				final Predicate<SealedEntity> inCandidatePool = it ->
+					hasAnyIndexedPrice(it, CURRENCY_EUR, PRICE_LIST_VIP) ||
+						hasAnyIndexedPrice(it, CURRENCY_EUR, PRICE_LIST_BASIC);
+				final Predicate<SealedEntity> matchesPriceBetween = it -> it.hasPriceInInterval(
+					from, to, QueryPriceMode.WITH_TAX, CURRENCY_EUR, null, PRICE_LIST_VIP, PRICE_LIST_BASIC
+				);
+
+				final List<SealedEntity> matchingProducts = pickSpreadingInnerRecordHandling(
+					originalProductEntities, inCandidatePool.and(matchesPriceBetween), null, 3
+				);
+				final List<SealedEntity> filteredOutProducts = pickSpreadingInnerRecordHandling(
+					originalProductEntities, inCandidatePool.and(matchesPriceBetween.negate()), null, 3
+				);
+
+				// verify our test works — the pool must hold both entities the price filter keeps and entities
+				// it removes, otherwise the histogram could not prove it ignores that filter
+				assertEquals(
+					3, matchingProducts.size(),
+					"Fixture doesn't offer three products matching the price between query!"
+				);
+				assertEquals(
+					3, filteredOutProducts.size(),
+					"Fixture doesn't offer three products the price between query filters out. " +
+						"Test is not testing anything!"
+				);
+
+				final List<SealedEntity> filteredProducts = Stream
+					.concat(matchingProducts.stream(), filteredOutProducts.stream())
+					.collect(Collectors.toList());
+
+				// pin the granularity coverage of the pool the prefetched plan actually sees: it has to span
+				// every handling mode the dataset can supply (capped by how many entities we select), so the
+				// mixed-pool contract of issue #1433 stays exercised here. On the homogeneous subclass datasets
+				// this degrades to the single mode they offer and asserts nothing beyond it.
+				final Set<PriceInnerRecordHandling> availableHandlings = collectInnerRecordHandlings(
+					originalProductEntities.stream().filter(inCandidatePool).toList()
+				);
+				assertTrue(
+					collectInnerRecordHandlings(filteredProducts).size() >= Math.min(3, availableHandlings.size()),
+					"Prefetched pool must span every price inner record handling the dataset offers, but " +
+						"the dataset has " + availableHandlings + " and the pool only " +
+						collectInnerRecordHandlings(filteredProducts)
+				);
+
+				// spanning the handling modes is not enough on its own — a pool of single-variant LOWEST_PRICE
+				// masters returns identical numbers under both granularities, so the regression it is meant to
+				// catch would pass straight through it. Demand at least one entity contributing more than one
+				// data point wherever the dataset can supply one.
+				if (availableHandlings.contains(PriceInnerRecordHandling.LOWEST_PRICE)) {
+					assertTrue(
+						collectExpectedHistogramDataPoints(filteredProducts, null).size() > filteredProducts.size(),
+						"Prefetched pool must contain a multi-inner-record LOWEST_PRICE entity, otherwise " +
+							"per-entity and per-inner-record granularity are indistinguishable here"
+					);
+				}
 
 				final EvitaResponse<SealedEntity> result = session.query(
 					query(
@@ -1922,18 +2016,8 @@ public class EntityByPriceFilteringFunctionalTest {
 					SealedEntity.class
 				);
 
-				// verify our test works
-				final Predicate<SealedEntity> priceForSaleBetweenPredicate = it -> {
-					final BigDecimal price = it.getPriceForSale(CURRENCY_EUR, null, PRICE_LIST_VIP, PRICE_LIST_BASIC)
-						.orElseThrow()
-						.priceWithTax();
-					return price.compareTo(from) >= 0 && price.compareTo(to) <= 0;
-				};
-				assertEquals(3, result.getTotalRecordCount());
-				assertTrue(
-					filteredProducts.size() > filteredProducts.stream().filter(priceForSaleBetweenPredicate).count(),
-					"Price between query didn't filter out any products. Test is not testing anything!"
-				);
+				// the prefetched plan must agree with the model on which entities the price filter keeps
+				assertEquals(matchingProducts.size(), result.getTotalRecordCount());
 
 				// the price between query must be ignored while computing price histogram
 				assertHistogramIntegrity(result, filteredProducts, from, to, null);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/FindFirstPriceEntityByPriceFilteringFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/FindFirstPriceEntityByPriceFilteringFunctionalTest.java
@@ -24,6 +24,7 @@
 package io.evitadb.api.functional.price;
 
 import com.github.javafaker.Faker;
+import io.evitadb.api.query.require.DebugMode;
 import io.evitadb.api.requestResponse.EvitaResponse;
 import io.evitadb.api.requestResponse.data.EntityReferenceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
@@ -52,7 +53,9 @@ import static io.evitadb.api.query.Query.query;
 import static io.evitadb.api.query.QueryConstraints.and;
 import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
 import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.debug;
 import static io.evitadb.api.query.QueryConstraints.entityFetch;
+import static io.evitadb.api.query.QueryConstraints.entityPrimaryKeyInSet;
 import static io.evitadb.api.query.QueryConstraints.filterBy;
 import static io.evitadb.api.query.QueryConstraints.page;
 import static io.evitadb.api.query.QueryConstraints.priceBetween;
@@ -71,6 +74,7 @@ import static io.evitadb.test.generator.DataGenerator.CURRENCY_EUR;
 import static io.evitadb.test.generator.DataGenerator.PRICE_LIST_BASIC;
 import static io.evitadb.test.generator.DataGenerator.PRICE_LIST_REFERENCE;
 import static io.evitadb.test.generator.DataGenerator.PRICE_LIST_VIP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -313,6 +317,7 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 
 	@DisplayName("Should return price histogram for returned products excluding price between query")
 	@UseDataSet(HUNDRED_PRODUCTS_WITH_FIND_FIRST_PRICES)
+	@Test
 	@Override
 	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(evita, originalProductEntities);
@@ -386,9 +391,9 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 	@Test
 	@Tag(HISTOGRAM)
 	void shouldExpandLowestPriceHistogramToPerInnerRecordPrices(@Nonnull Evita evita, @Nonnull List<SealedEntity> originalProductEntities) {
-		// the engine's per-inner-record bypass fires only when every `FilteredPriceRecordAccessor` in
-		// the filtering formula tree is histogram-aware. This requires a pure LOWEST_PRICE catalog
-		// (no `Sum`/`Plain` siblings) and no prefetch wrappers (no `entityPrimaryKeyInSet`).
+		// a pure LOWEST_PRICE catalog — every entity in the pool expands into one data point per
+		// inner-record id, so the expected count is derived from the whole fixture. The mixed-pool
+		// variant of this contract is covered by `CombinedPriceEntityByPriceFilteringFunctionalTest`.
 		final List<SealedEntity> lowestPriceProducts = originalProductEntities
 			.stream()
 			.filter(it -> hasAnyIndexedPrice(it, CURRENCY_EUR, PRICE_LIST_VIP) ||
@@ -421,18 +426,18 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 				"entity count (" + lowestPriceProducts.size() + ") when multi-inner-record entities exist"
 		);
 
-		// case 1: query without priceBetween — verify the basic per-inner-record expansion. The
-		// `VERIFY_ALTERNATIVE_INDEX_RESULTS` / `VERIFY_POSSIBLE_CACHING_TREES` debug modes are
-		// intentionally **not** added here. The per-inner-record bypass now fires both through the
-		// preferred prefetch-eligible plan (`SelectionFormula` propagates the histogram capability
-		// from its inner LP) and through the bare index plan. Both plans therefore agree on the
-		// per-inner-record count when this fixture is used in isolation. The cross-plan verifier is
-		// still disabled because the bypass is only exercised by histogram queries running against a
-		// pure LOWEST_PRICE catalog — the verifier rebuilds alternative plans whose accessor lists
-		// differ in subtle ways (`getFilteredPriceRecordsForHistogram` vs the per-entity collector)
-		// and the resulting `Histogram[overall=N]` counts diverge across plans, which the verifier
-		// would surface as `InconsistentResultsException`. The per-inner-record assertion below is
-		// itself the cross-plan invariant we care about.
+		// case 1: query without priceBetween — verify the basic per-inner-record expansion.
+		//
+		// `VERIFY_ALTERNATIVE_INDEX_RESULTS` and `VERIFY_POSSIBLE_CACHING_TREES` are enabled here on
+		// purpose. They used to be omitted because the alternative plans disagreed on
+		// `Histogram[overall=N]`: the accessor list of a rebuilt plan could differ enough to flip the
+		// old all-or-nothing capability gate, so one plan produced per-inner-record counts and another
+		// per-entity ones, and the verifier surfaced that as `InconsistentResultsException`. Deciding
+		// the granularity per accessor and topping up the uncovered entities from the per-entity
+		// collector (#1433) removed that degree of freedom — every plan now describes the same entity
+		// set at the same granularity. `VERIFY_POSSIBLE_CACHING_TREES` additionally substitutes the
+		// flagged LP with its cached `FlattenedFormulaWithFilteredPricesForHistogram` payload, which is
+		// what gives the cached form of the per-inner-record path its coverage.
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
@@ -447,6 +452,7 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 						),
 						require(
 							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES),
 							entityFetch(),
 							priceHistogram(20)
 						)
@@ -462,8 +468,7 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 
 		// case 2: query with priceBetween — the histogram must still cover the relaxed-baseline scope
 		// (i.e. include inner-record prices outside the [from, to] slider) because the engine's
-		// per-inner-record funnel ignores the sellingPricePredicate. See the note in case 1 for why
-		// the standard debug verification flags are omitted.
+		// per-inner-record funnel ignores the sellingPricePredicate.
 		final BigDecimal from = new BigDecimal("80");
 		final BigDecimal to = new BigDecimal("150");
 		evita.queryCatalog(
@@ -483,6 +488,7 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 						),
 						require(
 							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES),
 							entityFetch(),
 							priceHistogram(20)
 						)
@@ -493,6 +499,69 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 				// the relaxed baseline must still cover the same per-inner-record set — `priceBetween`
 				// in `userFilter` cannot shrink the histogram scope
 				assertHistogramIntegrityPerInnerRecord(result, lowestPriceProducts, from, to, null);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should limit the per-inner-record price histogram to entities matched by a non-price constraint")
+	@UseDataSet(HUNDRED_PRODUCTS_WITH_FIND_FIRST_PRICES)
+	@Test
+	@Tag(HISTOGRAM)
+	void shouldLimitPerInnerRecordHistogramToEntitiesMatchedByNonPriceConstraint(
+		@Nonnull Evita evita,
+		@Nonnull List<SealedEntity> originalProductEntities
+	) {
+		// a `LowestPriceTerminationFormula` collects its per-inner-record side-output from its own price
+		// sub-tree, which knows nothing about the non-price parts of the query. Narrowing that side-output
+		// to the entities the whole filter matched is what keeps the histogram from describing entities the
+		// query excluded — this fixture pins that down with an `entityPrimaryKeyInSet` handle.
+		final List<SealedEntity> selectedProducts = originalProductEntities
+			.stream()
+			.filter(it -> it.getAllPricesForSale(CURRENCY_EUR, null, PRICE_LIST_VIP, PRICE_LIST_BASIC).size() > 1)
+			.limit(5)
+			.toList();
+
+		assertFalse(
+			selectedProducts.isEmpty(),
+			"LOWEST_PRICE-only fixture must contain entities with more than one inner record in scope!"
+		);
+		assertTrue(
+			countInnerRecordPricesInScope(selectedProducts, null) < originalProductEntities.size(),
+			"The selected subset must expand to fewer data points than the whole catalog has entities — " +
+				"otherwise an un-narrowed histogram would be indistinguishable from a narrowed one"
+		);
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<SealedEntity> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(
+									selectedProducts.stream().map(SealedEntity::getPrimaryKey).toArray(Integer[]::new)
+								),
+								priceInCurrency(CURRENCY_EUR),
+								priceInPriceLists(PRICE_LIST_VIP, PRICE_LIST_BASIC)
+							)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES),
+							entityFetch(),
+							priceHistogram(20)
+						)
+					),
+					SealedEntity.class
+				);
+
+				assertEquals(selectedProducts.size(), result.getTotalRecordCount());
+				// only the five selected masters may contribute — and each of them with every one of its
+				// inner-record prices, not just its price for sale
+				assertHistogramIntegrityPerInnerRecord(result, selectedProducts, null, null, null);
 
 				return null;
 			}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/SumPriceEntityByPriceFilteringFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/price/SumPriceEntityByPriceFilteringFunctionalTest.java
@@ -288,6 +288,7 @@ public class SumPriceEntityByPriceFilteringFunctionalTest extends EntityByPriceF
 
 	@DisplayName("Should return price histogram for returned products excluding price between query")
 	@UseDataSet(HUNDRED_PRODUCTS_WITH_SUM_PRICES)
+	@Test
 	@Override
 	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(evita, originalProductEntities);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/BuilderReferenceBundleTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/BuilderReferenceBundleTest.java
@@ -449,4 +449,76 @@ class BuilderReferenceBundleTest {
 		bundle.upsertWithDuplicateReferenceConversion(dupl, key -> prev);
 		assertThrows(InvalidMutationException.class, () -> bundle.upsertWithDuplicateReferenceConversion(colliding, key -> prev));
 	}
+
+	@Test
+	@DisplayName("shouldStopReportingReferenceKeyOnceAllDuplicatesAreRemoved")
+	void shouldStopReportingReferenceKeyOnceAllDuplicatesAreRemoved() {
+		final BuilderReferenceBundle bundle = new BuilderReferenceBundle(2);
+		final ReferenceSchemaContract referenceSchema = Mockito.mock(ReferenceSchemaContract.class);
+		Mockito.when(referenceSchema.getAttributes()).thenReturn(representativeSchema());
+
+		final ReferenceContract prev = mockReference(1001, referenceSchema, Collections.singletonMap("country", "CZ"));
+		final ReferenceContract next = mockReference(2002, referenceSchema, Collections.singletonMap("country", "US"));
+
+		bundle.upsertNonDuplicateReference(prev);
+		bundle.convertToDuplicateReference(next, prev);
+		assertTrue(bundle.containsReferenceKey(prev.getReferenceKey()));
+
+		bundle.removeDuplicateReference(next);
+		assertTrue(bundle.containsReferenceKey(prev.getReferenceKey()));
+
+		// the business key holds two references, so exactly two removals must retire it - the conversion
+		// must not count the incoming reference twice
+		bundle.removeDuplicateReference(prev);
+		assertEquals(0, bundle.count());
+		assertFalse(bundle.containsReferenceKey(prev.getReferenceKey()));
+	}
+
+	@Test
+	@DisplayName("shouldNotCountRepeatedUpsertsOfTheSameDuplicateReference")
+	void shouldNotCountRepeatedUpsertsOfTheSameDuplicateReference() {
+		final BuilderReferenceBundle bundle = new BuilderReferenceBundle(2);
+		final ReferenceSchemaContract referenceSchema = Mockito.mock(ReferenceSchemaContract.class);
+		Mockito.when(referenceSchema.getAttributes()).thenReturn(representativeSchema());
+
+		final ReferenceContract prev = mockReference(1001, referenceSchema, Collections.singletonMap("country", "CZ"));
+		final ReferenceContract next = mockReference(2002, referenceSchema, Collections.singletonMap("country", "US"));
+
+		bundle.upsertNonDuplicateReference(prev);
+		bundle.convertToDuplicateReference(next, prev);
+
+		// committing the very same reference again is an update, not an insertion - builders re-register a
+		// reference on every commit, and each re-registration must leave the reference count alone
+		bundle.upsertDuplicateReference(next);
+		bundle.upsertDuplicateReference(next);
+		assertEquals(2, bundle.count());
+
+		bundle.removeDuplicateReference(next);
+		bundle.removeDuplicateReference(prev);
+		assertEquals(0, bundle.count());
+		assertFalse(bundle.containsReferenceKey(prev.getReferenceKey()));
+	}
+
+	@Test
+	@DisplayName("shouldNotCountReKeyingOfAnAlreadyRegisteredDuplicateReference")
+	void shouldNotCountReKeyingOfAnAlreadyRegisteredDuplicateReference() {
+		final BuilderReferenceBundle bundle = new BuilderReferenceBundle(2);
+		final ReferenceSchemaContract referenceSchema = Mockito.mock(ReferenceSchemaContract.class);
+		Mockito.when(referenceSchema.getAttributes()).thenReturn(representativeSchema());
+
+		final ReferenceContract prev = mockReference(1001, referenceSchema, Collections.singletonMap("country", "CZ"));
+		final ReferenceContract next = mockReference(2002, referenceSchema, Collections.singletonMap("country", "US"));
+		// same internal primary key as `next`, but a different representative value
+		final ReferenceContract reKeyed = mockReference(2002, referenceSchema, Collections.singletonMap("country", "SK"));
+
+		bundle.upsertNonDuplicateReference(prev);
+		bundle.convertToDuplicateReference(next, prev);
+		bundle.upsertDuplicateReference(reKeyed);
+		assertEquals(2, bundle.count());
+
+		bundle.removeDuplicateReference(reKeyed);
+		bundle.removeDuplicateReference(prev);
+		assertEquals(0, bundle.count());
+		assertFalse(bundle.containsReferenceKey(prev.getReferenceKey()));
+	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/CreateReferenceDuplicateBookkeepingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/CreateReferenceDuplicateBookkeepingTest.java
@@ -1,0 +1,364 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.data.structure;
+
+import io.evitadb.api.exception.InvalidMutationException;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.api.requestResponse.data.ReferenceContract;
+import io.evitadb.api.requestResponse.data.ReferenceEditor.ReferenceBuilder;
+import io.evitadb.api.requestResponse.data.ReferencesContract;
+import io.evitadb.api.requestResponse.data.ReferencesEditor.ReferencesBuilder;
+import io.evitadb.api.requestResponse.data.mutation.attribute.UpsertAttributeMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceAttributeMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
+import io.evitadb.api.requestResponse.data.structure.predicate.ReferenceContractSerializablePredicate;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.api.requestResponse.schema.builder.InternalEntitySchemaBuilder;
+import io.evitadb.utils.Functions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies the duplicate-reference bookkeeping of the create-then-populate flow.
+ *
+ * {@link InitialReferencesBuilder#createReference(String, int)} registers a brand new - and therefore
+ * still empty - reference in its {@link BuilderReferenceBundle} straight away, and only afterwards hands
+ * the {@link ReferenceKey} back so the caller can populate the attributes. At registration time the
+ * representative attribute values are consequently all {@code null}, so the reference is filed under the
+ * representative key {@code [null]}.
+ *
+ * That key is provisional: it must be refreshed once the caller commits the populated builder back, or the
+ * {@code [null]} slot stays occupied by a reference that no longer matches it. Until the refresh existed,
+ * exactly two references per business key stayed healthy - the second one self-healed only its predecessor
+ * through {@link BuilderReferenceBundle#convertToDuplicateReference(ReferenceContract, ReferenceContract)} -
+ * and the third collided with the stale slot and was rejected with representative attributes {@code [null]}.
+ *
+ * The production trigger is the entity proxy: every {@code getOrCreate}-style reference method in
+ * {@code SetReferenceMethodClassifier} routes to {@code createReference}, runs the caller's consumer and
+ * only then propagates the builder back, which is precisely the order reproduced here.
+ *
+ * The tests pin both halves of the contract - the refresh has to vacate the stale slot, and it must not
+ * weaken the detection of references that genuinely are indistinguishable.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("createReference duplicate bookkeeping")
+@Tag(CONTRACT)
+@Tag(REFERENCE)
+@Tag(ATTRIBUTE)
+class CreateReferenceDuplicateBookkeepingTest extends AbstractBuilderTest {
+
+	private static final String BRAND = "brand";
+	private static final String STORE = "store";
+	private static final String COUNTRY = "country";
+	private static final int BRAND_PK = 143434;
+
+	/**
+	 * Builds a schema whose {@link #BRAND} reference allows duplicates and is discriminated by the
+	 * representative {@link #COUNTRY} attribute.
+	 *
+	 * @return the entity schema used by all tests in this class
+	 */
+	@Nonnull
+	private static EntitySchemaContract createSchemaWithDuplicableReference() {
+		return new InternalEntitySchemaBuilder(CATALOG_SCHEMA, PRODUCT_SCHEMA)
+			.withReferenceToEntity(
+				STORE, STORE, Cardinality.ZERO_OR_MORE,
+				r -> {}
+			)
+			.withReferenceToEntity(
+				BRAND, BRAND, Cardinality.ZERO_OR_MORE_WITH_DUPLICATES,
+				r -> r.withAttribute(COUNTRY, String.class, AttributeSchemaEditor::representative)
+			)
+			.toInstance();
+	}
+
+	/**
+	 * Replays exactly what the entity proxy does for a single {@code addOrUpdateXxx(id, discriminator,
+	 * consumer)} call: create the reference first, populate its representative attribute afterwards,
+	 * then propagate the populated builder back into the entity.
+	 *
+	 * @param builder the references builder under test
+	 * @param schema  the owning entity schema
+	 * @param country the representative attribute value assigned after creation
+	 * @return the key of the reference that was created
+	 */
+	@Nonnull
+	private static ReferenceKey createThenPopulate(
+		@Nonnull ReferencesBuilder builder,
+		@Nonnull EntitySchemaContract schema,
+		@Nonnull String country
+	) {
+		final ReferenceKey referenceKey = builder.createReference(BRAND, BRAND_PK);
+		final ReferenceContract created = builder.getReference(referenceKey).orElseThrow();
+		final ReferenceBuilder referenceBuilder = new ExistingReferenceBuilder(
+			created, schema, new HashMap<>()
+		);
+		referenceBuilder.setAttribute(COUNTRY, country);
+		builder.addOrReplaceReferenceMutations(referenceBuilder, true);
+		return referenceKey;
+	}
+
+	/**
+	 * Applies a single representative attribute change through the mutation replay path, which refreshes
+	 * the reference in the collection without ever going through a {@link ReferenceBuilder}.
+	 *
+	 * @param builder      the references builder under test
+	 * @param referenceKey the key of the reference to update
+	 * @param country      the new representative attribute value
+	 */
+	private static void mutateCountry(
+		@Nonnull ReferencesBuilder builder,
+		@Nonnull ReferenceKey referenceKey,
+		@Nonnull String country
+	) {
+		builder.mutateReference(
+			new ReferenceAttributeMutation(
+				referenceKey,
+				new UpsertAttributeMutation(new AttributeKey(COUNTRY), country)
+			)
+		);
+	}
+
+	/**
+	 * Returns the representative attribute values of every {@link #BRAND} reference pointing at
+	 * {@link #BRAND_PK}. The result is sorted, because {@link References} orders its references by
+	 * {@link ReferenceContract#FULL_COMPARATOR} rather than by insertion order - which of the two
+	 * orders comes out is irrelevant to what these tests assert.
+	 *
+	 * @param references the built references
+	 * @return sorted list of {@link #COUNTRY} values
+	 */
+	@Nonnull
+	private static List<String> countriesOf(@Nonnull ReferencesContract references) {
+		return references.getReferences(BRAND)
+			.stream()
+			.map(it -> it.getAttributeValue(COUNTRY).map(av -> (String) av.value()).orElse(null))
+			.sorted(Comparator.nullsFirst(Comparator.naturalOrder()))
+			.toList();
+	}
+
+	@Nested
+	@DisplayName("InitialReferencesBuilder (new entity)")
+	class InitialBuilderTest {
+
+		@Test
+		@DisplayName("two duplicates created via createReference are accepted")
+		void shouldAcceptTwoDuplicatesCreatedViaCreateReference() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			createThenPopulate(builder, schema, "CZ");
+			createThenPopulate(builder, schema, "DE");
+
+			final References built = builder.build();
+			assertEquals(2, built.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE"), countriesOf(built));
+		}
+
+		@Test
+		@DisplayName("three duplicates created via createReference are accepted")
+		void shouldAcceptThreeDuplicatesCreatedViaCreateReference() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			createThenPopulate(builder, schema, "CZ");
+			createThenPopulate(builder, schema, "DE");
+			// this third call used to fail, because the second reference still occupied the `[null]`
+			// representative slot it had been registered under before it was populated
+			createThenPopulate(builder, schema, "SK");
+
+			final References built = builder.build();
+			assertEquals(3, built.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE", "SK"), countriesOf(built));
+		}
+
+		@Test
+		@DisplayName("arbitrarily many duplicates created via createReference are accepted")
+		void shouldAcceptManyDuplicatesCreatedViaCreateReference() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			final List<String> countries = List.of("AT", "CZ", "DE", "HU", "PL", "SK");
+			for (final String country : countries) {
+				createThenPopulate(builder, schema, country);
+			}
+
+			final References built = builder.build();
+			assertEquals(countries.size(), built.getReferences(BRAND).size());
+			assertEquals(countries, countriesOf(built));
+		}
+
+		@Test
+		@DisplayName("populate-then-register via setOrUpdateReference stays healthy")
+		void shouldAcceptThreeDuplicatesCreatedViaSetOrUpdateReference() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			// setOrUpdateReference runs the consumer BEFORE registering in the bundle, so the
+			// representative values are present at registration time - this is the control case
+			builder.setOrUpdateReference(
+				BRAND, BRAND_PK, Functions.alwaysFalse(), ref -> ref.setAttribute(COUNTRY, "CZ")
+			);
+			builder.setOrUpdateReference(
+				BRAND, BRAND_PK, Functions.alwaysFalse(), ref -> ref.setAttribute(COUNTRY, "DE")
+			);
+			builder.setOrUpdateReference(
+				BRAND, BRAND_PK, Functions.alwaysFalse(), ref -> ref.setAttribute(COUNTRY, "SK")
+			);
+
+			final References built = builder.build();
+			assertEquals(3, built.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE", "SK"), countriesOf(built));
+		}
+
+		@Test
+		@DisplayName("duplicates sharing representative attributes are still rejected")
+		void shouldThrowExceptionWhenDuplicatesShareRepresentativeAttributes() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			createThenPopulate(builder, schema, "CZ");
+
+			// refreshing the provisional key must not weaken duplicate detection - these two references
+			// really are indistinguishable and the second one has to be refused
+			assertThrows(
+				InvalidMutationException.class,
+				() -> createThenPopulate(builder, schema, "CZ")
+			);
+		}
+
+		@Test
+		@DisplayName("representative attribute change is reflected in the bundle")
+		void shouldRefreshRepresentativeKeyWhenAttributeMutationIsApplied() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			final ReferenceKey first = createThenPopulate(builder, schema, "CZ");
+			createThenPopulate(builder, schema, "DE");
+
+			// the mutation replay path refreshes the reference in the collection directly - the bundle
+			// has to follow, otherwise `CZ` would stay reserved and `FR` would never be claimed
+			mutateCountry(builder, first, "FR");
+
+			final References built = builder.build();
+			assertEquals(2, built.getReferences(BRAND).size());
+			assertEquals(List.of("DE", "FR"), countriesOf(built));
+
+			// the vacated `CZ` slot must be free for a brand new duplicate
+			createThenPopulate(builder, schema, "CZ");
+			assertEquals(List.of("CZ", "DE", "FR"), countriesOf(builder.build()));
+		}
+
+		@Test
+		@DisplayName("attribute change colliding with a sibling duplicate is rejected")
+		void shouldThrowExceptionWhenAttributeMutationCollidesWithSibling() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			final ReferenceKey first = createThenPopulate(builder, schema, "CZ");
+			createThenPopulate(builder, schema, "DE");
+
+			assertThrows(
+				InvalidMutationException.class,
+				() -> mutateCountry(builder, first, "DE")
+			);
+
+			// the rejected re-key must have left the builder exactly as it was
+			final References built = builder.build();
+			assertEquals(2, built.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE"), countriesOf(built));
+		}
+	}
+
+	@Nested
+	@DisplayName("ExistingReferencesBuilder (existing entity)")
+	class ExistingBuilderTest {
+
+		/**
+		 * Creates an {@link ExistingReferencesBuilder} on top of an entity that carries no references yet.
+		 *
+		 * @param schema the owning entity schema
+		 * @return the builder under test
+		 */
+		@Nonnull
+		private ExistingReferencesBuilder createBuilder(@Nonnull EntitySchemaContract schema) {
+			final References base = new InitialReferencesBuilder(schema).build();
+			return new ExistingReferencesBuilder(
+				schema, base,
+				ReferenceContractSerializablePredicate.DEFAULT_INSTANCE,
+				key -> Optional.empty()
+			);
+		}
+
+		@Test
+		@DisplayName("three duplicates created via createReference are accepted")
+		void shouldAcceptThreeDuplicatesCreatedViaCreateReference() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final ExistingReferencesBuilder builder = createBuilder(schema);
+
+			createThenPopulate(builder, schema, "CZ");
+			createThenPopulate(builder, schema, "DE");
+			createThenPopulate(builder, schema, "SK");
+
+			final References built = builder.build();
+			assertNotNull(built);
+			assertEquals(3, built.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE", "SK"), countriesOf(built));
+		}
+
+		@Test
+		@DisplayName("arbitrarily many duplicates created via createReference are accepted")
+		void shouldAcceptManyDuplicatesCreatedViaCreateReference() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final ExistingReferencesBuilder builder = createBuilder(schema);
+
+			final List<String> countries = List.of("AT", "CZ", "DE", "HU", "PL", "SK");
+			for (final String country : countries) {
+				createThenPopulate(builder, schema, country);
+			}
+
+			final References built = builder.build();
+			assertEquals(countries.size(), built.getReferences(BRAND).size());
+			assertEquals(countries, countriesOf(built));
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/InsertReferenceMutationBookkeepingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/InsertReferenceMutationBookkeepingTest.java
@@ -1,0 +1,259 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.data.structure;
+
+import io.evitadb.api.exception.InvalidMutationException;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.api.requestResponse.data.ReferenceContract;
+import io.evitadb.api.requestResponse.data.ReferencesContract;
+import io.evitadb.api.requestResponse.data.ReferencesEditor.ReferencesBuilder;
+import io.evitadb.api.requestResponse.data.mutation.LocalMutation;
+import io.evitadb.api.requestResponse.data.mutation.attribute.UpsertAttributeMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.InsertReferenceMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceAttributeMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
+import io.evitadb.api.requestResponse.data.mutation.reference.RemoveReferenceMutation;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.api.requestResponse.schema.builder.InternalEntitySchemaBuilder;
+import io.evitadb.utils.Functions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that a reference inserted through {@link InsertReferenceMutation} is registered in the
+ * {@link BuilderReferenceBundle}, exactly like one created through
+ * {@link InitialReferencesBuilder#createReference(String, int)}.
+ *
+ * The mutation replay path used to add the reference straight to the reference collection without
+ * telling the bundle about it. Everything the bundle is responsible for was therefore skipped for such
+ * a reference:
+ *
+ * - removing it failed outright, because `removeNonDuplicateReference` looks the reference up in the
+ *   bundle and rejects what it cannot find with "is not present in the structure";
+ * - duplicate detection never ran, so two references with identical representative attributes were
+ *   accepted into the entity without complaint.
+ *
+ * The path is reachable through {@code InitialEntityBuilder.mutate(...)}, which is how a mutation
+ * stream is replayed - from the WAL, from gRPC, or from an entity's own {@code toMutation()} output.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("InsertReferenceMutation bundle bookkeeping")
+@Tag(CONTRACT)
+@Tag(REFERENCE)
+@Tag(ATTRIBUTE)
+class InsertReferenceMutationBookkeepingTest extends AbstractBuilderTest {
+
+	private static final String BRAND = "brand";
+	private static final String COUNTRY = "country";
+	private static final int BRAND_PK = 100;
+
+	/**
+	 * Builds a schema whose {@link #BRAND} reference allows duplicates discriminated by the
+	 * representative {@link #COUNTRY} attribute.
+	 *
+	 * @return the entity schema used by all tests in this class
+	 */
+	@Nonnull
+	private static EntitySchemaContract createSchemaWithDuplicableReference() {
+		return new InternalEntitySchemaBuilder(CATALOG_SCHEMA, PRODUCT_SCHEMA)
+			.withReferenceToEntity(
+				BRAND, BRAND, Cardinality.ZERO_OR_MORE_WITH_DUPLICATES,
+				r -> r.withAttribute(COUNTRY, String.class, AttributeSchemaEditor::representative)
+			)
+			.toInstance();
+	}
+
+	/**
+	 * Replays the pair of mutations a builder emits for one populated reference: the insert followed by
+	 * its own representative attribute.
+	 *
+	 * @param builder     the references builder under test
+	 * @param internalPk  the internal primary key the reference is inserted under
+	 * @param country     the representative attribute value assigned to it
+	 */
+	private static void insertThenPopulate(
+		@Nonnull ReferencesBuilder builder,
+		int internalPk,
+		@Nonnull String country
+	) {
+		final ReferenceKey referenceKey = new ReferenceKey(BRAND, BRAND_PK, internalPk);
+		builder.mutateReference(
+			new InsertReferenceMutation(referenceKey, Cardinality.ZERO_OR_MORE_WITH_DUPLICATES, BRAND)
+		);
+		builder.mutateReference(
+			new ReferenceAttributeMutation(
+				referenceKey,
+				new UpsertAttributeMutation(new AttributeKey(COUNTRY), country)
+			)
+		);
+	}
+
+	/**
+	 * Returns the sorted representative attribute values of every {@link #BRAND} reference.
+	 *
+	 * @param references the built references
+	 * @return sorted list of {@link #COUNTRY} values
+	 */
+	@Nonnull
+	private static List<String> countriesOf(@Nonnull ReferencesContract references) {
+		return references.getReferences(BRAND)
+			.stream()
+			.map(it -> it.getAttributeValue(COUNTRY).map(av -> (String) av.value()).orElse(null))
+			.sorted(Comparator.nullsFirst(Comparator.naturalOrder()))
+			.toList();
+	}
+
+	@Nested
+	@DisplayName("removal of a mutation-inserted reference")
+	class RemovalTest {
+
+		@Test
+		@DisplayName("removeReference finds a reference inserted through a mutation")
+		void shouldRemoveReferenceInsertedThroughMutation() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			builder.mutateReference(
+				new InsertReferenceMutation(
+					new ReferenceKey(BRAND, BRAND_PK), Cardinality.ZERO_OR_MORE_WITH_DUPLICATES, BRAND
+				)
+			);
+			// used to fail with GenericEvitaInternalError "is not present in the structure", because the
+			// mutation path never registered the reference in the bundle the removal looks it up in
+			builder.removeReference(BRAND, BRAND_PK);
+
+			assertEquals(0, builder.build().getReferences(BRAND).size());
+		}
+
+		@Test
+		@DisplayName("RemoveReferenceMutation undoes a preceding InsertReferenceMutation")
+		void shouldRemoveReferenceThroughRemoveReferenceMutation() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			final ReferenceKey referenceKey = new ReferenceKey(BRAND, BRAND_PK);
+			builder.mutateReference(
+				new InsertReferenceMutation(referenceKey, Cardinality.ZERO_OR_MORE_WITH_DUPLICATES, BRAND)
+			);
+			// an add-then-remove pair inside one replayed stream is ordinary, and used to abort the replay
+			builder.mutateReference(new RemoveReferenceMutation(referenceKey));
+
+			assertEquals(0, builder.build().getReferences(BRAND).size());
+		}
+	}
+
+	@Nested
+	@DisplayName("duplicate detection for mutation-inserted references")
+	class DuplicateDetectionTest {
+
+		@Test
+		@DisplayName("distinguishable duplicates are accepted")
+		void shouldAcceptDistinguishableReferencesInsertedThroughMutations() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			insertThenPopulate(builder, -1, "CZ");
+			insertThenPopulate(builder, -2, "DE");
+			insertThenPopulate(builder, -3, "SK");
+
+			final References built = builder.build();
+			assertEquals(3, built.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE", "SK"), countriesOf(built));
+		}
+
+		@Test
+		@DisplayName("indistinguishable duplicates are rejected")
+		void shouldRejectIndistinguishableReferencesInsertedThroughMutations() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialReferencesBuilder builder = new InitialReferencesBuilder(schema);
+
+			insertThenPopulate(builder, -1, "CZ");
+
+			// these two carry the very same representative attributes - without bundle registration the
+			// collision went undetected and both were written into the entity
+			assertThrows(
+				InvalidMutationException.class,
+				() -> insertThenPopulate(builder, -2, "CZ")
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("mutation stream round-trip")
+	class RoundTripTest {
+
+		@Test
+		@DisplayName("an entity replays its own mutation stream")
+		void shouldReplayItsOwnMutationStream() {
+			final EntitySchemaContract schema = createSchemaWithDuplicableReference();
+			final InitialEntityBuilder source = new InitialEntityBuilder(schema, 1);
+			source.setOrUpdateReference(
+				BRAND, BRAND_PK, Functions.alwaysFalse(), r -> r.setAttribute(COUNTRY, "CZ")
+			);
+			source.setOrUpdateReference(
+				BRAND, BRAND_PK, Functions.alwaysFalse(), r -> r.setAttribute(COUNTRY, "DE")
+			);
+			source.setOrUpdateReference(
+				BRAND, BRAND_PK, Functions.alwaysFalse(), r -> r.setAttribute(COUNTRY, "SK")
+			);
+
+			final Collection<? extends LocalMutation<?, ?>> mutations = source.toMutation()
+				.orElseThrow()
+				.getLocalMutations();
+
+			// registering the reference eagerly makes the emission order load-bearing: each insert must be
+			// followed by its own attributes before the next insert, or two still-empty references would
+			// collide on their identical default representative values. buildChangeSet emits exactly that,
+			// and this test is what keeps it that way.
+			final InitialEntityBuilder target = new InitialEntityBuilder(schema, 1);
+			for (final LocalMutation<?, ?> mutation : mutations) {
+				target.mutate(mutation);
+			}
+
+			final ReferencesContract replayed = target.toInstance();
+			assertEquals(3, replayed.getReferences(BRAND).size());
+			assertEquals(List.of("CZ", "DE", "SK"), countriesOf(replayed));
+			assertTrue(
+				source.toInstance().getReferences(BRAND).stream().map(ReferenceContract::getReferenceName).allMatch(BRAND::equals)
+			);
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/prefetch/SelectionFormulaHistogramCapabilityTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/prefetch/SelectionFormulaHistogramCapabilityTest.java
@@ -32,11 +32,13 @@ import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.AndFormula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.price.FilteredPriceRecordAccessor;
 import io.evitadb.core.query.algebra.price.filteredPriceRecords.FilteredPriceRecords;
 import io.evitadb.core.query.algebra.price.filteredPriceRecords.ResolvedFilteredPriceRecords;
 import io.evitadb.core.query.algebra.price.predicate.PricePredicate;
 import io.evitadb.core.query.algebra.price.termination.LowestPriceTerminationFormula;
 import io.evitadb.core.query.algebra.price.termination.PriceEvaluationContext;
+import io.evitadb.core.query.algebra.price.translate.PriceIdToEntityIdTranslateFormula;
 import io.evitadb.index.bitmap.ArrayBitmap;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.EmptyBitmap;
@@ -50,6 +52,7 @@ import org.mockito.Mockito;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Currency;
+import java.util.List;
 
 import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.HISTOGRAM;
@@ -95,18 +98,20 @@ class SelectionFormulaHistogramCapabilityTest {
 		}
 
 		@Test
-		@DisplayName("should not expose histogram capability when any inner accessor is missing it")
-		void shouldNotExposeHistogramCapabilityWhenAnyInnerAccessorMissing() {
+		@DisplayName("should expose histogram capability when only some inner accessors expose it")
+		void shouldExposeHistogramCapabilityWhenAnyInnerAccessorExposes() {
 			final LowestPriceTerminationFormula withFlag = newLp(new ArrayBitmap(1, 2), true);
 			final LowestPriceTerminationFormula withoutFlag = newLp(new ArrayBitmap(3, 4), false);
 			final SelectionFormula selection = new SelectionFormula(
 				new AndFormula(withFlag, withoutFlag), new NoopBitmapFilter()
 			);
 
-			// the "all-true" semantics mean a single un-flagged accessor poisons the wrapper's capability —
-			// otherwise the histogram producer would try to call `getFilteredPriceRecordsForHistogram` on
-			// the un-flagged LP and trip its `GenericEvitaInternalError` guard
-			assertFalse(selection.exposesPerInnerRecordHistogramRecords());
+			// "any-true" semantics: a single SelectionFormula wraps the whole price filter container, so in
+			// a catalog mixing PriceInnerRecordHandling values its inner set legitimately holds both a
+			// flagged LOWEST_PRICE branch and un-flagged NONE/SUM branches. Poisoning the capability on the
+			// un-flagged one is what silently dropped the histogram to per-entity granularity (issue #1433);
+			// the un-flagged branch's entities are topped up by the producer's per-entity collector pass.
+			assertTrue(selection.exposesPerInnerRecordHistogramRecords());
 		}
 
 		@Test
@@ -145,28 +150,30 @@ class SelectionFormulaHistogramCapabilityTest {
 		}
 
 		/**
-		 * The size-1 fast path must consult `exposesPerInnerRecordHistogramRecords` on the inner accessor
-		 * before delegating to its histogram-side accessor. When the inner accessor does NOT expose the
-		 * per-inner-record side-output (the common case for un-flagged LPs), the fast path must instead
-		 * fall back to the per-entity `getFilteredPriceRecords(...)` — matching the default interface
-		 * behaviour for non-histogram-aware accessors.
+		 * With no exposing inner accessor at all there is nothing per-inner-record to contribute, so the
+		 * wrapper must fall back to its own per-entity `getFilteredPriceRecords(...)` — matching the default
+		 * interface behaviour for non-histogram-aware accessors — rather than tripping the un-flagged LP's
+		 * histogram-collection guard. Defensive only: the producer probes the capability first.
 		 */
 		@Test
-		@DisplayName("should fall back to per-entity records when single inner accessor misses capability")
-		void shouldFallBackToPerEntityRecordsWhenSingleInnerAccessorMissesCapability() {
+		@DisplayName("should fall back to per-entity records when no inner accessor exposes the capability")
+		void shouldFallBackToPerEntityRecordsWhenNoInnerAccessorExposesCapability() {
 			final LowestPriceTerminationFormula unflaggedLp = newLp(EmptyFormula.INSTANCE, false);
 			// trigger compute() so the un-flagged LP populates `filteredPriceRecords` (per-entity side)
-			// while leaving `perInnerRecordPriceRecords` deliberately null — the fast path must therefore
+			// while leaving `perInnerRecordPriceRecords` deliberately null — the fallback must therefore
 			// route to the per-entity records via the capability check rather than tripping the LP's guard
 			unflaggedLp.compute();
-			final FilteredPriceRecords expected = unflaggedLp.getFilteredPriceRecords(null);
 			final SelectionFormula selection = new SelectionFormula(unflaggedLp, new NoopBitmapFilter());
+			// the per-entity fallback asserts a non-null execution context — the production planner always
+			// sets one via initialize() before any histogram fabrication
+			initializeForNonPrefetch(selection);
 
 			final FilteredPriceRecords actual = selection.getFilteredPriceRecordsForHistogram(null);
 
-			// fast path must mirror the default interface behaviour for non-histogram-aware accessors —
-			// delegate to `getFilteredPriceRecords(...)` rather than propagating the LP's guard error
-			assertSame(expected, actual);
+			// per-entity shape, no merge attempt, no guard error — the LP's delegate is EmptyFormula so the
+			// per-entity view is legitimately empty
+			assertInstanceOf(ResolvedFilteredPriceRecords.class, actual);
+			assertEquals(0, ((ResolvedFilteredPriceRecords) actual).getPriceRecords().length);
 		}
 
 		/**
@@ -247,15 +254,15 @@ class SelectionFormulaHistogramCapabilityTest {
 		}
 
 		/**
-		 * When the inner-accessor set is mixed (one flag-on, one flag-off LP), the size>=2 branch of
-		 * `SelectionFormula.getFilteredPriceRecordsForHistogram` must short-circuit on the same
-		 * capability probe the size-1 fast path uses, falling back to per-entity records rather than
-		 * routing the flag-off LP through its histogram side-output (which would trip the LP's guard).
-		 * This mirrors the default interface behaviour for non-histogram-aware accessors.
+		 * The mixed inner-accessor set is the shape a catalog mixing `PriceInnerRecordHandling` values
+		 * produces (issue #1433): one flagged `LOWEST_PRICE` termination formula next to an un-flagged
+		 * branch. The wrapper must contribute the flagged accessor's per-inner-record side-output and
+		 * silently skip the un-flagged one — never route the un-flagged LP through its histogram accessor
+		 * (which would trip its guard) and never discard the flagged contribution.
 		 */
 		@Test
-		@DisplayName("should fall back to per-entity records when accessor set is mixed")
-		void shouldFallBackToPerEntityRecordsWhenAccessorSetIsMixed() {
+		@DisplayName("should contribute only the exposing accessor's records when accessor set is mixed")
+		void shouldContributeOnlyExposingAccessorRecordsWhenAccessorSetIsMixed() {
 			final LowestPriceTerminationFormula flagOn = newLp(EmptyFormula.INSTANCE, true);
 			final LowestPriceTerminationFormula flagOff = newLp(EmptyFormula.INSTANCE, false);
 			flagOn.compute();
@@ -263,25 +270,76 @@ class SelectionFormulaHistogramCapabilityTest {
 			final SelectionFormula selection = new SelectionFormula(
 				new AndFormula(flagOn, flagOff), new NoopBitmapFilter()
 			);
-			// size>=2 fallback routes through `this.getFilteredPriceRecords()` which asserts a non-null
-			// execution context — the production planner always sets one via initialize() before any
-			// histogram fabrication, so the unit test mirrors that invariant rather than testing an
-			// uninitialised formula
-			initializeForNonPrefetch(selection);
 
-			// graceful-fallback contract: the wrapper consults exposesPerInnerRecordHistogramRecords()
-			// before entering the size>=2 merge loop. A flag-off inner accessor poisons the wrapper's
-			// capability, so the producer reads per-entity records instead of tripping the flag-off LP.
-			assertFalse(selection.exposesPerInnerRecordHistogramRecords());
+			assertTrue(selection.exposesPerInnerRecordHistogramRecords());
+
+			// exactly one exposing inner accessor → fast path hands back that accessor's own side-output
+			// instance; reaching the un-flagged LP would have thrown GenericEvitaInternalError instead
 			final FilteredPriceRecords actual = selection.getFilteredPriceRecordsForHistogram(null);
 
-			// no exception, no merge attempt — the wrapper produced a valid per-entity FilteredPriceRecords
-			// matching what `getFilteredPriceRecords(...)` would return. `getFilteredPriceRecords` allocates
-			// a fresh ResolvedFilteredPriceRecords per call, so identity comparison would not hold; the
-			// invariant under test is "fallback returns per-entity shape", which is captured by the
-			// instance check plus an empty-array assertion (both LP delegates wrap EmptyFormula.INSTANCE).
-			assertInstanceOf(ResolvedFilteredPriceRecords.class, actual);
-			assertEquals(0, ((ResolvedFilteredPriceRecords) actual).getPriceRecords().length);
+			assertSame(flagOn.getFilteredPriceRecordsForHistogram(null), actual);
+		}
+	}
+
+	@Nested
+	@DisplayName("Accessor set partitioning")
+	class AccessorPartitioningTest {
+
+		/**
+		 * Regression guard for the second half of issue #1433: `SelectionFormula` implements
+		 * {@link FilteredPriceRecordAccessor} unconditionally, so a wrapper the planner inserted above a
+		 * **price-free** sub-tree is gathered into the histogram's accessor list even though it has no
+		 * prices at all. Under the old all-or-nothing rule that lone empty wrapper closed the
+		 * per-inner-record path for every sibling accessor on its own.
+		 */
+		@Test
+		@DisplayName("should keep the exposing accessor when a price-free wrapper sits beside it")
+		void shouldKeepExposingAccessorBesidePriceFreeWrapper() {
+			final SelectionFormula priceFreeWrapper = new SelectionFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2, 3)), new NoopBitmapFilter()
+			);
+			final LowestPriceTerminationFormula flaggedLp = newLp(new ArrayBitmap(4, 5), true);
+			final List<FilteredPriceRecordAccessor> accessors = List.of(priceFreeWrapper, flaggedLp);
+
+			assertTrue(FilteredPriceRecords.anyAccessorExposesPerInnerRecordHistogram(accessors));
+			assertEquals(
+				List.of(flaggedLp),
+				FilteredPriceRecords.collectPerInnerRecordHistogramAccessors(accessors),
+				"A price-free wrapper must drop out of the partition without taking its siblings with it"
+			);
+		}
+
+		/**
+		 * The raw `PriceIdToEntityIdTranslateFormula` the SHALLOW accessor scan surfaces for the `NONE`
+		 * branch (it pierces the non-accessor `PlainPriceTerminationFormula` above it) must stay out of the
+		 * per-inner-record partition: it holds one record per translated price id rather than per-entity
+		 * winners, so merging it would inflate the buckets. It is served by the per-entity collector instead.
+		 */
+		@Test
+		@DisplayName("should exclude the price-id translate formula from the per-inner-record partition")
+		void shouldExcludeTranslateFormulaFromPerInnerRecordPartition() {
+			final PriceIdToEntityIdTranslateFormula translateFormula = new PriceIdToEntityIdTranslateFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2))
+			);
+			final LowestPriceTerminationFormula flaggedLp = newLp(new ArrayBitmap(3, 4), true);
+			final List<FilteredPriceRecordAccessor> accessors = List.of(translateFormula, flaggedLp);
+
+			assertFalse(translateFormula.exposesPerInnerRecordHistogramRecords());
+			assertEquals(
+				List.of(flaggedLp),
+				FilteredPriceRecords.collectPerInnerRecordHistogramAccessors(accessors)
+			);
+		}
+
+		@Test
+		@DisplayName("should report no exposing accessors when none carry the histogram flag")
+		void shouldReportNoExposingAccessorsWhenNoneCarryTheFlag() {
+			final List<FilteredPriceRecordAccessor> accessors = List.of(
+				newLp(new ArrayBitmap(1, 2), false), newLp(new ArrayBitmap(3, 4), false)
+			);
+
+			assertFalse(FilteredPriceRecords.anyAccessorExposesPerInnerRecordHistogram(accessors));
+			assertTrue(FilteredPriceRecords.collectPerInnerRecordHistogramAccessors(accessors).isEmpty());
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadWriteTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadWriteTest.java
@@ -87,6 +87,7 @@ import io.evitadb.driver.config.ClientTlsOptions;
 import io.evitadb.driver.config.ClientTimeoutOptions;
 import io.evitadb.driver.config.EvitaClientConfiguration;
 import io.evitadb.exception.EvitaInvalidUsageException;
+import io.evitadb.exception.UnexpectedIOException;
 import io.evitadb.externalApi.configuration.ApiOptions;
 import io.evitadb.externalApi.configuration.HostDefinition;
 import io.evitadb.externalApi.grpc.GrpcProvider;
@@ -1557,6 +1558,97 @@ class EvitaClientReadWriteTest implements TestConstants, EvitaTestSupport {
 				}
 			)
 		);
+	}
+
+	/**
+	 * A chunked unary upload that stops half way must not leave its archive on the server.
+	 *
+	 * Nothing else would ever collect it: the temporary file is not reserved by
+	 * `FileManagementService`, no sweeper walks the work directory, and the restore step that deletes
+	 * it only runs for an upload that completed. There is also no half-close for the server to notice
+	 * the client's absence by - every chunk is its own request - so the cleanup hangs off the
+	 * restoration task's future instead, and the driver cancels that task on its way out.
+	 *
+	 * The assertion is deliberately "the work directory is exactly as it was", rather than a check on
+	 * one file name: it catches an archive left behind under any name, including one this test does not
+	 * know how to predict.
+	 */
+	@Test
+	@UseDataSet(value = EVITA_CLIENT_DATA_SET, destroyAfterTest = true)
+	void shouldDiscardTheArchiveOfAnAbandonedChunkedRestoreUpload(
+		EvitaClient evitaClient,
+		Evita evita
+	) throws ExecutionException, InterruptedException, TimeoutException {
+		final EvitaManagementContract management = evitaClient.management();
+		final FileForFetch fileForFetch = management
+			.backupCatalog(TEST_CATALOG, null, null, true)
+			.get(3, TimeUnit.MINUTES);
+
+		final Path workDirectory = evita.getConfiguration().storage().workDirectory();
+		final Set<String> filesBefore = listWorkDirectory(workDirectory);
+
+		// announce far more than will ever be sent, so the server keeps the task waiting for the rest of
+		// an upload that is about to die - which is the state the archive would otherwise be stranded in
+		final long announcedSize = fileForFetch.totalSizeInBytes() * 2;
+		assertThrows(
+			UnexpectedIOException.class,
+			() -> management.restoreCatalog(
+				TEST_CATALOG + "_abandoned",
+				announcedSize,
+				new FailAfterFirstChunkInputStream(management.fetchFile(fileForFetch.fileId()))
+			),
+			"An upload whose source dies part way through must surface as a failure, not a silent stall."
+		);
+
+		assertEquals(
+			filesBefore, listWorkDirectory(workDirectory),
+			"The abandoned upload's archive must be gone - the restoration task's completion hook owns " +
+				"it, and nothing else in the server would ever delete it."
+		);
+	}
+
+	/**
+	 * Lists the work directory by name, so a test can assert that an upload left nothing behind.
+	 *
+	 * @param workDirectory the engine's work directory
+	 * @return names of the files currently in it, never null
+	 */
+	@Nonnull
+	private static Set<String> listWorkDirectory(@Nonnull Path workDirectory) {
+		final String[] names = workDirectory.toFile().list();
+		return names == null ? Set.of() : Set.of(names);
+	}
+
+	/**
+	 * Input stream that yields one chunk and then fails, standing in for a source that dies mid-upload -
+	 * a disconnected volume, a truncated pipe, a killed producer.
+	 */
+	private static final class FailAfterFirstChunkInputStream extends InputStream {
+		private final InputStream delegate;
+		private boolean firstChunkDelivered;
+
+		FailAfterFirstChunkInputStream(@Nonnull InputStream delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public int read() throws IOException {
+			throw new IOException("Single-byte reads are not used by the chunked upload loop.");
+		}
+
+		@Override
+		public int read(@Nonnull byte[] buffer, int off, int len) throws IOException {
+			if (this.firstChunkDelivered) {
+				throw new IOException("Backup source went away mid-upload.");
+			}
+			this.firstChunkDelivered = true;
+			return this.delegate.read(buffer, off, len);
+		}
+
+		@Override
+		public void close() throws IOException {
+			this.delegate.close();
+		}
 	}
 
 	@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/services/RestoreCatalogUploadObserverTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/services/RestoreCatalogUploadObserverTest.java
@@ -1,0 +1,422 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc.services;
+
+import com.google.protobuf.ByteString;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import io.evitadb.core.management.EvitaManagement;
+import io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogRequest;
+import io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogResponse;
+import io.evitadb.externalApi.grpc.services.EvitaManagementService.RestoreCatalogUploadObserver;
+import io.grpc.stub.ServerCallStreamObserver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.STREAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Pins down what happens to a half-uploaded catalog archive when the request pool refuses the work that
+ * would have written the next chunk.
+ *
+ * The upload's temporary file has no owner other than this observer: `createTempFile` does not reserve it,
+ * nothing sweeps the work directory, and the restore step that would delete it never runs for an upload
+ * that stopped half way. A hand-off the pool rejects therefore has to end the call, not merely lose the
+ * step - otherwise the archive stays on disk for the lifetime of the process.
+ *
+ * **The rejection has to be timed to land while the chain is still running.** A pool that refuses the
+ * *first* hand-off is a much weaker test: `CompletableFuture#thenRunAsync` throws on the calling thread in
+ * that case, so even the original code surfaced something. The failure that hangs a client is the other
+ * one - a rejection while a previous step is in flight, which the old code lost inside
+ * `CompletableFuture#postComplete` on an unrelated worker. {@link RejectAfterFirstExecutor} reproduces
+ * exactly that, and {@link #shouldDiscardThePartialArchiveWhenTheUploadPoolRejectsALaterChunk()} is the
+ * test that separates a real fix from one that still leaks.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("A rejected upload hand-off must discard the partial archive")
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(STREAM)
+class RestoreCatalogUploadObserverTest {
+	/**
+	 * Streaming budget handed to the observer. Never reached - no test here waits on a timeout - it only
+	 * has to be a positive number so the re-arm path is exercised rather than skipped.
+	 */
+	private static final long STREAMING_BUDGET_MILLIS = 300_000L;
+	/**
+	 * How long a latch may wait before the test is declared broken. Generous on purpose: it is a
+	 * *positive* wait, so it only ever elapses when the code under test has genuinely failed to progress.
+	 */
+	private static final long LATCH_TIMEOUT_SECONDS = 30L;
+	/**
+	 * How long the one *negative* assertion here waits before concluding nothing happened. Deliberately
+	 * short: a negative wait pays its full duration on every green run, and lengthening it would not make
+	 * the assertion any stronger - only slower.
+	 */
+	private static final long NEGATIVE_WAIT_MILLIS = 250L;
+
+	/**
+	 * Executor that accepts a fixed number of hand-offs and rejects every one after them, the way the
+	 * bounded request pool does once its queue fills (`EvitaRejectingExecutorHandler` throws).
+	 *
+	 * Accepted work runs on a single background thread, so a step is genuinely in flight - and the chain
+	 * genuinely incomplete - when the next hand-off is refused.
+	 */
+	private static final class RejectAfterFirstExecutor implements Executor {
+		private final ExecutorService delegate = Executors.newSingleThreadExecutor();
+		private final AtomicInteger accepted = new AtomicInteger();
+		/**
+		 * Counted down once the first accepted task has finished. Lets a test wait for the write to land
+		 * rather than poll the directory for it.
+		 */
+		private final CountDownLatch firstTaskCompleted = new CountDownLatch(1);
+		private final int acceptLimit;
+
+		RejectAfterFirstExecutor(int acceptLimit) {
+			this.acceptLimit = acceptLimit;
+		}
+
+		@Override
+		public void execute(@Nonnull Runnable command) {
+			if (this.accepted.incrementAndGet() > this.acceptLimit) {
+				throw new RejectedExecutionException("Evita executor queue full.");
+			}
+			this.delegate.execute(
+				() -> {
+					try {
+						command.run();
+					} finally {
+						this.firstTaskCompleted.countDown();
+					}
+				}
+			);
+		}
+
+		/**
+		 * Waits for the first accepted task to finish.
+		 *
+		 * @return true when it finished within {@link #LATCH_TIMEOUT_SECONDS}
+		 */
+		boolean awaitFirstTask() throws InterruptedException {
+			return this.firstTaskCompleted.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+		}
+
+		void shutdown() {
+			this.delegate.shutdownNow();
+		}
+	}
+
+	/**
+	 * Captures the terminal outcome the client would observe, so a test can tell "the call ended with an
+	 * error" from "the call never ended at all".
+	 */
+	private static final class RecordingResponseObserver extends ServerCallStreamObserver<GrpcRestoreCatalogResponse> {
+		private final CountDownLatch terminated = new CountDownLatch(1);
+		private final List<Throwable> errors = new ArrayList<>(2);
+		private final AtomicInteger requested = new AtomicInteger();
+
+		@Override
+		public void onNext(GrpcRestoreCatalogResponse value) {
+			// a successful upload is not what any test here drives
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			this.errors.add(t);
+			this.terminated.countDown();
+		}
+
+		@Override
+		public void onCompleted() {
+			this.terminated.countDown();
+		}
+
+		@Override
+		public void request(int count) {
+			this.requested.addAndGet(count);
+		}
+
+		@Override
+		public boolean isReady() {
+			return true;
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return false;
+		}
+
+		@Override
+		public void setOnCancelHandler(Runnable onCancelHandler) {
+			// not exercised
+		}
+
+		@Override
+		public void setCompression(String compression) {
+			// not exercised
+		}
+
+		@Override
+		public void disableAutoRequest() {
+			// not exercised
+		}
+
+		@Override
+		public void disableAutoInboundFlowControl() {
+			// not exercised
+		}
+
+		@Override
+		public void setOnReadyHandler(Runnable onReadyHandler) {
+			// not exercised
+		}
+
+		@Override
+		public void setMessageCompression(boolean enable) {
+			// not exercised
+		}
+
+		boolean awaitTermination() throws InterruptedException {
+			return this.terminated.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+		}
+
+		boolean awaitTerminationBriefly() throws InterruptedException {
+			return this.terminated.await(NEGATIVE_WAIT_MILLIS, TimeUnit.MILLISECONDS);
+		}
+	}
+
+	/**
+	 * Builds an observer writing into the given directory, driven by the given executor.
+	 *
+	 * @param workDirectory   directory the assembled archive is written into
+	 * @param responseObserver observer capturing the terminal outcome
+	 * @param uploadExecutor  executor the file work is handed to
+	 * @return the observer under test
+	 */
+	@Nonnull
+	private static RestoreCatalogUploadObserver observerFor(
+		@Nonnull Path workDirectory,
+		@Nonnull RecordingResponseObserver responseObserver,
+		@Nonnull Executor uploadExecutor
+	) {
+		return new RestoreCatalogUploadObserver(
+			responseObserver,
+			ServiceRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/test")).build(),
+			workDirectory,
+			mock(EvitaManagement.class),
+			uploadExecutor,
+			STREAMING_BUDGET_MILLIS
+		);
+	}
+
+	/**
+	 * Builds one upload chunk carrying the given payload.
+	 *
+	 * @param payload bytes the chunk carries
+	 * @return the request message
+	 */
+	@Nonnull
+	private static GrpcRestoreCatalogRequest chunkOf(@Nonnull byte[] payload) {
+		return GrpcRestoreCatalogRequest.newBuilder()
+			.setCatalogName("testCatalog")
+			.setBackupFile(ByteString.copyFrom(payload))
+			.build();
+	}
+
+	/**
+	 * Lists the archives the observer has left in the work directory.
+	 *
+	 * @param workDirectory directory to inspect
+	 * @return the archive files present, never null
+	 */
+	@Nonnull
+	private static File[] archivesIn(@Nonnull Path workDirectory) {
+		final File[] files = workDirectory.toFile().listFiles(
+			(dir, name) -> name.startsWith("catalog_backup_for_restore-")
+		);
+		return files == null ? new File[0] : files;
+	}
+
+	@Test
+	@DisplayName("A rejected later chunk ends the call and leaves no archive behind")
+	void shouldDiscardThePartialArchiveWhenTheUploadPoolRejectsALaterChunk(@TempDir Path workDirectory)
+		throws InterruptedException {
+		final RecordingResponseObserver responseObserver = new RecordingResponseObserver();
+		// the first chunk's write is accepted and runs; every hand-off after it is refused
+		final RejectAfterFirstExecutor uploadExecutor = new RejectAfterFirstExecutor(1);
+		try {
+			final RestoreCatalogUploadObserver observer = observerFor(
+				workDirectory, responseObserver, uploadExecutor
+			);
+
+			observer.onNext(chunkOf(new byte[]{1, 2, 3, 4}));
+			observer.onNext(chunkOf(new byte[]{5, 6, 7, 8}));
+
+			assertTrue(
+				responseObserver.awaitTermination(),
+				"A rejected hand-off must terminate the call - the client is otherwise left waiting for a " +
+					"chunk that will never be written, until its own deadline expires."
+			);
+			assertEquals(
+				1, responseObserver.errors.size(),
+				"The client must be told exactly once why the upload ended."
+			);
+			assertNotNull(responseObserver.errors.get(0));
+
+			// the point of the whole exercise: nothing may be left on disk
+			assertEquals(
+				0, archivesIn(workDirectory).length,
+				"The partial archive must be discarded when the pool refuses the work that would have " +
+					"extended it - nothing else ever deletes it."
+			);
+
+			// The chain must stay poisoned. A rejection that leaves it healthy lets this chunk through to
+			// `openBackupFileIfNeeded`, which finds a closed stream and reopens the file in APPEND mode -
+			// recreating on disk exactly the archive that was just deleted.
+			observer.onNext(chunkOf(new byte[]{9, 10, 11, 12}));
+			assertEquals(
+				0, archivesIn(workDirectory).length,
+				"A chunk arriving after a failed upload must not recreate the archive."
+			);
+		} finally {
+			uploadExecutor.shutdown();
+		}
+	}
+
+	@Test
+	@DisplayName("A rejected first chunk also ends the call and leaves nothing behind")
+	void shouldDiscardThePartialArchiveWhenTheUploadPoolRejectsTheFirstChunk(@TempDir Path workDirectory)
+		throws InterruptedException {
+		final RecordingResponseObserver responseObserver = new RecordingResponseObserver();
+		// nothing is accepted at all - the pool is already saturated when the upload starts
+		final RejectAfterFirstExecutor uploadExecutor = new RejectAfterFirstExecutor(0);
+		try {
+			final RestoreCatalogUploadObserver observer = observerFor(
+				workDirectory, responseObserver, uploadExecutor
+			);
+
+			observer.onNext(chunkOf(new byte[]{1, 2, 3, 4}));
+
+			assertTrue(responseObserver.awaitTermination(), "A rejected hand-off must terminate the call.");
+			assertEquals(
+				0, archivesIn(workDirectory).length,
+				"A rejection before the file is even opened must leave the work directory untouched."
+			);
+		} finally {
+			uploadExecutor.shutdown();
+		}
+	}
+
+	@Test
+	@DisplayName("A client abort discards the archive even when the pool refuses the cleanup")
+	void shouldDiscardThePartialArchiveWhenTheCleanupHandOffIsRejected(@TempDir Path workDirectory)
+		throws InterruptedException {
+		final RecordingResponseObserver responseObserver = new RecordingResponseObserver();
+		// the first chunk lands, then the client aborts and the pool refuses to run the cleanup
+		final RejectAfterFirstExecutor uploadExecutor = new RejectAfterFirstExecutor(1);
+		try {
+			final RestoreCatalogUploadObserver observer = observerFor(
+				workDirectory, responseObserver, uploadExecutor
+			);
+
+			observer.onNext(chunkOf(new byte[]{1, 2, 3, 4}));
+			// let the accepted write land, so there is a real archive for the abort to discard
+			assertTrue(
+				uploadExecutor.awaitFirstTask(),
+				"The accepted first chunk should have been written before the abort is driven."
+			);
+			assertEquals(
+				1, archivesIn(workDirectory).length,
+				"The accepted first chunk should have created the archive this test is about to abort."
+			);
+
+			observer.onError(new RuntimeException("client went away"));
+
+			assertTrue(
+				responseObserver.awaitTermination(),
+				"An aborted upload must still terminate the call."
+			);
+			assertEquals(
+				0, archivesIn(workDirectory).length,
+				"Cleanup refused by the pool must fall back to the calling thread rather than be dropped."
+			);
+		} finally {
+			uploadExecutor.shutdown();
+		}
+	}
+
+	@Test
+	@DisplayName("An upload the pool never refuses leaves the archive in place for the restore step")
+	void shouldKeepTheArchiveWhileTheUploadIsProgressing(@TempDir Path workDirectory) throws InterruptedException {
+		final RecordingResponseObserver responseObserver = new RecordingResponseObserver();
+		// a pool that accepts everything - the control case, so the assertions above cannot pass merely
+		// because the observer discards the archive on any code path at all
+		final RejectAfterFirstExecutor uploadExecutor = new RejectAfterFirstExecutor(Integer.MAX_VALUE);
+		try {
+			final RestoreCatalogUploadObserver observer = observerFor(
+				workDirectory, responseObserver, uploadExecutor
+			);
+
+			observer.onNext(chunkOf(new byte[]{1, 2, 3, 4}));
+
+			assertTrue(uploadExecutor.awaitFirstTask(), "An accepted chunk must be written to the archive.");
+			assertEquals(
+				1, archivesIn(workDirectory).length,
+				"An upload that is progressing normally must keep its archive - it is what the restore " +
+					"step will read."
+			);
+			assertFalse(
+				responseObserver.awaitTerminationBriefly(),
+				"An upload that is progressing normally must not be terminated."
+			);
+		} finally {
+			uploadExecutor.shutdown();
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/services/interceptors/ObservabilityInterceptorReadinessTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/services/interceptors/ObservabilityInterceptorReadinessTest.java
@@ -1,0 +1,163 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc.services.interceptors;
+
+import io.evitadb.externalApi.grpc.generated.EvitaManagementServiceGrpc;
+import io.evitadb.externalApi.grpc.generated.GrpcFetchFileRequest;
+import io.evitadb.externalApi.grpc.generated.GrpcFetchFileResponse;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the transport-readiness signal that {@link ObservabilityInterceptor} sits on top of.
+ *
+ * The interceptor wraps every {@link ServerCall} in its own decorator before handing it to the
+ * service implementation. {@link ServerCall#isReady()} is **not** abstract - `io.grpc.ServerCall`
+ * ships a default implementation that unconditionally returns `true`. A decorator that forgets to
+ * delegate it therefore does not merely lose an optimisation: it reports "the transport can accept
+ * more data" forever, which silently defeats any flow-control loop written against
+ * `ServerCallStreamObserver.isReady()` in a streaming service method (most notably
+ * `EvitaManagementService.fetchFile`, which streams whole backup/export files).
+ *
+ * The failure mode is invisible on a fast consumer and only shows up as unbounded outbound
+ * buffering - and eventually a heap blow-up - when the consumer is slower than the producer, so it
+ * needs a unit-level guard rather than an end-to-end one. The complementary end-to-end evidence
+ * lives in `LongRunningGrpcFetchFileBackpressureTest` in the long-running module.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("gRPC observability interceptor must preserve the transport readiness signal")
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(OBSERVABILITY)
+class ObservabilityInterceptorReadinessTest {
+
+	/**
+	 * Runs the interceptor against a delegate call and returns the decorated call the interceptor
+	 * handed down to the service implementation.
+	 *
+	 * @param delegate the call the interceptor is asked to decorate
+	 * @return the decorated call as seen by the service implementation
+	 */
+	@Nonnull
+	private static ServerCall<GrpcFetchFileRequest, GrpcFetchFileResponse> intercept(
+		@Nonnull ServerCall<GrpcFetchFileRequest, GrpcFetchFileResponse> delegate
+	) {
+		final AtomicReference<ServerCall<GrpcFetchFileRequest, GrpcFetchFileResponse>> decorated =
+			new AtomicReference<>();
+		final ServerCallHandler<GrpcFetchFileRequest, GrpcFetchFileResponse> handler =
+			(call, headers) -> {
+				decorated.set(call);
+				return new Listener<>() {
+				};
+			};
+		new ObservabilityInterceptor().interceptCall(delegate, new Metadata(), handler);
+		final ServerCall<GrpcFetchFileRequest, GrpcFetchFileResponse> result = decorated.get();
+		assertNotNull(result, "Interceptor did not start the downstream call.");
+		return result;
+	}
+
+	@Test
+	@DisplayName("isReady() of the decorated call reflects a transport that cannot accept more data")
+	void shouldPropagateNotReadyTransportStateToServiceImplementation() {
+		final MockServerCall delegate = new MockServerCall(false);
+		assertFalse(
+			intercept(delegate).isReady(),
+			"ObservabilityInterceptor reported the transport as ready while the underlying call is not - " +
+				"any isReady()-driven flow control in a streaming service method is silently disabled."
+		);
+	}
+
+	@Test
+	@DisplayName("isReady() of the decorated call reflects a transport that can accept more data")
+	void shouldPropagateReadyTransportStateToServiceImplementation() {
+		final MockServerCall delegate = new MockServerCall(true);
+		assertTrue(
+			intercept(delegate).isReady(),
+			"ObservabilityInterceptor reported the transport as not ready while the underlying call is."
+		);
+	}
+
+	/**
+	 * Minimal {@link ServerCall} stub whose only interesting property is the readiness flag it was
+	 * constructed with - everything else is a no-op, because the interceptor is not expected to
+	 * touch it during `interceptCall`.
+	 */
+	private static class MockServerCall extends ServerCall<GrpcFetchFileRequest, GrpcFetchFileResponse> {
+		private final boolean ready;
+
+		MockServerCall(boolean ready) {
+			this.ready = ready;
+		}
+
+		@Override
+		public void request(int numMessages) {
+		}
+
+		@Override
+		public void sendHeaders(Metadata headers) {
+		}
+
+		@Override
+		public void sendMessage(GrpcFetchFileResponse message) {
+		}
+
+		@Override
+		public boolean isReady() {
+			return this.ready;
+		}
+
+		@Override
+		public void close(Status status, Metadata trailers) {
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return false;
+		}
+
+		@Override
+		public MethodDescriptor<GrpcFetchFileRequest, GrpcFetchFileResponse> getMethodDescriptor() {
+			return EvitaManagementServiceGrpc.getFetchFileMethod();
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/utils/GrpcOutboundGateTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/utils/GrpcOutboundGateTest.java
@@ -1,0 +1,420 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc.utils;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.common.util.TimeoutMode;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import io.evitadb.externalApi.grpc.exception.StalledGrpcStreamException;
+import io.grpc.stub.ServerCallStreamObserver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.STREAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Deterministic guard for {@link GrpcOutboundGate}, the back-pressure gate every server-streaming RPC
+ * paces itself with.
+ *
+ * This is the *only* fast-loop coverage the gate has, and that is a deliberate consequence of how the
+ * engine is wired for tests: the default test engine collapses the request pool into a direct executor,
+ * so a service method's hand-off lands back on the transport event loop, where the gate detects the
+ * self-deadlock and runs ungated on purpose. Every functional test that streams therefore takes the
+ * *ungated* branch, and the gated one is only reached by an end-to-end test that opts into real thread
+ * pools - which lives in the long-running module behind `@Tag(SLOW)`. Driving the gate directly against
+ * a fake observer is what keeps its contract checked on every build.
+ *
+ * The behaviours pinned here are the ones whose absence is invisible until production:
+ *
+ * - waiting must wake on the on-ready callback, or a slow client hangs forever rather than being paced;
+ * - cancellation must be answered **without parking**. Armeria increments its pending-message counter
+ *   in `sendMessage` and only unwinds it when the payload is genuinely consumed, which never happens
+ *   for a cancelled call - so readiness stays false forever, and a gate that consulted it first would
+ *   pin a request-executor thread for the full stall timeout on every client that simply pressed
+ *   cancel;
+ * - a client that keeps the stream open but stops reading must eventually be abandoned, or that same
+ *   thread is pinned indefinitely with no transport event ever coming to release it.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("gRPC outbound gate paces a producer against transport readiness")
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(STREAM)
+class GrpcOutboundGateTest {
+	/**
+	 * Stall timeout used wherever the test must prove the gate does *not* run into it. Long enough that
+	 * reaching it is unmistakably a failure rather than a slow machine.
+	 */
+	private static final long GENEROUS_STALL_TIMEOUT_MILLIS = 60_000L;
+	/**
+	 * Smallest grace beyond the stall timeout the gate's deadline re-arm must leave. Set below the
+	 * gate's actual `STALL_DETECTION_GRACE_MILLIS` on purpose - the test pins that a grace *exists*,
+	 * which is what stops the gate losing the stall race to Armeria, without freezing its value.
+	 */
+	private static final long MINIMUM_EXPECTED_GRACE_MILLIS = 4_000L;
+
+	/**
+	 * Starts a daemon thread that calls {@link GrpcOutboundGate#awaitWritable()} and records what came
+	 * back - a returned verdict, or the exception it threw.
+	 *
+	 * @param gate     gate to wait on
+	 * @param verdict  receives `TRUE`/`FALSE` as returned by the gate
+	 * @param failure  receives the exception, if the call threw one
+	 * @param finished counted down once the call has returned or thrown
+	 * @return the started thread, so the caller can join it
+	 */
+	@Nonnull
+	private static Thread awaitInBackground(
+		@Nonnull GrpcOutboundGate gate,
+		@Nonnull AtomicReference<Boolean> verdict,
+		@Nonnull AtomicReference<Throwable> failure,
+		@Nonnull CountDownLatch finished
+	) {
+		final Thread producer = new Thread(
+			() -> {
+				try {
+					verdict.set(gate.awaitWritable());
+				} catch (Throwable t) {
+					failure.set(t);
+				} finally {
+					finished.countDown();
+				}
+			},
+			"grpc-outbound-gate-test-producer"
+		);
+		producer.setDaemon(true);
+		producer.start();
+		return producer;
+	}
+
+	@Test
+	@DisplayName("Granting a message re-arms the call deadline to the stall budget, not the call's own")
+	void shouldReArmTheCallDeadlineToTheStallBudgetOnEveryGrant() {
+		final long callTimeoutMillis = 1_000L;
+		final long stallTimeoutMillis = 30_000L;
+		final ServiceRequestContext serviceContext = ServiceRequestContext
+			.builder(HttpRequest.of(HttpMethod.POST, "/test"))
+			.build();
+		serviceContext.setRequestTimeout(TimeoutMode.SET_FROM_START, Duration.ofMillis(callTimeoutMillis));
+
+		final FakeServerCallObserver observer = new FakeServerCallObserver(true);
+		// the gate reads the context at attach time, exactly as a service method would
+		try (final SafeCloseable ignored = serviceContext.push()) {
+			final GrpcOutboundGate gate = GrpcOutboundGate.attach(observer, "testMethod", null, stallTimeoutMillis);
+			assertTrue(gate.awaitWritable(), "A ready transport must grant immediately.");
+		}
+
+		// The horizon must be the *streaming* budget, not the 1 s the call arrived with. Asserted as a
+		// lower bound because Armeria stores the timeout relative to request start, so elapsed time only
+		// pushes it further out - see `GrpcTimeoutUtilTest`.
+		assertTrue(
+			serviceContext.requestTimeoutMillis() >= stallTimeoutMillis,
+			"A granted message must be re-armed to at least the stall budget, but the horizon was " +
+				serviceContext.requestTimeoutMillis() + " ms against a " + stallTimeoutMillis +
+				" ms stall timeout. Re-arming from the call's own budget is the defect this guards."
+		);
+		// ...and beyond it by a *material* margin, so the gate's own stall detection wins the race and the
+		// client gets DEADLINE_EXCEEDED naming the method rather than a bare RST_STREAM.
+		//
+		// The margin is asserted rather than a bare `>` for a reason worth stating: Armeria stores the
+		// timeout relative to request start, so even with the grace deleted the horizon would read
+		// `elapsed + stall` and clear a strict `>` on elapsed time alone. That assertion would have passed
+		// against the very regression this test exists to catch. `MINIMUM_EXPECTED_GRACE_MILLIS` is
+		// deliberately below the gate's actual 5 s so the test pins the *existence* of a grace without
+		// pinning its exact value.
+		assertTrue(
+			serviceContext.requestTimeoutMillis() >= stallTimeoutMillis + MINIMUM_EXPECTED_GRACE_MILLIS,
+			"The deadline must sit materially beyond the stall timeout so the gate detects the stall " +
+				"first, but the horizon was " + serviceContext.requestTimeoutMillis() + " ms against a " +
+				stallTimeoutMillis + " ms stall timeout."
+		);
+	}
+
+	@Test
+	@DisplayName("A call that arrived without a deadline is not given one by the gate")
+	void shouldLeaveADisabledDeadlineDisabled() {
+		final ServiceRequestContext serviceContext = ServiceRequestContext
+			.builder(HttpRequest.of(HttpMethod.POST, "/test"))
+			.build();
+		serviceContext.clearRequestTimeout();
+
+		final FakeServerCallObserver observer = new FakeServerCallObserver(true);
+		try (final SafeCloseable ignored = serviceContext.push()) {
+			final GrpcOutboundGate gate = GrpcOutboundGate.attach(observer, "testMethod", null, 30_000L);
+			assertTrue(gate.awaitWritable(), "A ready transport must grant immediately.");
+		}
+
+		// an open-ended stream that deliberately asked for no deadline must not acquire one here
+		assertEquals(
+			0L, serviceContext.requestTimeoutMillis(),
+			"Granting a message must not arm a deadline the caller declined."
+		);
+	}
+
+	@Test
+	@DisplayName("A ready transport lets the producer straight through")
+	void shouldNotWaitWhenTransportIsReady() {
+		final FakeServerCallObserver observer = new FakeServerCallObserver(true);
+		final GrpcOutboundGate gate = GrpcOutboundGate.attach(observer, "testMethod");
+
+		assertTimeoutPreemptively(
+			Duration.ofSeconds(5),
+			() -> assertTrue(gate.awaitWritable(), "A ready transport must not make the producer wait.")
+		);
+	}
+
+	@Test
+	@DisplayName("The producer waits while the transport is busy and resumes on the on-ready callback")
+	void shouldWaitUntilTransportSignalsReadiness() throws InterruptedException {
+		final FakeServerCallObserver observer = new FakeServerCallObserver(false);
+		final GrpcOutboundGate gate = GrpcOutboundGate.attach(observer, "testMethod");
+		final AtomicReference<Boolean> verdict = new AtomicReference<>();
+		final AtomicReference<Throwable> failure = new AtomicReference<>();
+		final CountDownLatch finished = new CountDownLatch(1);
+		final Thread producer = awaitInBackground(gate, verdict, failure, finished);
+
+		// negative wait - a busy machine can only make the gate wait longer, never release early, so a
+		// short window cannot produce a false failure here
+		assertFalse(
+			finished.await(250, TimeUnit.MILLISECONDS),
+			"Producer sailed past a transport that cannot accept another message."
+		);
+
+		observer.becomeReady();
+
+		assertTrue(finished.await(30, TimeUnit.SECONDS), "Producer never woke up after the transport drained.");
+		producer.join();
+		assertNull(failure.get(), "Producer failed unexpectedly.");
+		assertEquals(Boolean.TRUE, verdict.get(), "Producer must be cleared to send once the transport is ready.");
+	}
+
+	@Test
+	@DisplayName("A cancelled call is answered immediately, without ever parking the producer")
+	void shouldRefuseImmediatelyWhenCallIsAlreadyCancelled() {
+		// not ready *and* cancelled - which is exactly the state Armeria leaves a cancelled call in,
+		// because the pending-message counter it increments in `sendMessage` is never unwound
+		final FakeServerCallObserver observer = new FakeServerCallObserver(false);
+		final GrpcOutboundGate gate = GrpcOutboundGate.attach(
+			observer, "testMethod", null, GENEROUS_STALL_TIMEOUT_MILLIS
+		);
+		observer.cancel();
+
+		assertTimeoutPreemptively(
+			Duration.ofSeconds(5),
+			() -> assertFalse(
+				gate.awaitWritable(),
+				"Gate must report a cancelled call as unwritable rather than waiting for a readiness " +
+					"signal that can never arrive."
+			)
+		);
+	}
+
+	@Test
+	@DisplayName("Cancellation releases a producer that is already waiting, and runs the chained cleanup")
+	void shouldReleaseWaitingProducerOnCancellation() throws InterruptedException {
+		final FakeServerCallObserver observer = new FakeServerCallObserver(false);
+		final AtomicBoolean cleanedUp = new AtomicBoolean();
+		final GrpcOutboundGate gate = GrpcOutboundGate.attach(
+			observer, "testMethod", () -> cleanedUp.set(true), GENEROUS_STALL_TIMEOUT_MILLIS
+		);
+		final AtomicReference<Boolean> verdict = new AtomicReference<>();
+		final AtomicReference<Throwable> failure = new AtomicReference<>();
+		final CountDownLatch finished = new CountDownLatch(1);
+		final Thread producer = awaitInBackground(gate, verdict, failure, finished);
+
+		assertFalse(finished.await(250, TimeUnit.MILLISECONDS), "Producer did not wait for a busy transport.");
+
+		observer.cancel();
+
+		assertTrue(finished.await(30, TimeUnit.SECONDS), "Cancelling the call did not release the producer.");
+		producer.join();
+		assertNull(failure.get(), "Producer failed unexpectedly.");
+		assertEquals(Boolean.FALSE, verdict.get(), "A cancelled call must be reported as unwritable.");
+		assertTrue(
+			cleanedUp.get(),
+			"The gate owns the call's cancel handler, so the cleanup handed to it must still run."
+		);
+	}
+
+	@Test
+	@DisplayName("Closing the call releases a producer that is already waiting")
+	void shouldReleaseWaitingProducerWhenCallCloses() throws InterruptedException {
+		final FakeServerCallObserver observer = new FakeServerCallObserver(false);
+		final GrpcOutboundGate gate = GrpcOutboundGate.attach(
+			observer, "testMethod", null, GENEROUS_STALL_TIMEOUT_MILLIS
+		);
+		final AtomicReference<Boolean> verdict = new AtomicReference<>();
+		final AtomicReference<Throwable> failure = new AtomicReference<>();
+		final CountDownLatch finished = new CountDownLatch(1);
+		final Thread producer = awaitInBackground(gate, verdict, failure, finished);
+
+		assertFalse(finished.await(250, TimeUnit.MILLISECONDS), "Producer did not wait for a busy transport.");
+
+		// a close the producer did not initiate - an interceptor failing the call, or the server
+		// shutting the stream down underneath it
+		observer.close();
+
+		assertTrue(finished.await(30, TimeUnit.SECONDS), "Closing the call did not release the producer.");
+		producer.join();
+		assertNull(failure.get(), "Producer failed unexpectedly.");
+		assertEquals(Boolean.FALSE, verdict.get(), "A closed call must be reported as unwritable.");
+	}
+
+	@Test
+	@DisplayName("A client that holds the stream open but stops reading is abandoned")
+	void shouldAbandonStreamWhenClientStopsConsuming() {
+		final FakeServerCallObserver observer = new FakeServerCallObserver(false);
+		// the transport never becomes ready and the client never hangs up - the only way out is the
+		// stall timeout, which is what stops a vanished client from pinning a worker thread forever
+		final GrpcOutboundGate gate = GrpcOutboundGate.attach(observer, "testMethod", null, 200L);
+
+		assertThrows(
+			StalledGrpcStreamException.class,
+			gate::awaitWritable,
+			"A stream nobody is reading must be abandoned once the stall timeout elapses."
+		);
+	}
+
+	/**
+	 * Stand-in for gRPC's `ServerCallStreamObserverImpl` that exposes the two transport transitions the
+	 * gate reacts to - readiness and termination - as ordinary method calls.
+	 *
+	 * It deliberately mirrors gRPC's own dispatch order: {@link #cancel()} sets the cancellation flag
+	 * *before* running the handler, which is what lets the test distinguish "the gate saw the flag"
+	 * from "the gate was woken by the callback".
+	 */
+	private static class FakeServerCallObserver extends ServerCallStreamObserver<Object> {
+		private final AtomicBoolean ready;
+		private final AtomicBoolean cancelled = new AtomicBoolean();
+		private Runnable onReadyHandler;
+		private Runnable onCancelHandler;
+		private Runnable onCloseHandler;
+
+		FakeServerCallObserver(boolean ready) {
+			this.ready = new AtomicBoolean(ready);
+		}
+
+		/**
+		 * Simulates the transport draining its queue.
+		 */
+		void becomeReady() {
+			this.ready.set(true);
+			if (this.onReadyHandler != null) {
+				this.onReadyHandler.run();
+			}
+		}
+
+		/**
+		 * Simulates a client-initiated cancellation.
+		 */
+		void cancel() {
+			this.cancelled.set(true);
+			if (this.onCancelHandler != null) {
+				this.onCancelHandler.run();
+			}
+		}
+
+		/**
+		 * Simulates a server-initiated close of the call.
+		 */
+		void close() {
+			if (this.onCloseHandler != null) {
+				this.onCloseHandler.run();
+			}
+		}
+
+		@Override
+		public boolean isReady() {
+			return this.ready.get();
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return this.cancelled.get();
+		}
+
+		@Override
+		public void setOnReadyHandler(Runnable onReadyHandler) {
+			this.onReadyHandler = onReadyHandler;
+		}
+
+		@Override
+		public void setOnCancelHandler(Runnable onCancelHandler) {
+			this.onCancelHandler = onCancelHandler;
+		}
+
+		@Override
+		public void setOnCloseHandler(Runnable onCloseHandler) {
+			this.onCloseHandler = onCloseHandler;
+		}
+
+		@Override
+		public void setCompression(String compression) {
+		}
+
+		@Override
+		public void setMessageCompression(boolean enable) {
+		}
+
+		@Override
+		public void disableAutoInboundFlowControl() {
+		}
+
+		@Override
+		public void request(int count) {
+		}
+
+		@Override
+		public void onNext(Object value) {
+		}
+
+		@Override
+		public void onError(Throwable t) {
+		}
+
+		@Override
+		public void onCompleted() {
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/utils/GrpcTimeoutUtilTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/utils/GrpcTimeoutUtilTest.java
@@ -1,0 +1,224 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc.utils;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.util.TimeoutMode;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.time.Duration;
+
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.STREAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins down how a streaming call's Armeria deadline must be rolled forward, and - more importantly -
+ * how it must **not** be.
+ *
+ * Every long-lived producer in this module re-arms the request timeout per message, because Armeria's
+ * request timeout bounds the whole request while a stream needs a bound on *silence*. The subtlety that
+ * cost six call sites is where the budget for that re-arm comes from.
+ * {@link ServiceRequestContext#requestTimeoutMillis()} reads like "the configured timeout" and is not:
+ * Armeria stores the timeout relative to the request's start, and {@link TimeoutMode#SET_FROM_NOW}
+ * writes `elapsed + newTimeout` into that same field. Reading it back inside the loop therefore feeds
+ * each re-arm a budget that already contains every previous one.
+ *
+ * The second test below is a **characterisation test of Armeria**, deliberately. The fix depends on that
+ * behaviour, it is not part of Armeria's documented contract, and an upgrade could change it - in which
+ * case this test fails and says so, instead of the ratchet quietly coming back.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Streaming request timeouts must be re-armed from a captured budget")
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(STREAM)
+class GrpcTimeoutUtilTest {
+	/**
+	 * Budget each context under test starts with. Small enough to keep the test quick, large enough that
+	 * the two strategies below separate by far more than scheduling noise.
+	 */
+	private static final long CONFIGURED_TIMEOUT_MILLIS = 1_000L;
+	/**
+	 * Pause between successive re-arms. This is a *detection widener*, not a poll: the compounding the
+	 * test is looking for is proportional to elapsed time, so a slower machine makes the two strategies
+	 * diverge **further**. It cannot produce a false failure.
+	 */
+	private static final long REARM_SPACING_MILLIS = 120L;
+	/**
+	 * How many times each strategy re-arms. Three is enough for the ratchet to overtake the correct
+	 * strategy by more than a spacing interval, while keeping the whole test under a second.
+	 */
+	private static final int REARM_COUNT = 3;
+	/**
+	 * Stand-in for `api.endpoints.gRPC.streamingRequestTimeoutInMillis`. Deliberately unlike
+	 * {@link #CONFIGURED_TIMEOUT_MILLIS} so a test cannot pass by the two being confused.
+	 */
+	private static final long STREAMING_BUDGET_MILLIS = 300_000L;
+	/**
+	 * Tolerance absorbing millisecond truncation and the gap between the last re-arm and the reading. Far
+	 * smaller than the ~360 ms by which a compounding implementation overshoots, so it costs the
+	 * assertion no teeth.
+	 */
+	private static final long CLOCK_SLACK_MILLIS = 50L;
+
+	/**
+	 * Builds a service request context carrying a configured request timeout, the way a real gRPC call
+	 * with a `grpc-timeout` header arrives.
+	 *
+	 * @return context whose request timeout is {@link #CONFIGURED_TIMEOUT_MILLIS}
+	 */
+	@Nonnull
+	private static ServiceRequestContext contextWithConfiguredTimeout() {
+		final ServiceRequestContext serviceContext = ServiceRequestContext
+			.builder(HttpRequest.of(HttpMethod.POST, "/test"))
+			.build();
+		// SET_FROM_START is how a budget is established, as opposed to rolled forward
+		serviceContext.setRequestTimeout(
+			TimeoutMode.SET_FROM_START, Duration.ofMillis(CONFIGURED_TIMEOUT_MILLIS)
+		);
+		return serviceContext;
+	}
+
+	@Test
+	@DisplayName("Capturing before the first message yields the configured budget")
+	void shouldCaptureConfiguredRequestTimeout() {
+		final ServiceRequestContext serviceContext = contextWithConfiguredTimeout();
+
+		assertEquals(
+			CONFIGURED_TIMEOUT_MILLIS,
+			GrpcTimeoutUtil.captureRequestTimeoutMillis(serviceContext),
+			"Captured before any re-arm, the budget must be the one the call was configured with."
+		);
+	}
+
+	@Test
+	@DisplayName("A disabled request timeout is left disabled rather than rejected")
+	void shouldSkipReArmingWhenRequestTimeoutIsDisabled() {
+		// no timeout configured at all - the normal state for a client that sends no `grpc-timeout`
+		final ServiceRequestContext serviceContext = ServiceRequestContext
+			.builder(HttpRequest.of(HttpMethod.POST, "/test"))
+			.build();
+		serviceContext.clearRequestTimeout();
+
+		final long captured = GrpcTimeoutUtil.captureRequestTimeoutMillis(serviceContext);
+		assertEquals(0L, captured, "A disabled request timeout must read as zero.");
+
+		// `SET_FROM_NOW` is the one timeout mode that rejects a zero duration outright, so re-arming has
+		// to be skipped rather than attempted - this call must not throw
+		GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(serviceContext, captured);
+
+		assertEquals(
+			0L, serviceContext.requestTimeoutMillis(),
+			"Re-arming a disabled timeout must leave it disabled."
+		);
+	}
+
+	@Test
+	@DisplayName("A streaming call is budgeted from the streaming timeout, not the call's own request timeout")
+	void shouldResolveStreamingBudgetIndependentlyOfTheCallsOwnTimeout() {
+		final ServiceRequestContext serviceContext = contextWithConfiguredTimeout();
+
+		// The call asked for 1 s; a stream gets the deployment's streaming budget instead. Substituting
+		// is safe because a gRPC deadline is enforced by the *client* - the caller still sees its own
+		// deadline honoured, and only a live-but-silent peer occupies the server for longer.
+		assertEquals(
+			STREAMING_BUDGET_MILLIS,
+			GrpcTimeoutUtil.resolveStreamingBudgetMillis(serviceContext, STREAMING_BUDGET_MILLIS),
+			"A call that has a deadline must be re-armed from the streaming budget, not its own."
+		);
+	}
+
+	@Test
+	@DisplayName("A call with no deadline is not given one by the streaming budget")
+	void shouldLeaveADisabledTimeoutDisabledWhenResolvingTheStreamingBudget() {
+		final ServiceRequestContext serviceContext = ServiceRequestContext
+			.builder(HttpRequest.of(HttpMethod.POST, "/test"))
+			.build();
+		serviceContext.clearRequestTimeout();
+
+		// Whether a call has a deadline stays the caller's decision; only its *value* is substituted.
+		// Returning the budget here would silently impose a 5-minute deadline on an open-ended stream
+		// (a CDC subscription, say) that deliberately asked for none.
+		assertEquals(
+			0L,
+			GrpcTimeoutUtil.resolveStreamingBudgetMillis(serviceContext, STREAMING_BUDGET_MILLIS),
+			"A deliberately disabled deadline must stay disabled."
+		);
+	}
+
+	@Test
+	@DisplayName("Re-arming from a captured budget holds the horizon; re-reading the context ratchets it")
+	void shouldNotCompoundTheBudgetWhenReArmingFromCapturedValue() throws InterruptedException {
+		// the stopwatch starts before the contexts do: each context's own clock begins when it is built,
+		// so measuring from here keeps `elapsedMillis` an upper bound on the scheduler's notion of elapsed
+		final long startNanos = System.nanoTime();
+		final ServiceRequestContext capturedContext = contextWithConfiguredTimeout();
+		final ServiceRequestContext ratchetingContext = contextWithConfiguredTimeout();
+		// captured once, before the first re-arm - this is what every producing loop must do
+		final long capturedBudget = GrpcTimeoutUtil.captureRequestTimeoutMillis(capturedContext);
+
+		for (int i = 0; i < REARM_COUNT; i++) {
+			Thread.sleep(REARM_SPACING_MILLIS);
+			GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(capturedContext, capturedBudget);
+			// the mistake, reproduced side by side: the budget is read back from the context, so it
+			// already contains everything the previous re-arms added to it
+			GrpcTimeoutUtil.reArmRequestTimeoutIfEnabled(
+				ratchetingContext, ratchetingContext.requestTimeoutMillis()
+			);
+		}
+		final long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+
+		final long capturedHorizon = capturedContext.requestTimeoutMillis();
+		final long ratchetingHorizon = ratchetingContext.requestTimeoutMillis();
+
+		// Re-armed from a constant, the deadline sits one budget past the last message - which is exactly
+		// what "the client has `timeout` to send the next one" means. Stated relative to the measured
+		// elapsed time so a loaded machine cannot fail it.
+		assertTrue(
+			capturedHorizon <= elapsedMillis + CONFIGURED_TIMEOUT_MILLIS + CLOCK_SLACK_MILLIS,
+			"Re-arming from a captured budget must leave the horizon at last-message + budget, but it " +
+				"was " + capturedHorizon + " ms after " + elapsedMillis + " ms elapsed."
+		);
+
+		// Re-armed from the context, each step adds the elapsed time to a budget that already included
+		// it. The gap grows with every message, so a stalled client is never caught.
+		assertTrue(
+			ratchetingHorizon > capturedHorizon + REARM_SPACING_MILLIS,
+			"Reading the budget back from the context must be shown to compound it - the ratcheting " +
+				"horizon was " + ratchetingHorizon + " ms against " + capturedHorizon + " ms for the " +
+				"captured one. If these now agree, Armeria changed `requestTimeoutMillis()` semantics " +
+				"and `GrpcTimeoutUtil#captureRequestTimeoutMillis` needs revisiting."
+		);
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ChainIndexLegacyLoadTransactionalFlushTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ChainIndexLegacyLoadTransactionalFlushTest.java
@@ -1,0 +1,318 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.attribute;
+
+import io.evitadb.api.requestResponse.mutation.Mutation;
+import io.evitadb.core.buffer.TrappedChanges;
+import io.evitadb.core.transaction.Transaction;
+import io.evitadb.core.transaction.TransactionHandler;
+import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
+import io.evitadb.dataType.ChainableType;
+import io.evitadb.dataType.Predecessor;
+import io.evitadb.index.array.UnorderedLookupTree;
+import io.evitadb.index.attribute.ChainIndex.ChainElementState;
+import io.evitadb.index.attribute.ChainIndex.ElementState;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.ChainIndexLeafPagePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.ChainIndexStoragePart;
+import io.evitadb.utils.CollectionUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for issue #1437: the first transactional flush of a {@link ChainIndex} restored from a
+ * **legacy, non-paged** `ChainIndexStoragePart` used to abort the whole commit with
+ * `Transaction is already committed / rolled back, no new transactional memory layer may be created at this time!`,
+ * which marks the catalog CORRUPTED.
+ *
+ * The mechanism this class pins down:
+ *
+ * - `AttributeIndexLoader.fetchChain` rebuilds a legacy part through the `int[][] chains` constructor, so **every**
+ *   leaf of the element tree carries `UNASSIGNED_PAGE_SEQUENCE` — unlike a natively-paged index, whose leaves are
+ *   restored with their persisted page sequences;
+ * - the flush that assigns those sequences (`PageStreamRegistry.collectChangedPages`) runs INSIDE the commit:
+ *   `TransactionTrunkFinalizer.commitCatalogChanges` flushes the catalog after
+ *   {@link TransactionalLayerMaintainer} has already forbidden new transactional layer creation;
+ * - the flush walks EVERY leaf, so it stamps leaves the transaction never touched, and those carry no diff layer.
+ *
+ * The fixture therefore builds a legacy-shaped index spanning three leaves, mutates only the LAST one, and performs
+ * the flush from inside {@link TransactionHandler#commit(TransactionalLayerMaintainer)} — the one moment where the
+ * transaction is still bound to the thread but layer creation is already sealed, exactly as on the trunk path.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Legacy (non-paged) chain index flushed inside a sealed commit")
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
+@Tag(TRANSACTION)
+class ChainIndexLegacyLoadTransactionalFlushTest {
+
+	/**
+	 * Primary key of the owning entity index — mirrors the global index of the collection in the reported incident.
+	 */
+	private static final int ENTITY_INDEX_PK = 1;
+	/**
+	 * The chained attribute the reported incident failed on.
+	 */
+	private static final AttributeIndexKey ORDER_KEY = new AttributeIndexKey(null, "order", null);
+	/**
+	 * Number of chained records in the fixture. Leaves of a paged tree hold {@link UnorderedLookupTree#PAGE_RECORDS}
+	 * records, so this spans three leaves (1024 + 1024 + 52) — matching the three-leaf chain index observed in the
+	 * reported incident, and leaving the last leaf room to accept the mutation without splitting.
+	 */
+	private static final int RECORD_COUNT = (2 * UnorderedLookupTree.PAGE_RECORDS) + 52;
+	/**
+	 * Primary key appended by the in-transaction mutation. It lands in the LAST leaf, so the first two leaves stay
+	 * untouched and therefore carry no transactional diff layer when the flush stamps them.
+	 */
+	private static final int APPENDED_PK = RECORD_COUNT + 1;
+
+	/**
+	 * Builds a {@link ChainIndex} exactly the way `AttributeIndexLoader.fetchChain` rebuilds a **legacy** (non-paged)
+	 * `ChainIndexStoragePart`: one chain run `1..RECORD_COUNT` plus the per-element state map, fed through the
+	 * `int[][] chains` constructor. Every leaf of the resulting element tree is unpaged.
+	 *
+	 * @return the legacy-shaped, freshly loaded (clean) chain index
+	 */
+	@Nonnull
+	private static ChainIndex legacyLoadedChainIndex() {
+		final int[] chain = new int[RECORD_COUNT];
+		final Map<Integer, ChainElementState> elementStates = CollectionUtils.createHashMap(RECORD_COUNT);
+		for (int i = 0; i < RECORD_COUNT; i++) {
+			final int primaryKey = i + 1;
+			chain[i] = primaryKey;
+			elementStates.put(
+				primaryKey,
+				new ChainElementState(
+					// every element belongs to the single chain headed by primary key 1
+					1,
+					// the head's predecessor is the HEAD sentinel, every successor points at the previous element
+					i == 0 ? ChainableType.HEAD_PK : primaryKey - 1,
+					i == 0 ? ElementState.HEAD : ElementState.SUCCESSOR
+				)
+			);
+		}
+		return new ChainIndex(null, ORDER_KEY, new int[][]{chain}, elementStates);
+	}
+
+	/**
+	 * Drives one transaction over `chainIndex` the way the trunk-incorporation path does: the mutation runs inside the
+	 * transaction, and the flush (`appendStorageParts`) runs from inside the commit callback — after the maintainer
+	 * sealed layer creation, while the transaction is still bound to the thread. Mirrors
+	 * `TransactionManager.commitChangesToSharedCatalog` → `TransactionTrunkFinalizer.commitCatalogChanges` →
+	 * `Catalog.flush`.
+	 *
+	 * @param chainIndex the index to mutate and flush
+	 * @param mutation   the mutation to apply inside the transaction
+	 * @param sink       collects the storage parts the flush emits
+	 * @return the merged (committed) copy of the index
+	 */
+	@Nonnull
+	private static ChainIndex commitWithTrunkFlush(
+		@Nonnull ChainIndex chainIndex,
+		@Nonnull Runnable mutation,
+		@Nonnull TrappedChanges sink
+	) {
+		final TrunkFlushTransactionHandler handler = new TrunkFlushTransactionHandler(chainIndex, sink);
+		final Transaction transaction = new Transaction(UUID.randomUUID(), handler, false);
+		Transaction.executeInTransactionIfProvided(
+			transaction,
+			() -> {
+				try {
+					mutation.run();
+				} finally {
+					transaction.close();
+				}
+			}
+		);
+		final ChainIndex committed = handler.getCommitted();
+		assertNotNull(committed, "The commit callback must have produced a merged chain index!");
+		return committed;
+	}
+
+	/**
+	 * Splits the parts collected by a flush into the emitted leaf pages and the (optional) root.
+	 *
+	 * @param sink the collected changes
+	 * @return the flush outcome
+	 */
+	@Nonnull
+	private static FlushOutcome readFlush(@Nonnull TrappedChanges sink) {
+		final List<ChainIndexLeafPagePart> leafPages = new ArrayList<>(8);
+		ChainIndexStoragePart root = null;
+		final Iterator<StoragePart> iterator = sink.getTrappedChangesIterator();
+		while (iterator.hasNext()) {
+			final StoragePart part = iterator.next();
+			if (part instanceof final ChainIndexLeafPagePart leafPage) {
+				leafPages.add(leafPage);
+			} else if (part instanceof final ChainIndexStoragePart chainRoot) {
+				root = chainRoot;
+			}
+		}
+		return new FlushOutcome(leafPages, root);
+	}
+
+	@Nested
+	@DisplayName("First flush after a legacy load")
+	class FirstFlushTest {
+
+		@Test
+		@DisplayName("stamps page sequences on leaves the transaction never touched without tripping the sealed layer")
+		void shouldStampUntouchedLeavesDuringSealedCommitFlush() {
+			final ChainIndex chainIndex = legacyLoadedChainIndex();
+			final TrappedChanges sink = new TrappedChanges();
+
+			// before the fix this threw GenericEvitaInternalError: "Transaction is already committed / rolled back,
+			// no new transactional memory layer may be created at this time!" while stamping the first untouched leaf
+			final ChainIndex committed = commitWithTrunkFlush(
+				chainIndex,
+				() -> chainIndex.upsertPredecessor(new Predecessor(RECORD_COUNT), APPENDED_PK),
+				sink
+			);
+
+			final FlushOutcome outcome = readFlush(sink);
+			assertNotNull(outcome.root(), "A first PAGED flush must re-emit the root carrying the new page list!");
+			assertTrue(outcome.root().isPaged(), "A three-leaf chain index must persist in the PAGED shape!");
+			assertArrayEquals(
+				new int[]{0, 1, 2},
+				outcome.root().getPageSequencesOrThrowException(),
+				"Every leaf must have been allocated a page sequence, in ascending key order!"
+			);
+			assertEquals(
+				3, outcome.leafPages().size(),
+				"A legacy index has no persisted pages yet, so all three leaves are fresh and must be written!"
+			);
+			assertEquals(
+				RECORD_COUNT + 1,
+				committed.getUnorderedLookup().size(),
+				"The appended record must be part of the merged index!"
+			);
+		}
+
+		@Test
+		@DisplayName("carries the stamps through the commit merge so the next flush reuses the same pages")
+		void shouldCarryPageStampsThroughCommitMerge() {
+			final ChainIndex chainIndex = legacyLoadedChainIndex();
+			final ChainIndex committed = commitWithTrunkFlush(
+				chainIndex,
+				() -> chainIndex.upsertPredecessor(new Predecessor(RECORD_COUNT), APPENDED_PK),
+				new TrappedChanges()
+			);
+
+			final TrappedChanges secondSink = new TrappedChanges();
+			commitWithTrunkFlush(
+				committed,
+				() -> committed.upsertPredecessor(new Predecessor(APPENDED_PK), APPENDED_PK + 1),
+				secondSink
+			);
+
+			final FlushOutcome outcome = readFlush(secondSink);
+			assertEquals(
+				1, outcome.leafPages().size(),
+				"Only the mutated leaf may be re-written — the stamps assigned by the first flush must have survived " +
+					"the commit merge, otherwise every leaf would look fresh again!"
+			);
+			assertEquals(
+				2, outcome.leafPages().get(0).getPageSequence(),
+				"The mutation lands in the last leaf, so its already-allocated page must be reused!"
+			);
+			// a content-only commit leaves the persisted leaf-page list byte-identical, so the root is skipped; a
+			// re-emitted root here would mean the page stamps had been re-allocated from scratch
+			assertNull(outcome.root(), "The live page list did not change, so the PAGED root must not be re-emitted!");
+		}
+
+	}
+
+	/**
+	 * Carrier for the parts one flush emitted.
+	 *
+	 * @param leafPages the emitted leaf pages, in emission order
+	 * @param root      the emitted PAGED root, or `null` when the flush skipped it
+	 */
+	private record FlushOutcome(
+		@Nonnull List<ChainIndexLeafPagePart> leafPages,
+		@Nullable ChainIndexStoragePart root
+	) {
+	}
+
+	/**
+	 * Transaction handler modelling `TransactionTrunkFinalizer`: the catalog flush runs inside the commit callback,
+	 * i.e. after the maintainer has forbidden new transactional layer creation, and before the state copy with merged
+	 * changes is produced.
+	 */
+	private static class TrunkFlushTransactionHandler implements TransactionHandler {
+		private final ChainIndex chainIndex;
+		private final TrappedChanges sink;
+		@Nullable private ChainIndex committed;
+
+		TrunkFlushTransactionHandler(@Nonnull ChainIndex chainIndex, @Nonnull TrappedChanges sink) {
+			this.chainIndex = chainIndex;
+			this.sink = sink;
+		}
+
+		@Nullable
+		ChainIndex getCommitted() {
+			return this.committed;
+		}
+
+		@Override
+		public void registerMutation(@Nonnull Mutation mutation) {
+			// no mutation bookkeeping is needed for this fixture
+		}
+
+		@Override
+		public void commit(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
+			// the flush precedes the merge on the trunk path — see TransactionTrunkFinalizer.commitCatalogChanges
+			this.chainIndex.appendStorageParts(ENTITY_INDEX_PK, this.sink);
+			this.committed = transactionalLayer.getStateCopyWithCommittedChanges(this.chainIndex);
+			transactionalLayer.verifyLayerWasFullySwept();
+		}
+
+		@Override
+		public void rollback(@Nonnull TransactionalLayerMaintainer transactionalLayer, @Nullable Throwable cause) {
+			throw new IllegalStateException("Rollback is not expected in this fixture!", cause);
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/ExceptionUtilsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/ExceptionUtilsTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -271,6 +272,80 @@ class ExceptionUtilsTest {
 			final RuntimeException topLevel = new RuntimeException("top", intermediate);
 
 			assertTrue(ExceptionUtils.causeChainContains(topLevel, IllegalStateException.class));
+		}
+	}
+
+	@Nested
+	@DisplayName("Cause chain instance lookup")
+	class FindInCauseChainTest {
+
+		@Test
+		@DisplayName("should return the matching instance itself, not merely a verdict")
+		void shouldReturnMatchingInstance() {
+			// the point of this method over causeChainContains: callers need state off the instance
+			final IOException rootCause = new IOException("IO error");
+			final RuntimeException topLevel = new RuntimeException("top", rootCause);
+
+			assertSame(rootCause, ExceptionUtils.findInCauseChain(topLevel, IOException.class));
+		}
+
+		@Test
+		@DisplayName("should return the throwable itself when it already matches")
+		void shouldReturnThrowableItselfWhenMatching() {
+			final IOException exception = new IOException("IO error");
+
+			assertSame(exception, ExceptionUtils.findInCauseChain(exception, IOException.class));
+		}
+
+		@Test
+		@DisplayName("should return the outermost match when several are present")
+		void shouldReturnOutermostMatch() {
+			final IllegalStateException rootCause = new IllegalStateException("inner");
+			final IllegalStateException intermediate = new IllegalStateException("outer", rootCause);
+			final RuntimeException topLevel = new RuntimeException("top", intermediate);
+
+			assertSame(intermediate, ExceptionUtils.findInCauseChain(topLevel, IllegalStateException.class));
+		}
+
+		@Test
+		@DisplayName("should return null when the type is absent from the chain")
+		void shouldReturnNullWhenTypeAbsent() {
+			final RuntimeException topLevel = new RuntimeException("top", new IOException("io"));
+
+			assertNull(ExceptionUtils.findInCauseChain(topLevel, CancellationException.class));
+		}
+
+		@Test
+		@DisplayName("should terminate on a two-element circular reference when the type is absent")
+		void shouldTerminateOnCircularReferenceWhenTypeAbsent() {
+			// `A -> B -> A` is the shape a self-reference guard (`current.getCause() == current`)
+			// misses; only the visited-set traversal terminates here
+			final CircularException exception1 = new CircularException("Exception 1");
+			final CircularException exception2 = new CircularException("Exception 2", exception1);
+			exception1.initCause(exception2);
+
+			assertNull(ExceptionUtils.findInCauseChain(exception1, CancellationException.class));
+		}
+
+		@Test
+		@DisplayName("should find the type inside a circular reference chain")
+		void shouldFindTypeInCircularReferenceChain() {
+			final CircularException exception1 = new CircularException("Exception 1");
+			final CircularException exception2 = new CircularException("Exception 2", exception1);
+			exception1.initCause(exception2);
+
+			assertSame(exception1, ExceptionUtils.findInCauseChain(exception1, CircularException.class));
+		}
+
+		@Test
+		@DisplayName("should match a superclass of an exception in the chain")
+		void shouldMatchSuperclassInCauseChain() {
+			// the top level is deliberately *not* a RuntimeException, so the match can only come from
+			// the cause - otherwise this would pass without walking the chain at all
+			final IllegalArgumentException rootCause = new IllegalArgumentException("arg");
+			final IOException topLevel = new IOException("top", rootCause);
+
+			assertSame(rootCause, ExceptionUtils.findInCauseChain(topLevel, RuntimeException.class));
 		}
 	}
 

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningEvitaClientLargeFileDownloadTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningEvitaClientLargeFileDownloadTest.java
@@ -1,0 +1,223 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc;
+
+import io.evitadb.api.file.FileForFetch;
+import io.evitadb.core.Evita;
+import io.evitadb.driver.EvitaClient;
+import io.evitadb.driver.config.ClientTimeoutOptions;
+import io.evitadb.driver.config.ClientTlsOptions;
+import io.evitadb.driver.config.EvitaClientConfiguration;
+import io.evitadb.externalApi.configuration.ApiOptions;
+import io.evitadb.externalApi.configuration.HostDefinition;
+import io.evitadb.externalApi.system.SystemProvider;
+import io.evitadb.server.EvitaServer;
+import io.evitadb.spi.export.model.ExportFileHandle;
+import io.evitadb.test.annotation.DataSet;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import io.evitadb.utils.CertificateUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nonnull;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.CRC32;
+
+import static io.evitadb.test.TestTags.EXPORT;
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static io.evitadb.test.TestTags.SLOW;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Proves the Java driver can download a file bigger than Armeria's default response-length cap.
+ *
+ * Armeria caps a client response at 10 MiB by default, and the cap counts the **whole** HTTP body -
+ * which for a server-streaming call is every message added together, not the largest one. `EvitaClient`
+ * never overrode it, so `management().fetchFile(...)` could not fetch a backup larger than that: it
+ * failed part-way through with a bare `RESOURCE_EXHAUSTED`, indistinguishable from the unbounded-
+ * buffering failure this whole line of work started from. The cap is now lifted on the driver's
+ * streaming and CDC channels and kept on the unary one, where a 10 MiB reply genuinely is anomalous.
+ *
+ * Two existing tests look like they would have caught this and do not, which is why this one exists:
+ *
+ * - `EvitaClientReadWriteTest#shouldBackupAndRestoreCatalogViaDownloadingAndUploadingFileContents`
+ *   downloads through the driver, but backs up a ten-product catalog - about 1 MB, an order of
+ *   magnitude under the cap;
+ * - `LongRunningGrpcFetchFileBackpressureTest` moves 512 MiB, but through its own stub built with
+ *   `maxResponseLength(0)`, so it never exercises the driver's default at all.
+ *
+ * **Calibration.** {@link #FILE_SIZE} is asserted against {@link #ARMERIA_DEFAULT_MAX_RESPONSE_LENGTH}
+ * rather than assumed to exceed it: shrink the file below the cap and this test passes whether the fix
+ * is present or not.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Java driver must download files larger than Armeria's default response-length cap")
+@ExtendWith(EvitaParameterResolver.class)
+@Slf4j
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(MANAGEMENT)
+@Tag(EXPORT)
+@Tag(SLOW)
+public class LongRunningEvitaClientLargeFileDownloadTest {
+	private static final String DATA_SET = "GrpcLargeFileDownload";
+	/**
+	 * Armeria's `ClientOptions.MAX_RESPONSE_LENGTH` default - the ceiling this test exists to cross.
+	 */
+	private static final long ARMERIA_DEFAULT_MAX_RESPONSE_LENGTH = 10L * 1024L * 1024L;
+	/**
+	 * Size of the file to download. Comfortably over the cap, small enough to build and move quickly.
+	 */
+	private static final long FILE_SIZE = 24L * 1024L * 1024L;
+	/**
+	 * Size of the buffer the file is written and read with.
+	 */
+	private static final int BUFFER_SIZE = 65_536;
+
+	/**
+	 * Creates a file of the requested size and publishes it for fetching.
+	 *
+	 * @param evita       engine whose export service the file is stored in
+	 * @param contentsCrc accumulator the written contents are checksummed into
+	 * @return descriptor of the published file
+	 */
+	@Nonnull
+	private static FileForFetch createExportedFile(@Nonnull Evita evita, @Nonnull CRC32 contentsCrc) throws Exception {
+		final byte[] pattern = new byte[BUFFER_SIZE];
+		for (int i = 0; i < pattern.length; i++) {
+			pattern[i] = (byte) (i * 31 + 7);
+		}
+		final ExportFileHandle handle = evita.management().exportService().storeFile(
+			"grpc-large-file-download.bin",
+			"Large file used by the driver download test",
+			"application/octet-stream",
+			"test"
+		);
+		try {
+			final OutputStream outputStream = handle.outputStream();
+			long written = 0L;
+			while (written < FILE_SIZE) {
+				final int toWrite = (int) Math.min(pattern.length, FILE_SIZE - written);
+				outputStream.write(pattern, 0, toWrite);
+				contentsCrc.update(pattern, 0, toWrite);
+				written += toWrite;
+			}
+		} finally {
+			handle.close();
+		}
+		final FileForFetch fileForFetch = handle.fileForFetchFuture().get(60, TimeUnit.SECONDS);
+		assertEquals(FILE_SIZE, fileForFetch.totalSizeInBytes(), "Exported file has an unexpected size.");
+		return fileForFetch;
+	}
+
+	@DataSet(
+		value = DATA_SET, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE},
+		readOnly = false, destroyAfterClass = true,
+		// the download is gated on transport readiness, which only exists when the request executor is a
+		// real pool - see LongRunningGrpcFetchFileBackpressureTest for the full explanation
+		useRealThreadPools = true
+	)
+	static EvitaClient setUp(EvitaServer evitaServer) {
+		final ApiOptions apiOptions = evitaServer.getExternalApiServer().getApiOptions();
+		final HostDefinition grpcHost = apiOptions.getEndpointConfiguration(GrpcProvider.CODE).getHost()[0];
+		final HostDefinition systemHost = apiOptions.getEndpointConfiguration(SystemProvider.CODE).getHost()[0];
+
+		final String serverCertificates = apiOptions.certificate().getFolderPath().toString();
+		final int lastDash = serverCertificates.lastIndexOf('-');
+		assertTrue(lastDash > 0, "Dash not found! Look at the evita-configuration.yml in test resources!");
+		final Path clientCertificates = Path.of(serverCertificates.substring(0, lastDash) + "-client");
+
+		return new EvitaClient(
+			EvitaClientConfiguration.builder()
+				.host(grpcHost.hostAddress())
+				.port(grpcHost.port())
+				.systemApiPort(systemHost.port())
+				.tls(
+					ClientTlsOptions.builder()
+						.mtlsEnabled(false)
+						.certificateFolderPath(clientCertificates)
+						.certificateFileName(Path.of(CertificateUtils.getGeneratedClientCertificateFileName()))
+						.certificateKeyFileName(
+							Path.of(CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName())
+						)
+						.build()
+				)
+				.timeouts(
+					ClientTimeoutOptions.builder()
+						.timeout(10, TimeUnit.MINUTES)
+						.build()
+				)
+				.build()
+		);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET)
+	@DisplayName("Should download a 24 MB file through EvitaClient with its default channel configuration")
+	void shouldDownloadFileLargerThanDefaultResponseLengthCap(Evita evita, EvitaClient evitaClient) throws Exception {
+		assertTrue(
+			FILE_SIZE > ARMERIA_DEFAULT_MAX_RESPONSE_LENGTH,
+			"File is not larger than Armeria's default response-length cap, so this test would pass " +
+				"with or without the fix it exists to guard."
+		);
+
+		final CRC32 expectedCrc = new CRC32();
+		final FileForFetch bigFile = createExportedFile(evita, expectedCrc);
+		try {
+			final CRC32 receivedCrc = new CRC32();
+			long receivedBytes = 0L;
+			// the driver stages the download into a temp file and hands back a stream over it, so this
+			// reads from disk rather than holding 24 MB in memory
+			try (final InputStream inputStream = evitaClient.management().fetchFile(bigFile.fileId())) {
+				final byte[] buffer = new byte[BUFFER_SIZE];
+				int bytesRead;
+				while ((bytesRead = inputStream.read(buffer)) != -1) {
+					receivedCrc.update(buffer, 0, bytesRead);
+					receivedBytes += bytesRead;
+				}
+			}
+
+			log.info("Downloaded {} B through the driver's default channel configuration.", receivedBytes);
+			assertEquals(FILE_SIZE, receivedBytes, "Client did not receive the whole file.");
+			assertEquals(
+				expectedCrc.getValue(), receivedCrc.getValue(),
+				"Downloaded contents differ from the stored file."
+			);
+		} finally {
+			evita.management().deleteFile(bigFile.fileId());
+		}
+	}
+
+}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningGrpcFetchFileBackpressureTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningGrpcFetchFileBackpressureTest.java
@@ -1,0 +1,480 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc;
+
+import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import io.evitadb.api.file.FileForFetch;
+import io.evitadb.core.Evita;
+import io.evitadb.driver.config.EvitaClientConfiguration;
+import io.evitadb.driver.interceptor.ClientSessionInterceptor;
+import io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter;
+import io.evitadb.externalApi.grpc.generated.EvitaManagementServiceGrpc.EvitaManagementServiceStub;
+import io.evitadb.externalApi.grpc.generated.GrpcFetchFileRequest;
+import io.evitadb.externalApi.grpc.generated.GrpcFetchFileResponse;
+import io.evitadb.externalApi.system.SystemProvider;
+import io.evitadb.server.EvitaServer;
+import io.evitadb.spi.export.model.ExportFileHandle;
+import io.evitadb.test.annotation.DataSet;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import io.evitadb.utils.VersionUtils.SemVer;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import io.netty.util.internal.PlatformDependent;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nonnull;
+import java.io.OutputStream;
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.CRC32;
+
+import static io.evitadb.test.TestTags.EXPORT;
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static io.evitadb.test.TestTags.SLOW;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Proves that `EvitaManagementService.fetchFile` bounds the memory it holds on behalf of a client
+ * that stops consuming the stream.
+ *
+ * `fetchFile` streams a file to the client in chunks. Armeria hands every `onNext` straight into the
+ * response `StreamMessage`, whose write queue is unbounded, and reports back-pressure only through
+ * `ServerCallStreamObserver.isReady()` (which, in Armeria, is `pendingMessages == 0`). A handler that
+ * reads the file in a tight loop and never consults readiness therefore converts "slow consumer" into
+ * "the whole file is resident in the server's memory" - the observed production symptom being a large
+ * backup download over a slow tunnel that dies part-way through with a bare `UNKNOWN` status and no
+ * message. `StreamingServerCall.sendMessage` marshals on the Armeria event loop, so the allocation
+ * that finally fails - direct buffer memory, bounded by `MaxDirectMemorySize` rather than `-Xmx` -
+ * fails inside Armeria, whose fallback for an escaping `Throwable` is exactly `UNKNOWN` with no
+ * description (`verboseResponses` is off). Nothing in evitaDB remaps it either:
+ * `executeWithClientContext` catches only `RuntimeException`, and `ObservableRunnable.run` catches
+ * only `Exception`. The handler now paces itself with `GrpcOutboundGate`; this test is what holds it
+ * to that.
+ *
+ * The test reproduces that shape deterministically and without relying on an actual memory
+ * exhaustion (an OOME inside a surefire fork would take the rest of the module down with it):
+ * a manual-flow-control client asks for a handful of messages and then stops requesting, and the
+ * server is given a settle window in which an unbounded handler would drain the whole file into its
+ * outbound queue. The assertion is on retained memory - heap *and* off-heap, because Armeria
+ * marshals each message into a pooled buffer before queueing it - with a wide margin: it is an
+ * order-of-magnitude question, not a precise one.
+ *
+ * **Calibration** (measured against the ungated handler, 512 MB file, `-Xmx5g`): the client
+ * consumed 4 chunks / 256 KB, no thread remained inside `fetchFile` - the streaming loop had run to
+ * completion - and the retained delta was **1035 MB**, against a 64 MB limit: a 16x margin. Almost
+ * none of it was heap (70 MB -> 77 MB); it was Netty direct memory (4 MB -> 1084 MB). The ~2x
+ * amplification over the file size is pooled-arena rounding - a 64 KB payload plus the 5-byte gRPC
+ * frame header lands in the next size class up, so every chunk costs about 128 KB. That is why the
+ * production ceiling is `MaxDirectMemorySize` rather than `-Xmx`, and why a 690 MB download needs
+ * roughly 1.4 GB of direct memory to buffer.
+ *
+ * If this test stops failing when the readiness gating is removed from `fetchFile`, it has gone
+ * decorative - the most likely reason being that `ObservabilityInterceptor` stopped delegating
+ * `ServerCall.isReady()` (the `io.grpc.ServerCall` default returns `true` unconditionally, so a
+ * non-delegating decorator silently disables the gating); that specific trap is guarded separately
+ * and cheaply by `ObservabilityInterceptorReadinessTest` in the functional module.
+ *
+ * The gRPC-Web serialization format is deliberate: it is the framing evitaLab uses, and the one the
+ * production report came from. It shares the framed code path with plain gRPC-proto, so the
+ * buffering behaviour is identical either way.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("gRPC fetchFile must not buffer a whole file for a client that stops consuming")
+@ExtendWith(EvitaParameterResolver.class)
+@Slf4j
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(MANAGEMENT)
+@Tag(EXPORT)
+@Tag(SLOW)
+public class LongRunningGrpcFetchFileBackpressureTest {
+	private static final String DATA_SET = "GrpcFetchFileBackpressure";
+	/**
+	 * Chunk size the server streams with - mirrors `EvitaManagementService.FETCH_FILE_CHUNK_SIZE`.
+	 * Only used to make the log lines and the failure message legible; nothing here depends on the
+	 * server actually using this value.
+	 */
+	private static final int CHUNK_SIZE = 1_048_576;
+	/**
+	 * Size of the file the client asks for. Big enough that "the server buffered all of it" and
+	 * "the server buffered a couple of messages" are separated by three orders of magnitude, small
+	 * enough to be written and read within a long-running test's budget.
+	 */
+	private static final long FILE_SIZE = 512L * 1024L * 1024L;
+	/**
+	 * Number of messages the client consumes before it stops requesting and goes silent.
+	 */
+	private static final int CHUNKS_CONSUMED_BEFORE_STALL = 4;
+	/**
+	 * Upper bound on the memory the server may retain while the client is silent, set from measurements
+	 * on **both** sides rather than from a round fraction of the file:
+	 *
+	 * - gated (this fix): **14.4 MiB** retained, of which **12.0 MiB** was still there after the client
+	 *   drained the stream - i.e. allocator arena growth, not queued messages. Genuine in-flight data
+	 *   was ~2.4 MiB, about two 1 MB chunks, exactly what one message in flight predicts;
+	 * - ungated (the bug): **1035 MiB**, the whole file plus pooled-arena rounding.
+	 *
+	 * 32 MiB sits ~2x above the green measurement - enough headroom for a machine whose Netty arenas
+	 * (which scale with core count) reserve more than this one's - and 32x below the red one. It is
+	 * deliberately *not* the 64 MiB the failing side alone would have justified: that would also pass a
+	 * half-working fix that buffered 50 MB.
+	 *
+	 * **This measurement is JVM-wide, so a shared surefire fork can fail it spuriously.** It samples the
+	 * whole heap and both direct-memory counters, not this call's allocations, so any sibling test
+	 * allocating in the same fork counts against the budget. Running the module's whole `LongRunning*`
+	 * set together does exactly that: the generational fuzz tests push the baseline heap near a gigabyte
+	 * and the "retained" figure to ~3.6 GB, and this assertion fires while the fix is working perfectly.
+	 * Before believing a failure here, read the two diagnostics logged just above it - a thread count of
+	 * `1` inside `fetchFile` with the producer `TIMED_WAITING` **is the gate doing its job**, and points
+	 * at a contaminated fork rather than a regression. Confirm by running this class on its own: the
+	 * same code that "retained 3.6 GB" alongside the fuzz tests retains ~5 MB alone.
+	 *
+	 * Contamination cuts the other way too, and that direction is worse because it is silent: a sibling
+	 * GC between the two samples can make the delta *negative* (observed: -91 MB), which sails past this
+	 * assertion. A negative or implausibly small reading means the baseline was contaminated high, not
+	 * that the gate is working - so it is only evidence when this class runs alone.
+	 */
+	private static final long MAX_TOLERATED_SERVER_BUFFERING = 32L * 1024L * 1024L;
+	/**
+	 * How long the server is given to drain the file into its outbound queue while the client is
+	 * silent. This is a settle window, not a wait for a condition - a slower machine only reads
+	 * *less* of the file within it, so it can never turn a genuine failure into a false pass, and a
+	 * correct server has nothing to do during it at all.
+	 */
+	private static final long SETTLE_WINDOW_MILLIS = 20_000L;
+
+	/**
+	 * Memory the process is holding, split by where it is held.
+	 *
+	 * Both halves are needed: `StreamingServerCall` marshals every message into an `HttpData`
+	 * *eagerly* and queues that, so a message waiting to be written retains a (typically pooled and
+	 * direct) `ByteBuf` rather than the protobuf object it came from. Measuring only the Java heap
+	 * would therefore under-report - possibly to zero - exactly the buffering this test is about.
+	 *
+	 * @param heapBytes       live data on the Java heap
+	 * @param directBytes     off-heap buffer memory, whichever of the two counters sees more of it
+	 * @param nettyDirect     Netty's own direct-memory counter (`-1` when Netty has it disabled)
+	 * @param nioDirect       direct memory visible to the JVM's `BufferPoolMXBean`
+	 */
+	private record MemoryFootprint(long heapBytes, long directBytes, long nettyDirect, long nioDirect) {
+
+		/**
+		 * Returns the total memory retained regardless of where it sits.
+		 */
+		long total() {
+			return this.heapBytes + this.directBytes;
+		}
+
+	}
+
+	/**
+	 * Returns the memory in use after asking the collector to run, so that anything unreachable is
+	 * not counted as retained. Neither `System.gc()` nor the pauses between the rounds are a wait
+	 * for a condition - they only sharpen the measurement.
+	 *
+	 * @return snapshot of retained heap and off-heap memory
+	 */
+	@Nonnull
+	private static MemoryFootprint memoryAfterGc() throws InterruptedException {
+		for (int i = 0; i < 3; i++) {
+			System.gc();
+			Thread.sleep(250L);
+		}
+		final long heap = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+		// Netty's counter covers buffers allocated without a Cleaner (invisible to the JVM's own
+		// bean); the JVM bean covers plain `ByteBuffer.allocateDirect`. Whichever is larger is the
+		// better estimate - summing them would double-count buffers that both of them see.
+		final long nettyDirect = PlatformDependent.usedDirectMemory();
+		final long nioDirect = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)
+			.stream()
+			.filter(it -> "direct".equals(it.getName()))
+			.mapToLong(BufferPoolMXBean::getMemoryUsed)
+			.sum();
+		return new MemoryFootprint(heap, Math.max(Math.max(nettyDirect, 0L), nioDirect), nettyDirect, nioDirect);
+	}
+
+	/**
+	 * Logs whether any thread is currently inside the `fetchFile` streaming loop. Diagnostic only:
+	 * a handler that ignores back-pressure has long since run the loop to completion by the time the
+	 * settle window expires, whereas a gated one is either parked in it or waiting for an on-ready
+	 * callback - which is why this is logged rather than asserted.
+	 */
+	private static void logFetchFileThreadState() {
+		final ThreadInfo[] threads = ManagementFactory.getThreadMXBean().dumpAllThreads(false, false);
+		final long inFetchFile = Arrays.stream(threads)
+			.filter(it -> Arrays.stream(it.getStackTrace())
+				.anyMatch(frame -> frame.getClassName().endsWith("EvitaManagementService") &&
+					frame.getMethodName().contains("fetchFile")))
+			.count();
+		log.info("Threads currently inside EvitaManagementService.fetchFile: {}", inFetchFile);
+		Arrays.stream(threads)
+			.filter(it -> Arrays.stream(it.getStackTrace())
+				.anyMatch(frame -> frame.getClassName().contains("GrpcOutboundGate") ||
+					(frame.getClassName().endsWith("EvitaManagementService") &&
+						frame.getMethodName().contains("fetchFile"))))
+			.forEach(
+				it -> log.info(
+					"Producer thread `{}` is {}:\n\t{}",
+					it.getThreadName(), it.getThreadState(),
+					Arrays.stream(it.getStackTrace()).limit(12).map(StackTraceElement::toString)
+						.reduce((a, b) -> a + "\n\t" + b).orElse("<no stack>")
+				)
+			);
+	}
+
+	/**
+	 * Creates a file of the requested size and publishes it for fetching.
+	 *
+	 * @param evita        engine whose export service the file is stored in
+	 * @param size         size of the file in bytes
+	 * @param contentsCrc  accumulator the written contents are checksummed into
+	 * @return descriptor of the published file
+	 */
+	@Nonnull
+	private static FileForFetch createExportedFile(
+		@Nonnull Evita evita,
+		long size,
+		@Nonnull CRC32 contentsCrc
+	) throws Exception {
+		final byte[] pattern = new byte[CHUNK_SIZE];
+		for (int i = 0; i < pattern.length; i++) {
+			pattern[i] = (byte) (i * 31 + 7);
+		}
+		final ExportFileHandle handle = evita.management().exportService().storeFile(
+			"grpc-fetch-file-backpressure.bin",
+			"Large file used by the fetchFile back-pressure test",
+			"application/octet-stream",
+			"test"
+		);
+		try {
+			final OutputStream outputStream = handle.outputStream();
+			long written = 0L;
+			while (written < size) {
+				final int toWrite = (int) Math.min(pattern.length, size - written);
+				outputStream.write(pattern, 0, toWrite);
+				contentsCrc.update(pattern, 0, toWrite);
+				written += toWrite;
+			}
+		} finally {
+			handle.close();
+		}
+		final FileForFetch fileForFetch = handle.fileForFetchFuture().get(60, TimeUnit.SECONDS);
+		assertEquals(size, fileForFetch.totalSizeInBytes(), "Exported file has an unexpected size.");
+		return fileForFetch;
+	}
+
+	@DataSet(
+		value = DATA_SET, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE},
+		readOnly = false, destroyAfterClass = true,
+		// Mandatory here, not a preference. The default test engine collapses the request pool into a
+		// direct executor, which makes `executeWithClientContext` run the streaming loop on the
+		// transport event loop - the one thread that has to drain the outbound queue. Readiness gating
+		// is impossible there by construction (the gate detects it and deliberately runs ungated), so
+		// without real pools this test would measure the *unbounded* path no matter what the server
+		// does, and could never fail. A networked server always runs on real pools.
+		useRealThreadPools = true
+	)
+	GrpcClientBuilder setUp(EvitaServer evitaServer) {
+		return TestGrpcClientBuilderCreator.getBuilder(
+			new ClientSessionInterceptor(
+				EvitaClientConfiguration.builder().build().clientId(),
+				new SemVer(2025, 4)
+			),
+			evitaServer.getExternalApiServer()
+		);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET)
+	@DisplayName(
+		"Should keep server memory bounded while a client stalls mid-download, " +
+			"and still deliver the file when it resumes"
+	)
+	void shouldNotBufferWholeFileForStalledClient(Evita evita, GrpcClientBuilder clientBuilder) throws Exception {
+		final CRC32 expectedCrc = new CRC32();
+		final FileForFetch bigFile = createExportedFile(evita, FILE_SIZE, expectedCrc);
+		final AtomicReference<ClientCallStreamObserver<GrpcFetchFileRequest>> call = new AtomicReference<>();
+		try {
+			final EvitaManagementServiceStub managementStub = clientBuilder
+				// gRPC-Web framing - the format evitaLab uses and the one the production report came from
+				.serializationFormat(GrpcSerializationFormats.PROTO_WEB)
+				// the client stalls on purpose; neither a response timeout nor the 10 MB default
+				// response-length cap may be what ends the call
+				.responseTimeoutMillis(0)
+				.maxResponseLength(0)
+				.build(EvitaManagementServiceStub.class);
+
+			final CountDownLatch initialChunks = new CountDownLatch(CHUNKS_CONSUMED_BEFORE_STALL);
+			final CountDownLatch terminated = new CountDownLatch(1);
+			final AtomicReference<Throwable> failure = new AtomicReference<>();
+			final AtomicInteger chunksReceived = new AtomicInteger();
+			final AtomicLong bytesReceived = new AtomicLong();
+			final CRC32 receivedCrc = new CRC32();
+
+			final MemoryFootprint memoryBeforeDownload = memoryAfterGc();
+
+			managementStub.fetchFile(
+				GrpcFetchFileRequest.newBuilder()
+					.setFileId(EvitaDataTypesConverter.toGrpcUuid(bigFile.fileId()))
+					.build(),
+				new ClientResponseObserver<GrpcFetchFileRequest, GrpcFetchFileResponse>() {
+
+					@Override
+					public void beforeStart(ClientCallStreamObserver<GrpcFetchFileRequest> requestStream) {
+						// take manual control of the demand - the client asks for a handful of
+						// messages up front and then deliberately goes silent
+						requestStream.disableAutoRequestWithInitial(CHUNKS_CONSUMED_BEFORE_STALL);
+						call.set(requestStream);
+					}
+
+					@Override
+					public void onNext(GrpcFetchFileResponse value) {
+						final byte[] contents = value.getFileContents().toByteArray();
+						receivedCrc.update(contents);
+						bytesReceived.addAndGet(contents.length);
+						chunksReceived.incrementAndGet();
+						initialChunks.countDown();
+					}
+
+					@Override
+					public void onError(Throwable t) {
+						failure.set(t);
+						initialChunks.countDown();
+						terminated.countDown();
+					}
+
+					@Override
+					public void onCompleted() {
+						terminated.countDown();
+					}
+				}
+			);
+
+			final boolean initialChunksDelivered = initialChunks.await(30, TimeUnit.SECONDS);
+			if (!initialChunksDelivered) {
+				// the producer's own state is the only thing that distinguishes "the gate is stuck"
+				// from "the client never asked", and it is gone by the time the assertion is reported
+				logFetchFileThreadState();
+			}
+			assertTrue(
+				initialChunksDelivered,
+				"Server did not deliver the first " + CHUNKS_CONSUMED_BEFORE_STALL + " chunks within 30 " +
+					"seconds - got " + chunksReceived.get() + " (" + bytesReceived.get() + " B), failure: " +
+					failure.get()
+			);
+
+			// give an unbounded server the time it needs to drain the whole file into its outbound queue
+			Thread.sleep(SETTLE_WINDOW_MILLIS);
+
+			final MemoryFootprint memoryWhileStalled = memoryAfterGc();
+			final long retained = memoryWhileStalled.total() - memoryBeforeDownload.total();
+			logFetchFileThreadState();
+			log.info(
+				"Client consumed {} chunks ({} B) of a {} B file; server retained {} B ({} MB). " +
+					"Before: {}; while stalled: {}",
+				chunksReceived.get(), bytesReceived.get(), FILE_SIZE, retained, retained / (1024 * 1024),
+				memoryBeforeDownload, memoryWhileStalled
+			);
+			if (failure.get() instanceof StatusRuntimeException sre) {
+				log.info(
+					"Call already terminated while the client was stalled: status={}, description={}",
+					sre.getStatus().getCode(), sre.getStatus().getDescription()
+				);
+			}
+
+			// preconditions for the measurement to mean anything at all
+			assertNull(
+				failure.get(),
+				"The call must survive a stalled client, but it ended with: " + failure.get()
+			);
+			assertEquals(
+				CHUNKS_CONSUMED_BEFORE_STALL, chunksReceived.get(),
+				"Client received messages it never requested - manual flow control is not in effect, " +
+					"so this run proves nothing about server-side buffering."
+			);
+
+			// The client resumes: the transfer must still complete, intact. This runs *before* the
+			// memory verdict on purpose - asserting the bound here would abort the method on the
+			// currently-unbounded implementation and leave the correctness half of the test never
+			// executed, so it would run for the first time on the day the fix lands and any bug in
+			// it would read as a broken fix.
+			call.get().request(Integer.MAX_VALUE);
+			assertTrue(
+				terminated.await(300, TimeUnit.SECONDS),
+				"Download did not finish within 300 seconds after the client resumed consuming."
+			);
+			assertNull(failure.get(), "Download failed after the client resumed: " + failure.get());
+			assertEquals(FILE_SIZE, bytesReceived.get(), "Client did not receive the whole file.");
+			assertEquals(
+				expectedCrc.getValue(), receivedCrc.getValue(),
+				"Downloaded contents differ from the stored file."
+			);
+
+			// once everything has been drained the queue is empty again - the delta measured here is
+			// the noise floor of the measurement itself (allocator growth, counter drift), and is
+			// what makes the MAX_TOLERATED_SERVER_BUFFERING margin legible rather than arbitrary
+			final MemoryFootprint memoryAfterDrain = memoryAfterGc();
+			log.info(
+				"After the client drained the stream, retained {} B relative to the start; footprint: {}",
+				memoryAfterDrain.total() - memoryBeforeDownload.total(), memoryAfterDrain
+			);
+
+			assertTrue(
+				retained < MAX_TOLERATED_SERVER_BUFFERING,
+				"Server retained " + retained + " B for a client that consumed only " +
+					(long) CHUNKS_CONSUMED_BEFORE_STALL * CHUNK_SIZE + " B - fetchFile is streaming " +
+					"without regard for transport readiness and buffers the whole file (limit " +
+					MAX_TOLERATED_SERVER_BUFFERING + " B)."
+			);
+		} finally {
+			// an assertion that fires mid-download leaves the call - and whatever the server queued
+			// behind it - alive; cancel it so the next test in the fork does not inherit the memory
+			final ClientCallStreamObserver<GrpcFetchFileRequest> pendingCall = call.get();
+			if (pendingCall != null) {
+				pendingCall.cancel("test finished", null);
+			}
+			evita.management().deleteFile(bigFile.fileId());
+		}
+	}
+
+}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningGrpcFetchFileDeadlineTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningGrpcFetchFileDeadlineTest.java
@@ -1,0 +1,364 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc;
+
+import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import io.evitadb.api.file.FileForFetch;
+import io.evitadb.core.Evita;
+import io.evitadb.driver.config.EvitaClientConfiguration;
+import io.evitadb.driver.interceptor.ClientSessionInterceptor;
+import io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter;
+import io.evitadb.externalApi.grpc.generated.EvitaManagementServiceGrpc.EvitaManagementServiceStub;
+import io.evitadb.externalApi.grpc.generated.GrpcFetchFileRequest;
+import io.evitadb.externalApi.grpc.generated.GrpcFetchFileResponse;
+import io.evitadb.externalApi.system.SystemProvider;
+import io.evitadb.server.EvitaServer;
+import io.evitadb.spi.export.model.ExportFileHandle;
+import io.evitadb.test.annotation.DataSet;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import io.evitadb.utils.VersionUtils.SemVer;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nonnull;
+import java.io.OutputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.CRC32;
+
+import static io.evitadb.test.TestTags.EXPORT;
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static io.evitadb.test.TestTags.SLOW;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Proves that a **progressing** download survives a server request deadline far shorter than the
+ * transfer takes - i.e. that the deadline bounds *silence* rather than the length of the exchange.
+ *
+ * This is the invariant `GrpcOutboundGate` re-arms for, and it only became load-bearing once the gate
+ * existed. Before it, `fetchFile` pushed the whole file into Armeria's unbounded outbound queue at disk
+ * speed; afterwards the handler lives exactly as long as the *client* takes to consume, so any fixed
+ * request budget becomes a cap on file size divided by link speed. A 1-2 s budget is not a contrived
+ * setting either - it is what a client sending no `grpc-timeout` at all actually gets, because
+ * Armeria's `FramedGrpcService` overrides the context timeout **only** when the header is present and
+ * otherwise leaves `api.requestTimeoutInMillis` (1 s code default, 2 s shipped) in force. A browser
+ * over gRPC-Web is therefore the *most* exposed client, not the least.
+ *
+ * **Why the test is shaped the way it is.** Three earlier attempts failed to reach the defect at all,
+ * and each trap is easy to fall back into:
+ *
+ * - **The deadline has to be set by the client but enforced only by the server.** `responseTimeoutMillis(0)`
+ *   stops Armeria's client from ending the call on its own - but it also stops it emitting the
+ *   `grpc-timeout` header, so the server silently falls back to its configured budget (10 minutes under
+ *   the test harness) and nothing can ever expire. The header is therefore injected by hand, through a
+ *   {@link ClientInterceptor}, which sets it without arming any client-side clock.
+ * - **Size alone does not make a client slow.** At 8 MB the server produced every chunk in ~6 ms: the
+ *   handler had finished before any deadline could bite, and a "slow" consumer throttled nothing. What
+ *   paces the handler is the gate, and what paces the gate is *demand* - so the client here takes manual
+ *   control of flow control and drip-feeds `request(1)`.
+ * - **The producer must not be on the event loop.** See `useRealThreadPools` on the data set below.
+ *
+ * **Calibration.** With the re-arm removed from {@link io.evitadb.externalApi.grpc.utils.GrpcOutboundGate}
+ * this test fails, the stream dying with `RST_STREAM`/`DEADLINE_EXCEEDED` at roughly
+ * {@link #SERVER_REQUEST_TIMEOUT_MILLIS} - about a fifth of the way in. The measured numbers are quoted
+ * in `documentation/adr/2026-08-24-grpc-streaming-backpressure-readiness-gate.md`.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Slf4j
+@ExtendWith(EvitaParameterResolver.class)
+@DisplayName("gRPC fetchFile must not cap a progressing download at the request deadline")
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(MANAGEMENT)
+@Tag(EXPORT)
+@Tag(SLOW)
+public class LongRunningGrpcFetchFileDeadlineTest {
+	private static final String DATA_SET = "GrpcFetchFileDeadline";
+	/**
+	 * Chunk size the server streams with - mirrors `EvitaManagementService.FETCH_FILE_CHUNK_SIZE`.
+	 */
+	private static final int CHUNK_SIZE = 1_048_576;
+	/**
+	 * Size of the downloaded file. Chosen together with {@link #CONSUMER_PACING_MILLIS} so the transfer
+	 * takes several times {@link #SERVER_REQUEST_TIMEOUT_MILLIS} while no single gap between messages
+	 * comes anywhere near it - the two conditions the test needs to hold simultaneously.
+	 */
+	private static final long FILE_SIZE = 64L * 1024L * 1024L;
+	/**
+	 * Delay the client inserts before asking for each subsequent message. This paces the *server*,
+	 * because the gate advances only on demand. It is not a poll and cannot fail the test spuriously:
+	 * a loaded machine stretches the transfer, which only widens the margin the test asserts.
+	 */
+	private static final long CONSUMER_PACING_MILLIS = 100L;
+	/**
+	 * Request deadline the client asks the server to enforce, in milliseconds. Deliberately far below
+	 * the transfer's duration and far above one message's worth of pacing.
+	 */
+	private static final long SERVER_REQUEST_TIMEOUT_MILLIS = 2_000L;
+	/**
+	 * Upper bound on the whole download. Generous by design - it exists to fail a hang, not to time the
+	 * transfer, and a passing run returns as soon as the stream completes.
+	 */
+	private static final long COMPLETION_TIMEOUT_SECONDS = 120L;
+
+	/**
+	 * gRPC's own header carrying the caller's deadline. Injected by hand rather than by
+	 * `withDeadlineAfter`, so that the deadline exists on the server and nowhere else.
+	 */
+	private static final Metadata.Key<String> GRPC_TIMEOUT = Metadata.Key.of(
+		"grpc-timeout", Metadata.ASCII_STRING_MARSHALLER
+	);
+
+	/**
+	 * Sets `grpc-timeout` on every outgoing call without arming any client-side clock.
+	 *
+	 * The point of the separation is that the test must observe the *server* abandoning a healthy
+	 * transfer. Had the deadline been set through `CallOptions.deadline`, gRPC would enforce it locally
+	 * too and a failure would prove nothing about which side gave up.
+	 */
+	private static final ClientInterceptor SERVER_ONLY_DEADLINE = new ClientInterceptor() {
+
+		@Override
+		public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+			MethodDescriptor<ReqT, RespT> method,
+			CallOptions callOptions,
+			Channel next
+		) {
+			return new SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+
+				@Override
+				public void start(Listener<RespT> responseListener, Metadata headers) {
+					// `m` is the gRPC wire unit for milliseconds
+					headers.put(GRPC_TIMEOUT, SERVER_REQUEST_TIMEOUT_MILLIS + "m");
+					super.start(responseListener, headers);
+				}
+			};
+		}
+	};
+
+	/**
+	 * Creates a file of the requested size and publishes it for fetching.
+	 *
+	 * @param evita       engine whose export service the file is stored in
+	 * @param size        size of the file in bytes
+	 * @param contentsCrc accumulator the written contents are checksummed into
+	 * @return descriptor of the published file
+	 */
+	@Nonnull
+	private static FileForFetch createExportedFile(
+		@Nonnull Evita evita,
+		long size,
+		@Nonnull CRC32 contentsCrc
+	) throws Exception {
+		final byte[] pattern = new byte[CHUNK_SIZE];
+		for (int i = 0; i < pattern.length; i++) {
+			pattern[i] = (byte) (i * 31 + 7);
+		}
+		final ExportFileHandle handle = evita.management().exportService().storeFile(
+			"grpc-fetch-file-deadline.bin",
+			"Large file used by the fetchFile deadline test",
+			"application/octet-stream",
+			"test"
+		);
+		try {
+			final OutputStream outputStream = handle.outputStream();
+			long written = 0L;
+			while (written < size) {
+				final int toWrite = (int) Math.min(pattern.length, size - written);
+				outputStream.write(pattern, 0, toWrite);
+				contentsCrc.update(pattern, 0, toWrite);
+				written += toWrite;
+			}
+		} finally {
+			handle.close();
+		}
+		final FileForFetch fileForFetch = handle.fileForFetchFuture().get(60, TimeUnit.SECONDS);
+		assertEquals(size, fileForFetch.totalSizeInBytes(), "Exported file has an unexpected size.");
+		return fileForFetch;
+	}
+
+	@DataSet(
+		value = DATA_SET, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE},
+		readOnly = false, destroyAfterClass = true,
+		// Mandatory, for the same reason as the back-pressure test: the default test engine collapses
+		// the request pool into a direct executor, which runs the producing loop on the transport event
+		// loop. The gate detects that and deliberately runs ungated, so the handler would again outrun
+		// the client and finish long before any deadline mattered.
+		useRealThreadPools = true
+	)
+	GrpcClientBuilder setUp(EvitaServer evitaServer) {
+		return TestGrpcClientBuilderCreator.getBuilder(
+			new ClientSessionInterceptor(
+				EvitaClientConfiguration.builder().build().clientId(),
+				new SemVer(2025, 4)
+			),
+			evitaServer.getExternalApiServer()
+		);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET)
+	@DisplayName(
+		"Should deliver a whole file to a slow but steady client, though the transfer far outlives " +
+			"the server's request deadline"
+	)
+	void shouldNotEndAProgressingDownloadAtTheRequestDeadline(
+		Evita evita,
+		GrpcClientBuilder clientBuilder
+	) throws Exception {
+		final CRC32 expectedCrc = new CRC32();
+		final FileForFetch bigFile = createExportedFile(evita, FILE_SIZE, expectedCrc);
+
+		final ThreadFactory daemonFactory = runnable -> {
+			final Thread thread = new Thread(runnable, "grpc-fetch-file-deadline-pacer");
+			thread.setDaemon(true);
+			return thread;
+		};
+		final ScheduledExecutorService pacer = Executors.newSingleThreadScheduledExecutor(daemonFactory);
+		try {
+			final EvitaManagementServiceStub managementStub = clientBuilder
+				// gRPC-Web framing - the format evitaLab uses, and the client shape most exposed to this
+				.serializationFormat(GrpcSerializationFormats.PROTO_WEB)
+				// only the server may end this call: no client response timeout, and no response-length
+				// cap that could terminate it for an unrelated reason
+				.responseTimeoutMillis(0)
+				.maxResponseLength(0)
+				.intercept(SERVER_ONLY_DEADLINE)
+				.build(EvitaManagementServiceStub.class);
+
+			final CountDownLatch terminated = new CountDownLatch(1);
+			final AtomicReference<Throwable> failure = new AtomicReference<>();
+			final AtomicInteger chunksReceived = new AtomicInteger();
+			final AtomicLong bytesReceived = new AtomicLong();
+			final CRC32 receivedCrc = new CRC32();
+			final long startNanos = System.nanoTime();
+
+			managementStub.fetchFile(
+				GrpcFetchFileRequest.newBuilder()
+					.setFileId(EvitaDataTypesConverter.toGrpcUuid(bigFile.fileId()))
+					.build(),
+				new ClientResponseObserver<GrpcFetchFileRequest, GrpcFetchFileResponse>() {
+					private ClientCallStreamObserver<GrpcFetchFileRequest> call;
+
+					@Override
+					public void beforeStart(ClientCallStreamObserver<GrpcFetchFileRequest> requestStream) {
+						// one message in flight at a time, so that the pacing below governs the server
+						requestStream.disableAutoRequestWithInitial(1);
+						this.call = requestStream;
+					}
+
+					@Override
+					public void onNext(GrpcFetchFileResponse value) {
+						final byte[] contents = value.getFileContents().toByteArray();
+						receivedCrc.update(contents);
+						bytesReceived.addAndGet(contents.length);
+						chunksReceived.incrementAndGet();
+						// ask for the next message *later*, and from another thread - this callback runs
+						// on the transport event loop, where sleeping would stall the very thread that
+						// has to deliver what we are waiting for
+						pacer.schedule(
+							() -> this.call.request(1), CONSUMER_PACING_MILLIS, TimeUnit.MILLISECONDS
+						);
+					}
+
+					@Override
+					public void onError(Throwable t) {
+						failure.set(t);
+						terminated.countDown();
+					}
+
+					@Override
+					public void onCompleted() {
+						terminated.countDown();
+					}
+				}
+			);
+
+			final boolean completed = terminated.await(COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+			final long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000L;
+
+			log.info(
+				"Download of {} B ended after {} ms in {} chunks ({} B received); server deadline was {} ms.",
+				FILE_SIZE, elapsedMillis, chunksReceived.get(), bytesReceived.get(),
+				SERVER_REQUEST_TIMEOUT_MILLIS
+			);
+
+			assertTrue(
+				completed,
+				"The download neither completed nor failed within " + COMPLETION_TIMEOUT_SECONDS +
+					" s - it received " + bytesReceived.get() + " B of " + FILE_SIZE + " B."
+			);
+			assertNull(
+				failure.get(),
+				() -> "A steadily progressing download was terminated after " + elapsedMillis + " ms " +
+					"with " + bytesReceived.get() + " B of " + FILE_SIZE + " B delivered: " +
+					Status.fromThrowable(failure.get()) + ". The request deadline is meant to bound " +
+					"silence, not the length of the transfer - see `GrpcOutboundGate`."
+			);
+
+			// Without this the test could pass on a machine fast enough to finish inside the deadline,
+			// proving nothing at all. It is an assertion about the *scenario*, not about the code.
+			assertTrue(
+				elapsedMillis > 2 * SERVER_REQUEST_TIMEOUT_MILLIS,
+				"The transfer took only " + elapsedMillis + " ms against a " +
+					SERVER_REQUEST_TIMEOUT_MILLIS + " ms deadline, so it never outlived the budget it " +
+					"is supposed to outlive. Raise FILE_SIZE or CONSUMER_PACING_MILLIS."
+			);
+			assertEquals(FILE_SIZE, bytesReceived.get(), "Client did not receive the whole file.");
+			assertEquals(
+				expectedCrc.getValue(), receivedCrc.getValue(),
+				"Downloaded contents differ from what was exported."
+			);
+		} finally {
+			pacer.shutdownNow();
+		}
+	}
+
+}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningGrpcRestoreCatalogUploadTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/externalApi/grpc/LongRunningGrpcRestoreCatalogUploadTest.java
@@ -1,0 +1,602 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.grpc;
+
+import com.google.protobuf.ByteString;
+import io.evitadb.api.EvitaManagementContract;
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.file.FileForFetch;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
+import io.evitadb.driver.ClientTask;
+import io.evitadb.driver.EvitaClient;
+import io.evitadb.driver.EvitaClientManagement;
+import io.evitadb.driver.interceptor.ClientSessionInterceptor;
+import io.evitadb.driver.config.EvitaClientConfiguration;
+import io.evitadb.externalApi.configuration.ApiOptions;
+import io.evitadb.externalApi.configuration.HostDefinition;
+import io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter;
+import io.evitadb.externalApi.grpc.generated.EvitaManagementServiceGrpc.EvitaManagementServiceStub;
+import io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogRequest;
+import io.evitadb.externalApi.grpc.generated.GrpcRestoreCatalogResponse;
+import io.evitadb.externalApi.system.SystemProvider;
+import io.evitadb.server.EvitaServer;
+import io.evitadb.test.annotation.DataSet;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import io.evitadb.utils.CertificateUtils;
+import io.evitadb.utils.VersionUtils.SemVer;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.stub.StreamObserver;
+import io.evitadb.driver.config.ClientTimeoutOptions;
+import io.evitadb.driver.config.ClientTlsOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nonnull;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static io.evitadb.test.TestTags.SLOW;
+import static io.evitadb.test.TestTags.STREAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Proves that a catalog backup survives being uploaded across many messages - over both restore RPCs
+ * evitaDB exposes, because each one is load-bearing for a different reason.
+ *
+ * **`RestoreCatalogUnary`, which the driver uses.** A client-streaming RPC delivers the whole
+ * conversation as a single HTTP request, so the server's `maxRequestLength` - which evitaDB wires to
+ * `api.maxEntitySizeInBytes`, 2 MB by default - bounded the *entire backup*. Anything larger died
+ * part-way through with a bare `RESOURCE_EXHAUSTED`, which made `EvitaClient`'s restore unusable for a
+ * catalog of any real size. The driver now uploads through `RestoreCatalogUnary`, where every chunk is
+ * a request of its own and only the chunk has to fit. {@link #SERVER_REQUEST_LIMIT} is asserted from
+ * below for exactly this reason: shrink the payload under it and the test stops proving anything.
+ *
+ * **The client-streaming `RestoreCatalog`, which third parties still use.** The server no longer
+ * writes to disk inline on the Armeria event loop; each chunk is appended on a per-call
+ * {@link java.util.concurrent.CompletableFuture} chain running on a worker, and the conversation
+ * advances only because each completed write hand-issues demand for the next chunk. Since the driver
+ * was rerouted to the unary RPC, nothing else drives that path across more than one message.
+ * {@link #shouldRestoreCatalogUploadedThroughClientStreamingRpc} is what keeps it covered - read that
+ * method's JavaDoc before trusting it, because it records both what its calibration detected and, more
+ * importantly, what it could not.
+ *
+ * A ZIP is the ideal detector for both - its central directory and per-entry CRCs make reordering or
+ * truncation fail loudly - so the assertion is that the restored catalog opens and holds exactly what
+ * was backed up, payloads compared byte for byte.
+ *
+ * **Why this lives in the long-running module rather than beside the functional backup/restore test.**
+ * The functional round trip
+ * (`EvitaClientReadWriteTest#shouldBackupAndRestoreCatalogViaDownloadingAndUploadingFileContents`)
+ * backs up a ten-product catalog, whose archive fits in a **single** message - so neither the size
+ * ceiling nor the per-chunk hand-off is exercised by it at all. Making the upload span many messages
+ * costs the time to build and archive a payload that large, which is what buys the `@Tag(SLOW)`.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("gRPC catalog restore must carry an upload intact - past the request-body limit, and in order")
+@ExtendWith(EvitaParameterResolver.class)
+@Slf4j
+@Tag(GRPC)
+@Tag(EXTERNAL_API)
+@Tag(MANAGEMENT)
+@Tag(STREAM)
+@Tag(SLOW)
+public class LongRunningGrpcRestoreCatalogUploadTest {
+	private static final String DATA_SET = "GrpcRestoreCatalogUpload";
+	private static final String TEST_CATALOG = "testCatalog";
+	/**
+	 * Second, deliberately small catalog. The client-streaming RPC cannot carry a backup past
+	 * {@link #SERVER_REQUEST_LIMIT} at all - that ceiling is the whole reason the driver left it - so
+	 * the test that keeps that RPC covered needs a payload that fits under it while still spanning
+	 * enough messages to exercise the per-chunk hand-off.
+	 */
+	private static final String TEST_CATALOG_SMALL = "testCatalogSmall";
+	private static final String ENTITY_TYPE = "blob";
+	private static final String ATTRIBUTE_PAYLOAD = "payload";
+	/**
+	 * Number of entities the backed-up catalog holds. Chosen so that the resulting archive lands
+	 * comfortably **over** {@link #SERVER_REQUEST_LIMIT} - the ceiling the upload used to die on.
+	 */
+	private static final int ENTITY_COUNT = 200;
+	/**
+	 * Number of entities {@link #TEST_CATALOG_SMALL} holds. Sized for the opposite constraint: the
+	 * archive must stay under {@link #SERVER_REQUEST_LIMIT} with headroom, yet still take at least
+	 * {@link #MIN_EXPECTED_STREAMED_CHUNKS} messages of {@link #STREAMING_CHUNK_SIZE}.
+	 */
+	private static final int SMALL_ENTITY_COUNT = 20;
+	/**
+	 * Size of each entity's payload attribute. The content is high-entropy on purpose - a compressible
+	 * payload would shrink the archive back to a couple of messages and quietly defeat the test.
+	 */
+	private static final int PAYLOAD_SIZE = 32_768;
+	/**
+	 * Chunk size the driver uploads with (`EvitaClientManagement.RESTORE_CHUNK_SIZE`).
+	 */
+	private static final int CLIENT_CHUNK_SIZE = 524_288;
+	/**
+	 * Largest request body the server accepts: Armeria's `maxRequestLength`, which evitaDB wires to
+	 * `api.maxEntitySizeInBytes` (`ApiOptions.DEFAULT_MAX_ENTITY_SIZE`, 2 MB).
+	 *
+	 * This is what made the *client-streaming* `RestoreCatalog` unusable for a real catalog: the whole
+	 * upload is one request, so the limit bounded the entire backup rather than a chunk, and anything
+	 * larger died part-way through with a bare `RESOURCE_EXHAUSTED`. The limit is deliberate operator
+	 * policy and stays; the driver now uploads through `RestoreCatalogUnary`, where each chunk is a
+	 * request of its own and only the chunk has to fit.
+	 */
+	private static final long SERVER_REQUEST_LIMIT = 2L * 1024L * 1024L;
+	/**
+	 * Lower bound on the number of messages the upload must span for this test to be testing anything
+	 * the functional backup/restore test does not already cover - that one fits in a single message.
+	 */
+	private static final int MIN_EXPECTED_CHUNKS = 8;
+	/**
+	 * Chunk size the client-streaming upload is cut into. Much smaller than {@link #CLIENT_CHUNK_SIZE}
+	 * so that a backup which must stay under {@link #SERVER_REQUEST_LIMIT} still spans many messages -
+	 * roughly 17 at the current fixture size, which leaves room for the archive to shrink before the
+	 * precondition below starts failing on its own.
+	 */
+	private static final int STREAMING_CHUNK_SIZE = 32_768;
+	/**
+	 * Lower bound on the number of messages the client-streaming upload must span. One message would
+	 * leave the chunk-by-chunk hand-off - the thing that test exists for - entirely unexercised.
+	 */
+	private static final int MIN_EXPECTED_STREAMED_CHUNKS = 8;
+	/**
+	 * Fixed seed - the payloads must be reproducible across the two sessions that write and verify them.
+	 */
+	private static final long PAYLOAD_SEED = 0x5EEDL;
+
+	/**
+	 * Builds the payload of the entity with the given primary key. Deterministic, so the verification
+	 * pass can regenerate exactly what the setup wrote.
+	 *
+	 * @param primaryKey primary key of the entity the payload belongs to
+	 * @return payload contents
+	 */
+	@Nonnull
+	private static String payloadOf(int primaryKey) {
+		// a per-entity seed keeps the payloads independent of the order they are generated in
+		final Random random = new Random(PAYLOAD_SEED + primaryKey);
+		final char[] contents = new char[PAYLOAD_SIZE];
+		for (int i = 0; i < contents.length; i++) {
+			// printable, high-entropy, single-byte in UTF-8
+			contents[i] = (char) ('!' + random.nextInt('~' - '!' + 1));
+		}
+		return new String(contents);
+	}
+
+	@DataSet(
+		value = DATA_SET, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE},
+		readOnly = false, destroyAfterClass = true,
+		// Mandatory, not a preference: the default test engine collapses the request pool into a direct
+		// executor, so the upload's hand-off would run inline on the event loop - the very topology this
+		// test exists to verify the absence of. Without it the ordered chain is never scheduled and the
+		// test would pass against the old, event-loop-blocking implementation too.
+		useRealThreadPools = true
+	)
+	static EvitaClient setUp(EvitaServer evitaServer) {
+		final EvitaClient evitaClient = createClient(evitaServer);
+		// `testCatalog` is the one the harness pre-creates; the small one has to be defined by hand
+		fillCatalog(evitaClient, TEST_CATALOG, ENTITY_COUNT);
+		evitaClient.defineCatalog(TEST_CATALOG_SMALL);
+		fillCatalog(evitaClient, TEST_CATALOG_SMALL, SMALL_ENTITY_COUNT);
+		return evitaClient;
+	}
+
+	/**
+	 * Fills the given catalog with `entityCount` entities carrying {@link #payloadOf(int)} payloads and
+	 * takes it live, so it can be backed up.
+	 *
+	 * @param evitaClient client to work through
+	 * @param catalogName catalog to fill
+	 * @param entityCount number of entities to create
+	 */
+	private static void fillCatalog(
+		@Nonnull EvitaClient evitaClient,
+		@Nonnull String catalogName,
+		int entityCount
+	) {
+		evitaClient.updateCatalog(
+			catalogName,
+			session -> {
+				session.defineEntitySchema(ENTITY_TYPE)
+					.withAttribute(ATTRIBUTE_PAYLOAD, String.class, AttributeSchemaEditor::nullable)
+					.updateVia(session);
+				for (int primaryKey = 1; primaryKey <= entityCount; primaryKey++) {
+					session.createNewEntity(ENTITY_TYPE, primaryKey)
+						.setAttribute(ATTRIBUTE_PAYLOAD, payloadOf(primaryKey))
+						.upsertVia(session);
+				}
+				session.goLiveAndClose();
+				return null;
+			}
+		);
+	}
+
+	/**
+	 * Builds a driver client pointed at the running test server.
+	 *
+	 * @param evitaServer the running server
+	 * @return a client connected to it
+	 */
+	@Nonnull
+	private static EvitaClient createClient(@Nonnull EvitaServer evitaServer) {
+		final ApiOptions apiOptions = evitaServer.getExternalApiServer().getApiOptions();
+		final HostDefinition grpcHost = apiOptions.getEndpointConfiguration(GrpcProvider.CODE).getHost()[0];
+		final HostDefinition systemHost = apiOptions.getEndpointConfiguration(SystemProvider.CODE).getHost()[0];
+
+		final String serverCertificates = apiOptions.certificate().getFolderPath().toString();
+		final int lastDash = serverCertificates.lastIndexOf('-');
+		assertTrue(lastDash > 0, "Dash not found! Look at the evita-configuration.yml in test resources!");
+		final Path clientCertificates = Path.of(serverCertificates.substring(0, lastDash) + "-client");
+
+		return new EvitaClient(
+			EvitaClientConfiguration.builder()
+				.host(grpcHost.hostAddress())
+				.port(grpcHost.port())
+				.systemApiPort(systemHost.port())
+				.tls(
+					ClientTlsOptions.builder()
+						.mtlsEnabled(false)
+						.certificateFolderPath(clientCertificates)
+						.certificateFileName(Path.of(CertificateUtils.getGeneratedClientCertificateFileName()))
+						.certificateKeyFileName(
+							Path.of(CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName())
+						)
+						.build()
+				)
+				.timeouts(
+					ClientTimeoutOptions.builder()
+						.timeout(10, TimeUnit.MINUTES)
+						.build()
+				)
+				.build()
+		);
+	}
+
+	/**
+	 * Asserts that a restored catalog holds exactly what was backed up. The entity count alone would
+	 * survive a payload that arrived scrambled or short, so every payload is compared byte for byte -
+	 * that comparison is what actually pins the ordering of the uploaded chunks.
+	 *
+	 * @param evitaClient         client to verify through
+	 * @param restoredCatalogName name the catalog was restored under
+	 * @param entityCount         number of entities the catalog held when it was backed up
+	 */
+	private static void assertCatalogRestoredIntact(
+		@Nonnull EvitaClient evitaClient,
+		@Nonnull String restoredCatalogName,
+		int entityCount
+	) {
+		final Set<String> catalogNames = evitaClient.getCatalogNames();
+		assertTrue(catalogNames.contains(restoredCatalogName), "Restored catalog is not present on the server.");
+		evitaClient.activateCatalog(restoredCatalogName);
+
+		assertEquals(
+			Integer.valueOf(entityCount),
+			evitaClient.queryCatalog(
+				// a block body with an explicit return keeps this off the void-returning overload
+				restoredCatalogName, session -> {
+					return session.getEntityCollectionSize(ENTITY_TYPE);
+				}
+			),
+			"Restored catalog does not hold every entity that was backed up."
+		);
+
+		evitaClient.queryCatalog(
+			restoredCatalogName,
+			(Consumer<EvitaSessionContract>) session -> {
+				for (int primaryKey = 1; primaryKey <= entityCount; primaryKey++) {
+					final int currentKey = primaryKey;
+					final SealedEntity entity = session
+						.getEntity(ENTITY_TYPE, currentKey, attributeContentAll())
+						.orElseThrow(
+							() -> new IllegalStateException(
+								"Entity " + ENTITY_TYPE + " #" + currentKey + " is missing after restore."
+							)
+						);
+					assertEquals(
+						payloadOf(currentKey),
+						entity.getAttribute(ATTRIBUTE_PAYLOAD),
+						"Payload of entity " + currentKey + " differs from the backed-up one."
+					);
+				}
+			}
+		);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET)
+	@DisplayName("Should restore a catalog uploaded across hundreds of messages, byte for byte")
+	void shouldRestoreCatalogUploadedInManyChunks(EvitaClient evitaClient) throws Exception {
+		final EvitaManagementContract management = evitaClient.management();
+		final FileForFetch backup = management.backupCatalog(TEST_CATALOG, null, null, true)
+			.get(10, TimeUnit.MINUTES);
+
+		final long expectedChunks = backup.totalSizeInBytes() / CLIENT_CHUNK_SIZE;
+		log.info(
+			"Backed up {} B, which the driver uploads as roughly {} messages of {} B.",
+			backup.totalSizeInBytes(), expectedChunks, CLIENT_CHUNK_SIZE
+		);
+		assertTrue(
+			expectedChunks >= MIN_EXPECTED_CHUNKS,
+			"Backup is only " + backup.totalSizeInBytes() + " B, i.e. about " + expectedChunks +
+				" upload messages - too few to exercise the chunk-by-chunk hand-off this test guards. " +
+				"Raise ENTITY_COUNT/PAYLOAD_SIZE or lower MIN_EXPECTED_CHUNKS deliberately."
+		);
+		assertTrue(
+			backup.totalSizeInBytes() > SERVER_REQUEST_LIMIT,
+			"Backup is only " + backup.totalSizeInBytes() + " B, under the server's " + SERVER_REQUEST_LIMIT +
+				" B request-body limit - so it would upload happily through the old client-streaming path " +
+				"too, and this test would no longer prove that the ceiling is gone. Grow the payload."
+		);
+
+		final String restoredCatalogName = TEST_CATALOG + "_restored";
+		try (final InputStream inputStream = management.fetchFile(backup.fileId())) {
+			management.restoreCatalog(restoredCatalogName, backup.totalSizeInBytes(), inputStream)
+				.getFutureResult()
+				.get(10, TimeUnit.MINUTES);
+		}
+
+		assertCatalogRestoredIntact(evitaClient, restoredCatalogName, ENTITY_COUNT);
+	}
+
+	/**
+	 * Keeps the **client-streaming** `RestoreCatalog` RPC covered end to end. The driver no longer calls
+	 * it - it was rerouted to `RestoreCatalogUnary` to escape {@link #SERVER_REQUEST_LIMIT} - but it
+	 * stays on the wire for gRPC-Web and third-party clients, and this is the only test that drives
+	 * `RestoreCatalogUploadObserver` across more than one message.
+	 *
+	 * **What it demonstrably guards: the hand-issued demand protocol.** The server uploads with
+	 * `disableAutoRequest()` and re-issues `request(1)` from inside each completed write step, so the
+	 * whole conversation advances only because a worker asks for the next chunk. Delete that
+	 * `eventLoop().execute(() -> request(1))` and the upload stops dead after chunk one: no error, no
+	 * status, the call simply never terminates. Verified - the counterfactual fails here at the 30 s
+	 * latch with "Client-streaming upload never terminated", deterministically.
+	 *
+	 * **What it does *not* prove, despite the byte-for-byte comparison: write ordering.** Two mechanisms
+	 * serialise the writes - the per-call `CompletableFuture` chain and the one-message-at-a-time demand
+	 * above - and they are redundant. Removing the chain from `onCompleted()` alone leaves this test
+	 * green, because demand for the next chunk is issued from inside the *completed* write step, so
+	 * half-close cannot reach `submitRestoration` before the last write has landed. Removing **both**,
+	 * with a 2 ms widener inside the write step, also left it green - the writes still arrived in order
+	 * (measured at nine chunks, before {@link #STREAMING_CHUNK_SIZE} was halved to widen the margin on
+	 * the precondition above). That is a failure to detect, not evidence of safety - a race that does
+	 * not manifest is not a race that is absent. Treat the ordering invariant as **unverified by this
+	 * test**, and do not read a green run here as licence to delete either mechanism.
+	 *
+	 * @param evitaClient driver client, used for the backup, the download and the verification
+	 * @param evitaServer running server, needed to build a raw stub that speaks the streaming RPC
+	 */
+	@Test
+	@UseDataSet(DATA_SET)
+	@DisplayName("Should restore a catalog uploaded through the client-streaming RPC, byte for byte")
+	void shouldRestoreCatalogUploadedThroughClientStreamingRpc(
+		EvitaClient evitaClient,
+		EvitaServer evitaServer
+	) throws Exception {
+		final EvitaManagementContract management = evitaClient.management();
+		final FileForFetch backup = management.backupCatalog(TEST_CATALOG_SMALL, null, null, true)
+			.get(10, TimeUnit.MINUTES);
+
+		final byte[] backupContents;
+		try (final InputStream inputStream = management.fetchFile(backup.fileId())) {
+			backupContents = inputStream.readAllBytes();
+		}
+		final int expectedChunks = (backupContents.length + STREAMING_CHUNK_SIZE - 1) / STREAMING_CHUNK_SIZE;
+		log.info(
+			"Backed up {} B, uploaded through the client-streaming RPC as {} messages of {} B.",
+			backupContents.length, expectedChunks, STREAMING_CHUNK_SIZE
+		);
+		assertTrue(
+			expectedChunks >= MIN_EXPECTED_STREAMED_CHUNKS,
+			"Backup is only " + backupContents.length + " B, i.e. " + expectedChunks + " upload messages - " +
+				"too few to exercise the per-chunk hand-off this test guards. Lower STREAMING_CHUNK_SIZE: " +
+				"this bound and the SERVER_REQUEST_LIMIT one below hold the fixture from opposite sides, so " +
+				"growing SMALL_ENTITY_COUNT to satisfy this one walks straight into that one."
+		);
+		assertTrue(
+			backupContents.length < SERVER_REQUEST_LIMIT,
+			"Backup is " + backupContents.length + " B, at or over the server's " + SERVER_REQUEST_LIMIT +
+				" B request-body limit. A client-streaming upload is one request, so this would be rejected " +
+				"outright and the failure would read as a regression of the ordered chain rather than an " +
+				"oversized fixture. Shrink SMALL_ENTITY_COUNT."
+		);
+
+		final EvitaManagementServiceStub managementStub = TestGrpcClientBuilderCreator.getBuilder(
+				new ClientSessionInterceptor(
+					EvitaClientConfiguration.builder().build().clientId(),
+					new SemVer(2025, 4)
+				),
+				evitaServer.getExternalApiServer()
+			)
+			.build(EvitaManagementServiceStub.class);
+
+		final String restoredCatalogName = TEST_CATALOG_SMALL + "_streamRestored";
+		final CountDownLatch uploadFinished = new CountDownLatch(1);
+		final AtomicReference<GrpcRestoreCatalogResponse> uploadResponse = new AtomicReference<>();
+		final AtomicReference<Throwable> uploadFailure = new AtomicReference<>();
+		final StreamObserver<GrpcRestoreCatalogRequest> requestObserver = managementStub.restoreCatalog(
+			new StreamObserver<>() {
+				@Override
+				public void onNext(GrpcRestoreCatalogResponse value) {
+					uploadResponse.set(value);
+				}
+
+				@Override
+				public void onError(Throwable t) {
+					uploadFailure.set(t);
+					uploadFinished.countDown();
+				}
+
+				@Override
+				public void onCompleted() {
+					uploadFinished.countDown();
+				}
+			}
+		);
+
+		int chunksSent = 0;
+		for (int offset = 0; offset < backupContents.length; offset += STREAMING_CHUNK_SIZE) {
+			final int length = Math.min(STREAMING_CHUNK_SIZE, backupContents.length - offset);
+			requestObserver.onNext(
+				GrpcRestoreCatalogRequest.newBuilder()
+					.setCatalogName(restoredCatalogName)
+					.setBackupFile(ByteString.copyFrom(backupContents, offset, length))
+					.build()
+			);
+			chunksSent++;
+		}
+		requestObserver.onCompleted();
+
+		// positive wait - a latch sized generously, so a loaded box cannot fail it spuriously
+		assertTrue(uploadFinished.await(30, TimeUnit.SECONDS), "Client-streaming upload never terminated.");
+		// nothing else covers this path, so its failure message is the whole diagnostic - a bare
+		// Throwable concatenation would read "failed: null" for a status carrying no message
+		assertNull(
+			uploadFailure.get(),
+			() -> "Client-streaming upload failed: " + Status.fromThrowable(uploadFailure.get())
+		);
+
+		final GrpcRestoreCatalogResponse response = uploadResponse.get();
+		assertNotNull(response, "Server completed the upload without handing back a restoration task.");
+		// the server's own byte accounting - independent of ZIP integrity, and the first thing to check
+		// when the chain drops a chunk, because it localises the loss to the upload rather than the restore
+		assertEquals(
+			backupContents.length, response.getRead(),
+			"Server accounted for a different number of bytes than the " + chunksSent + " messages carried."
+		);
+
+		// the restoration task runs asynchronously on the server; the driver's own task tracker turns it
+		// into a real future, which is what keeps this off a sleep-poll loop
+		final ClientTask<?, ?> restorationTask = ((EvitaClientManagement) management)
+			.createTask(EvitaDataTypesConverter.toTaskStatus(response.getTask()));
+		restorationTask.getFutureResult().get(10, TimeUnit.MINUTES);
+
+		assertCatalogRestoredIntact(evitaClient, restoredCatalogName, SMALL_ENTITY_COUNT);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET)
+	@DisplayName("Should tell a client that still streams an oversized upload which limit it hit")
+	void shouldExplainWhyAnOversizedStreamingUploadIsRejected(EvitaServer evitaServer) throws Exception {
+		// the driver no longer uses the client-streaming RPC, but it stays on the wire for gRPC-Web and
+		// third-party clients - and for them the server's request-body limit is still a hard ceiling.
+		// What must not happen is what used to: a bare RESOURCE_EXHAUSTED with no description, which a
+		// client cannot distinguish from any other resource failure.
+		final EvitaManagementServiceStub managementStub = TestGrpcClientBuilderCreator.getBuilder(
+				new ClientSessionInterceptor(
+					EvitaClientConfiguration.builder().build().clientId(),
+					new SemVer(2025, 4)
+				),
+				evitaServer.getExternalApiServer()
+			)
+			.build(EvitaManagementServiceStub.class);
+
+		final CountDownLatch terminated = new CountDownLatch(1);
+		final AtomicReference<Throwable> failure = new AtomicReference<>();
+		final StreamObserver<GrpcRestoreCatalogRequest> requestObserver = managementStub.restoreCatalog(
+			new StreamObserver<>() {
+				@Override
+				public void onNext(GrpcRestoreCatalogResponse value) {
+				}
+
+				@Override
+				public void onError(Throwable t) {
+					failure.set(t);
+					terminated.countDown();
+				}
+
+				@Override
+				public void onCompleted() {
+					terminated.countDown();
+				}
+			}
+		);
+
+		final byte[] chunk = new byte[65_536];
+		long sent = 0L;
+		try {
+			// push past the server's request-body limit; the exact overshoot does not matter
+			while (sent <= SERVER_REQUEST_LIMIT) {
+				requestObserver.onNext(
+					GrpcRestoreCatalogRequest.newBuilder()
+						.setCatalogName(TEST_CATALOG + "_oversized")
+						.setBackupFile(ByteString.copyFrom(chunk))
+						.build()
+				);
+				sent += chunk.length;
+			}
+			requestObserver.onCompleted();
+		} catch (RuntimeException ex) {
+			// the server may abort the call while we are still pushing - that is the condition under
+			// test, not a failure of it
+			log.debug("Upload aborted by the server after {} B.", sent);
+		}
+
+		assertTrue(terminated.await(30, TimeUnit.SECONDS), "Oversized upload never terminated.");
+		final Throwable serverFailure = failure.get();
+		assertNotNull(serverFailure, "Server accepted an upload larger than its own request-body limit.");
+
+		final Status status = Status.fromThrowable(serverFailure);
+		assertEquals(
+			Code.RESOURCE_EXHAUSTED, status.getCode(),
+			"Oversized upload should be reported as RESOURCE_EXHAUSTED, got: " + status
+		);
+		final String description = status.getDescription();
+		assertNotNull(
+			description,
+			"Oversized upload was rejected with a bare status and no description - the client cannot tell " +
+				"a configured limit from any other resource failure."
+		);
+		assertTrue(
+			description.contains("maxEntitySizeInBytes"),
+			"Rejection should name the limit that was hit, was: " + description
+		);
+		assertTrue(
+			description.contains("RestoreCatalogUnary"),
+			"Rejection should point at the RPC that has no such ceiling, was: " + description
+		);
+	}
+
+}


### PR DESCRIPTION
Unifies the four fixes queued against `release_2026-2` into a single release-triggering merge to
`master`, following the `hotfix-2026-2-4` precedent (#1412). `master` and `release_2026-2` are the
same commit (`a7c9b78ba`), so each branch is merged here exactly as it was reviewed — no rebase, no
squash, no content change.

## What is in it

| Issue | Fix | Supersedes |
|---|---|---|
| #1433 | Price histogram silently reverted to per-entity granularity when the pool mixed `PriceInnerRecordHandling` values — granularity is now decided per accessor, not per query | #1435 |
| #1437 | A catalog upgraded to 2026.2 was marked `CORRUPTED` on the first write to a legacy `ChainIndex` — leaf page stamping stays create-free during the commit flush | #1439 |
| #1438 | The third duplicate reference on a new entity was rejected with representative attributes `[null]` — the provisional representative key is refreshed on every commit | #1442 |
| #1441 | gRPC server-streaming had no flow control: `fetchFile` buffered a whole file for a slow client — server-streaming producers are paced and streams get their own timeout budget | #1450 |

50 files changed, 7,538 insertions, 616 deletions.

## Merge notes

Both merge conflicts were in `documentation/adr/README.md` and only inside the `ADR-INDEX` markers.
That table is generated, never hand-merged, so each was resolved by rerunning
`tools/generate-adr-index.sh`; `--check` passes at 29 records.

## Verification status

Each constituent branch carries its own tests, all green on its own PR. A WARM_UP full-reindex
performance measurement against a production catalog export is **in progress** — a ~2.4x slowdown was
observed on the demo dataset between 5 Aug and 25 Aug, and the regression window covers both the
already-released 2026.2.4 hotfix batch and these four branches. **This PR should not be merged until
that measurement attributes the slowdown.**

Closes #1433
Closes #1437
Closes #1438
Closes #1441
