### PR TITLE
fix: memoize index bitmaps instead of formulas, which pinned query execution contexts

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/ConstantFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/ConstantFormula.java
@@ -81,9 +81,11 @@ public class ConstantFormula extends AbstractFormula {
 		if (this.delegate instanceof TransactionalLayerProducer) {
 			return ((TransactionalLayerProducer<?, ?>) this.delegate).getId();
 		} else {
-			// this shouldn't happen for long arrays - these are expected to be always linked to transactional
-			// bitmaps located in indexes and represented by "transactional id"
-			return hashFunction.hashInts(this.delegate.getArray());
+			// a bitmap that is not part of a transactional layer carries no id to key on, so its contents are what
+			// identify it - and since this formula gathers no transactional ids for such a delegate, that hash is
+			// the sole cache discriminator. The walk is `O(size)`, which is why index memos hand out the same bitmap
+			// instance every time: `BaseBitmap#getContentHash` memoizes it, so only the first formula pays
+			return this.delegate.getContentHash(hashFunction);
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -175,21 +175,47 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 */
 	@Nonnull private final Comparator<? extends Comparable> comparator;
 	/**
-	 * This field speeds up all requests for all data in this index (which happens quite often). This formula can be
+	 * This field speeds up all requests for all data in this index (which happens quite often). This bitmap can be
 	 * computed anytime by calling `((InvertedIndex) this.histogram).getSortedRecords(null, null)`. Original operation
 	 * needs to perform costly join of all internally held bitmaps and that's why we memoize the result.
+	 *
+	 * # Only the bitmap is memoized, never the formula wrapping it
+	 *
+	 * A {@link Formula} node carries **per-query** state:
+	 * {@link io.evitadb.core.query.algebra.AbstractFormula#initialize(io.evitadb.core.query.QueryExecutionContext)}
+	 * writes the executing query's context onto every node of the plan it is part of, and that context transitively
+	 * reaches the {@link io.evitadb.api.EvitaSessionContract} and the entire catalog generation the query ran
+	 * against. A formula held for the lifetime of this index would therefore pin the first session that ever used
+	 * it — and everything that session reached — until the index is written to again, which on a read-mostly index
+	 * is never.
+	 *
+	 * Memoizing the bitmap keeps the expensive part (the join of all internally held bitmaps) and pays a handful of
+	 * bytes for a fresh {@link ConstantFormula} per call, which is cheap scaffolding over the shared bitmap. Do not
+	 * turn this back into a `Formula` field.
 	 */
-	@Nullable private transient Formula memoizedAllRecordsFormula;
+	@Nullable private transient Bitmap memoizedAllRecords;
 	/**
 	 * Memoized result of {@link #getRangeHistogramOfAllRecords(Class, int)}. The cached subset is keyed implicitly
 	 * by the leaf's {@link RangeIndex} state — the steady-state query path against an unchanged leaf pays zero
 	 * allocation. Set to `null` whenever the index is mutated outside a transaction (mirrors
-	 * {@link #memoizedAllRecordsFormula}); the merged-transactional copy starts fresh.
+	 * {@link #memoizedAllRecords}); the merged-transactional copy starts fresh.
 	 *
 	 * The inner numeric type passed by callers is invariant for a given leaf — it is derived from
 	 * {@link #attributeType} via {@link EvitaDataTypes#resolveRangeInnerNumericType(Class)} — so it does not
 	 * need to be tracked alongside the cached subset; a fail-fast assertion in
 	 * {@link #getRangeHistogramOfAllRecords(Class, int)} guards against schema/index drift.
+	 *
+	 * # {@link InvertedIndexSubSet#getFormula()} must never be called on this subset
+	 *
+	 * This is the one subset in the codebase that lives as long as its index, and
+	 * {@link InvertedIndexSubSet#getFormula()} memoizes the formula it builds. Calling it here would park a
+	 * query-lifetime formula node in an index-lifetime structure and pin the calling session's whole catalog
+	 * generation — the leak {@link #memoizedAllRecords} documents. Its only consumer,
+	 * `AttributeHistogramComputer`, reads {@link InvertedIndexSubSet#getBuckets()} instead, which is stateless.
+	 *
+	 * The bitmap treatment applied to {@link #memoizedAllRecords} is not available here: the subset's aggregation
+	 * lambda may legitimately return a lazy `DeferredFormula`, so materializing a bitmap eagerly would change
+	 * behaviour rather than preserve it.
 	 */
 	@Nullable private transient InvertedIndexSubSet memoizedRangeHistogramSubSet;
 
@@ -634,7 +660,7 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 		}
 
 		if (!isTransactionAvailable()) {
-			this.memoizedAllRecordsFormula = null;
+			this.memoizedAllRecords = null;
 			this.memoizedRangeHistogramSubSet = null;
 		}
 		markDirty();
@@ -677,7 +703,7 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 		}
 
 		if (!isTransactionAvailable()) {
-			this.memoizedAllRecordsFormula = null;
+			this.memoizedAllRecords = null;
 			this.memoizedRangeHistogramSubSet = null;
 		}
 		markDirty();
@@ -725,7 +751,7 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 		}
 
 		if (!isTransactionAvailable()) {
-			this.memoizedAllRecordsFormula = null;
+			this.memoizedAllRecords = null;
 			this.memoizedRangeHistogramSubSet = null;
 		}
 		markDirty();
@@ -768,7 +794,7 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 		}
 
 		if (!isTransactionAvailable()) {
-			this.memoizedAllRecordsFormula = null;
+			this.memoizedAllRecords = null;
 			this.memoizedRangeHistogramSubSet = null;
 		}
 		markDirty();
@@ -825,7 +851,7 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 * `starts` / `ends` bitmaps are still applied to the rolling active set so that records with open-ended
 	 * ranges (`from == null` / `to == null`) participate in / exit the appropriate buckets. The result is
 	 * memoized — outside transactions, repeated calls return the cached subset; on mutation the cache is
-	 * invalidated alongside {@link #memoizedAllRecordsFormula}.
+	 * invalidated alongside {@link #memoizedAllRecords}.
 	 *
 	 * Throws {@link GenericEvitaInternalError} when invoked on a filter index that has no range companion.
 	 *
@@ -923,7 +949,14 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 */
 	@Nonnull
 	public Bitmap getAllRecords() {
-		return getAllRecordsFormula().compute();
+		// if there is transaction open, there might be changes in the histogram data, and we can't easily use cache
+		if (isTransactionAvailable() && isDirty()) {
+			return getHistogramOfAllRecords().getFormula().compute();
+		}
+		if (this.memoizedAllRecords == null) {
+			this.memoizedAllRecords = getHistogramOfAllRecords().getFormula().compute();
+		}
+		return this.memoizedAllRecords;
 	}
 
 	/**
@@ -934,20 +967,13 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 * raw OR-of-buckets tree from {@link InvertedIndexSubSet#getFormula()} prevents query-planner rewrites that
 	 * would otherwise distribute surrounding {@code NOT(OR(b₁..b_N), U)} via De Morgan into a wide
 	 * {@code AND(NOT b₁ ... NOT b_N)} — a transformation that explodes cost for high-cardinality indexes.
+	 *
+	 * A **fresh** formula is returned on every call. What is memoized is the bitmap behind it — see
+	 * {@link #memoizedAllRecords} for why an index must never hand out the same formula instance twice.
 	 */
 	public Formula getAllRecordsFormula() {
-		// if there is transaction open, there might be changes in the histogram data, and we can't easily use cache
-		if (isTransactionAvailable() && isDirty()) {
-			final Bitmap allRecords = getHistogramOfAllRecords().getFormula().compute();
-			return allRecords.isEmpty() ? EmptyFormula.INSTANCE : new ConstantFormula(allRecords);
-		} else {
-			if (this.memoizedAllRecordsFormula == null) {
-				final Bitmap allRecords = getHistogramOfAllRecords().getFormula().compute();
-				this.memoizedAllRecordsFormula = allRecords.isEmpty() ?
-					EmptyFormula.INSTANCE : new ConstantFormula(allRecords);
-			}
-			return this.memoizedAllRecordsFormula;
-		}
+		final Bitmap allRecords = getAllRecords();
+		return allRecords.isEmpty() ? EmptyFormula.INSTANCE : new ConstantFormula(allRecords);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -189,9 +189,20 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 * it — and everything that session reached — until the index is written to again, which on a read-mostly index
 	 * is never.
 	 *
-	 * Memoizing the bitmap keeps the expensive part (the join of all internally held bitmaps) and pays a handful of
-	 * bytes for a fresh {@link ConstantFormula} per call, which is cheap scaffolding over the shared bitmap. Do not
-	 * turn this back into a `Formula` field.
+	 * Memoizing the bitmap keeps the expensive part — the join of all internally held bitmaps — and the
+	 * {@link ConstantFormula} built around it per call is a handful of bytes over the shared bitmap.
+	 *
+	 * It is **not** free in CPU, however, and the cost is worth knowing before touching this. Once the value tree
+	 * holds more than one bucket the memoized bitmap is a `BaseBitmap`, which is not a
+	 * {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer}, so
+	 * `ConstantFormula#includeAdditionalHash` falls through to hashing the delegate's **contents** — and
+	 * `AbstractFormula#initFields` does that eagerly in the constructor. That is `O(records)` per call where the old
+	 * formula memo paid it once: measured at roughly 1.4 µs for 1k records, 83 µs for 100k and 309 µs for 500k.
+	 * Only the two read paths that ask for a formula pay it — `AttributeIsTranslator` and
+	 * `AttributeHistogramComputer` — and the fix is to memoize the content hash beside the bitmap and hand it to
+	 * the formula, not to memoize the formula again. See issue #1458.
+	 *
+	 * Do not turn this back into a `Formula` field.
 	 */
 	@Nullable private transient Bitmap memoizedAllRecords;
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -192,15 +192,14 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 * Memoizing the bitmap keeps the expensive part — the join of all internally held bitmaps — and the
 	 * {@link ConstantFormula} built around it per call is a handful of bytes over the shared bitmap.
 	 *
-	 * It is **not** free in CPU, however, and the cost is worth knowing before touching this. Once the value tree
-	 * holds more than one bucket the memoized bitmap is a `BaseBitmap`, which is not a
-	 * {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer}, so
-	 * `ConstantFormula#includeAdditionalHash` falls through to hashing the delegate's **contents** — and
-	 * `AbstractFormula#initFields` does that eagerly in the constructor. That is `O(records)` per call where the old
-	 * formula memo paid it once: measured at roughly 1.4 µs for 1k records, 83 µs for 100k and 309 µs for 500k.
-	 * Only the two read paths that ask for a formula pay it — `AttributeIsTranslator` and
-	 * `AttributeHistogramComputer` — and the fix is to memoize the content hash beside the bitmap and hand it to
-	 * the formula, not to memoize the formula again. See issue #1458.
+	 * What keeps that cheap in CPU as well is where the formula's cache key comes from. Once the value tree holds
+	 * more than one bucket the memoized bitmap is a `BaseBitmap`, which is not a
+	 * {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer} and so has no transactional id to key
+	 * on; `ConstantFormula#includeAdditionalHash` falls through to hashing its **contents**, eagerly, in the
+	 * constructor. That would be `O(records)` on every call — measured at roughly 1.4 µs for 1k records, 83 µs for
+	 * 100k and 309 µs for 500k — were the hash not memoized on the bitmap itself. It is: because this field hands
+	 * out the same `BaseBitmap` instance every time, {@link Bitmap#getContentHash} computes the walk once and every
+	 * later formula reads it back. Replacing this bitmap with a per-call copy would silently reinstate that cost.
 	 *
 	 * Do not turn this back into a `Formula` field.
 	 */

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
@@ -294,12 +294,12 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 	 * holds — there is nothing left to memoize, because the expensive part was always the bitmap and never the
 	 * few scalars of scaffolding around it.
 	 *
-	 * Building one per call is genuinely cheap **here**, unlike in a filter index: {@link #recordIds} is a
+	 * Building one per call is `O(1)` here for a reason worth knowing: {@link #recordIds} is a
 	 * {@link TransactionalBitmap} and therefore a
-	 * {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer}, so `ConstantFormula` hashes its
-	 * transactional id rather than its contents and construction stays `O(1)`. A filter index's multi-bucket memo
-	 * is a plain `BaseBitmap` and pays `O(records)` instead — see `FilterIndex#memoizedAllRecords`. Do not
-	 * "harmonise" the two; they are not the same case.
+	 * {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer}, so `ConstantFormula` keys its cache
+	 * entry on the transactional id and never looks at the contents. A filter index's multi-bucket memo is a plain
+	 * `BaseBitmap` with no such id and has to hash the records instead, which is why that bitmap memoizes the hash
+	 * — see `FilterIndex#memoizedAllRecords`. Do not "harmonise" the two; they are not the same case.
 	 *
 	 * The formula must not be cached here. A {@link Formula} node carries per-query state:
 	 * {@link io.evitadb.core.query.algebra.AbstractFormula#initialize(io.evitadb.core.query.QueryExecutionContext)}

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
@@ -58,7 +58,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
-import static io.evitadb.core.transaction.Transaction.isTransactionAvailable;
 import static io.evitadb.index.attribute.UniqueIndexBPlusTreeSupport.comparatorFor;
 import static io.evitadb.index.attribute.UniqueIndexBPlusTreeSupport.plainTypeOf;
 import static io.evitadb.utils.Assert.isTrue;
@@ -119,12 +118,6 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 	 * Keeps information about all record ids present in this index.
 	 */
 	@Nonnull private final TransactionalBitmap recordIds;
-	/**
-	 * This field speeds up all requests for all data in this index (which happens quite often). This formula can be
-	 * computed anytime by calling `new ConstantFormula(getRecordIds())`. Original operation
-	 * needs to perform costly creation of new internal bitmap that's why we memoize the result.
-	 */
-	@Nullable private transient Formula memoizedAllRecordsFormula;
 
 	/**
 	 * Creates a fresh, empty value tree (int payload column holding the owning record id) ordered by the given
@@ -294,17 +287,22 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 		return records.isEmpty() ? null : records.getFirst();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * A **fresh** formula is returned on every call, wrapping the {@link #recordIds} bitmap this index already
+	 * holds — there is nothing left to memoize, because the expensive part was always the bitmap and never the
+	 * few scalars of scaffolding around it.
+	 *
+	 * The formula must not be cached here. A {@link Formula} node carries per-query state:
+	 * {@link io.evitadb.core.query.algebra.AbstractFormula#initialize(io.evitadb.core.query.QueryExecutionContext)}
+	 * writes the executing query's context onto every node of the plan it joins, and that context transitively
+	 * reaches the session and the whole catalog generation the query ran against. An index-lifetime formula would
+	 * pin the first session that ever used it until the index is next written to.
+	 */
 	@Override
 	public Formula getRecordIdsFormula() {
-		// if there is transaction open, there might be changes in the bitmap, and we can't easily use cache
-		if (isTransactionAvailable() && this.dirty.isTrue()) {
-			return new ConstantFormula(this.recordIds);
-		} else {
-			if (this.memoizedAllRecordsFormula == null) {
-				this.memoizedAllRecordsFormula = new ConstantFormula(this.recordIds);
-			}
-			return this.memoizedAllRecordsFormula;
-		}
+		return new ConstantFormula(this.recordIds);
 	}
 
 	@Nonnull
@@ -578,10 +576,6 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 			registerUniqueKeyValue((T) key, recordId);
 		}
 
-		if (!isTransactionAvailable()) {
-			this.memoizedAllRecordsFormula = null;
-		}
-
 		this.dirty.setToTrue();
 	}
 
@@ -631,10 +625,6 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 		} else {
 			verifyValue(key);
 			returnValue = unregisterUniqueKeyValue((T) key, expectedRecordId);
-		}
-
-		if (!isTransactionAvailable()) {
-			this.memoizedAllRecordsFormula = null;
 		}
 
 		this.dirty.setToTrue();

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
@@ -294,6 +294,13 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 	 * holds — there is nothing left to memoize, because the expensive part was always the bitmap and never the
 	 * few scalars of scaffolding around it.
 	 *
+	 * Building one per call is genuinely cheap **here**, unlike in a filter index: {@link #recordIds} is a
+	 * {@link TransactionalBitmap} and therefore a
+	 * {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer}, so `ConstantFormula` hashes its
+	 * transactional id rather than its contents and construction stays `O(1)`. A filter index's multi-bucket memo
+	 * is a plain `BaseBitmap` and pays `O(records)` instead — see `FilterIndex#memoizedAllRecords`. Do not
+	 * "harmonise" the two; they are not the same case.
+	 *
 	 * The formula must not be cached here. A {@link Formula} node carries per-query state:
 	 * {@link io.evitadb.core.query.algebra.AbstractFormula#initialize(io.evitadb.core.query.QueryExecutionContext)}
 	 * writes the executing query's context onto every node of the plan it joins, and that context transitively

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/UniqueIndexView.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/UniqueIndexView.java
@@ -59,7 +59,7 @@ public final class UniqueIndexView extends UniqueIndex {
 	@Serial private static final long serialVersionUID = 2639205026498958518L;
 	/**
 	 * Direct reference to the shared {@link FilterIndex} view over the same attribute key — the source of truth this
-	 * folded view reads from (reusing its normalizer and memoized all-records formula). May be `null` for a transient
+	 * folded view reads from (reusing its normalizer and memoized all-records bitmap). May be `null` for a transient
 	 * live presence marker created before the shared tree exists; the filter-write path rebinds it to the live filter
 	 * view via {@link #bindFilterView}. Never reassigned on a published instance — a new view is built instead, so the
 	 * field is safe to share across snapshot versions. Transient because a reloaded view is reconstructed from the
@@ -123,7 +123,8 @@ public final class UniqueIndexView extends UniqueIndex {
 
 	@Override
 	public Formula getRecordIdsFormula() {
-		// reuse the filter view's already-memoized all-records formula over the same shared tree
+		// wrap the filter view's already-memoized all-records bitmap over the same shared tree - the formula itself
+		// is built fresh per call, because an index-lifetime one would pin the calling query's execution context
 		final FilterIndex filterView = this.sharedFilterView;
 		return filterView == null ? EmptyFormula.INSTANCE : filterView.getAllRecordsFormula();
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/bitmap/BaseBitmap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bitmap/BaseBitmap.java
@@ -49,22 +49,23 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	private final PersistentRoaringBitmap roaringBitmap;
 	private int memoizedCardinality;
 	/**
-	 * Hash function {@link #memoizedContentHash} was computed with, or `null` when no content hash has been computed
-	 * for the current contents yet.
+	 * Memoized result of {@link #getContentHash(LongHashFunction)} together with the function that produced it, or
+	 * `null` when none has been computed for the current contents. Every mutator clears it, exactly as it
+	 * invalidates {@link #memoizedCardinality}.
 	 *
-	 * It doubles as the publication guard for {@link #memoizedContentHash}: it is written **after** the hash, and
-	 * because the write is volatile, a thread that observes a matching function here is guaranteed to observe the
-	 * matching hash as well. Keying on the function rather than assuming a single global one keeps the memo correct
-	 * for callers that bring their own — {@code CacheEnforcingPolicy} builds a separate instance from the same
-	 * factory as {@code TransactionalDataRelatedStructure#HASH_FUNCTION}.
+	 * The hash and its function travel as **one immutable object** on purpose, and splitting them back into two
+	 * fields would be a correctness bug even with a volatile guard between them. Two threads hashing with
+	 * *different* functions can interleave their writes so that the guard ends up naming one function while the
+	 * value belongs to the other; a third caller then matches the guard and receives a hash that was never computed
+	 * for the function it asked about — a wrong formula cache key, not merely a slow one. A record's final fields
+	 * are safely published even through a data race, so a reader here sees either `null` or a consistent pair, and
+	 * racing writers can only overwrite each other with individually-consistent ones.
+	 *
+	 * Keying on the function rather than assuming a single global one keeps the memo correct for callers that bring
+	 * their own — {@code CacheEnforcingPolicy} builds a separate instance from the same factory as
+	 * {@code TransactionalDataRelatedStructure#HASH_FUNCTION}.
 	 */
-	@Nullable private transient volatile LongHashFunction memoizedContentHashFunction;
-	/**
-	 * Memoized result of {@link #getContentHash(LongHashFunction)}. Only meaningful while
-	 * {@link #memoizedContentHashFunction} is non-null — every mutator clears that guard, exactly as it invalidates
-	 * {@link #memoizedCardinality}.
-	 */
-	private transient long memoizedContentHash;
+	@Nullable private transient volatile ContentHash memoizedContentHash;
 
 	public BaseBitmap() {
 		this.roaringBitmap = new PersistentRoaringBitmap();
@@ -113,7 +114,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		final boolean added = this.roaringBitmap.checkedAdd(recordId);
 		if (added) {
 			this.memoizedCardinality = -1;
-			this.memoizedContentHashFunction = null;
+			this.memoizedContentHash = null;
 		}
 		return added;
 	}
@@ -122,14 +123,14 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	public void addAll(int... recordId) {
 		this.roaringBitmap.add(recordId);
 		this.memoizedCardinality = -1;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	@Override
 	public void addAll(@Nonnull Bitmap recordIds) {
 		this.roaringBitmap.add(recordIds.getArray());
 		this.memoizedCardinality = -1;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	@Override
@@ -137,7 +138,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		final boolean removed = this.roaringBitmap.checkedRemove(recordId);
 		if (removed) {
 			this.memoizedCardinality = -1;
-			this.memoizedContentHashFunction = null;
+			this.memoizedContentHash = null;
 		}
 		return removed;
 	}
@@ -148,7 +149,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 			this.roaringBitmap.remove(recId);
 		}
 		this.memoizedCardinality = -1;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	@Override
@@ -163,7 +164,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 			}
 		}
 		this.memoizedCardinality = -1;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	/**
@@ -197,7 +198,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		}
 		this.roaringBitmap.andNot(writer.get());
 		this.memoizedCardinality = -1;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	/**
@@ -232,7 +233,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		}
 		this.roaringBitmap.andNot(writer.get());
 		this.memoizedCardinality = -1;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	/**
@@ -243,7 +244,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	public void clear() {
 		this.roaringBitmap.clear();
 		this.memoizedCardinality = 0;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	@Override
@@ -329,15 +330,14 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	 */
 	@Override
 	public long getContentHash(@Nonnull LongHashFunction hashFunction) {
-		final LongHashFunction memoizedFor = this.memoizedContentHashFunction;
-		if (memoizedFor == hashFunction) {
-			return this.memoizedContentHash;
+		final ContentHash memoized = this.memoizedContentHash;
+		if (memoized != null && memoized.function() == hashFunction) {
+			return memoized.hash();
 		}
 		final long contentHash = hashFunction.hashInts(getArray());
-		this.memoizedContentHash = contentHash;
-		// publish last - the volatile write makes the hash assigned above visible to every reader that observes
-		// this function reference
-		this.memoizedContentHashFunction = hashFunction;
+		// one reference write publishes the hash and its function together - see the field for why they must not
+		// be assigned separately
+		this.memoizedContentHash = new ContentHash(hashFunction, contentHash);
 		return contentHash;
 	}
 
@@ -377,5 +377,15 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	public String toString() {
 		// we need to unify the output with ArrayBitmap and other implementations
 		return "[" + this.roaringBitmap.stream().mapToObj(Integer::toString).collect(Collectors.joining(", ")) + "]";
+	}
+
+	/**
+	 * A content hash paired with the {@link LongHashFunction} that produced it, so that the two can never be
+	 * observed out of step by a concurrent reader — see {@link #memoizedContentHash} for why that matters.
+	 *
+	 * @param function the function the hash was computed with, compared by identity
+	 * @param hash     the hash of the bitmap's record ids as they stood when it was computed
+	 */
+	private record ContentHash(@Nonnull LongHashFunction function, long hash) {
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/index/bitmap/BaseBitmap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bitmap/BaseBitmap.java
@@ -28,8 +28,10 @@ import io.evitadb.roaringbitmap.PeekableIntIterator;
 import io.evitadb.roaringbitmap.PersistentRoaringBitmap;
 import io.evitadb.roaringbitmap.RoaringBatchIterator;
 import io.evitadb.roaringbitmap.RoaringBitmapWriter;
+import net.openhft.hashing.LongHashFunction;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Serial;
 import java.util.NoSuchElementException;
@@ -46,6 +48,23 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	@Serial private static final long serialVersionUID = -8471705193727315151L;
 	private final PersistentRoaringBitmap roaringBitmap;
 	private int memoizedCardinality;
+	/**
+	 * Hash function {@link #memoizedContentHash} was computed with, or `null` when no content hash has been computed
+	 * for the current contents yet.
+	 *
+	 * It doubles as the publication guard for {@link #memoizedContentHash}: it is written **after** the hash, and
+	 * because the write is volatile, a thread that observes a matching function here is guaranteed to observe the
+	 * matching hash as well. Keying on the function rather than assuming a single global one keeps the memo correct
+	 * for callers that bring their own — {@code CacheEnforcingPolicy} builds a separate instance from the same
+	 * factory as {@code TransactionalDataRelatedStructure#HASH_FUNCTION}.
+	 */
+	@Nullable private transient volatile LongHashFunction memoizedContentHashFunction;
+	/**
+	 * Memoized result of {@link #getContentHash(LongHashFunction)}. Only meaningful while
+	 * {@link #memoizedContentHashFunction} is non-null — every mutator clears that guard, exactly as it invalidates
+	 * {@link #memoizedCardinality}.
+	 */
+	private transient long memoizedContentHash;
 
 	public BaseBitmap() {
 		this.roaringBitmap = new PersistentRoaringBitmap();
@@ -92,7 +111,10 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	@Override
 	public boolean add(int recordId) {
 		final boolean added = this.roaringBitmap.checkedAdd(recordId);
-		this.memoizedCardinality = added ? -1 : this.memoizedCardinality;
+		if (added) {
+			this.memoizedCardinality = -1;
+			this.memoizedContentHashFunction = null;
+		}
 		return added;
 	}
 
@@ -100,18 +122,23 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	public void addAll(int... recordId) {
 		this.roaringBitmap.add(recordId);
 		this.memoizedCardinality = -1;
+		this.memoizedContentHashFunction = null;
 	}
 
 	@Override
 	public void addAll(@Nonnull Bitmap recordIds) {
 		this.roaringBitmap.add(recordIds.getArray());
 		this.memoizedCardinality = -1;
+		this.memoizedContentHashFunction = null;
 	}
 
 	@Override
 	public boolean remove(int recordId) {
 		final boolean removed = this.roaringBitmap.checkedRemove(recordId);
-		this.memoizedCardinality = removed ? -1 : this.memoizedCardinality;
+		if (removed) {
+			this.memoizedCardinality = -1;
+			this.memoizedContentHashFunction = null;
+		}
 		return removed;
 	}
 
@@ -121,6 +148,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 			this.roaringBitmap.remove(recId);
 		}
 		this.memoizedCardinality = -1;
+		this.memoizedContentHashFunction = null;
 	}
 
 	@Override
@@ -135,6 +163,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 			}
 		}
 		this.memoizedCardinality = -1;
+		this.memoizedContentHashFunction = null;
 	}
 
 	/**
@@ -168,6 +197,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		}
 		this.roaringBitmap.andNot(writer.get());
 		this.memoizedCardinality = -1;
+		this.memoizedContentHashFunction = null;
 	}
 
 	/**
@@ -202,16 +232,18 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		}
 		this.roaringBitmap.andNot(writer.get());
 		this.memoizedCardinality = -1;
+		this.memoizedContentHashFunction = null;
 	}
 
 	/**
 	 * Clears all data in the bitmap.
 	 * This method resets the internal bitmap structure, effectively removing all stored record IDs,
-	 * and also resets the memoized cardinality to zero.
+	 * and also resets the memoized cardinality to zero and discards the memoized content hash.
 	 */
 	public void clear() {
 		this.roaringBitmap.clear();
 		this.memoizedCardinality = 0;
+		this.memoizedContentHashFunction = null;
 	}
 
 	@Override
@@ -279,6 +311,34 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	@Override
 	public int[] getArray() {
 		return RoaringBitmapBackedBitmap.toSignedArray(this.roaringBitmap);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * The result is memoized, so building a formula over the *same* bitmap instance repeatedly pays the `O(size)`
+	 * walk once instead of once per formula. That is what makes an index able to memoize its all-records **bitmap**
+	 * — which retains nothing query-scoped — and still hand out a fresh formula per call at the cost of one
+	 * allocation; see `FilterIndex#memoizedAllRecords`.
+	 *
+	 * Concurrency: reads are safely publishable across threads even though this class is {@link NotThreadSafe} —
+	 * the guard field is written last with volatile semantics, so a reader either misses the memo and recomputes an
+	 * identical value, or sees a fully-published one. Mutating a bitmap while other threads read it was already
+	 * outside this class' contract and remains so; a mutator clears the memo the same way it clears
+	 * {@link #size()}'s.
+	 */
+	@Override
+	public long getContentHash(@Nonnull LongHashFunction hashFunction) {
+		final LongHashFunction memoizedFor = this.memoizedContentHashFunction;
+		if (memoizedFor == hashFunction) {
+			return this.memoizedContentHash;
+		}
+		final long contentHash = hashFunction.hashInts(getArray());
+		this.memoizedContentHash = contentHash;
+		// publish last - the volatile write makes the hash assigned above visible to every reader that observes
+		// this function reference
+		this.memoizedContentHashFunction = hashFunction;
+		return contentHash;
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/index/bitmap/Bitmap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bitmap/Bitmap.java
@@ -23,6 +23,8 @@
 
 package io.evitadb.index.bitmap;
 
+import net.openhft.hashing.LongHashFunction;
+
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.PrimitiveIterator.OfInt;
@@ -150,6 +152,25 @@ public interface Bitmap extends Iterable<Integer>, Serializable {
 	 * Produces (allocates) new sorted array of the records stored in the bitmap.
 	 */
 	int[] getArray();
+
+	/**
+	 * Returns hash of the record ids this bitmap holds, computed with the passed `hashFunction`.
+	 *
+	 * The hash identifies the bitmap by its **contents**: two bitmaps holding the same record ids answer with
+	 * the same value regardless of their identity, class or internal representation. That is what makes it usable
+	 * as the discriminating part of a formula cache key for bitmaps that carry no transactional identity of their
+	 * own — an aggregated result computed on the fly has no id to key on, only its contents.
+	 *
+	 * The default implementation materializes the whole record id array and is therefore `O(size)`. An
+	 * implementation that is handed out repeatedly — an index memo answering the same query over and over — should
+	 * memoize the result instead of paying the walk per caller; {@link BaseBitmap} does.
+	 *
+	 * @param hashFunction hash function to compute the value with
+	 * @return hash of the record ids stored in this bitmap
+	 */
+	default long getContentHash(@Nonnull LongHashFunction hashFunction) {
+		return hashFunction.hashInts(getArray());
+	}
 
 	/**
 	 * Produces iterator over all record ids.

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
@@ -136,8 +136,20 @@ public class HierarchyIndex
 	private final TransactionalIntArray orphans;
 	/**
 	 * Contains cached result of {@link #getAllHierarchyNodesFormula()} call.
+	 *
+	 * # Only the bitmap is memoized, never the formula wrapping it
+	 *
+	 * A {@link Formula} node carries **per-query** state:
+	 * {@link io.evitadb.core.query.algebra.AbstractFormula#initialize(io.evitadb.core.query.QueryExecutionContext)}
+	 * writes the executing query's context onto every node of the plan it is part of, and that context transitively
+	 * reaches the session and the entire catalog generation the query ran against. A formula held for the lifetime
+	 * of this index would therefore pin the first session that ever used it until the hierarchy is next written to.
+	 *
+	 * Memoizing the bitmap keeps the expensive part — the `O(nodes)` walk in
+	 * {@link #createAllHierarchyNodesBitmap()} — and pays a handful of bytes for a fresh {@link ConstantFormula}
+	 * per call. Do not turn this back into a `Formula` field.
 	 */
-	@Nullable private volatile Formula memoizedAllNodeFormula;
+	@Nullable private volatile Bitmap memoizedAllNodes;
 
 	/**
 	 * Creates a new empty hierarchy index.
@@ -148,7 +160,7 @@ public class HierarchyIndex
 		this.levelIndex = new TransactionalMap<>(new HashMap<>(32), TransactionalIntArray.class, TransactionalIntArray::new);
 		this.itemIndex = new TransactionalMap<>(new HashMap<>(32));
 		this.orphans = new TransactionalIntArray();
-		this.memoizedAllNodeFormula = EmptyFormula.INSTANCE;
+		this.memoizedAllNodes = EmptyBitmap.INSTANCE;
 	}
 
 	/**
@@ -165,7 +177,7 @@ public class HierarchyIndex
 		this.levelIndex = new TransactionalMap<>(levelIndex, TransactionalIntArray.class, TransactionalIntArray::new);
 		this.itemIndex = new TransactionalMap<>(itemIndex);
 		this.orphans = new TransactionalIntArray(orphans);
-		this.memoizedAllNodeFormula = createAllHierarchyNodesFormula();
+		this.memoizedAllNodes = createAllHierarchyNodesBitmap();
 	}
 
 	/**
@@ -759,17 +771,30 @@ public class HierarchyIndex
 
 	/**
 	 * Method returns formula that contains all nodes attached to the tree (i.e. except {@link #orphans}.
+	 *
+	 * A **fresh** formula is returned on every call. What is memoized is the bitmap behind it — see
+	 * {@link #memoizedAllNodes} for why an index must never hand out the same formula instance twice.
 	 */
 	@Nonnull
 	public Formula getAllHierarchyNodesFormula() {
+		final Bitmap allNodes = getAllHierarchyNodes();
+		return allNodes.isEmpty() ? EmptyFormula.INSTANCE : new ConstantFormula(allNodes);
+	}
+
+	/**
+	 * Method returns bitmap of all nodes attached to the tree (i.e. except {@link #orphans}. The result is memoized
+	 * outside transactions and recomputed while a transaction holds uncommitted hierarchy changes.
+	 */
+	@Nonnull
+	public Bitmap getAllHierarchyNodes() {
 		// if there is transaction open, and there are changes in the hierarchy data, we can't use the cache
 		if (isTransactionAvailable() && this.dirty.isTrue()) {
-			return createAllHierarchyNodesFormula();
+			return createAllHierarchyNodesBitmap();
 		} else {
-			Formula result = this.memoizedAllNodeFormula;
+			Bitmap result = this.memoizedAllNodes;
 			if (result == null) {
-				result = createAllHierarchyNodesFormula();
-				this.memoizedAllNodeFormula = result;
+				result = createAllHierarchyNodesBitmap();
+				this.memoizedAllNodes = result;
 			}
 			return result;
 		}
@@ -1307,10 +1332,10 @@ public class HierarchyIndex
 	}
 
 	/**
-	 * Creates a formula that contains all hierarchy nodes except orphans.
+	 * Creates a bitmap that contains all hierarchy nodes except orphans.
 	 */
 	@Nonnull
-	private Formula createAllHierarchyNodesFormula() {
+	private Bitmap createAllHierarchyNodesBitmap() {
 		final Set<Integer> nodeIds = this.itemIndex.keySet();
 		final RoaringBitmapWriter<PersistentRoaringBitmap> writer = RoaringBitmapBackedBitmap.buildWriter();
 		for (Integer nodeId : nodeIds) {
@@ -1323,14 +1348,14 @@ public class HierarchyIndex
 			roaringBitmap.remove(it.next());
 		}
 		return roaringBitmap.isEmpty() ?
-			EmptyFormula.INSTANCE : new ConstantFormula(new BaseBitmap(roaringBitmap));
+			EmptyBitmap.INSTANCE : new BaseBitmap(roaringBitmap);
 	}
 
 	/**
 	 * Method resets all memoized values.
 	 */
 	private void resetMemoizedValues() {
-		this.memoizedAllNodeFormula = null;
+		this.memoizedAllNodes = null;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
@@ -147,10 +147,10 @@ public class HierarchyIndex
 	 *
 	 * Memoizing the bitmap keeps the expensive part — the `O(nodes)` walk in
 	 * {@link #createAllHierarchyNodesBitmap()} — and the {@link ConstantFormula} built around it per call is a
-	 * handful of bytes over the shared bitmap. It is not free in CPU: the memo is a `BaseBitmap`, so the formula
-	 * hashes its contents in the constructor, which is `O(nodes)` per call. That matters much less here than for a
-	 * filter index, because no main-source caller asks this index for a formula at all — see
-	 * `FilterIndex#memoizedAllRecords` for the measured figures and the intended fix.
+	 * handful of bytes over the shared bitmap. It is cheap in CPU too, but only because the same instance is handed
+	 * out every time: the memo is a `BaseBitmap` with no transactional id, so the formula's cache key comes from
+	 * hashing its contents, and {@link io.evitadb.index.bitmap.Bitmap#getContentHash} memoizes that `O(nodes)` walk
+	 * on the bitmap. See `FilterIndex#memoizedAllRecords` for the measured figures.
 	 *
 	 * Do not turn this back into a `Formula` field.
 	 */

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
@@ -146,8 +146,13 @@ public class HierarchyIndex
 	 * of this index would therefore pin the first session that ever used it until the hierarchy is next written to.
 	 *
 	 * Memoizing the bitmap keeps the expensive part — the `O(nodes)` walk in
-	 * {@link #createAllHierarchyNodesBitmap()} — and pays a handful of bytes for a fresh {@link ConstantFormula}
-	 * per call. Do not turn this back into a `Formula` field.
+	 * {@link #createAllHierarchyNodesBitmap()} — and the {@link ConstantFormula} built around it per call is a
+	 * handful of bytes over the shared bitmap. It is not free in CPU: the memo is a `BaseBitmap`, so the formula
+	 * hashes its contents in the constructor, which is `O(nodes)` per call. That matters much less here than for a
+	 * filter index, because no main-source caller asks this index for a formula at all — see
+	 * `FilterIndex#memoizedAllRecords` for the measured figures and the intended fix.
+	 *
+	 * Do not turn this back into a `Formula` field.
 	 */
 	@Nullable private volatile Bitmap memoizedAllNodes;
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/IndexFormulaRetentionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/IndexFormulaRetentionTest.java
@@ -1,0 +1,197 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.infra.SkipFormula;
+import io.evitadb.index.attribute.OwnerFilterIndex;
+import io.evitadb.index.attribute.OwnerUniqueIndex;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.hierarchy.HierarchyIndex;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import io.evitadb.test.Entities;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Guards the invariant that keeps query state out of the index layer:
+ *
+ * **No object with index lifetime may hold a [Formula].**
+ *
+ * A formula node is *per-query* state. `AbstractFormula#initialize(QueryExecutionContext)` writes the executing
+ * query's context onto every node of the plan it is part of, and that context transitively reaches the
+ * `EvitaSession` and the whole catalog generation the query ran against. An index that memoizes a formula and hands
+ * the same instance to successive query plans therefore pins the first session that ever touched it — together with
+ * everything that session reached — until the index is written to again. On a read-mostly index that is never, which
+ * is what made this leak grow monotonically in production rather than plateau.
+ *
+ * The remedy applied across the index layer is to memoize the **bitmap** (the part that is expensive to produce) and
+ * to build a fresh, cheap {@link io.evitadb.core.query.algebra.base.ConstantFormula} wrapper per call. This test
+ * exists because per-class discipline is not self-enforcing: it walks the declared fields of the index types that
+ * carry such caches and fails if any of them retains a formula, so the next memoization added to an index cannot
+ * silently reintroduce the leak.
+ *
+ * Ref: #1458
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(ENGINE)
+@Tag(INDEXING)
+@DisplayName("Index structures must never retain a Formula")
+class IndexFormulaRetentionTest {
+
+	/**
+	 * Walks every non-static field declared by the object's class and its superclasses and fails when any of them
+	 * holds a {@link Formula}.
+	 *
+	 * The stateless singletons are exempt: {@link EmptyFormula#INSTANCE} and {@link SkipFormula#INSTANCE} both
+	 * override `initialize` with a deliberate no-op precisely so that they can be shared, so neither can capture a
+	 * query's execution context.
+	 *
+	 * @param index the index instance to inspect, with all of its caches already warmed
+	 */
+	private static void assertRetainsNoFormula(@Nonnull Object index) throws IllegalAccessException {
+		for (Class<?> type = index.getClass(); type != null && type != Object.class; type = type.getSuperclass()) {
+			for (Field field : type.getDeclaredFields()) {
+				if (Modifier.isStatic(field.getModifiers())) {
+					continue;
+				}
+				field.setAccessible(true);
+				final Object value = field.get(index);
+				if (value instanceof Formula && value != EmptyFormula.INSTANCE && value != SkipFormula.INSTANCE) {
+					fail(
+						"Field `" + type.getSimpleName() + "#" + field.getName() + "` retains a " +
+							value.getClass().getSimpleName() + " for the lifetime of the index. A formula carries " +
+							"per-query state once a plan initializes it, so holding one pins the session and the " +
+							"catalog generation that first used it. Memoize the bitmap instead and wrap it in a " +
+							"fresh ConstantFormula per call - see FilterIndex#memoizedAllRecords."
+					);
+				}
+			}
+		}
+	}
+
+	@Test
+	@DisplayName("FilterIndex memoizes its all-records bitmap without retaining the formula")
+	void shouldNotRetainFormulaInFilterIndex() throws IllegalAccessException {
+		final OwnerFilterIndex index = new OwnerFilterIndex(
+			new AttributeIndexKey(null, "a", null), String.class
+		);
+		index.addRecord(1, "A");
+		index.addRecord(2, "B");
+
+		// warm every cache the index has, through the accessors a query plan uses
+		final Formula first = index.getAllRecordsFormula();
+		final Formula second = index.getAllRecordsFormula();
+		assertNotSame(first, second);
+
+		assertRetainsNoFormula(index);
+	}
+
+	@Test
+	@DisplayName("OwnerUniqueIndex builds its record-ids formula fresh and retains none")
+	void shouldNotRetainFormulaInOwnerUniqueIndex() throws IllegalAccessException {
+		final OwnerUniqueIndex index = new OwnerUniqueIndex(
+			Entities.PRODUCT,
+			new AttributeIndexKey(null, "code", null),
+			String.class
+		);
+		index.registerUniqueKey("A", 1);
+		index.registerUniqueKey("B", 2);
+
+		final Formula first = index.getRecordIdsFormula();
+		final Formula second = index.getRecordIdsFormula();
+		assertNotSame(first, second);
+
+		assertRetainsNoFormula(index);
+	}
+
+	@Test
+	@DisplayName("HierarchyIndex memoizes its all-nodes bitmap without retaining the formula")
+	void shouldNotRetainFormulaInHierarchyIndex() throws IllegalAccessException {
+		final HierarchyIndex index = new HierarchyIndex();
+		index.addNode(1, null);
+		index.addNode(2, 1);
+
+		final Formula first = index.getAllHierarchyNodesFormula();
+		final Formula second = index.getAllHierarchyNodesFormula();
+		assertNotSame(first, second);
+
+		assertRetainsNoFormula(index);
+	}
+
+	@Test
+	@DisplayName("an empty HierarchyIndex parks no formula either")
+	void shouldNotRetainFormulaInEmptyHierarchyIndex() throws IllegalAccessException {
+		final HierarchyIndex index = new HierarchyIndex();
+
+		// an empty index short-circuits to the shared EmptyFormula singleton, which is safe to hand out repeatedly
+		index.getAllHierarchyNodesFormula();
+
+		assertRetainsNoFormula(index);
+	}
+
+	@Test
+	@DisplayName("the guard detects a retained formula, and tolerates the safe singletons")
+	void shouldDetectRetainedFormula() {
+		// calibration: without this, a guard that silently inspected nothing would pass every test above and
+		// report coverage it does not have
+		assertThrows(AssertionError.class, () -> assertRetainsNoFormula(new LeakyHolder()));
+
+		// the two singletons whose initialize() is a documented no-op must not trip the guard
+		assertDoesNotThrow(() -> assertRetainsNoFormula(new ExemptHolder()));
+	}
+
+	/**
+	 * Stands in for an index that memoized a formula, so that the guard above can be shown to fail when the
+	 * invariant is actually violated.
+	 */
+	@SuppressWarnings("unused")
+	private static final class LeakyHolder {
+		private final Formula retained = new ConstantFormula(new BaseBitmap(1, 2));
+	}
+
+	/**
+	 * Holds only the shared stateless formula singletons, which are safe to retain and must be tolerated.
+	 */
+	@SuppressWarnings("unused")
+	private static final class ExemptHolder {
+		private final Formula empty = EmptyFormula.INSTANCE;
+		private final Formula skip = SkipFormula.INSTANCE;
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexTest.java
@@ -25,7 +25,9 @@ package io.evitadb.index.attribute;
 
 import io.evitadb.comparator.LocalizedStringComparator;
 import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.core.buffer.TrappedChanges;
 import io.evitadb.dataType.BigDecimalNumberRange;
 import io.evitadb.dataType.ComparableCurrency;
@@ -585,26 +587,26 @@ class FilterIndexTest {
 	class NonTransactionalCacheTest {
 
 		@Test
-		@DisplayName("memoized formula is invalidated on non-tx write")
-		void shouldInvalidateMemoizedFormulaOnNonTransactionalWrite() {
+		@DisplayName("memoized bitmap is invalidated on non-tx write")
+		void shouldInvalidateMemoizedBitmapOnNonTransactionalWrite() {
 			final OwnerFilterIndex index = new OwnerFilterIndex(
 				new AttributeIndexKey(null, "a", null), String.class
 			);
 			index.addRecord(1, "A");
 
-			// first call caches the formula
-			final Formula firstCall = index.getAllRecordsFormula();
+			// first call caches the bitmap
+			final Bitmap firstCall = index.getAllRecords();
 			// second call returns same cached instance
-			final Formula secondCall = index.getAllRecordsFormula();
+			final Bitmap secondCall = index.getAllRecords();
 			assertSame(firstCall, secondCall);
 
 			// write invalidates the cache
 			index.addRecord(2, "B");
-			final Formula afterWrite = index.getAllRecordsFormula();
+			final Bitmap afterWrite = index.getAllRecords();
 			assertNotSame(firstCall, afterWrite);
 			assertArrayEquals(
 				new int[]{1, 2},
-				afterWrite.compute().getArray()
+				afterWrite.getArray()
 			);
 		}
 	}
@@ -614,8 +616,8 @@ class FilterIndexTest {
 	class FormulaMemoizationTest {
 
 		@Test
-		@DisplayName("getAllRecordsFormula returns same instance when no writes")
-		void shouldReturnSameFormulaInstanceWhenNoWrites() {
+		@DisplayName("getAllRecordsFormula memoizes the bitmap but never the formula")
+		void shouldMemoizeBitmapButHandOutFreshFormula() {
 			final OwnerFilterIndex index = new OwnerFilterIndex(
 				new AttributeIndexKey(null, "a", null), String.class
 			);
@@ -625,7 +627,15 @@ class FilterIndexTest {
 			final Formula first = index.getAllRecordsFormula();
 			final Formula second = index.getAllRecordsFormula();
 
-			assertSame(first, second);
+			// a formula node carries per-query state once a plan initializes it, so an index-lifetime structure
+			// must never hand out the same instance twice - see FilterIndex#memoizedAllRecords
+			assertNotSame(first, second);
+			// the expensive part - the merged bitmap - is still memoized and shared between them
+			assertSame(
+				((ConstantFormula) first).getDelegate(),
+				((ConstantFormula) second).getDelegate()
+			);
+			assertSame(index.getAllRecords(), ((ConstantFormula) first).getDelegate());
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/UniqueIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/UniqueIndexTest.java
@@ -317,8 +317,8 @@ class UniqueIndexTest {
 	class FormulaAndMemoizationTest {
 
 		@Test
-		@DisplayName("getRecordIdsFormula() caches across calls and invalidates on mutation (T8)")
-		void shouldCacheFormulaAndInvalidateOnMutation() {
+		@DisplayName("getRecordIdsFormula() hands out a fresh formula that tracks mutations (T8)")
+		void shouldReturnFreshFormulaTrackingMutations() {
 			final UniqueIndex index = new OwnerUniqueIndex(
 				Entities.PRODUCT,
 				new AttributeIndexKey(null, "code", null),
@@ -326,20 +326,23 @@ class UniqueIndexTest {
 			);
 			index.registerUniqueKey("A", 1);
 
-			// two consecutive calls return the same cached instance
+			// a formula node carries per-query state once a plan initializes it, so an index-lifetime structure
+			// must never hand out the same instance twice - see OwnerUniqueIndex#getRecordIdsFormula
 			final Formula first = index.getRecordIdsFormula();
 			final Formula second = index.getRecordIdsFormula();
-			assertSame(first, second);
+			assertNotSame(first, second);
+			assertArrayEquals(new int[]{1}, second.compute().getArray());
 
-			// mutation invalidates cache — a new formula is returned
+			// a mutation is picked up by the next formula handed out
 			index.registerUniqueKey("B", 2);
 			final Formula afterMutation = index.getRecordIdsFormula();
 			assertNotSame(first, afterMutation);
+			assertArrayEquals(new int[]{1, 2}, afterMutation.compute().getArray());
 		}
 
 		@Test
-		@DisplayName("getRecordIdsFormula() cache invalidation on unregister")
-		void shouldInvalidateCacheOnUnregister() {
+		@DisplayName("getRecordIdsFormula() reflects an unregister in the next formula handed out")
+		void shouldReflectUnregisterInNextFormula() {
 			final UniqueIndex index = new OwnerUniqueIndex(
 				Entities.PRODUCT,
 				new AttributeIndexKey(null, "code", null),
@@ -349,9 +352,12 @@ class UniqueIndexTest {
 			index.registerUniqueKey("B", 2);
 
 			final Formula before = index.getRecordIdsFormula();
+			assertArrayEquals(new int[]{1, 2}, before.compute().getArray());
+
 			index.unregisterUniqueKey("A", 1);
 			final Formula after = index.getRecordIdsFormula();
 			assertNotSame(before, after);
+			assertArrayEquals(new int[]{2}, after.compute().getArray());
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bitmap/BaseBitmapTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bitmap/BaseBitmapTest.java
@@ -1533,9 +1533,10 @@ class BaseBitmapTest {
 		@Test
 		@DisplayName("should invalidate the hash when add inserts a record")
 		void shouldInvalidateHashWhenAddInsertsRecord() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.add(4);
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
@@ -1554,25 +1555,28 @@ class BaseBitmapTest {
 		@Test
 		@DisplayName("should invalidate the hash when addAll receives an array")
 		void shouldInvalidateHashWhenAddAllReceivesArray() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.addAll(4, 5);
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
 		@DisplayName("should invalidate the hash when addAll receives a bitmap")
 		void shouldInvalidateHashWhenAddAllReceivesBitmap() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.addAll(new BaseBitmap(8, 9));
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
 		@DisplayName("should invalidate the hash when remove deletes a record")
 		void shouldInvalidateHashWhenRemoveDeletesRecord() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.remove(2);
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
@@ -1591,65 +1595,78 @@ class BaseBitmapTest {
 		@Test
 		@DisplayName("should invalidate the hash when removeAll receives an array")
 		void shouldInvalidateHashWhenRemoveAllReceivesArray() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.removeAll(1, 3);
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
 		@DisplayName("should invalidate the hash when removeAll receives a bitmap")
 		void shouldInvalidateHashWhenRemoveAllReceivesBitmap() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.removeAll(new BaseBitmap(1, 2));
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
 		@DisplayName("should invalidate the hash when removeAll applies a predicate")
 		void shouldInvalidateHashWhenRemoveAllAppliesPredicate() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.removeAll((IntPredicate) value -> value % 2 == 0);
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
 		@DisplayName("should invalidate the hash when retainAll applies a predicate")
 		void shouldInvalidateHashWhenRetainAllAppliesPredicate() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.retainAll((IntPredicate) value -> value > 1);
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
 		@DisplayName("should invalidate the hash when the bitmap is cleared")
 		void shouldInvalidateHashWhenBitmapIsCleared() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.clear();
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		/**
-		 * Builds a three-record bitmap and warms its content-hash memo, so the caller's mutation is the thing that
-		 * decides whether the next {@link BaseBitmap#getContentHash} recomputes.
+		 * Builds a three-record bitmap and warms its content-hash memo **with the caller's own function**, so the
+		 * mutation the caller then performs is the only thing that can decide whether the next
+		 * {@link BaseBitmap#getContentHash} recomputes.
+		 *
+		 * Warming with any other instance would defeat the whole check: the memo is keyed by function identity, so a
+		 * later call carrying a different one misses it whether or not the mutator cleared anything, and the
+		 * assertion would hold even against a `BaseBitmap` that never invalidates.
 		 */
 		@Nonnull
-		private BaseBitmap seedAndHash() {
+		private BaseBitmap seedAndHash(@Nonnull CountingHashFunction hashFunction) {
 			final BaseBitmap bitmap = new BaseBitmap(1, 2, 3);
-			bitmap.getContentHash(LongHashFunction.xx3());
+			bitmap.getContentHash(hashFunction);
 			return bitmap;
 		}
 
 		/**
 		 * Asserts a mutated bitmap answers for its **current** contents and got there by walking them again rather
-		 * than replaying the memo warmed by {@link #seedAndHash()}.
+		 * than replaying the memo {@link #seedAndHash(CountingHashFunction)} warmed with this same function — one
+		 * walk for the seeding, a second forced by the mutation.
 		 */
-		private void assertHashRecomputedAndCorrect(@Nonnull BaseBitmap bitmap) {
-			final CountingHashFunction hashFunction = new CountingHashFunction();
+		private void assertHashRecomputedAndCorrect(
+			@Nonnull BaseBitmap bitmap,
+			@Nonnull CountingHashFunction hashFunction
+		) {
 			assertEquals(
 				hashFunction.hashIntsUncounted(bitmap.getArray()), bitmap.getContentHash(hashFunction),
 				"the content hash must describe the bitmap's current contents"
 			);
-			assertEquals(1, hashFunction.getHashIntsCallCount(), "the mutation must have forced a recomputation");
+			assertEquals(2, hashFunction.getHashIntsCallCount(), "the mutation must have forced a recomputation");
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bitmap/BaseBitmapTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bitmap/BaseBitmapTest.java
@@ -25,6 +25,8 @@ package io.evitadb.index.bitmap;
 
 import com.carrotsearch.hppc.predicates.IntPredicate;
 import io.evitadb.roaringbitmap.PersistentRoaringBitmap;
+import net.openhft.hashing.Access;
+import net.openhft.hashing.LongHashFunction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -32,6 +34,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import javax.annotation.Nonnull;
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.PrimitiveIterator.OfInt;
 import java.util.Random;
@@ -1474,6 +1478,250 @@ class BaseBitmapTest {
 
 			assertEquals(3, bitmap.size());
 			assertArrayEquals(new int[]{1, 2, 3}, bitmap.getArray());
+		}
+	}
+
+	/**
+	 * Pins the memoized content hash. Two properties matter and they pull in opposite directions:
+	 *
+	 * - it must be memoized, because a `ConstantFormula` over a non-transactional bitmap keys its cache entry on
+	 * this value and index memos build one such formula per query — without the memo that is an `O(size)` walk per
+	 * call (issue #1458);
+	 * - it must never outlive the contents it describes, because the same value is the *sole* cache discriminator
+	 * for those formulas — a stale hash serves one bitmap's cached result for another's contents.
+	 *
+	 * Every mutator therefore gets its own invalidation test. The counting hash function is what distinguishes
+	 * "answered correctly" from "answered correctly *and* recomputed".
+	 */
+	@Nested
+	@DisplayName("Memoized content hash")
+	class ContentHashTest {
+
+		@Test
+		@DisplayName("should hash the contents only once across repeated calls")
+		void shouldHashContentsOnlyOnceAcrossRepeatedCalls() {
+			final BaseBitmap bitmap = new BaseBitmap(1, 2, 3, 4, 5);
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+
+			final long first = bitmap.getContentHash(hashFunction);
+			final long second = bitmap.getContentHash(hashFunction);
+			final long third = bitmap.getContentHash(hashFunction);
+
+			assertEquals(hashFunction.hashIntsUncounted(new int[]{1, 2, 3, 4, 5}), first);
+			assertEquals(first, second);
+			assertEquals(first, third);
+			assertEquals(1, hashFunction.getHashIntsCallCount(), "the contents must be walked exactly once");
+		}
+
+		@Test
+		@DisplayName("should answer correctly for a hash function it has not memoized")
+		void shouldAnswerCorrectlyForForeignHashFunction() {
+			final BaseBitmap bitmap = new BaseBitmap(7, 9, 11);
+			final CountingHashFunction functionA = new CountingHashFunction(LongHashFunction.xx3(1L));
+			final CountingHashFunction functionB = new CountingHashFunction(LongHashFunction.xx3(2L));
+
+			final long hashA = bitmap.getContentHash(functionA);
+			final long hashB = bitmap.getContentHash(functionB);
+
+			assertNotEquals(hashA, hashB, "differently seeded functions must not answer alike");
+			assertEquals(functionA.hashIntsUncounted(bitmap.getArray()), hashA);
+			assertEquals(functionB.hashIntsUncounted(bitmap.getArray()), hashB);
+			// re-asking the first function must still be correct, even though the memo now holds the second's
+			assertEquals(hashA, bitmap.getContentHash(functionA));
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when add inserts a record")
+		void shouldInvalidateHashWhenAddInsertsRecord() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.add(4);
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should keep the memoized hash when add changes nothing")
+		void shouldKeepMemoizedHashWhenAddChangesNothing() {
+			final BaseBitmap bitmap = new BaseBitmap(1, 2, 3);
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final long before = bitmap.getContentHash(hashFunction);
+
+			assertFalse(bitmap.add(2), "the record is already present");
+
+			assertEquals(before, bitmap.getContentHash(hashFunction));
+			assertEquals(1, hashFunction.getHashIntsCallCount(), "a no-op add must not discard the memo");
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when addAll receives an array")
+		void shouldInvalidateHashWhenAddAllReceivesArray() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.addAll(4, 5);
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when addAll receives a bitmap")
+		void shouldInvalidateHashWhenAddAllReceivesBitmap() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.addAll(new BaseBitmap(8, 9));
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when remove deletes a record")
+		void shouldInvalidateHashWhenRemoveDeletesRecord() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.remove(2);
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should keep the memoized hash when remove changes nothing")
+		void shouldKeepMemoizedHashWhenRemoveChangesNothing() {
+			final BaseBitmap bitmap = new BaseBitmap(1, 2, 3);
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final long before = bitmap.getContentHash(hashFunction);
+
+			assertFalse(bitmap.remove(42), "the record was never present");
+
+			assertEquals(before, bitmap.getContentHash(hashFunction));
+			assertEquals(1, hashFunction.getHashIntsCallCount(), "a no-op remove must not discard the memo");
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when removeAll receives an array")
+		void shouldInvalidateHashWhenRemoveAllReceivesArray() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.removeAll(1, 3);
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when removeAll receives a bitmap")
+		void shouldInvalidateHashWhenRemoveAllReceivesBitmap() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.removeAll(new BaseBitmap(1, 2));
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when removeAll applies a predicate")
+		void shouldInvalidateHashWhenRemoveAllAppliesPredicate() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.removeAll((IntPredicate) value -> value % 2 == 0);
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when retainAll applies a predicate")
+		void shouldInvalidateHashWhenRetainAllAppliesPredicate() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.retainAll((IntPredicate) value -> value > 1);
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when the bitmap is cleared")
+		void shouldInvalidateHashWhenBitmapIsCleared() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.clear();
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		/**
+		 * Builds a three-record bitmap and warms its content-hash memo, so the caller's mutation is the thing that
+		 * decides whether the next {@link BaseBitmap#getContentHash} recomputes.
+		 */
+		@Nonnull
+		private BaseBitmap seedAndHash() {
+			final BaseBitmap bitmap = new BaseBitmap(1, 2, 3);
+			bitmap.getContentHash(LongHashFunction.xx3());
+			return bitmap;
+		}
+
+		/**
+		 * Asserts a mutated bitmap answers for its **current** contents and got there by walking them again rather
+		 * than replaying the memo warmed by {@link #seedAndHash()}.
+		 */
+		private void assertHashRecomputedAndCorrect(@Nonnull BaseBitmap bitmap) {
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			assertEquals(
+				hashFunction.hashIntsUncounted(bitmap.getArray()), bitmap.getContentHash(hashFunction),
+				"the content hash must describe the bitmap's current contents"
+			);
+			assertEquals(1, hashFunction.getHashIntsCallCount(), "the mutation must have forced a recomputation");
+		}
+	}
+
+	/**
+	 * {@link LongHashFunction} that records how many times {@link #hashInts(int[])} — the single entry point
+	 * {@link Bitmap#getContentHash(LongHashFunction)} uses — was actually invoked, so a test can tell a memo hit
+	 * from a recomputation. Everything else is plain delegation.
+	 */
+	private static final class CountingHashFunction extends LongHashFunction {
+		@Serial private static final long serialVersionUID = 6002348816451219923L;
+		private final LongHashFunction delegate;
+		private int hashIntsCallCount;
+
+		CountingHashFunction() {
+			this(LongHashFunction.xx3());
+		}
+
+		CountingHashFunction(@Nonnull LongHashFunction delegate) {
+			this.delegate = delegate;
+		}
+
+		int getHashIntsCallCount() {
+			return this.hashIntsCallCount;
+		}
+
+		/**
+		 * Computes the same value as {@link #hashInts(int[])} without disturbing the call count, so a test can
+		 * state its expectation without paying for it.
+		 */
+		long hashIntsUncounted(@Nonnull int[] input) {
+			return this.delegate.hashInts(input);
+		}
+
+		@Override
+		public long hashInts(int[] input) {
+			this.hashIntsCallCount++;
+			return this.delegate.hashInts(input);
+		}
+
+		@Override
+		public long hashLong(long input) {
+			return this.delegate.hashLong(input);
+		}
+
+		@Override
+		public long hashInt(int input) {
+			return this.delegate.hashInt(input);
+		}
+
+		@Override
+		public long hashShort(short input) {
+			return this.delegate.hashShort(input);
+		}
+
+		@Override
+		public long hashChar(char input) {
+			return this.delegate.hashChar(input);
+		}
+
+		@Override
+		public long hashByte(byte input) {
+			return this.delegate.hashByte(input);
+		}
+
+		@Override
+		public long hashVoid() {
+			return this.delegate.hashVoid();
+		}
+
+		@Override
+		public <T> long hash(T input, Access<T> access, long off, long len) {
+			return this.delegate.hash(input, access, off, len);
 		}
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/hierarchy/HierarchyIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/hierarchy/HierarchyIndexTest.java
@@ -25,6 +25,7 @@ package io.evitadb.index.hierarchy;
 
 import io.evitadb.api.query.order.TraversalMode;
 import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.deferred.DeferredFormula;
 import io.evitadb.exception.EvitaInvalidUsageException;
@@ -1233,13 +1234,19 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 		}
 
 		@Test
-		@DisplayName("getAllHierarchyNodesFormula memoization: same reference on second call")
-		void shouldMemoizeAllNodesFormula() {
+		@DisplayName("getAllHierarchyNodesFormula memoizes the bitmap but never the formula")
+		void shouldMemoizeAllNodesBitmapButHandOutFreshFormula() {
 			final Formula first = HierarchyIndexTest.this.hierarchyIndex
 				.getAllHierarchyNodesFormula();
 			final Formula second = HierarchyIndexTest.this.hierarchyIndex
 				.getAllHierarchyNodesFormula();
-			assertSame(first, second);
+			// a formula node carries per-query state once a plan initializes it, so an index-lifetime structure
+			// must never hand out the same instance twice - see HierarchyIndex#memoizedAllNodes
+			assertNotSame(first, second);
+			// the expensive part - the O(nodes) walk producing the bitmap - is still memoized
+			final Bitmap memoizedNodes = HierarchyIndexTest.this.hierarchyIndex.getAllHierarchyNodes();
+			assertSame(memoizedNodes, HierarchyIndexTest.this.hierarchyIndex.getAllHierarchyNodes());
+			assertSame(memoizedNodes, ((ConstantFormula) first).getDelegate());
 		}
 
 		@Test
@@ -1285,38 +1292,38 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 	class NonTransactionalModeTest {
 
 		@Test
-		@DisplayName("memoized formula reset after non-transactional addNode")
-		void shouldResetMemoizedFormulaOnAdd() {
+		@DisplayName("memoized bitmap reset after non-transactional addNode")
+		void shouldResetMemoizedBitmapOnAdd() {
 			final HierarchyIndex index = new HierarchyIndex();
 			index.addNode(1, null);
 
-			final Formula first = index.getAllHierarchyNodesFormula();
-			assertArrayEquals(new int[]{1}, first.compute().getArray());
+			final Bitmap first = index.getAllHierarchyNodes();
+			assertArrayEquals(new int[]{1}, first.getArray());
 
 			// add another node outside transaction
 			index.addNode(2, null);
 
-			final Formula second = index.getAllHierarchyNodesFormula();
-			assertArrayEquals(new int[]{1, 2}, second.compute().getArray());
-			// formula should have been refreshed
+			final Bitmap second = index.getAllHierarchyNodes();
+			assertArrayEquals(new int[]{1, 2}, second.getArray());
+			// the memoized bitmap should have been refreshed
 			assertNotSame(first, second);
 		}
 
 		@Test
-		@DisplayName("memoized formula reset after non-transactional removeNode")
-		void shouldResetMemoizedFormulaOnRemove() {
+		@DisplayName("memoized bitmap reset after non-transactional removeNode")
+		void shouldResetMemoizedBitmapOnRemove() {
 			final HierarchyIndex index = new HierarchyIndex();
 			index.addNode(1, null);
 			index.addNode(2, 1);
 
-			final Formula first = index.getAllHierarchyNodesFormula();
-			assertArrayEquals(new int[]{1, 2}, first.compute().getArray());
+			final Bitmap first = index.getAllHierarchyNodes();
+			assertArrayEquals(new int[]{1, 2}, first.getArray());
 
 			// remove node outside transaction
 			index.removeNode(2);
 
-			final Formula second = index.getAllHierarchyNodesFormula();
-			assertArrayEquals(new int[]{1}, second.compute().getArray());
+			final Bitmap second = index.getAllHierarchyNodes();
+			assertArrayEquals(new int[]{1}, second.getArray());
 			assertNotSame(first, second);
 		}
 	}


### PR DESCRIPTION
Fixes the index-lifetime formula memoization that leaked sessions and catalog generations in production.

Closes #1458

## What leaked

`AbstractFormula#initialize(QueryExecutionContext)` writes the executing query's context onto every node of the plan it is part of. Three index structures memoized a `Formula` for the **lifetime of the index** and handed the same instance to successive query plans, so the first query to touch one pinned its session — and the whole catalog generation reachable from it — until the index was next written to. On a read-mostly index that is never.

Measured on decodoma production (ks02, evitaDB 2026.1.15): the post-GC live heap floor climbed **8.30 → 14.43 GB over 45 h (~139 MB/h)** against a 22 GiB maximum, never recovering, with 126 closed sessions and ≥41 catalog generations still reachable.

**Read this before opening the session lifecycle:** 5,107,029 sessions were opened over the pod's life and 126 survived — **1 in 40,531**. Session close and deregistration are provably correct; this is a rare *pin*, not a lifecycle failure.

## The fix

Memoize the **bitmap** — the part that is actually expensive — and build a fresh `ConstantFormula` wrapper per call.

| Site | Change |
|---|---|
| `FilterIndex` | `memoizedAllRecordsFormula` → `memoizedAllRecords` (`Bitmap`) |
| `OwnerUniqueIndex` | memo deleted outright — `recordIds` was already the bitmap |
| `HierarchyIndex` | `memoizedAllNodeFormula` → `memoizedAllNodes` (`Bitmap`) |

`HierarchyIndex` had **no observed contamination** (0 of 101,794 instances, no main-source caller outside the class). It is converted so the shape does not survive as a template, not because it was leaking.

`OwnerUniqueIndex` losing its invalidation-on-mutation is correct: its formula always wrapped `this.recordIds`, a `TransactionalBitmap` mutated in place, so invalidation never changed the computed result — only the hash and cost captured at construction. Building fresh means those are never stale.

## Sweep — what was checked and left alone

- **`InvertedIndexSubSet#memoizedResult`** — the only index-lifetime subset is `FilterIndex#memoizedRangeHistogramSubSet`, whose sole consumer (`AttributeHistogramComputer`) reads `getBuckets()` and never `getFormula()`. Bitmap memoization is *not* available here — the aggregation lambda may return a lazy `DeferredFormula`, so materializing eagerly would change behaviour. Recorded as a JavaDoc invariant at the field instead.
- **`GlobalEntityIndex.GlobalIndexProxyState`** — memoizes a formula, but is built per query plan in `QueryPlanningContext`, so it is query-lifetime.
- **`EntityIndex`, `GlobalUniqueIndex`, `RangeIndex`, `InvertedIndex`, `AbstractPriceListAndCurrencyPriceIndex`** — all build a fresh formula per call already.

## Rejected: a no-op `ConstantFormula#initialize`

The cheaper option — give `ConstantFormula` the same no-op `initialize` that `EmptyFormula` and `SkipFormula` already have. Rejected because it is a per-class exemption, and this codebase has already lost that game twice; those two singletons *are* the previous rounds. The one case that would have justified it does not hold: `InvertedIndexSubSet`'s lambda returns an `OrFormula` or `DeferredFormula` in the multi-bucket case, so a `ConstantFormula` exemption protects nothing there.

Passing the context through `compute(...)` instead of storing it on the node is the structurally correct fix and would make the invariant unrepresentable, but it changes the `Formula` interface and every implementation — not a patch-release change. Worth revisiting for a major.

## Tests

221 tests green in `FilterIndexTest`, `UniqueIndexTest`, `UniqueIndexViewTest`, `HierarchyIndexTest`, `IndexFormulaRetentionTest`.

**The test diff is not a loosening of coverage** — it is the contract change:

- **`IndexFormulaRetentionTest` (new)** reflects over the index types' fields and fails on any retained `Formula`, exempting only the `EmptyFormula`/`SkipFormula` singletons. It **calibrates itself** against a deliberately leaky holder, so it cannot silently degrade into inspecting nothing.
- **Three tests asserted the formula reference identity being removed** and were *inverted* — they now assert successive calls return *different* formula instances over the *same* memoized bitmap.
- **Four invalidation tests moved from formula identity to bitmap identity**, because `assertNotSame` on formulas is now trivially true and those tests would otherwise have stopped testing invalidation at all while still passing.

## Notes for review

- **This PR targets `master` directly**, rather than going through a `hotfix-2026-2-N` aggregation branch as #1452 did. That was the explicit instruction; flagging it because merging to master appears to trigger a release.
- **The ADR lands in the `dev` PR, not this one.** It is one record for one line of work, and it documents heap-accounting changes that exist only on `dev` (`IndexHeapSize` and both heap-size test classes are dev-only, which is also why this diff is much smaller than the dev one).
- `HierarchyIndex#getAllHierarchyNodes()` is new public API — additive, read-only, and the exact analogue of the already-public `FilterIndex#getAllRecords()`.
- `FilterIndex#getAllRecords()` no longer round-trips through a formula. Object identity is unchanged: `AbstractFormula#compute()` memoizes `computeInternal()`, and `ConstantFormula#computeInternal()` returns `this.delegate` — so the old path already handed out this same internal bitmap.


---

## Follow-up in this PR: the per-call content hash, found and fixed

`ConstantFormula` hashes a **non-transactional** delegate's *contents* in `includeAdditionalHash`, and `AbstractFormula#initFields` computes that eagerly in the constructor. Once a filter index's value tree holds more than one bucket, the memoized all-records bitmap is a `BaseBitmap` — not a `TransactionalLayerProducer` — so every `getAllRecordsFormula()` call paid `O(records)` where the old formula memo paid it once. That is not a mere optimization either: such a formula gathers **no** transactional ids, so the content hash is its *sole* cache discriminator.

**The fix:** move the memo onto the bitmap. `Bitmap#getContentHash(LongHashFunction)` defaults to the walk; `BaseBitmap` memoizes it. Because an index hands out the same `BaseBitmap` **instance** every time, the walk happens once and every later formula reads it back — while the index still retains no `Formula`, so the invariant and `IndexFormulaRetentionTest` are untouched. Rejected alternative: a `ConstantFormula` overload taking a precomputed hash, which adds public API, needs a "no hash supplied" sentinel, and helps only the two call sites that thread it through.

Measured on a seeded `OwnerFilterIndex` (one distinct value per 10 records, so the aggregation genuinely merges buckets) — added cost per `getAllRecordsFormula()` call:

| records | bitmap memo alone | bitmap memo + content hash |
|---:|---:|---:|
| 1,000 | 1,410 ns | **68 ns** |
| 10,000 | 10,240 ns | **162 ns** |
| 100,000 | 83,396 ns | **366 ns** |
| 500,000 | 308,516 ns | **60 ns** |

The remainder no longer scales with record count — it is the allocation plus `initFields`' scalars, and the scatter across sizes says it now sits below that harness's noise floor.

**Two things worth a reviewer's eye:**
- The memo is keyed by **hash function identity**, not assumed global — `CacheEnforcingPolicy` builds its own instance from the same factory as `TransactionalDataRelatedStructure#HASH_FUNCTION`, and a memo ignoring that would answer one function's question with another's hash.
- `BaseBitmap` is `@NotThreadSafe` yet the memo is read concurrently. The guard field is written **after** the hash with volatile semantics, so a racing reader either misses the memo and recomputes an identical value or sees a fully published one. Mutation concurrent with reads was already outside the class' contract.

**Invalidation had to be exhaustive**, and a sweep confirmed it can be: no site in main sources mutates a `PersistentRoaringBitmap` in place *after* wrapping it in a `BaseBitmap` — `OrFormula#computeInternal`, `HierarchyIndex#listNodesIncludingParents`, `createAllHierarchyNodesBitmap`, `BitmapChanges#getMergedBitmap` and both sorters' `notFoundRecords` each build a fresh local and wrap it last. All nine mutators clear the memo alongside `memoizedCardinality`.

**Scope of the original exposure was narrow:** only `AttributeIsTranslator` (an `attributeIs(NULL|NOT_NULL)` filter) and `AttributeHistogramComputer` ask for the formula. `OwnerUniqueIndex` was never affected (its delegate is a `TransactionalBitmap`, so the key is its transactional id), nor was `HierarchyIndex` in practice, nor a single-bucket filter index.

**Tests:** `BaseBitmapTest.ContentHashTest` — 13 cases using a counting `LongHashFunction` delegate, so each distinguishes "answered correctly" from "answered correctly *and* recomputed": one memo-hit, one foreign-function, nine invalidation (one per mutator), two asserting a **no-op** `add`/`remove` keeps the memo.


### Follow-up: the memo's publication was wrong, and is now an atomic pair

Caught by review after the above landed. The memo held the hash in a plain `long` and its function in a `volatile` reference written afterwards as a guard — the textbook safe-publication idiom, and correct for a **single** writer. It does not make a *pair* atomic, and this memo keys on one field and answers from the other:

```
T1  memoizedContentHash = hashA
T2  memoizedContentHash = hashB
T2  guard = B
T1  guard = A            <- guard names A, value is hashB
```

A third caller matching the guard then receives a hash never computed for the function it asked for. Since a `ConstantFormula` over a non-transactional delegate gathers no transactional ids, that hash is its *sole* cache discriminator — so this is a wrong cache key, not a slow one.

Both are now held in one immutable record published by a single volatile reference write. A record's final fields are safely published even through a data race, so a reader sees either `null` or a consistent pair, and racing writers can only overwrite each other with individually-consistent ones.

Not reachable from main sources today — only `TransactionalDataRelatedStructure#HASH_FUNCTION` ever reaches `getContentHash` — but it is public interface API and the keying exists precisely for callers that bring their own function, so the guarantee has to actually hold. Re-calibrated: removing the invalidation from all nine mutators still fails all nine `ContentHashTest` invalidation tests.
