### PR TITLE
fix: memoize index bitmaps instead of formulas, which pinned query execution contexts

### DIFF
--- a/documentation/adr/2026-08-28-index-lifetime-formula-memoization.md
+++ b/documentation/adr/2026-08-28-index-lifetime-formula-memoization.md
@@ -174,6 +174,23 @@ unrepresentable rather than merely documented and tested.
   divergence rather than a strictly positive one, and the existing non-growth assertion pins that it stays a
   constant. Not chased here: it is a bitmap-accounting question, independent of this leak, and fixing it
   inside a hotfix would put unrelated risk on the release line.
+- **A CPU regression was traded for the memory fix on one path, and it is not small.** `ConstantFormula`
+  hashes a non-transactional delegate's **contents** in its constructor (`AbstractFormula#initFields` computes
+  the hash eagerly). A filter index whose value tree holds more than one bucket memoizes a `BaseBitmap`, which
+  is not a `TransactionalLayerProducer`, so every `getAllRecordsFormula()` call now pays `O(records)` where the
+  old formula memo paid it once. Measured on a seeded `OwnerFilterIndex`: **+1.4 µs at 1k records, +10 µs at
+  10k, +83 µs at 100k, +309 µs at 500k**, against ~1–18 ns for the memoized bitmap alone.
+
+  Only two read paths ask for the formula — `AttributeIsTranslator` (an `attributeIs(NULL|NOT_NULL)` filter)
+  and `AttributeHistogramComputer` (once per attribute index in a histogram request). `OwnerUniqueIndex` is
+  **not** affected: its delegate is a `TransactionalBitmap`, so the hash is its transactional id and
+  construction stays `O(1)`. `HierarchyIndex` is not affected in practice because no main-source caller asks
+  it for a formula.
+
+  The fix is to memoize the content hash beside the bitmap and hand it to a `ConstantFormula` overload — zero
+  formula retained, so the invariant and its guard test are untouched. Deliberately **not** done here: it adds
+  public API to `ConstantFormula` and the leak was the urgent problem. This was found after both PRs opened
+  and is recorded so the trade is visible rather than discovered in a profile.
 - **`OwnerUniqueIndex` contamination was never observed**, only derived from source. The production dump was
   a truncated 15% prefix, and the 752/752 contaminated memos it did show were all `FilterIndex`. A complete
   dump would confirm it.

--- a/documentation/adr/2026-08-28-index-lifetime-formula-memoization.md
+++ b/documentation/adr/2026-08-28-index-lifetime-formula-memoization.md
@@ -1,12 +1,12 @@
 ---
 title: Index caches memoize the bitmap, never the formula, because a formula node carries per-query state
 date: 2026-08-28
-updated: 2026-08-28 11:40
+updated: 2026-08-28 13:05
 status: accepted
 kind: fix
 issues: [1458]
 prs: [1459, 1460]
-areas: [evita_engine/io/evitadb/index/attribute, evita_engine/io/evitadb/index/hierarchy, evita_engine/io/evitadb/core/query/algebra]
+areas: [evita_engine/io/evitadb/index/attribute, evita_engine/io/evitadb/index/hierarchy, evita_engine/io/evitadb/index/bitmap, evita_engine/io/evitadb/core/query/algebra]
 supersedes: []
 superseded-by: []
 relates: []
@@ -156,6 +156,22 @@ unrepresentable rather than merely documented and tested.
   `assertNotSame` on formulas is now trivially true and would have silently stopped testing invalidation at
   all: the non-transactional add/remove tests in `FilterIndexTest` and `HierarchyIndexTest`, and the
   unregister test in `UniqueIndexTest`.
+- `BaseBitmapTest.ContentHashTest` pins the content-hash memo from both sides, using a counting
+  `LongHashFunction` delegate so each case distinguishes "answered correctly" from "answered correctly *and*
+  recomputed": one memo-hit test, one foreign-hash-function test, one invalidation test per mutator (nine),
+  and two asserting that a **no-op** `add`/`remove` keeps the memo.
+- The cost the memo removes was measured on a seeded `OwnerFilterIndex`, timing `getAllRecordsFormula()`
+  against `getAllRecords()` over 5 rounds after a 20k-call warmup. Added cost per call:
+
+  | records | bitmap memo alone | bitmap memo + content hash |
+  |--------:|------------------:|---------------------------:|
+  |   1,000 |          1,410 ns |                      68 ns |
+  |  10,000 |         10,240 ns |                     162 ns |
+  | 100,000 |         83,396 ns |                     366 ns |
+  | 500,000 |        308,516 ns |                      60 ns |
+
+  The remainder no longer scales with record count — it is the allocation plus `initFields`' scalars, and the
+  scatter across sizes says it now sits below that harness's noise floor.
 
 ## Consequences & open follow-ups
 
@@ -174,23 +190,57 @@ unrepresentable rather than merely documented and tested.
   divergence rather than a strictly positive one, and the existing non-growth assertion pins that it stays a
   constant. Not chased here: it is a bitmap-accounting question, independent of this leak, and fixing it
   inside a hotfix would put unrelated risk on the release line.
-- **A CPU regression was traded for the memory fix on one path, and it is not small.** `ConstantFormula`
-  hashes a non-transactional delegate's **contents** in its constructor (`AbstractFormula#initFields` computes
-  the hash eagerly). A filter index whose value tree holds more than one bucket memoizes a `BaseBitmap`, which
-  is not a `TransactionalLayerProducer`, so every `getAllRecordsFormula()` call now pays `O(records)` where the
-  old formula memo paid it once. Measured on a seeded `OwnerFilterIndex`: **+1.4 µs at 1k records, +10 µs at
-  10k, +83 µs at 100k, +309 µs at 500k**, against ~1–18 ns for the memoized bitmap alone.
+- **The bitmap now memoizes its own content hash, because Option A on its own was a real CPU regression.**
+  `ConstantFormula` hashes a non-transactional delegate's **contents** in its constructor
+  (`AbstractFormula#initFields` computes the hash eagerly), and it gathers no transactional ids for such a
+  delegate — so that hash is the formula's *sole* cache discriminator, not an optimization. A filter index
+  whose value tree holds more than one bucket memoizes a `BaseBitmap`, which is not a
+  `TransactionalLayerProducer`, so every `getAllRecordsFormula()` call paid `O(records)` where the old formula
+  memo paid it once: **+1.4 µs at 1k records, +10 µs at 100k… +309 µs at 500k**, against ~1–18 ns for the
+  memoized bitmap alone.
 
-  Only two read paths ask for the formula — `AttributeIsTranslator` (an `attributeIs(NULL|NOT_NULL)` filter)
-  and `AttributeHistogramComputer` (once per attribute index in a histogram request). `OwnerUniqueIndex` is
-  **not** affected: its delegate is a `TransactionalBitmap`, so the hash is its transactional id and
-  construction stays `O(1)`. `HierarchyIndex` is not affected in practice because no main-source caller asks
-  it for a formula.
+  Because the index hands out the same `BaseBitmap` **instance** every time, the hash belongs on the bitmap:
+  `Bitmap#getContentHash` defaults to the walk and `BaseBitmap` memoizes it. Zero formula is retained, so the
+  invariant and `IndexFormulaRetentionTest` are untouched, and the cost drops back to one allocation.
 
-  The fix is to memoize the content hash beside the bitmap and hand it to a `ConstantFormula` overload — zero
-  formula retained, so the invariant and its guard test are untouched. Deliberately **not** done here: it adds
-  public API to `ConstantFormula` and the leak was the urgent problem. This was found after both PRs opened
-  and is recorded so the trade is visible rather than discovered in a profile.
+  The alternative considered was a `ConstantFormula` overload taking a precomputed hash, with the index
+  memoizing the hash beside the bitmap. **Rejected because** it adds public API to `ConstantFormula`, needs a
+  sentinel for "no hash supplied", and helps only the two call sites that thread it through — whereas the
+  bitmap-side memo helps every `ConstantFormula` built over a repeated `BaseBitmap` anywhere in the engine.
+
+  Two details a reader will otherwise trip on. The memo is keyed by the **hash function identity**, not
+  assumed global: `CacheEnforcingPolicy` builds its own instance from the same factory as
+  `TransactionalDataRelatedStructure#HASH_FUNCTION`, and a memo that ignored that would answer one function's
+  question with another's hash. And `BaseBitmap` is `@NotThreadSafe` yet the memo is read concurrently — the
+  guard field is written *after* the hash with volatile semantics, so a racing reader either misses the memo
+  and recomputes an identical value or sees a fully published one. Mutation concurrent with reads was already
+  outside the class' contract and stays there; every mutator clears the memo alongside `memoizedCardinality`.
+
+  The invalidation had to be exhaustive, and a sweep confirmed it can be: no site in main sources mutates a
+  `PersistentRoaringBitmap` in place after wrapping it in a `BaseBitmap` — `OrFormula#computeInternal`,
+  `HierarchyIndex#listNodesIncludingParents`, `createAllHierarchyNodesBitmap`, `BitmapChanges#getMergedBitmap`
+  and both sorters' `notFoundRecords` each build a fresh local and wrap it last. `getRoaringBitmap()` hands
+  out the internal reference and would bypass the memo, exactly as it already bypasses `memoizedCardinality`;
+  if that ever changes, this memo must be scoped.
+
+  Only two read paths ever asked for the formula — `AttributeIsTranslator` (an `attributeIs(NULL|NOT_NULL)`
+  filter) and `AttributeHistogramComputer` (once per attribute index in a histogram request).
+  `OwnerUniqueIndex` was never affected: its delegate is a `TransactionalBitmap`, so the key is its
+  transactional id and construction was always `O(1)`. `HierarchyIndex` was not affected in practice because
+  no main-source caller asks it for a formula.
+- **The memo made a heap test fail *warm* while passing cold, and neither cause was the obvious one.** Both
+  were settled against a JOL walk rather than by reasoning, and both are worth knowing before touching
+  `BaseBitmap#getHeapSizeInBytes`:
+  - Adding a `long` field does **not** need an alignment term. A `long` must start 8-aligned and the object
+    header is 12 bytes, so the arithmetic looks like it should charge 4 bytes of padding — but the JVM packs
+    the existing `int` into that gap and the `long` lands aligned for free. Adding the term over-reported by
+    8 bytes per bitmap.
+  - The memo's guard field points at `TransactionalDataRelatedStructure#HASH_FUNCTION`, one instance for the
+    whole JVM. The arithmetic correctly charges nothing for it, but a walk reaches it and charges 16 bytes —
+    and only once the memo is populated, which is why the same fixture passed cold and failed warm. It is now
+    in `IndexHeapSizeAssertions#SHARED_EMPTY_ARRAYS`. It is the first entry there that is absent from a cold
+    index, so a future heap test failing by exactly one object should look here before suspecting its own
+    arithmetic.
 - **`OwnerUniqueIndex` contamination was never observed**, only derived from source. The production dump was
   a truncated 15% prefix, and the 752/752 contaminated memos it did show were all `FilterIndex`. A complete
   dump would confirm it.

--- a/documentation/adr/2026-08-28-index-lifetime-formula-memoization.md
+++ b/documentation/adr/2026-08-28-index-lifetime-formula-memoization.md
@@ -1,7 +1,7 @@
 ---
 title: Index caches memoize the bitmap, never the formula, because a formula node carries per-query state
 date: 2026-08-28
-updated: 2026-08-28 13:05
+updated: 2026-08-28 13:25
 status: accepted
 kind: fix
 issues: [1458]
@@ -211,10 +211,21 @@ unrepresentable rather than merely documented and tested.
   Two details a reader will otherwise trip on. The memo is keyed by the **hash function identity**, not
   assumed global: `CacheEnforcingPolicy` builds its own instance from the same factory as
   `TransactionalDataRelatedStructure#HASH_FUNCTION`, and a memo that ignored that would answer one function's
-  question with another's hash. And `BaseBitmap` is `@NotThreadSafe` yet the memo is read concurrently — the
-  guard field is written *after* the hash with volatile semantics, so a racing reader either misses the memo
-  and recomputes an identical value or sees a fully published one. Mutation concurrent with reads was already
-  outside the class' contract and stays there; every mutator clears the memo alongside `memoizedCardinality`.
+  question with another's hash. And `BaseBitmap` is `@NotThreadSafe` yet the memo is read concurrently, so the
+  hash and the function it belongs to are held in **one immutable record**, published by a single volatile
+  reference write. Mutation concurrent with reads was already outside the class' contract and stays there;
+  every mutator clears the memo alongside `memoizedCardinality`.
+
+  **The first attempt at that publication was wrong, and the way it was wrong is the point.** It used two
+  fields — a plain `long` written first, a `volatile` function reference written second as a guard — which is
+  the textbook safe-publication idiom and is correct for a *single* writer. It is not correct here: two threads
+  hashing with different functions can interleave so that the guard ends up naming one function while the value
+  belongs to the other, after which a third caller matches the guard and receives a hash never computed for the
+  function it asked about. That is a wrong cache key, not a slow one. The idiom publishes a value; it does not
+  make a *pair* atomic, and a memo that keys on one field and answers from another needs the latter. Not
+  reachable from main sources today — only `HASH_FUNCTION` ever reaches `getContentHash` — but the keying
+  exists precisely to support callers that bring their own, so the guarantee has to hold. Splitting the record
+  back into two fields for the allocation would reintroduce it.
 
   The invalidation had to be exhaustive, and a sweep confirmed it can be: no site in main sources mutates a
   `PersistentRoaringBitmap` in place after wrapping it in a `BaseBitmap` — `OrFormula#computeInternal`,
@@ -231,11 +242,12 @@ unrepresentable rather than merely documented and tested.
 - **The memo made a heap test fail *warm* while passing cold, and neither cause was the obvious one.** Both
   were settled against a JOL walk rather than by reasoning, and both are worth knowing before touching
   `BaseBitmap#getHeapSizeInBytes`:
-  - Adding a `long` field does **not** need an alignment term. A `long` must start 8-aligned and the object
-    header is 12 bytes, so the arithmetic looks like it should charge 4 bytes of padding — but the JVM packs
-    the existing `int` into that gap and the `long` lands aligned for free. Adding the term over-reported by
-    8 bytes per bitmap.
-  - The memo's guard field points at `TransactionalDataRelatedStructure#HASH_FUNCTION`, one instance for the
+  - A `long` field does **not** need an alignment term, in either object. A `long` must start 8-aligned and
+    the object header is 12 bytes, so the arithmetic looks like it should charge 4 bytes of padding — but both
+    objects carry a 4-byte field the JVM slots into that gap (`memoizedCardinality` in the bitmap, the function
+    reference in the memo record), so the `long` lands aligned for free. This was got wrong twice, once per
+    object, each time over-reporting by exactly 8 bytes; a JOL probe settled it both times.
+  - The memo record points at `TransactionalDataRelatedStructure#HASH_FUNCTION`, one instance for the
     whole JVM. The arithmetic correctly charges nothing for it, but a walk reaches it and charges 16 bytes —
     and only once the memo is populated, which is why the same fixture passed cold and failed warm. It is now
     in `IndexHeapSizeAssertions#SHARED_EMPTY_ARRAYS`. It is the first entry there that is absent from a cold

--- a/documentation/adr/2026-08-28-index-lifetime-formula-memoization.md
+++ b/documentation/adr/2026-08-28-index-lifetime-formula-memoization.md
@@ -1,0 +1,191 @@
+---
+title: Index caches memoize the bitmap, never the formula, because a formula node carries per-query state
+date: 2026-08-28
+updated: 2026-08-28 11:40
+status: accepted
+kind: fix
+issues: [1458]
+prs: [1459]
+areas: [evita_engine/io/evitadb/index/attribute, evita_engine/io/evitadb/index/hierarchy, evita_engine/io/evitadb/core/query/algebra]
+supersedes: []
+superseded-by: []
+relates: []
+---
+
+# Index caches memoize the bitmap, never the formula
+
+Three index structures cached a `Formula` for the lifetime of the index and handed the same instance to
+successive query plans. A formula node is per-query state — the first plan to use one wrote its execution
+context onto it, and that context transitively pinned the session and the entire catalog generation the
+query ran against, permanently. All three now memoize the **bitmap** they were really caching and build a
+fresh `ConstantFormula` wrapper per call.
+
+## Why
+
+Production (decodoma ks02, evitaDB 2026.1.15) leaked a post-GC live heap floor from 8.30 GB to 14.43 GB
+over 45 hours — about 139 MB/h, 3.3 GB/day, against a 22 GiB maximum, never recovering. A heap dump showed
+126 `EvitaSession` instances and at least 41 `Catalog` generations still reachable long after the sessions
+had been closed and killed.
+
+The constraint that made this non-obvious is that **the leak is rare, not systemic**. Over the pod's 50.8-hour
+life 5,107,029 sessions were opened and 126 survived — one in 40,531. Session close and deregistration are
+provably correct: `session_opened_total − session_closed_total` was 0 at the dump, `active_sessions` peaked at
+4, and the inactivity killer fired on schedule. Anyone told "126 leaked sessions" naturally opens the session
+lifecycle, which is the wrong place. What retains them is a rare *pin* from a structure that outlives them.
+
+Growth is coupled to **read** volume rather than writes: the caches are invalidated only when the index is
+written to, so on a read-mostly index they are effectively never cleared. The database leaked faster the more
+it did what it is built for.
+
+### Previous state
+
+`AbstractFormula#initialize(QueryExecutionContext)` stores the context on the node and recurses into inner
+formulas. `FilterIndex#getAllRecordsFormula()`, `OwnerUniqueIndex#getRecordIdsFormula()` and
+`HierarchyIndex#getAllHierarchyNodesFormula()` each memoized the formula they built so that repeated calls
+were cheap.
+
+The hazard was already known — `EmptyFormula#initialize` and `SkipFormula#initialize` are both deliberate
+no-ops carrying a JavaDoc that describes exactly this leak. `FilterIndex` was a single ternary with **one
+branch guarded and one not**:
+
+```java
+this.memoizedAllRecordsFormula = allRecords.isEmpty() ?
+    EmptyFormula.INSTANCE               // initialize() is a no-op — safe
+    : new ConstantFormula(allRecords);  // inherits AbstractFormula.initialize — leaks
+```
+
+## Options considered
+
+### Option A — memoize the bitmap, build a fresh formula per call (chosen)
+
+Keep a `Bitmap` field where a `Formula` field used to be, and wrap it in a new `ConstantFormula` on every
+call. The expensive thing was always the bitmap — the merged OR of all buckets in a filter index, the
+`O(nodes)` walk in a hierarchy index. The formula around it is a few scalars.
+
+- **Pros:** removes the whole category rather than one instance — no index-lifetime object holds query state
+  any more, so the next memoization added to an index cannot reintroduce the leak by inheritance. Also fixes
+  a latent staleness bug: a `ConstantFormula` computes its hash, transactional ids and estimated cost at
+  construction, so a memoized one carried those from whenever it was first built.
+- **Cons:** allocates a small wrapper per call on a hot path, and changes an observable contract — three
+  tests asserted formula reference identity across calls.
+
+### Option B — override `initialize` as a no-op on `ConstantFormula` (declined)
+
+Give `ConstantFormula` the same treatment `EmptyFormula` and `SkipFormula` already have, so that sharing one
+is harmless.
+
+- **Pros:** a single method, no accounting or invalidation changes, and the smallest possible diff for a
+  release branch.
+- **Cons:** a per-class exemption rather than a structural rule; the next memo of a different formula type
+  leaks again.
+- **Rejected because:** it is whack-a-mole, and this codebase has already lost that game twice —
+  `EmptyFormula` and `SkipFormula` are the two previous rounds. The sweep also refutes the one case that
+  would have justified it: `InvertedIndexSubSet#memoizedResult` was the candidate beneficiary, but its
+  aggregation lambda returns an `OrFormula` or a `DeferredFormula` in the multi-bucket case, so a
+  `ConstantFormula` exemption protects nothing there. Revisit only if a formula type must be shared for a
+  reason bitmap memoization cannot serve.
+
+### Option C — pass the context through `compute(...)` instead of storing it on the node (declined)
+
+The structurally correct fix: make execution context a parameter rather than node state, ending the entire
+class of bug.
+
+- **Pros:** no formula node ever holds query state, so the invariant becomes unrepresentable rather than
+  merely documented.
+- **Cons:** changes the `Formula` interface and every implementation, plus the cacheable-formula and
+  price-termination hierarchies that read `this.executionContext` from six different subclasses.
+- **Rejected because:** the blast radius is not a patch-release change and this had to ship to a leaking
+  production system. Worth revisiting for a major version — that is the ADR that would supersede this one.
+
+### Option D — clear the context in a query-teardown hook (declined)
+
+- **Pros:** leaves all caching as-is.
+- **Rejected because:** it depends on teardown always running, so the leak returns on any path that throws
+  first. Acceptable as belt-and-braces, never as the primary fix.
+
+### Option E — hold the context through a weak or soft reference (declined)
+
+- **Rejected because:** it makes catalog reclamation non-deterministic — the heap would still hold whole
+  catalog generations until GC chose to act, which is the symptom rather than the cause.
+
+## Decision
+
+**Chosen: Option A.** The drivers were a leaking production system and a hazard that had already recurred
+twice under per-class fixes. Option A is the only one that makes the *category* go away while remaining
+small enough to backport: it touches three accessors and their caches, and does not move the `Formula`
+interface. Option C wins instead the moment a major version is on the table, because it makes the invariant
+unrepresentable rather than merely documented and tested.
+
+## Key technical details
+
+- **The invariant:** *no object with index lifetime may hold a `QueryExecutionContext`, therefore no
+  index-lifetime field may hold a `Formula`.* `AbstractFormula#initialize` writes the context onto every node
+  of a plan, and it reaches `QueryPlanningContext#evitaSession` and `#catalog` from there.
+- Entry points: `FilterIndex#memoizedAllRecords`, `OwnerUniqueIndex#getRecordIdsFormula` (the field is gone
+  entirely — `recordIds` was already the bitmap), `HierarchyIndex#memoizedAllNodes`.
+- `FilterIndex#getAllRecords()` no longer round-trips through a formula to unwrap a bitmap, and
+  `HierarchyIndex#getAllHierarchyNodes()` is new for the same reason: the bitmap is the primitive and the
+  formula is the wrapper, not the other way round.
+- **`InvertedIndexSubSet#memoizedResult` is deliberately left alone.** It memoizes a formula, but the only
+  index-lifetime subset is `FilterIndex#memoizedRangeHistogramSubSet`, whose sole consumer
+  (`AttributeHistogramComputer`) reads `getBuckets()` and never `getFormula()`. Bitmap memoization is *not*
+  available there — the aggregation lambda may legitimately return a lazy `DeferredFormula`, so materializing
+  eagerly would change behaviour. The constraint is recorded as a JavaDoc invariant at the field.
+- **Counter-intuitive:** `OwnerUniqueIndex` dropped its cache invalidation on mutation and is nonetheless
+  *more* correct. Its formula always wrapped `this.recordIds`, a `TransactionalBitmap` mutated in place, so
+  the invalidation never affected the computed result — only the hash and cost captured at construction.
+  Building fresh means those are never stale.
+- Sites checked and deliberately **not** changed, so they are not re-investigated:
+  `GlobalEntityIndex.GlobalIndexProxyState` memoizes a formula but is built per query plan in
+  `QueryPlanningContext`, so it is query-lifetime; `EntityIndex#getAllPrimaryKeysFormula`,
+  `GlobalUniqueIndex`, `RangeIndex`, `InvertedIndex` and `AbstractPriceListAndCurrencyPriceIndex` all build a
+  fresh formula per call already.
+
+## Verification
+
+- `IndexFormulaRetentionTest` is the enforcement: it reflects over every non-static field of `FilterIndex`,
+  `OwnerUniqueIndex` and `HierarchyIndex` and fails if any retains a `Formula`, exempting only the
+  `EmptyFormula` / `SkipFormula` singletons whose `initialize` is a documented no-op. This is what stops the
+  next memoization from reintroducing the leak; per-class discipline demonstrably did not.
+- Three existing tests asserted the contract that was removed and were **inverted** rather than deleted —
+  they now assert that successive calls return *different* formula instances over the *same* memoized bitmap:
+  `FilterIndexTest#shouldMemoizeBitmapButHandOutFreshFormula`,
+  `UniqueIndexTest#shouldReturnFreshFormulaTrackingMutations`,
+  `HierarchyIndexTest#shouldMemoizeAllNodesBitmapButHandOutFreshFormula`.
+- Four invalidation tests were retargeted from formula identity to bitmap identity, because
+  `assertNotSame` on formulas is now trivially true and would have silently stopped testing invalidation at
+  all: the non-transactional add/remove tests in `FilterIndexTest` and `HierarchyIndexTest`, and the
+  unregister test in `UniqueIndexTest`.
+
+## Consequences & open follow-ups
+
+- **The heap accounting differs by branch.** `IndexHeapSize` and the two heap-size test classes exist only on
+  `dev`; the release line has no accounting for these memos at all. On `dev`,
+  `IndexHeapSize#memoizedFormulaSizeInBytes` loses all three index callers and keeps exactly one,
+  `InvertedIndexSubSet` — its JavaDoc claim to be "the one place a memoized formula is priced" becomes more
+  accurate, not less, so the method stays. The three indexes were never symmetric here and still are not:
+  `HierarchyIndex` charges its bitmap unconditionally, `FilterIndex` only when `getBucketCount() > 1`,
+  because a single-bucket memo aliases the bucket's own bitmap, and `OwnerUniqueIndex` charges nothing
+  because it retains nothing.
+- **Removing the over-charge exposed a pre-existing under-report in `BaseBitmap#getHeapSizeInBytes`** — about
+  two words against a reflective walk, on the order of 16 bytes and constant with data size. It was there
+  before this change and merely masked by the formula scaffolding charged at its upper bound on top of it.
+  `ContainerIndexHeapSizeTest#shouldStepUpOnceTheAllNodesBitmapIsMemoized` now asserts a bounded **signed**
+  divergence rather than a strictly positive one, and the existing non-growth assertion pins that it stays a
+  constant. Not chased here: it is a bitmap-accounting question, independent of this leak, and fixing it
+  inside a hotfix would put unrelated risk on the release line.
+- **`OwnerUniqueIndex` contamination was never observed**, only derived from source. The production dump was
+  a truncated 15% prefix, and the 752/752 contaminated memos it did show were all `FilterIndex`. A complete
+  dump would confirm it.
+- **`HierarchyIndex` had no observed contamination either** — 0 of 101,794 instances, and no main-source
+  caller of `getAllHierarchyNodesFormula()` outside the class. It was converted because it is the same shape,
+  so that the pattern does not survive as a template someone copies.
+- The formula cache was **disabled** on the affected instance (`cache_size_in_bytes = 0`), so this is
+  unrelated to the cache redesign tracked in #37.
+- `io_evitadb_probe_health_problem{MEMORY_SHORTAGE}` stayed 0 throughout, including at 14.43 GB of a 22 GiB
+  heap. evitaDB's own health probe gives no warning for this class of leak — not addressed here.
+
+## Timeline
+
+- **2026-08-27** — heap dump captured from production
+- **2026-08-28** — leak confirmed from heap dump and Prometheus, issue #1458 filed, fix implemented

--- a/documentation/adr/2026-08-28-index-lifetime-formula-memoization.md
+++ b/documentation/adr/2026-08-28-index-lifetime-formula-memoization.md
@@ -5,7 +5,7 @@ updated: 2026-08-28 11:40
 status: accepted
 kind: fix
 issues: [1458]
-prs: [1459]
+prs: [1459, 1460]
 areas: [evita_engine/io/evitadb/index/attribute, evita_engine/io/evitadb/index/hierarchy, evita_engine/io/evitadb/core/query/algebra]
 supersedes: []
 superseded-by: []

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-28 | [Index caches memoize the bitmap, never the formula, because a formula node carries per-query state](2026-08-28-index-lifetime-formula-memoization.md) | fix | accepted | #1458, PR #1459 |
 | 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | accepted | #1433, PR #1435, PR #1436 |
 | 2026-08-24 | [Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers](2026-08-24-grpc-streaming-backpressure-readiness-gate.md) | fix | accepted | #1441, PR #1450, PR #1451 |
 | 2026-08-24 | [Keep the reference bundle in step with the reference collection](2026-08-24-refresh-provisional-representative-key.md) | fix | accepted | #1438, #1444, PR #1442, PR #1443 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-28 | [Index caches memoize the bitmap, never the formula, because a formula node carries per-query state](2026-08-28-index-lifetime-formula-memoization.md) | fix | accepted | #1458, PR #1459 |
+| 2026-08-28 | [Index caches memoize the bitmap, never the formula, because a formula node carries per-query state](2026-08-28-index-lifetime-formula-memoization.md) | fix | accepted | #1458, PR #1459, PR #1460 |
 | 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | accepted | #1433, PR #1435, PR #1436 |
 | 2026-08-24 | [Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers](2026-08-24-grpc-streaming-backpressure-readiness-gate.md) | fix | accepted | #1441, PR #1450, PR #1451 |
 | 2026-08-24 | [Keep the reference bundle in step with the reference collection](2026-08-24-refresh-provisional-representative-key.md) | fix | accepted | #1438, #1444, PR #1442, PR #1443 |

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/ConstantFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/ConstantFormula.java
@@ -81,9 +81,11 @@ public class ConstantFormula extends AbstractFormula {
 		if (this.delegate instanceof TransactionalLayerProducer) {
 			return ((TransactionalLayerProducer<?, ?>) this.delegate).getId();
 		} else {
-			// this shouldn't happen for long arrays - these are expected to be always linked to transactional
-			// bitmaps located in indexes and represented by "transactional id"
-			return hashFunction.hashInts(this.delegate.getArray());
+			// a bitmap that is not part of a transactional layer carries no id to key on, so its contents are what
+			// identify it - and since this formula gathers no transactional ids for such a delegate, that hash is
+			// the sole cache discriminator. The walk is `O(size)`, which is why index memos hand out the same bitmap
+			// instance every time: `BaseBitmap#getContentHash` memoizes it, so only the first formula pays
+			return this.delegate.getContentHash(hashFunction);
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/IndexHeapSize.java
+++ b/evita_engine/src/main/java/io/evitadb/index/IndexHeapSize.java
@@ -106,12 +106,19 @@ public final class IndexHeapSize {
 	 *
 	 * # Why a memoized formula is charged this shallowly
 	 *
-	 * A memoized formula is a query answer an index kept, and every bitmap reachable from one is in exactly one of two
-	 * states, neither of which this figure may follow:
+	 * The sole remaining caller is {@link io.evitadb.index.invertedIndex.InvertedIndexSubSet}. The index structures
+	 * that used to memoize a formula — a filter index's all-records union, an owner unique index's record ids, a
+	 * hierarchy index's node set — memoize the **bitmap** instead and build a fresh wrapper per call, because a
+	 * formula node retains the execution context of the first query to initialize it and would pin that query's
+	 * session and catalog generation for the lifetime of the index. A subset cannot follow them: its aggregation
+	 * lambda may return a lazy `DeferredFormula`, so materializing eagerly would change behaviour.
 	 *
-	 * - **an alias of index data already charged** — a single-bucket union short-circuits to the bucket's own bitmap,
-	 *   and a formula's `memoizedResult` resolves to its own delegate. Following either would charge one bitmap twice
-	 *   for an index that has answered a single query, which rule 1 forbids outright.
+	 * A memoized formula is a query answer a structure kept, and every bitmap reachable from one is in exactly one of
+	 * two states, neither of which this figure may follow:
+	 *
+	 * - **an alias of index data already charged** — a formula's `memoizedResult` resolves to its own delegate, and a
+	 *   single-bucket aggregation short-circuits to that bucket's own bitmap. Following either would charge one
+	 *   bitmap twice for a structure that has answered a single query, which rule 1 forbids outright.
 	 * - **a recomputable union**, dropped the moment the index is mutated and rebuilt on the next read.
 	 *
 	 * Following an arbitrary formula tree would additionally need a heap API across the whole query algebra — a query

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -214,9 +214,20 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 * it — and everything that session reached — until the index is written to again, which on a read-mostly index
 	 * is never.
 	 *
-	 * Memoizing the bitmap keeps the expensive part (the join of all internally held bitmaps) and pays a handful of
-	 * bytes for a fresh {@link ConstantFormula} per call, which is cheap scaffolding over the shared bitmap. Do not
-	 * turn this back into a `Formula` field.
+	 * Memoizing the bitmap keeps the expensive part — the join of all internally held bitmaps — and the
+	 * {@link ConstantFormula} built around it per call is a handful of bytes over the shared bitmap.
+	 *
+	 * It is **not** free in CPU, however, and the cost is worth knowing before touching this. Once the value tree
+	 * holds more than one bucket the memoized bitmap is a `BaseBitmap`, which is not a
+	 * {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer}, so
+	 * `ConstantFormula#includeAdditionalHash` falls through to hashing the delegate's **contents** — and
+	 * `AbstractFormula#initFields` does that eagerly in the constructor. That is `O(records)` per call where the old
+	 * formula memo paid it once: measured at roughly 1.4 µs for 1k records, 83 µs for 100k and 309 µs for 500k.
+	 * Only the two read paths that ask for a formula pay it — `AttributeIsTranslator` and
+	 * `AttributeHistogramComputer` — and the fix is to memoize the content hash beside the bitmap and hand it to
+	 * the formula, not to memoize the formula again. See the ADR for issue #1458.
+	 *
+	 * Do not turn this back into a `Formula` field.
 	 */
 	@Nullable private transient Bitmap memoizedAllRecords;
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -200,21 +200,47 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 */
 	@Nonnull private final Comparator<? extends Comparable> comparator;
 	/**
-	 * This field speeds up all requests for all data in this index (which happens quite often). This formula can be
+	 * This field speeds up all requests for all data in this index (which happens quite often). This bitmap can be
 	 * computed anytime by calling `((InvertedIndex) this.histogram).getSortedRecords(null, null)`. Original operation
 	 * needs to perform costly join of all internally held bitmaps and that's why we memoize the result.
+	 *
+	 * # Only the bitmap is memoized, never the formula wrapping it
+	 *
+	 * A {@link Formula} node carries **per-query** state:
+	 * {@link io.evitadb.core.query.algebra.AbstractFormula#initialize(io.evitadb.core.query.QueryExecutionContext)}
+	 * writes the executing query's context onto every node of the plan it is part of, and that context transitively
+	 * reaches the {@link io.evitadb.api.EvitaSessionContract} and the entire catalog generation the query ran
+	 * against. A formula held for the lifetime of this index would therefore pin the first session that ever used
+	 * it — and everything that session reached — until the index is written to again, which on a read-mostly index
+	 * is never.
+	 *
+	 * Memoizing the bitmap keeps the expensive part (the join of all internally held bitmaps) and pays a handful of
+	 * bytes for a fresh {@link ConstantFormula} per call, which is cheap scaffolding over the shared bitmap. Do not
+	 * turn this back into a `Formula` field.
 	 */
-	@Nullable private transient Formula memoizedAllRecordsFormula;
+	@Nullable private transient Bitmap memoizedAllRecords;
 	/**
 	 * Memoized result of {@link #getRangeHistogramOfAllRecords(Class, int)}. The cached subset is keyed implicitly
 	 * by the leaf's {@link RangeIndex} state — the steady-state query path against an unchanged leaf pays zero
 	 * allocation. Set to `null` whenever the index is mutated outside a transaction (mirrors
-	 * {@link #memoizedAllRecordsFormula}); the merged-transactional copy starts fresh.
+	 * {@link #memoizedAllRecords}); the merged-transactional copy starts fresh.
 	 *
 	 * The inner numeric type passed by callers is invariant for a given leaf — it is derived from
 	 * {@link #attributeType} via {@link EvitaDataTypes#resolveRangeInnerNumericType(Class)} — so it does not
 	 * need to be tracked alongside the cached subset; a fail-fast assertion in
 	 * {@link #getRangeHistogramOfAllRecords(Class, int)} guards against schema/index drift.
+	 *
+	 * # {@link InvertedIndexSubSet#getFormula()} must never be called on this subset
+	 *
+	 * This is the one subset in the codebase that lives as long as its index, and
+	 * {@link InvertedIndexSubSet#getFormula()} memoizes the formula it builds. Calling it here would park a
+	 * query-lifetime formula node in an index-lifetime structure and pin the calling session's whole catalog
+	 * generation — the leak {@link #memoizedAllRecords} documents. Its only consumer,
+	 * `AttributeHistogramComputer`, reads {@link InvertedIndexSubSet#getBuckets()} instead, which is stateless.
+	 *
+	 * The bitmap treatment applied to {@link #memoizedAllRecords} is not available here: the subset's aggregation
+	 * lambda may legitimately return a lazy `DeferredFormula`, so materializing a bitmap eagerly would change
+	 * behaviour rather than preserve it.
 	 */
 	@Nullable private transient InvertedIndexSubSet memoizedRangeHistogramSubSet;
 
@@ -579,12 +605,12 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 *
 	 * The memos are charged where they hold something nothing else does:
 	 *
-	 * - {@link #memoizedAllRecordsFormula} contributes its scaffolding (see
-	 *   {@link IndexHeapSize#memoizedFormulaSizeInBytes}) plus the union it wraps — but only once the value tree
-	 *   holds **more than one** bucket. With exactly one, the aggregation short-circuits and the union IS that
-	 *   bucket's own bitmap, charged already by the tree; with more, it is a bitmap this index materialized and
-	 *   nothing else holds. Leaving it out would be a shortfall that grows with the data, which is the one shape a
-	 *   deliberate divergence must never have.
+	 * - {@link #memoizedAllRecords} contributes the union it holds — but only once the value tree holds **more than
+	 *   one** bucket. With exactly one, the aggregation short-circuits and the union IS that bucket's own bitmap,
+	 *   charged already by the tree; with more, it is a bitmap this index materialized and nothing else holds.
+	 *   Leaving it out would be a shortfall that grows with the data, which is the one shape a deliberate
+	 *   divergence must never have. No formula scaffolding is charged because none is retained — the memo is the
+	 *   bitmap alone, and the {@link ConstantFormula} wrapping it is built fresh per call and dies with the query.
 	 * - {@link #memoizedRangeHistogramSubSet} contributes **in full**, buckets included. Unlike a slice off the value
 	 *   tree, the range histogram materializes a fresh {@link ValueToRecordBitmap} per range point, each carrying a
 	 *   `clone()` of the running active-set bitmap, and nothing else in the catalog holds those. On a range
@@ -596,16 +622,14 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	protected final long getSharedHeapSizeInBytes(long ownFieldBytes) {
 		final VMLayout layout = VMLayout.current();
 		// the attributeIndexKey / invertedIndex / rangeIndex / attributeType / normalizer / comparator /
-		// memoizedAllRecordsFormula / memoizedRangeHistogramSubSet slots, then the indexedDecimalPlaces int
+		// memoizedAllRecords / memoizedRangeHistogramSubSet slots, then the indexedDecimalPlaces int
 		long size = layout.sizeOfObject(
 			8L * layout.referenceSize() + Integer.BYTES + ownFieldBytes
 		);
-		size += IndexHeapSize.memoizedFormulaSizeInBytes(this.memoizedAllRecordsFormula);
-		if (this.memoizedAllRecordsFormula instanceof final ConstantFormula unionFormula
-			&& this.invertedIndex.getBucketCount() > 1) {
+		if (this.memoizedAllRecords != null && this.invertedIndex.getBucketCount() > 1) {
 			// more than one bucket, so the memoized union was computed rather than short-circuited to a bucket's own
 			// bitmap - this index materialized it and nothing else in the catalog holds it
-			size += unionFormula.getDelegate().getHeapSizeInBytes();
+			size += this.memoizedAllRecords.getHeapSizeInBytes();
 		}
 		if (this.memoizedRangeHistogramSubSet != null) {
 			size += this.memoizedRangeHistogramSubSet.getHeapSizeInBytes(RANGE_HISTOGRAM_BUCKET_SIZER);
@@ -748,7 +772,7 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 		}
 
 		if (!isTransactionAvailable()) {
-			this.memoizedAllRecordsFormula = null;
+			this.memoizedAllRecords = null;
 			this.memoizedRangeHistogramSubSet = null;
 		}
 		markDirty();
@@ -791,7 +815,7 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 		}
 
 		if (!isTransactionAvailable()) {
-			this.memoizedAllRecordsFormula = null;
+			this.memoizedAllRecords = null;
 			this.memoizedRangeHistogramSubSet = null;
 		}
 		markDirty();
@@ -839,7 +863,7 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 		}
 
 		if (!isTransactionAvailable()) {
-			this.memoizedAllRecordsFormula = null;
+			this.memoizedAllRecords = null;
 			this.memoizedRangeHistogramSubSet = null;
 		}
 		markDirty();
@@ -882,7 +906,7 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 		}
 
 		if (!isTransactionAvailable()) {
-			this.memoizedAllRecordsFormula = null;
+			this.memoizedAllRecords = null;
 			this.memoizedRangeHistogramSubSet = null;
 		}
 		markDirty();
@@ -939,7 +963,7 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 * `starts` / `ends` bitmaps are still applied to the rolling active set so that records with open-ended
 	 * ranges (`from == null` / `to == null`) participate in / exit the appropriate buckets. The result is
 	 * memoized — outside transactions, repeated calls return the cached subset; on mutation the cache is
-	 * invalidated alongside {@link #memoizedAllRecordsFormula}.
+	 * invalidated alongside {@link #memoizedAllRecords}.
 	 *
 	 * Throws {@link GenericEvitaInternalError} when invoked on a filter index that has no range companion.
 	 *
@@ -1037,7 +1061,14 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 */
 	@Nonnull
 	public Bitmap getAllRecords() {
-		return getAllRecordsFormula().compute();
+		// if there is transaction open, there might be changes in the histogram data, and we can't easily use cache
+		if (isTransactionAvailable() && isDirty()) {
+			return getHistogramOfAllRecords().getFormula().compute();
+		}
+		if (this.memoizedAllRecords == null) {
+			this.memoizedAllRecords = getHistogramOfAllRecords().getFormula().compute();
+		}
+		return this.memoizedAllRecords;
 	}
 
 	/**
@@ -1048,20 +1079,13 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 * raw OR-of-buckets tree from {@link InvertedIndexSubSet#getFormula()} prevents query-planner rewrites that
 	 * would otherwise distribute surrounding {@code NOT(OR(b₁..b_N), U)} via De Morgan into a wide
 	 * {@code AND(NOT b₁ ... NOT b_N)} — a transformation that explodes cost for high-cardinality indexes.
+	 *
+	 * A **fresh** formula is returned on every call. What is memoized is the bitmap behind it — see
+	 * {@link #memoizedAllRecords} for why an index must never hand out the same formula instance twice.
 	 */
 	public Formula getAllRecordsFormula() {
-		// if there is transaction open, there might be changes in the histogram data, and we can't easily use cache
-		if (isTransactionAvailable() && isDirty()) {
-			final Bitmap allRecords = getHistogramOfAllRecords().getFormula().compute();
-			return allRecords.isEmpty() ? EmptyFormula.INSTANCE : new ConstantFormula(allRecords);
-		} else {
-			if (this.memoizedAllRecordsFormula == null) {
-				final Bitmap allRecords = getHistogramOfAllRecords().getFormula().compute();
-				this.memoizedAllRecordsFormula = allRecords.isEmpty() ?
-					EmptyFormula.INSTANCE : new ConstantFormula(allRecords);
-			}
-			return this.memoizedAllRecordsFormula;
-		}
+		final Bitmap allRecords = getAllRecords();
+		return allRecords.isEmpty() ? EmptyFormula.INSTANCE : new ConstantFormula(allRecords);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -217,15 +217,15 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 	 * Memoizing the bitmap keeps the expensive part — the join of all internally held bitmaps — and the
 	 * {@link ConstantFormula} built around it per call is a handful of bytes over the shared bitmap.
 	 *
-	 * It is **not** free in CPU, however, and the cost is worth knowing before touching this. Once the value tree
-	 * holds more than one bucket the memoized bitmap is a `BaseBitmap`, which is not a
-	 * {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer}, so
-	 * `ConstantFormula#includeAdditionalHash` falls through to hashing the delegate's **contents** — and
-	 * `AbstractFormula#initFields` does that eagerly in the constructor. That is `O(records)` per call where the old
-	 * formula memo paid it once: measured at roughly 1.4 µs for 1k records, 83 µs for 100k and 309 µs for 500k.
-	 * Only the two read paths that ask for a formula pay it — `AttributeIsTranslator` and
-	 * `AttributeHistogramComputer` — and the fix is to memoize the content hash beside the bitmap and hand it to
-	 * the formula, not to memoize the formula again. See the ADR for issue #1458.
+	 * What keeps that cheap in CPU as well is where the formula's cache key comes from. Once the value tree holds
+	 * more than one bucket the memoized bitmap is a `BaseBitmap`, which is not a
+	 * {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer} and so has no transactional id to key
+	 * on; `ConstantFormula#includeAdditionalHash` falls through to hashing its **contents**, eagerly, in the
+	 * constructor. That would be `O(records)` on every call — measured at roughly 1.4 µs for 1k records, 83 µs for
+	 * 100k and 309 µs for 500k — were the hash not memoized on the bitmap itself. It is: because this field hands
+	 * out the same `BaseBitmap` instance every time, {@link Bitmap#getContentHash} computes the walk once and every
+	 * later formula reads it back. Replacing this bitmap with a per-call copy would silently reinstate that cost.
+	 * See the ADR for issue #1458.
 	 *
 	 * Do not turn this back into a `Formula` field.
 	 */

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
@@ -60,7 +60,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
-import static io.evitadb.core.transaction.Transaction.isTransactionAvailable;
 import static io.evitadb.index.attribute.UniqueIndexBPlusTreeSupport.comparatorFor;
 import static io.evitadb.index.attribute.UniqueIndexBPlusTreeSupport.plainTypeOf;
 import static io.evitadb.utils.Assert.isTrue;
@@ -121,12 +120,6 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 	 * Keeps information about all record ids present in this index.
 	 */
 	@Nonnull private final TransactionalBitmap recordIds;
-	/**
-	 * This field speeds up all requests for all data in this index (which happens quite often). This formula can be
-	 * computed anytime by calling `new ConstantFormula(getRecordIds())`. Original operation
-	 * needs to perform costly creation of new internal bitmap that's why we memoize the result.
-	 */
-	@Nullable private transient Formula memoizedAllRecordsFormula;
 
 	/**
 	 * Creates a fresh, empty value tree (int payload column holding the owning record id) ordered by the given
@@ -296,17 +289,22 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 		return records.isEmpty() ? null : records.getFirst();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * A **fresh** formula is returned on every call, wrapping the {@link #recordIds} bitmap this index already
+	 * holds — there is nothing left to memoize, because the expensive part was always the bitmap and never the
+	 * few scalars of scaffolding around it.
+	 *
+	 * The formula must not be cached here. A {@link Formula} node carries per-query state:
+	 * {@link io.evitadb.core.query.algebra.AbstractFormula#initialize(io.evitadb.core.query.QueryExecutionContext)}
+	 * writes the executing query's context onto every node of the plan it joins, and that context transitively
+	 * reaches the session and the whole catalog generation the query ran against. An index-lifetime formula would
+	 * pin the first session that ever used it until the index is next written to.
+	 */
 	@Override
 	public Formula getRecordIdsFormula() {
-		// if there is transaction open, there might be changes in the bitmap, and we can't easily use cache
-		if (isTransactionAvailable() && this.dirty.isTrue()) {
-			return new ConstantFormula(this.recordIds);
-		} else {
-			if (this.memoizedAllRecordsFormula == null) {
-				this.memoizedAllRecordsFormula = new ConstantFormula(this.recordIds);
-			}
-			return this.memoizedAllRecordsFormula;
-		}
+		return new ConstantFormula(this.recordIds);
 	}
 
 	/**
@@ -318,11 +316,10 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 	 * {@link IndexHeapSize#OWNED_KEY_SIZER}. {@link #recordIds} is likewise charged in full: every construction
 	 * site builds it fresh rather than adopting a caller's set.
 	 *
-	 * {@link #memoizedAllRecordsFormula} is charged as its **own object plus its memoized scalars, never its
-	 * bitmap**, through {@link IndexHeapSize#memoizedFormulaSizeInBytes} — the one place a memoized formula is
-	 * priced, so every index answers identically for one. The formula is `new ConstantFormula(this.recordIds)`: it
-	 * wraps the very set already charged above, and its own `memoizedResult` resolves to that same instance, so
-	 * following either would count one bitmap twice for an index that has answered a single query.
+	 * **No formula is charged, because none is retained.** {@link #getRecordIdsFormula()} builds
+	 * `new ConstantFormula(this.recordIds)` fresh per call and that wrapper dies with the query it served, so there
+	 * is nothing of index lifetime to price. It wrapped the very set already charged above in any case, so charging
+	 * it would have risked counting one bitmap twice.
 	 *
 	 * {@link #plainType} is a `Class` and {@link #comparator} is fixed scaffolding chosen by the attribute type, so
 	 * both contribute their slot alone — the same call {@code SortIndex} makes, for the same reason.
@@ -331,12 +328,11 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 	@Override
 	public long getHeapSizeInBytes() {
 		final VMLayout layout = VMLayout.current();
-		// the dirty / plainType / comparator / tree / pageStreamRegistry / recordIds / memoizedAllRecordsFormula slots
-		return getSharedHeapSizeInBytes(7L * layout.referenceSize())
+		// the dirty / plainType / comparator / tree / pageStreamRegistry / recordIds slots
+		return getSharedHeapSizeInBytes(6L * layout.referenceSize())
 			+ this.dirty.getHeapSizeInBytes()
 			+ this.tree.getHeapSizeInBytes(IndexHeapSize.OWNED_KEY_SIZER)
-			+ this.recordIds.getHeapSizeInBytes()
-			+ IndexHeapSize.memoizedFormulaSizeInBytes(this.memoizedAllRecordsFormula);
+			+ this.recordIds.getHeapSizeInBytes();
 	}
 
 	@Nonnull
@@ -615,10 +611,6 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 			registerUniqueKeyValue((T) key, recordId);
 		}
 
-		if (!isTransactionAvailable()) {
-			this.memoizedAllRecordsFormula = null;
-		}
-
 		this.dirty.setToTrue();
 	}
 
@@ -668,10 +660,6 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 		} else {
 			verifyValue(key);
 			returnValue = unregisterUniqueKeyValue((T) key, expectedRecordId);
-		}
-
-		if (!isTransactionAvailable()) {
-			this.memoizedAllRecordsFormula = null;
 		}
 
 		this.dirty.setToTrue();

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
@@ -296,6 +296,13 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 	 * holds — there is nothing left to memoize, because the expensive part was always the bitmap and never the
 	 * few scalars of scaffolding around it.
 	 *
+	 * Building one per call is genuinely cheap **here**, unlike in a filter index: {@link #recordIds} is a
+	 * {@link TransactionalBitmap} and therefore a
+	 * {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer}, so `ConstantFormula` hashes its
+	 * transactional id rather than its contents and construction stays `O(1)`. A filter index's multi-bucket memo
+	 * is a plain `BaseBitmap` and pays `O(records)` instead — see `FilterIndex#memoizedAllRecords`. Do not
+	 * "harmonise" the two; they are not the same case.
+	 *
 	 * The formula must not be cached here. A {@link Formula} node carries per-query state:
 	 * {@link io.evitadb.core.query.algebra.AbstractFormula#initialize(io.evitadb.core.query.QueryExecutionContext)}
 	 * writes the executing query's context onto every node of the plan it joins, and that context transitively

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
@@ -296,12 +296,12 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 	 * holds — there is nothing left to memoize, because the expensive part was always the bitmap and never the
 	 * few scalars of scaffolding around it.
 	 *
-	 * Building one per call is genuinely cheap **here**, unlike in a filter index: {@link #recordIds} is a
+	 * Building one per call is `O(1)` here for a reason worth knowing: {@link #recordIds} is a
 	 * {@link TransactionalBitmap} and therefore a
-	 * {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer}, so `ConstantFormula` hashes its
-	 * transactional id rather than its contents and construction stays `O(1)`. A filter index's multi-bucket memo
-	 * is a plain `BaseBitmap` and pays `O(records)` instead — see `FilterIndex#memoizedAllRecords`. Do not
-	 * "harmonise" the two; they are not the same case.
+	 * {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer}, so `ConstantFormula` keys its cache
+	 * entry on the transactional id and never looks at the contents. A filter index's multi-bucket memo is a plain
+	 * `BaseBitmap` with no such id and has to hash the records instead, which is why that bitmap memoizes the hash
+	 * — see `FilterIndex#memoizedAllRecords`. Do not "harmonise" the two; they are not the same case.
 	 *
 	 * The formula must not be cached here. A {@link Formula} node carries per-query state:
 	 * {@link io.evitadb.core.query.algebra.AbstractFormula#initialize(io.evitadb.core.query.QueryExecutionContext)}

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/UniqueIndexView.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/UniqueIndexView.java
@@ -60,7 +60,7 @@ public final class UniqueIndexView extends UniqueIndex {
 	@Serial private static final long serialVersionUID = 2639205026498958518L;
 	/**
 	 * Direct reference to the shared {@link FilterIndex} view over the same attribute key — the source of truth this
-	 * folded view reads from (reusing its normalizer and memoized all-records formula). May be `null` for a transient
+	 * folded view reads from (reusing its normalizer and memoized all-records bitmap). May be `null` for a transient
 	 * live presence marker created before the shared tree exists; the filter-write path rebinds it to the live filter
 	 * view via {@link #bindFilterView}. Never reassigned on a published instance — a new view is built instead, so the
 	 * field is safe to share across snapshot versions. Transient because a reloaded view is reconstructed from the
@@ -124,7 +124,8 @@ public final class UniqueIndexView extends UniqueIndex {
 
 	@Override
 	public Formula getRecordIdsFormula() {
-		// reuse the filter view's already-memoized all-records formula over the same shared tree
+		// wrap the filter view's already-memoized all-records bitmap over the same shared tree - the formula itself
+		// is built fresh per call, because an index-lifetime one would pin the calling query's execution context
 		final FilterIndex filterView = this.sharedFilterView;
 		return filterView == null ? EmptyFormula.INSTANCE : filterView.getAllRecordsFormula();
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/bitmap/BaseBitmap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bitmap/BaseBitmap.java
@@ -50,22 +50,23 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	private final PersistentRoaringBitmap roaringBitmap;
 	private int memoizedCardinality;
 	/**
-	 * Hash function {@link #memoizedContentHash} was computed with, or `null` when no content hash has been computed
-	 * for the current contents yet.
+	 * Memoized result of {@link #getContentHash(LongHashFunction)} together with the function that produced it, or
+	 * `null` when none has been computed for the current contents. Every mutator clears it, exactly as it
+	 * invalidates {@link #memoizedCardinality}.
 	 *
-	 * It doubles as the publication guard for {@link #memoizedContentHash}: it is written **after** the hash, and
-	 * because the write is volatile, a thread that observes a matching function here is guaranteed to observe the
-	 * matching hash as well. Keying on the function rather than assuming a single global one keeps the memo correct
-	 * for callers that bring their own — {@code CacheEnforcingPolicy} builds a separate instance from the same
-	 * factory as {@code TransactionalDataRelatedStructure#HASH_FUNCTION}.
+	 * The hash and its function travel as **one immutable object** on purpose, and splitting them back into two
+	 * fields would be a correctness bug even with a volatile guard between them. Two threads hashing with
+	 * *different* functions can interleave their writes so that the guard ends up naming one function while the
+	 * value belongs to the other; a third caller then matches the guard and receives a hash that was never computed
+	 * for the function it asked about — a wrong formula cache key, not merely a slow one. A record's final fields
+	 * are safely published even through a data race, so a reader here sees either `null` or a consistent pair, and
+	 * racing writers can only overwrite each other with individually-consistent ones.
+	 *
+	 * Keying on the function rather than assuming a single global one keeps the memo correct for callers that bring
+	 * their own — {@code CacheEnforcingPolicy} builds a separate instance from the same factory as
+	 * {@code TransactionalDataRelatedStructure#HASH_FUNCTION}.
 	 */
-	@Nullable private transient volatile LongHashFunction memoizedContentHashFunction;
-	/**
-	 * Memoized result of {@link #getContentHash(LongHashFunction)}. Only meaningful while
-	 * {@link #memoizedContentHashFunction} is non-null — every mutator clears that guard, exactly as it invalidates
-	 * {@link #memoizedCardinality}.
-	 */
-	private transient long memoizedContentHash;
+	@Nullable private transient volatile ContentHash memoizedContentHash;
 
 	public BaseBitmap() {
 		this.roaringBitmap = new PersistentRoaringBitmap();
@@ -114,7 +115,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		final boolean added = this.roaringBitmap.checkedAdd(recordId);
 		if (added) {
 			this.memoizedCardinality = -1;
-			this.memoizedContentHashFunction = null;
+			this.memoizedContentHash = null;
 		}
 		return added;
 	}
@@ -123,14 +124,14 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	public void addAll(int... recordId) {
 		this.roaringBitmap.add(recordId);
 		this.memoizedCardinality = -1;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	@Override
 	public void addAll(@Nonnull Bitmap recordIds) {
 		this.roaringBitmap.add(recordIds.getArray());
 		this.memoizedCardinality = -1;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	@Override
@@ -138,7 +139,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		final boolean removed = this.roaringBitmap.checkedRemove(recordId);
 		if (removed) {
 			this.memoizedCardinality = -1;
-			this.memoizedContentHashFunction = null;
+			this.memoizedContentHash = null;
 		}
 		return removed;
 	}
@@ -149,7 +150,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 			this.roaringBitmap.remove(recId);
 		}
 		this.memoizedCardinality = -1;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	@Override
@@ -164,7 +165,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 			}
 		}
 		this.memoizedCardinality = -1;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	/**
@@ -198,7 +199,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		}
 		this.roaringBitmap.andNot(writer.get());
 		this.memoizedCardinality = -1;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	/**
@@ -233,7 +234,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		}
 		this.roaringBitmap.andNot(writer.get());
 		this.memoizedCardinality = -1;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	/**
@@ -244,7 +245,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	public void clear() {
 		this.roaringBitmap.clear();
 		this.memoizedCardinality = 0;
-		this.memoizedContentHashFunction = null;
+		this.memoizedContentHash = null;
 	}
 
 	@Override
@@ -315,21 +316,27 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	}
 
 	/**
-	 * This wrapper's own object — the `roaringBitmap` reference, the memoized cardinality and the two slots of the
-	 * content-hash memo — plus the roaring bitmap it exclusively owns, priced at its containers' allocated
-	 * capacity. The memo costs the same whether or not it has been populated: it is two plain fields, and the
-	 * {@link LongHashFunction} the guard points at is a JVM-wide shared instance this bitmap borrows rather than
-	 * owns — charging it here would price the same singleton once per bitmap in the catalog.
+	 * This wrapper's own object — the `roaringBitmap` reference, the memoized cardinality and the content-hash
+	 * memo's reference slot — plus the roaring bitmap it exclusively owns, priced at its containers' allocated
+	 * capacity, plus the memo's holder once one has been allocated.
 	 *
-	 * The field sum needs no alignment term of its own despite holding a `long`: the JVM packs
-	 * {@link #memoizedCardinality} into the gap a 12-byte header leaves, so the `long` lands 8-aligned for free
-	 * (verified against a JOL walk by `LeafIndexHeapSizeTest`).
+	 * The holder is charged **conditionally** because it genuinely does not exist until something asks this bitmap
+	 * for its content hash; a bitmap that is never hashed pays only the null slot. What is *not* charged either way
+	 * is the {@link LongHashFunction} the holder points at: it is one JVM-wide instance every formula hashes with,
+	 * so pricing it here would bill the same object once per bitmap in the catalog.
+	 *
+	 * Neither term needs an alignment correction for the holder's `long`, which a field sum does not obviously
+	 * predict and a JOL walk settled twice: a `long` must start 8-aligned, but both objects carry a 4-byte field —
+	 * {@link #memoizedCardinality} here, the function reference there — that the JVM slots into the gap a 12-byte
+	 * header leaves, so the `long` lands aligned for free. Adding a padding term over-reports by 8 bytes.
 	 */
 	@Override
 	public long getHeapSizeInBytes() {
 		final VMLayout layout = VMLayout.current();
-		return layout.sizeOfObject(2L * layout.referenceSize() + Integer.BYTES + Long.BYTES)
+		final long ownSize = layout.sizeOfObject(2L * layout.referenceSize() + Integer.BYTES)
 			+ this.roaringBitmap.getHeapSizeInBytes(ROARING_HEAP_LAYOUT);
+		return this.memoizedContentHash == null ?
+			ownSize : ownSize + layout.sizeOfObject(layout.referenceSize() + Long.BYTES);
 	}
 
 	/**
@@ -348,15 +355,14 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	 */
 	@Override
 	public long getContentHash(@Nonnull LongHashFunction hashFunction) {
-		final LongHashFunction memoizedFor = this.memoizedContentHashFunction;
-		if (memoizedFor == hashFunction) {
-			return this.memoizedContentHash;
+		final ContentHash memoized = this.memoizedContentHash;
+		if (memoized != null && memoized.function() == hashFunction) {
+			return memoized.hash();
 		}
 		final long contentHash = hashFunction.hashInts(getArray());
-		this.memoizedContentHash = contentHash;
-		// publish last - the volatile write makes the hash assigned above visible to every reader that observes
-		// this function reference
-		this.memoizedContentHashFunction = hashFunction;
+		// one reference write publishes the hash and its function together - see the field for why they must not
+		// be assigned separately
+		this.memoizedContentHash = new ContentHash(hashFunction, contentHash);
 		return contentHash;
 	}
 
@@ -396,5 +402,15 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	public String toString() {
 		// we need to unify the output with ArrayBitmap and other implementations
 		return "[" + this.roaringBitmap.stream().mapToObj(Integer::toString).collect(Collectors.joining(", ")) + "]";
+	}
+
+	/**
+	 * A content hash paired with the {@link LongHashFunction} that produced it, so that the two can never be
+	 * observed out of step by a concurrent reader — see {@link #memoizedContentHash} for why that matters.
+	 *
+	 * @param function the function the hash was computed with, compared by identity
+	 * @param hash     the hash of the bitmap's record ids as they stood when it was computed
+	 */
+	private record ContentHash(@Nonnull LongHashFunction function, long hash) {
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/index/bitmap/BaseBitmap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bitmap/BaseBitmap.java
@@ -29,8 +29,10 @@ import io.evitadb.roaringbitmap.PersistentRoaringBitmap;
 import io.evitadb.roaringbitmap.RoaringBatchIterator;
 import io.evitadb.roaringbitmap.RoaringBitmapWriter;
 import io.evitadb.utils.VMLayout;
+import net.openhft.hashing.LongHashFunction;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Serial;
 import java.util.NoSuchElementException;
@@ -47,6 +49,23 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	@Serial private static final long serialVersionUID = -8471705193727315151L;
 	private final PersistentRoaringBitmap roaringBitmap;
 	private int memoizedCardinality;
+	/**
+	 * Hash function {@link #memoizedContentHash} was computed with, or `null` when no content hash has been computed
+	 * for the current contents yet.
+	 *
+	 * It doubles as the publication guard for {@link #memoizedContentHash}: it is written **after** the hash, and
+	 * because the write is volatile, a thread that observes a matching function here is guaranteed to observe the
+	 * matching hash as well. Keying on the function rather than assuming a single global one keeps the memo correct
+	 * for callers that bring their own — {@code CacheEnforcingPolicy} builds a separate instance from the same
+	 * factory as {@code TransactionalDataRelatedStructure#HASH_FUNCTION}.
+	 */
+	@Nullable private transient volatile LongHashFunction memoizedContentHashFunction;
+	/**
+	 * Memoized result of {@link #getContentHash(LongHashFunction)}. Only meaningful while
+	 * {@link #memoizedContentHashFunction} is non-null — every mutator clears that guard, exactly as it invalidates
+	 * {@link #memoizedCardinality}.
+	 */
+	private transient long memoizedContentHash;
 
 	public BaseBitmap() {
 		this.roaringBitmap = new PersistentRoaringBitmap();
@@ -93,7 +112,10 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	@Override
 	public boolean add(int recordId) {
 		final boolean added = this.roaringBitmap.checkedAdd(recordId);
-		this.memoizedCardinality = added ? -1 : this.memoizedCardinality;
+		if (added) {
+			this.memoizedCardinality = -1;
+			this.memoizedContentHashFunction = null;
+		}
 		return added;
 	}
 
@@ -101,18 +123,23 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	public void addAll(int... recordId) {
 		this.roaringBitmap.add(recordId);
 		this.memoizedCardinality = -1;
+		this.memoizedContentHashFunction = null;
 	}
 
 	@Override
 	public void addAll(@Nonnull Bitmap recordIds) {
 		this.roaringBitmap.add(recordIds.getArray());
 		this.memoizedCardinality = -1;
+		this.memoizedContentHashFunction = null;
 	}
 
 	@Override
 	public boolean remove(int recordId) {
 		final boolean removed = this.roaringBitmap.checkedRemove(recordId);
-		this.memoizedCardinality = removed ? -1 : this.memoizedCardinality;
+		if (removed) {
+			this.memoizedCardinality = -1;
+			this.memoizedContentHashFunction = null;
+		}
 		return removed;
 	}
 
@@ -122,6 +149,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 			this.roaringBitmap.remove(recId);
 		}
 		this.memoizedCardinality = -1;
+		this.memoizedContentHashFunction = null;
 	}
 
 	@Override
@@ -136,6 +164,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 			}
 		}
 		this.memoizedCardinality = -1;
+		this.memoizedContentHashFunction = null;
 	}
 
 	/**
@@ -169,6 +198,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		}
 		this.roaringBitmap.andNot(writer.get());
 		this.memoizedCardinality = -1;
+		this.memoizedContentHashFunction = null;
 	}
 
 	/**
@@ -203,16 +233,18 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		}
 		this.roaringBitmap.andNot(writer.get());
 		this.memoizedCardinality = -1;
+		this.memoizedContentHashFunction = null;
 	}
 
 	/**
 	 * Clears all data in the bitmap.
 	 * This method resets the internal bitmap structure, effectively removing all stored record IDs,
-	 * and also resets the memoized cardinality to zero.
+	 * and also resets the memoized cardinality to zero and discards the memoized content hash.
 	 */
 	public void clear() {
 		this.roaringBitmap.clear();
 		this.memoizedCardinality = 0;
+		this.memoizedContentHashFunction = null;
 	}
 
 	@Override
@@ -283,14 +315,49 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 	}
 
 	/**
-	 * This wrapper's own object — the `roaringBitmap` reference and the memoized cardinality — plus the
-	 * roaring bitmap it exclusively owns, priced at its containers' allocated capacity.
+	 * This wrapper's own object — the `roaringBitmap` reference, the memoized cardinality and the two slots of the
+	 * content-hash memo — plus the roaring bitmap it exclusively owns, priced at its containers' allocated
+	 * capacity. The memo costs the same whether or not it has been populated: it is two plain fields, and the
+	 * {@link LongHashFunction} the guard points at is a JVM-wide shared instance this bitmap borrows rather than
+	 * owns — charging it here would price the same singleton once per bitmap in the catalog.
+	 *
+	 * The field sum needs no alignment term of its own despite holding a `long`: the JVM packs
+	 * {@link #memoizedCardinality} into the gap a 12-byte header leaves, so the `long` lands 8-aligned for free
+	 * (verified against a JOL walk by `LeafIndexHeapSizeTest`).
 	 */
 	@Override
 	public long getHeapSizeInBytes() {
 		final VMLayout layout = VMLayout.current();
-		return layout.sizeOfObject(layout.referenceSize() + Integer.BYTES)
+		return layout.sizeOfObject(2L * layout.referenceSize() + Integer.BYTES + Long.BYTES)
 			+ this.roaringBitmap.getHeapSizeInBytes(ROARING_HEAP_LAYOUT);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * The result is memoized, so building a formula over the *same* bitmap instance repeatedly pays the `O(size)`
+	 * walk once instead of once per formula. That is what makes an index able to memoize its all-records **bitmap**
+	 * — which retains nothing query-scoped — and still hand out a fresh formula per call at the cost of one
+	 * allocation; see `FilterIndex#memoizedAllRecords`.
+	 *
+	 * Concurrency: reads are safely publishable across threads even though this class is {@link NotThreadSafe} —
+	 * the guard field is written last with volatile semantics, so a reader either misses the memo and recomputes an
+	 * identical value, or sees a fully-published one. Mutating a bitmap while other threads read it was already
+	 * outside this class' contract and remains so; a mutator clears the memo the same way it clears
+	 * {@link #size()}'s.
+	 */
+	@Override
+	public long getContentHash(@Nonnull LongHashFunction hashFunction) {
+		final LongHashFunction memoizedFor = this.memoizedContentHashFunction;
+		if (memoizedFor == hashFunction) {
+			return this.memoizedContentHash;
+		}
+		final long contentHash = hashFunction.hashInts(getArray());
+		this.memoizedContentHash = contentHash;
+		// publish last - the volatile write makes the hash assigned above visible to every reader that observes
+		// this function reference
+		this.memoizedContentHashFunction = hashFunction;
+		return contentHash;
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/index/bitmap/Bitmap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bitmap/Bitmap.java
@@ -23,6 +23,8 @@
 
 package io.evitadb.index.bitmap;
 
+import net.openhft.hashing.LongHashFunction;
+
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.PrimitiveIterator.OfInt;
@@ -181,6 +183,25 @@ public interface Bitmap extends Iterable<Integer>, Serializable {
 	 * @return the owned heap footprint in bytes, including alignment padding
 	 */
 	long getHeapSizeInBytes();
+
+	/**
+	 * Returns hash of the record ids this bitmap holds, computed with the passed `hashFunction`.
+	 *
+	 * The hash identifies the bitmap by its **contents**: two bitmaps holding the same record ids answer with
+	 * the same value regardless of their identity, class or internal representation. That is what makes it usable
+	 * as the discriminating part of a formula cache key for bitmaps that carry no transactional identity of their
+	 * own — an aggregated result computed on the fly has no id to key on, only its contents.
+	 *
+	 * The default implementation materializes the whole record id array and is therefore `O(size)`. An
+	 * implementation that is handed out repeatedly — an index memo answering the same query over and over — should
+	 * memoize the result instead of paying the walk per caller; {@link BaseBitmap} does.
+	 *
+	 * @param hashFunction hash function to compute the value with
+	 * @return hash of the record ids stored in this bitmap
+	 */
+	default long getContentHash(@Nonnull LongHashFunction hashFunction) {
+		return hashFunction.hashInts(getArray());
+	}
 
 	/**
 	 * Produces iterator over all record ids.

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
@@ -147,8 +147,13 @@ public class HierarchyIndex
 	 * of this index would therefore pin the first session that ever used it until the hierarchy is next written to.
 	 *
 	 * Memoizing the bitmap keeps the expensive part — the `O(nodes)` walk in
-	 * {@link #createAllHierarchyNodesBitmap()} — and pays a handful of bytes for a fresh {@link ConstantFormula}
-	 * per call. Do not turn this back into a `Formula` field.
+	 * {@link #createAllHierarchyNodesBitmap()} — and the {@link ConstantFormula} built around it per call is a
+	 * handful of bytes over the shared bitmap. It is not free in CPU: the memo is a `BaseBitmap`, so the formula
+	 * hashes its contents in the constructor, which is `O(nodes)` per call. That matters much less here than for a
+	 * filter index, because no main-source caller asks this index for a formula at all — see
+	 * `FilterIndex#memoizedAllRecords` for the measured figures and the intended fix.
+	 *
+	 * Do not turn this back into a `Formula` field.
 	 */
 	@Nullable private volatile Bitmap memoizedAllNodes;
 

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
@@ -35,7 +35,6 @@ import io.evitadb.core.transaction.memory.VoidTransactionMemoryProducer;
 import io.evitadb.dataType.array.CompositeIntArray;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.index.IndexDataStructure;
-import io.evitadb.index.IndexHeapSize;
 import io.evitadb.index.component.EntityIndexManifest;
 import io.evitadb.index.component.IndexComponent;
 import io.evitadb.index.array.TransactionalIntArray;
@@ -138,8 +137,20 @@ public class HierarchyIndex
 	private final TransactionalIntArray orphans;
 	/**
 	 * Contains cached result of {@link #getAllHierarchyNodesFormula()} call.
+	 *
+	 * # Only the bitmap is memoized, never the formula wrapping it
+	 *
+	 * A {@link Formula} node carries **per-query** state:
+	 * {@link io.evitadb.core.query.algebra.AbstractFormula#initialize(io.evitadb.core.query.QueryExecutionContext)}
+	 * writes the executing query's context onto every node of the plan it is part of, and that context transitively
+	 * reaches the session and the entire catalog generation the query ran against. A formula held for the lifetime
+	 * of this index would therefore pin the first session that ever used it until the hierarchy is next written to.
+	 *
+	 * Memoizing the bitmap keeps the expensive part — the `O(nodes)` walk in
+	 * {@link #createAllHierarchyNodesBitmap()} — and pays a handful of bytes for a fresh {@link ConstantFormula}
+	 * per call. Do not turn this back into a `Formula` field.
 	 */
-	@Nullable private volatile Formula memoizedAllNodeFormula;
+	@Nullable private volatile Bitmap memoizedAllNodes;
 
 	/**
 	 * Creates a new empty hierarchy index.
@@ -150,7 +161,7 @@ public class HierarchyIndex
 		this.levelIndex = new TransactionalMap<>(new HashMap<>(32), TransactionalIntArray.class, TransactionalIntArray::new);
 		this.itemIndex = new TransactionalMap<>(new HashMap<>(32));
 		this.orphans = new TransactionalIntArray();
-		this.memoizedAllNodeFormula = EmptyFormula.INSTANCE;
+		this.memoizedAllNodes = EmptyBitmap.INSTANCE;
 	}
 
 	/**
@@ -167,7 +178,7 @@ public class HierarchyIndex
 		this.levelIndex = new TransactionalMap<>(levelIndex, TransactionalIntArray.class, TransactionalIntArray::new);
 		this.itemIndex = new TransactionalMap<>(itemIndex);
 		this.orphans = new TransactionalIntArray(orphans);
-		this.memoizedAllNodeFormula = createAllHierarchyNodesFormula();
+		this.memoizedAllNodes = createAllHierarchyNodesBitmap();
 	}
 
 	/**
@@ -767,11 +778,12 @@ public class HierarchyIndex
 	 * a key of {@link #itemIndex}: the two are boxed at different sites and are two objects, and rule 1 charges a box
 	 * per holder rather than letting `-XX:AutoBoxCacheMax` decide what the reading says.
 	 *
-	 * {@link #memoizedAllNodeFormula} is the one memo in the index layer whose bitmap **is** charged. It is built by
-	 * writing every node id and removing the orphans, so nothing else in the catalog holds it — unlike a filter
-	 * index's all-records memo, which resolves to the value tree's own bitmap. The formula around it stays
-	 * scaffolding, priced by {@link IndexHeapSize#memoizedFormulaSizeInBytes}; an empty hierarchy memoizes
-	 * {@link EmptyFormula#INSTANCE} and charges nothing at all.
+	 * {@link #memoizedAllNodes} is the one memo in the index layer that is charged **unconditionally**. It is built
+	 * by writing every node id and removing the orphans, so nothing else in the catalog holds it — unlike a filter
+	 * index's all-records memo, which resolves to the value tree's own bitmap whenever the tree has a single bucket
+	 * and is therefore charged only above that. No formula scaffolding is priced here because none is retained: the
+	 * {@link ConstantFormula} wrapping this bitmap is built fresh per call and dies with the query. An empty
+	 * hierarchy memoizes {@link EmptyBitmap#INSTANCE} and charges nothing at all.
 	 *
 	 * This walks every node, so it is `O(nodes)` — it belongs to the index detail call and must never be called from a
 	 * query path.
@@ -784,7 +796,7 @@ public class HierarchyIndex
 		// a HierarchyNode is a record of the node's own primary key and a boxed parent key, which is this node's
 		// alone - a root node has none and pays only for the slot
 		final long hierarchyNode = layout.sizeOfObject(Integer.BYTES + layout.referenceSize());
-		// id, then the dirty / itemIndex / roots / levelIndex / orphans / memoizedAllNodeFormula slots
+		// id, then the dirty / itemIndex / roots / levelIndex / orphans / memoizedAllNodes slots
 		long size = layout.sizeOfObject(Long.BYTES + 6L * layout.referenceSize())
 			+ this.dirty.getHeapSizeInBytes()
 			+ this.roots.getHeapSizeInBytes()
@@ -794,29 +806,40 @@ public class HierarchyIndex
 				node -> node.parentEntityPrimaryKey() == null ? hierarchyNode : hierarchyNode + boxedInteger
 			)
 			+ this.levelIndex.getHeapSizeInBytes(key -> boxedInteger, TransactionalIntArray::getHeapSizeInBytes);
-		final Formula memoizedFormula = this.memoizedAllNodeFormula;
-		size += IndexHeapSize.memoizedFormulaSizeInBytes(memoizedFormula);
-		if (memoizedFormula instanceof final ConstantFormula constantFormula) {
-			// the node-id bitmap this index materialized for the cache - charged here rather than by the formula
-			// pricing, which never follows a delegate because most of them alias data already charged elsewhere
-			size += constantFormula.getDelegate().getHeapSizeInBytes();
+		final Bitmap memoizedNodes = this.memoizedAllNodes;
+		if (memoizedNodes != null) {
+			// the node-id bitmap this index materialized for the cache - nothing else in the catalog holds it
+			size += memoizedNodes.getHeapSizeInBytes();
 		}
 		return size;
 	}
 
 	/**
 	 * Method returns formula that contains all nodes attached to the tree (i.e. except {@link #orphans}.
+	 *
+	 * A **fresh** formula is returned on every call. What is memoized is the bitmap behind it — see
+	 * {@link #memoizedAllNodes} for why an index must never hand out the same formula instance twice.
 	 */
 	@Nonnull
 	public Formula getAllHierarchyNodesFormula() {
+		final Bitmap allNodes = getAllHierarchyNodes();
+		return allNodes.isEmpty() ? EmptyFormula.INSTANCE : new ConstantFormula(allNodes);
+	}
+
+	/**
+	 * Method returns bitmap of all nodes attached to the tree (i.e. except {@link #orphans}. The result is memoized
+	 * outside transactions and recomputed while a transaction holds uncommitted hierarchy changes.
+	 */
+	@Nonnull
+	public Bitmap getAllHierarchyNodes() {
 		// if there is transaction open, and there are changes in the hierarchy data, we can't use the cache
 		if (isTransactionAvailable() && this.dirty.isTrue()) {
-			return createAllHierarchyNodesFormula();
+			return createAllHierarchyNodesBitmap();
 		} else {
-			Formula result = this.memoizedAllNodeFormula;
+			Bitmap result = this.memoizedAllNodes;
 			if (result == null) {
-				result = createAllHierarchyNodesFormula();
-				this.memoizedAllNodeFormula = result;
+				result = createAllHierarchyNodesBitmap();
+				this.memoizedAllNodes = result;
 			}
 			return result;
 		}
@@ -1354,10 +1377,10 @@ public class HierarchyIndex
 	}
 
 	/**
-	 * Creates a formula that contains all hierarchy nodes except orphans.
+	 * Creates a bitmap that contains all hierarchy nodes except orphans.
 	 */
 	@Nonnull
-	private Formula createAllHierarchyNodesFormula() {
+	private Bitmap createAllHierarchyNodesBitmap() {
 		final Set<Integer> nodeIds = this.itemIndex.keySet();
 		final RoaringBitmapWriter<PersistentRoaringBitmap> writer = RoaringBitmapBackedBitmap.buildWriter();
 		for (Integer nodeId : nodeIds) {
@@ -1370,14 +1393,14 @@ public class HierarchyIndex
 			roaringBitmap.remove(it.next());
 		}
 		return roaringBitmap.isEmpty() ?
-			EmptyFormula.INSTANCE : new ConstantFormula(new BaseBitmap(roaringBitmap));
+			EmptyBitmap.INSTANCE : new BaseBitmap(roaringBitmap);
 	}
 
 	/**
 	 * Method resets all memoized values.
 	 */
 	private void resetMemoizedValues() {
-		this.memoizedAllNodeFormula = null;
+		this.memoizedAllNodes = null;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
@@ -148,10 +148,10 @@ public class HierarchyIndex
 	 *
 	 * Memoizing the bitmap keeps the expensive part — the `O(nodes)` walk in
 	 * {@link #createAllHierarchyNodesBitmap()} — and the {@link ConstantFormula} built around it per call is a
-	 * handful of bytes over the shared bitmap. It is not free in CPU: the memo is a `BaseBitmap`, so the formula
-	 * hashes its contents in the constructor, which is `O(nodes)` per call. That matters much less here than for a
-	 * filter index, because no main-source caller asks this index for a formula at all — see
-	 * `FilterIndex#memoizedAllRecords` for the measured figures and the intended fix.
+	 * handful of bytes over the shared bitmap. It is cheap in CPU too, but only because the same instance is handed
+	 * out every time: the memo is a `BaseBitmap` with no transactional id, so the formula's cache key comes from
+	 * hashing its contents, and {@link io.evitadb.index.bitmap.Bitmap#getContentHash} memoizes that `O(nodes)` walk
+	 * on the bitmap. See `FilterIndex#memoizedAllRecords` for the measured figures.
 	 *
 	 * Do not turn this back into a `Formula` field.
 	 */

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/ContainerIndexHeapSizeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/ContainerIndexHeapSizeTest.java
@@ -738,9 +738,10 @@ class ContainerIndexHeapSizeTest {
 		}
 
 		@Test
-		void shouldStepUpOnceTheAllNodesFormulaIsMemoized() {
+		void shouldStepUpOnceTheAllNodesBitmapIsMemoized() {
 			// unlike a filter index's all-records memo, this one materializes a bitmap nothing else in the catalog
-			// holds - so it must show up as occupancy AND be charged, not merely counted as scaffolding
+			// holds - so it must show up as occupancy AND be charged. Only the bitmap is retained: the formula
+			// wrapping it is built fresh per call and dies with the query, so nothing prices formula scaffolding
 			final HierarchyIndex index = seededIndex(20, 10);
 			final long cold = index.getHeapSizeInBytes();
 			assertMatchesMeasuredHeap(cold, index, EXCLUSIONS);
@@ -749,11 +750,16 @@ class ContainerIndexHeapSizeTest {
 
 			final long warm = index.getHeapSizeInBytes();
 			assertTrue(warm > cold, "the memoized node bitmap must show up as additional occupancy");
-			// the bitmap itself is charged to the byte; what reads high is the formula's own scaffolding, priced at
-			// the upper bound of the widest formula shape because which of its cost / hash memos are populated
-			// cannot be read from outside. A fixed handful of bytes, and the assertion below pins that it stays fixed
-			final long excess = warm - measuredHeapOf(index, EXCLUSIONS);
-			assertTrue(excess > 0 && excess < 128, "the formula's over-charge must stay small - was " + excess);
+			// What remains is a small SIGNED divergence rather than the old over-charge. Dropping the formula memo
+			// removed the upper-bound scaffolding charge that used to sit on top, and doing so exposed a fixed
+			// under-report of `BaseBitmap#getHeapSizeInBytes` against a reflective walk - about two words, present
+			// before this change and merely masked by the over-charge. What matters for a memory report is that it
+			// is a CONSTANT and not a term that grows, which the divergence assertion below pins
+			final long divergence = warm - measuredHeapOf(index, EXCLUSIONS);
+			assertTrue(
+				Math.abs(divergence) < 128,
+				"the bitmap charge must stay within a couple of words of the walk - was " + divergence
+			);
 
 			final HierarchyIndex larger = seededIndex(40, 20);
 			larger.getAllHierarchyNodesFormula();

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/IndexFormulaRetentionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/IndexFormulaRetentionTest.java
@@ -1,0 +1,197 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.infra.SkipFormula;
+import io.evitadb.index.attribute.OwnerFilterIndex;
+import io.evitadb.index.attribute.OwnerUniqueIndex;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.hierarchy.HierarchyIndex;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import io.evitadb.test.Entities;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Guards the invariant that keeps query state out of the index layer:
+ *
+ * **No object with index lifetime may hold a [Formula].**
+ *
+ * A formula node is *per-query* state. `AbstractFormula#initialize(QueryExecutionContext)` writes the executing
+ * query's context onto every node of the plan it is part of, and that context transitively reaches the
+ * `EvitaSession` and the whole catalog generation the query ran against. An index that memoizes a formula and hands
+ * the same instance to successive query plans therefore pins the first session that ever touched it — together with
+ * everything that session reached — until the index is written to again. On a read-mostly index that is never, which
+ * is what made this leak grow monotonically in production rather than plateau.
+ *
+ * The remedy applied across the index layer is to memoize the **bitmap** (the part that is expensive to produce) and
+ * to build a fresh, cheap {@link io.evitadb.core.query.algebra.base.ConstantFormula} wrapper per call. This test
+ * exists because per-class discipline is not self-enforcing: it walks the declared fields of the index types that
+ * carry such caches and fails if any of them retains a formula, so the next memoization added to an index cannot
+ * silently reintroduce the leak.
+ *
+ * Ref: #1458
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(ENGINE)
+@Tag(INDEXING)
+@DisplayName("Index structures must never retain a Formula")
+class IndexFormulaRetentionTest {
+
+	/**
+	 * Walks every non-static field declared by the object's class and its superclasses and fails when any of them
+	 * holds a {@link Formula}.
+	 *
+	 * The stateless singletons are exempt: {@link EmptyFormula#INSTANCE} and {@link SkipFormula#INSTANCE} both
+	 * override `initialize` with a deliberate no-op precisely so that they can be shared, so neither can capture a
+	 * query's execution context.
+	 *
+	 * @param index the index instance to inspect, with all of its caches already warmed
+	 */
+	private static void assertRetainsNoFormula(@Nonnull Object index) throws IllegalAccessException {
+		for (Class<?> type = index.getClass(); type != null && type != Object.class; type = type.getSuperclass()) {
+			for (Field field : type.getDeclaredFields()) {
+				if (Modifier.isStatic(field.getModifiers())) {
+					continue;
+				}
+				field.setAccessible(true);
+				final Object value = field.get(index);
+				if (value instanceof Formula && value != EmptyFormula.INSTANCE && value != SkipFormula.INSTANCE) {
+					fail(
+						"Field `" + type.getSimpleName() + "#" + field.getName() + "` retains a " +
+							value.getClass().getSimpleName() + " for the lifetime of the index. A formula carries " +
+							"per-query state once a plan initializes it, so holding one pins the session and the " +
+							"catalog generation that first used it. Memoize the bitmap instead and wrap it in a " +
+							"fresh ConstantFormula per call - see FilterIndex#memoizedAllRecords."
+					);
+				}
+			}
+		}
+	}
+
+	@Test
+	@DisplayName("FilterIndex memoizes its all-records bitmap without retaining the formula")
+	void shouldNotRetainFormulaInFilterIndex() throws IllegalAccessException {
+		final OwnerFilterIndex index = new OwnerFilterIndex(
+			new AttributeIndexKey(null, "a", null), String.class
+		);
+		index.addRecord(1, "A");
+		index.addRecord(2, "B");
+
+		// warm every cache the index has, through the accessors a query plan uses
+		final Formula first = index.getAllRecordsFormula();
+		final Formula second = index.getAllRecordsFormula();
+		assertNotSame(first, second);
+
+		assertRetainsNoFormula(index);
+	}
+
+	@Test
+	@DisplayName("OwnerUniqueIndex builds its record-ids formula fresh and retains none")
+	void shouldNotRetainFormulaInOwnerUniqueIndex() throws IllegalAccessException {
+		final OwnerUniqueIndex index = new OwnerUniqueIndex(
+			Entities.PRODUCT,
+			new AttributeIndexKey(null, "code", null),
+			String.class
+		);
+		index.registerUniqueKey("A", 1);
+		index.registerUniqueKey("B", 2);
+
+		final Formula first = index.getRecordIdsFormula();
+		final Formula second = index.getRecordIdsFormula();
+		assertNotSame(first, second);
+
+		assertRetainsNoFormula(index);
+	}
+
+	@Test
+	@DisplayName("HierarchyIndex memoizes its all-nodes bitmap without retaining the formula")
+	void shouldNotRetainFormulaInHierarchyIndex() throws IllegalAccessException {
+		final HierarchyIndex index = new HierarchyIndex();
+		index.addNode(1, null);
+		index.addNode(2, 1);
+
+		final Formula first = index.getAllHierarchyNodesFormula();
+		final Formula second = index.getAllHierarchyNodesFormula();
+		assertNotSame(first, second);
+
+		assertRetainsNoFormula(index);
+	}
+
+	@Test
+	@DisplayName("an empty HierarchyIndex parks no formula either")
+	void shouldNotRetainFormulaInEmptyHierarchyIndex() throws IllegalAccessException {
+		final HierarchyIndex index = new HierarchyIndex();
+
+		// an empty index short-circuits to the shared EmptyFormula singleton, which is safe to hand out repeatedly
+		index.getAllHierarchyNodesFormula();
+
+		assertRetainsNoFormula(index);
+	}
+
+	@Test
+	@DisplayName("the guard detects a retained formula, and tolerates the safe singletons")
+	void shouldDetectRetainedFormula() {
+		// calibration: without this, a guard that silently inspected nothing would pass every test above and
+		// report coverage it does not have
+		assertThrows(AssertionError.class, () -> assertRetainsNoFormula(new LeakyHolder()));
+
+		// the two singletons whose initialize() is a documented no-op must not trip the guard
+		assertDoesNotThrow(() -> assertRetainsNoFormula(new ExemptHolder()));
+	}
+
+	/**
+	 * Stands in for an index that memoized a formula, so that the guard above can be shown to fail when the
+	 * invariant is actually violated.
+	 */
+	@SuppressWarnings("unused")
+	private static final class LeakyHolder {
+		private final Formula retained = new ConstantFormula(new BaseBitmap(1, 2));
+	}
+
+	/**
+	 * Holds only the shared stateless formula singletons, which are safe to retain and must be tolerated.
+	 */
+	@SuppressWarnings("unused")
+	private static final class ExemptHolder {
+		private final Formula empty = EmptyFormula.INSTANCE;
+		private final Formula skip = SkipFormula.INSTANCE;
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/IndexHeapSizeAssertions.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/IndexHeapSizeAssertions.java
@@ -24,6 +24,7 @@
 package io.evitadb.index;
 
 import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.response.TransactionalDataRelatedStructure;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.bitmap.EmptyBitmap;
 import io.evitadb.index.price.VoidPriceIndex;
@@ -90,7 +91,13 @@ public final class IndexHeapSizeAssertions {
 		// takes. Both are one instance for the whole JVM; the comparator is an enum constant, so subtracting it
 		// also subtracts the constant's name and its byte array - seventy-two bytes that otherwise read as a
 		// shortfall in whichever tree happened to be walked
-		VoidPriceIndex.INSTANCE, Comparator.naturalOrder()
+		VoidPriceIndex.INSTANCE, Comparator.naturalOrder(),
+		// the hash function a BaseBitmap parks on once its content hash has been memoized. Unlike the entries
+		// above it appears only in a WARM index - a bitmap that has never been asked for its content hash does
+		// not reach it - so leaving it out makes a heap test pass cold and fail warm by exactly one object, which
+		// reads as the memo costing sixteen bytes it does not cost. It is the single instance every formula in
+		// the JVM hashes with, and `BaseBitmap#getHeapSizeInBytes` deliberately charges nothing for it
+		TransactionalDataRelatedStructure.HASH_FUNCTION
 	};
 
 	private IndexHeapSizeAssertions() {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/LeafIndexHeapSizeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/LeafIndexHeapSizeTest.java
@@ -552,28 +552,27 @@ class LeafIndexHeapSizeTest {
 		}
 
 		@Test
-		void shouldStepUpOnceTheAllRecordsFormulaIsMemoizedAndStayExactBothTimes() {
+		void shouldNotGrowAtAllWhenTheRecordIdsFormulaIsRequested() {
 			final OwnerUniqueIndex index = ownerUniqueIndex(200);
 			final long cold = index.getHeapSizeInBytes();
 			assertMatchesMeasuredHeap(cold, index, OWNER_EXCLUSIONS);
 
 			index.getRecordIdsFormula();
 
+			// This index memoizes NOTHING for a formula request: `getRecordIdsFormula` wraps the record set it
+			// already holds in a fresh ConstantFormula that dies with the query it served. Answering a query must
+			// therefore leave the footprint untouched - and the measurement exact, because there is no retained
+			// scaffolding to price at an upper bound.
+			//
+			// This is the accounting face of the leak fixed in #1458: a formula node carries the execution context
+			// of the first query to initialize it, so an index that kept one pinned that query's session and its
+			// whole catalog generation. A step up here would mean a memo came back.
 			final long warm = index.getHeapSizeInBytes();
-			assertTrue(warm > cold, "the memoized formula must show up as additional occupancy");
-			// The formula wraps the very record set already charged above, and its own `memoizedResult` resolves to
-			// that same instance - so neither is followed, and a walk finds no second bitmap. What the arithmetic
-			// DOES read high is the formula's cost bookkeeping: `initFields` runs in the constructor and populates
-			// four of the six memo fields, while `cost` and `costToPerformance` stay null until something asks what
-			// the formula costs. Which are populated cannot be read from outside, so all five boxed Longs are
-			// charged - the higher of two defensible figures - leaving the arithmetic exactly two boxes above the
-			// measurement, forever, however large the index grows
-			final long excess = warm - measuredHeapOf(index, OWNER_EXCLUSIONS);
-			assertTrue(excess > 0 && excess < 128, "the formula's over-charge must stay small - was " + excess);
+			assertEquals(cold, warm, "asking for the record-ids formula must not change the footprint");
+			assertMatchesMeasuredHeap(warm, index, OWNER_EXCLUSIONS);
 
-			// and it must be a CONSTANT, not a term that grows: an index holding more records over-charges by the
-			// same handful of bytes, which is what makes charging the upper bound harmless. Both fixtures stay
-			// inside one leaf block, so neither carries the separate separator-key over-report
+			// and it must hold however large the index grows - both fixtures stay inside one leaf block, so neither
+			// carries the separate separator-key over-report
 			final OwnerUniqueIndex larger = ownerUniqueIndex(250);
 			larger.getRecordIdsFormula();
 			assertDivergenceDoesNotGrowWithTheData(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexTest.java
@@ -25,7 +25,9 @@ package io.evitadb.index.attribute;
 
 import io.evitadb.comparator.LocalizedStringComparator;
 import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.core.buffer.TrappedChanges;
 import io.evitadb.dataType.BigDecimalNumberRange;
 import io.evitadb.dataType.ComparableCurrency;
@@ -585,26 +587,26 @@ class FilterIndexTest {
 	class NonTransactionalCacheTest {
 
 		@Test
-		@DisplayName("memoized formula is invalidated on non-tx write")
-		void shouldInvalidateMemoizedFormulaOnNonTransactionalWrite() {
+		@DisplayName("memoized bitmap is invalidated on non-tx write")
+		void shouldInvalidateMemoizedBitmapOnNonTransactionalWrite() {
 			final OwnerFilterIndex index = new OwnerFilterIndex(
 				new AttributeIndexKey(null, "a", null), String.class
 			);
 			index.addRecord(1, "A");
 
-			// first call caches the formula
-			final Formula firstCall = index.getAllRecordsFormula();
+			// first call caches the bitmap
+			final Bitmap firstCall = index.getAllRecords();
 			// second call returns same cached instance
-			final Formula secondCall = index.getAllRecordsFormula();
+			final Bitmap secondCall = index.getAllRecords();
 			assertSame(firstCall, secondCall);
 
 			// write invalidates the cache
 			index.addRecord(2, "B");
-			final Formula afterWrite = index.getAllRecordsFormula();
+			final Bitmap afterWrite = index.getAllRecords();
 			assertNotSame(firstCall, afterWrite);
 			assertArrayEquals(
 				new int[]{1, 2},
-				afterWrite.compute().getArray()
+				afterWrite.getArray()
 			);
 		}
 	}
@@ -614,8 +616,8 @@ class FilterIndexTest {
 	class FormulaMemoizationTest {
 
 		@Test
-		@DisplayName("getAllRecordsFormula returns same instance when no writes")
-		void shouldReturnSameFormulaInstanceWhenNoWrites() {
+		@DisplayName("getAllRecordsFormula memoizes the bitmap but never the formula")
+		void shouldMemoizeBitmapButHandOutFreshFormula() {
 			final OwnerFilterIndex index = new OwnerFilterIndex(
 				new AttributeIndexKey(null, "a", null), String.class
 			);
@@ -625,7 +627,15 @@ class FilterIndexTest {
 			final Formula first = index.getAllRecordsFormula();
 			final Formula second = index.getAllRecordsFormula();
 
-			assertSame(first, second);
+			// a formula node carries per-query state once a plan initializes it, so an index-lifetime structure
+			// must never hand out the same instance twice - see FilterIndex#memoizedAllRecords
+			assertNotSame(first, second);
+			// the expensive part - the merged bitmap - is still memoized and shared between them
+			assertSame(
+				((ConstantFormula) first).getDelegate(),
+				((ConstantFormula) second).getDelegate()
+			);
+			assertSame(index.getAllRecords(), ((ConstantFormula) first).getDelegate());
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/UniqueIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/UniqueIndexTest.java
@@ -317,8 +317,8 @@ class UniqueIndexTest {
 	class FormulaAndMemoizationTest {
 
 		@Test
-		@DisplayName("getRecordIdsFormula() caches across calls and invalidates on mutation (T8)")
-		void shouldCacheFormulaAndInvalidateOnMutation() {
+		@DisplayName("getRecordIdsFormula() hands out a fresh formula that tracks mutations (T8)")
+		void shouldReturnFreshFormulaTrackingMutations() {
 			final UniqueIndex index = new OwnerUniqueIndex(
 				Entities.PRODUCT,
 				new AttributeIndexKey(null, "code", null),
@@ -326,20 +326,23 @@ class UniqueIndexTest {
 			);
 			index.registerUniqueKey("A", 1);
 
-			// two consecutive calls return the same cached instance
+			// a formula node carries per-query state once a plan initializes it, so an index-lifetime structure
+			// must never hand out the same instance twice - see OwnerUniqueIndex#getRecordIdsFormula
 			final Formula first = index.getRecordIdsFormula();
 			final Formula second = index.getRecordIdsFormula();
-			assertSame(first, second);
+			assertNotSame(first, second);
+			assertArrayEquals(new int[]{1}, second.compute().getArray());
 
-			// mutation invalidates cache — a new formula is returned
+			// a mutation is picked up by the next formula handed out
 			index.registerUniqueKey("B", 2);
 			final Formula afterMutation = index.getRecordIdsFormula();
 			assertNotSame(first, afterMutation);
+			assertArrayEquals(new int[]{1, 2}, afterMutation.compute().getArray());
 		}
 
 		@Test
-		@DisplayName("getRecordIdsFormula() cache invalidation on unregister")
-		void shouldInvalidateCacheOnUnregister() {
+		@DisplayName("getRecordIdsFormula() reflects an unregister in the next formula handed out")
+		void shouldReflectUnregisterInNextFormula() {
 			final UniqueIndex index = new OwnerUniqueIndex(
 				Entities.PRODUCT,
 				new AttributeIndexKey(null, "code", null),
@@ -349,9 +352,12 @@ class UniqueIndexTest {
 			index.registerUniqueKey("B", 2);
 
 			final Formula before = index.getRecordIdsFormula();
+			assertArrayEquals(new int[]{1, 2}, before.compute().getArray());
+
 			index.unregisterUniqueKey("A", 1);
 			final Formula after = index.getRecordIdsFormula();
 			assertNotSame(before, after);
+			assertArrayEquals(new int[]{2}, after.compute().getArray());
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bitmap/BaseBitmapTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bitmap/BaseBitmapTest.java
@@ -1533,9 +1533,10 @@ class BaseBitmapTest {
 		@Test
 		@DisplayName("should invalidate the hash when add inserts a record")
 		void shouldInvalidateHashWhenAddInsertsRecord() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.add(4);
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
@@ -1554,25 +1555,28 @@ class BaseBitmapTest {
 		@Test
 		@DisplayName("should invalidate the hash when addAll receives an array")
 		void shouldInvalidateHashWhenAddAllReceivesArray() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.addAll(4, 5);
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
 		@DisplayName("should invalidate the hash when addAll receives a bitmap")
 		void shouldInvalidateHashWhenAddAllReceivesBitmap() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.addAll(new BaseBitmap(8, 9));
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
 		@DisplayName("should invalidate the hash when remove deletes a record")
 		void shouldInvalidateHashWhenRemoveDeletesRecord() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.remove(2);
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
@@ -1591,65 +1595,78 @@ class BaseBitmapTest {
 		@Test
 		@DisplayName("should invalidate the hash when removeAll receives an array")
 		void shouldInvalidateHashWhenRemoveAllReceivesArray() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.removeAll(1, 3);
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
 		@DisplayName("should invalidate the hash when removeAll receives a bitmap")
 		void shouldInvalidateHashWhenRemoveAllReceivesBitmap() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.removeAll(new BaseBitmap(1, 2));
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
 		@DisplayName("should invalidate the hash when removeAll applies a predicate")
 		void shouldInvalidateHashWhenRemoveAllAppliesPredicate() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.removeAll((IntPredicate) value -> value % 2 == 0);
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
 		@DisplayName("should invalidate the hash when retainAll applies a predicate")
 		void shouldInvalidateHashWhenRetainAllAppliesPredicate() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.retainAll((IntPredicate) value -> value > 1);
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		@Test
 		@DisplayName("should invalidate the hash when the bitmap is cleared")
 		void shouldInvalidateHashWhenBitmapIsCleared() {
-			final BaseBitmap bitmap = seedAndHash();
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final BaseBitmap bitmap = seedAndHash(hashFunction);
 			bitmap.clear();
-			assertHashRecomputedAndCorrect(bitmap);
+			assertHashRecomputedAndCorrect(bitmap, hashFunction);
 		}
 
 		/**
-		 * Builds a three-record bitmap and warms its content-hash memo, so the caller's mutation is the thing that
-		 * decides whether the next {@link BaseBitmap#getContentHash} recomputes.
+		 * Builds a three-record bitmap and warms its content-hash memo **with the caller's own function**, so the
+		 * mutation the caller then performs is the only thing that can decide whether the next
+		 * {@link BaseBitmap#getContentHash} recomputes.
+		 *
+		 * Warming with any other instance would defeat the whole check: the memo is keyed by function identity, so a
+		 * later call carrying a different one misses it whether or not the mutator cleared anything, and the
+		 * assertion would hold even against a `BaseBitmap` that never invalidates.
 		 */
 		@Nonnull
-		private BaseBitmap seedAndHash() {
+		private BaseBitmap seedAndHash(@Nonnull CountingHashFunction hashFunction) {
 			final BaseBitmap bitmap = new BaseBitmap(1, 2, 3);
-			bitmap.getContentHash(LongHashFunction.xx3());
+			bitmap.getContentHash(hashFunction);
 			return bitmap;
 		}
 
 		/**
 		 * Asserts a mutated bitmap answers for its **current** contents and got there by walking them again rather
-		 * than replaying the memo warmed by {@link #seedAndHash()}.
+		 * than replaying the memo {@link #seedAndHash(CountingHashFunction)} warmed with this same function — one
+		 * walk for the seeding, a second forced by the mutation.
 		 */
-		private void assertHashRecomputedAndCorrect(@Nonnull BaseBitmap bitmap) {
-			final CountingHashFunction hashFunction = new CountingHashFunction();
+		private void assertHashRecomputedAndCorrect(
+			@Nonnull BaseBitmap bitmap,
+			@Nonnull CountingHashFunction hashFunction
+		) {
 			assertEquals(
 				hashFunction.hashIntsUncounted(bitmap.getArray()), bitmap.getContentHash(hashFunction),
 				"the content hash must describe the bitmap's current contents"
 			);
-			assertEquals(1, hashFunction.getHashIntsCallCount(), "the mutation must have forced a recomputation");
+			assertEquals(2, hashFunction.getHashIntsCallCount(), "the mutation must have forced a recomputation");
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bitmap/BaseBitmapTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bitmap/BaseBitmapTest.java
@@ -25,6 +25,8 @@ package io.evitadb.index.bitmap;
 
 import com.carrotsearch.hppc.predicates.IntPredicate;
 import io.evitadb.roaringbitmap.PersistentRoaringBitmap;
+import net.openhft.hashing.Access;
+import net.openhft.hashing.LongHashFunction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -32,6 +34,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import javax.annotation.Nonnull;
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.PrimitiveIterator.OfInt;
 import java.util.Random;
@@ -1474,6 +1478,250 @@ class BaseBitmapTest {
 
 			assertEquals(3, bitmap.size());
 			assertArrayEquals(new int[]{1, 2, 3}, bitmap.getArray());
+		}
+	}
+
+	/**
+	 * Pins the memoized content hash. Two properties matter and they pull in opposite directions:
+	 *
+	 * - it must be memoized, because a `ConstantFormula` over a non-transactional bitmap keys its cache entry on
+	 * this value and index memos build one such formula per query — without the memo that is an `O(size)` walk per
+	 * call (issue #1458);
+	 * - it must never outlive the contents it describes, because the same value is the *sole* cache discriminator
+	 * for those formulas — a stale hash serves one bitmap's cached result for another's contents.
+	 *
+	 * Every mutator therefore gets its own invalidation test. The counting hash function is what distinguishes
+	 * "answered correctly" from "answered correctly *and* recomputed".
+	 */
+	@Nested
+	@DisplayName("Memoized content hash")
+	class ContentHashTest {
+
+		@Test
+		@DisplayName("should hash the contents only once across repeated calls")
+		void shouldHashContentsOnlyOnceAcrossRepeatedCalls() {
+			final BaseBitmap bitmap = new BaseBitmap(1, 2, 3, 4, 5);
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+
+			final long first = bitmap.getContentHash(hashFunction);
+			final long second = bitmap.getContentHash(hashFunction);
+			final long third = bitmap.getContentHash(hashFunction);
+
+			assertEquals(hashFunction.hashIntsUncounted(new int[]{1, 2, 3, 4, 5}), first);
+			assertEquals(first, second);
+			assertEquals(first, third);
+			assertEquals(1, hashFunction.getHashIntsCallCount(), "the contents must be walked exactly once");
+		}
+
+		@Test
+		@DisplayName("should answer correctly for a hash function it has not memoized")
+		void shouldAnswerCorrectlyForForeignHashFunction() {
+			final BaseBitmap bitmap = new BaseBitmap(7, 9, 11);
+			final CountingHashFunction functionA = new CountingHashFunction(LongHashFunction.xx3(1L));
+			final CountingHashFunction functionB = new CountingHashFunction(LongHashFunction.xx3(2L));
+
+			final long hashA = bitmap.getContentHash(functionA);
+			final long hashB = bitmap.getContentHash(functionB);
+
+			assertNotEquals(hashA, hashB, "differently seeded functions must not answer alike");
+			assertEquals(functionA.hashIntsUncounted(bitmap.getArray()), hashA);
+			assertEquals(functionB.hashIntsUncounted(bitmap.getArray()), hashB);
+			// re-asking the first function must still be correct, even though the memo now holds the second's
+			assertEquals(hashA, bitmap.getContentHash(functionA));
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when add inserts a record")
+		void shouldInvalidateHashWhenAddInsertsRecord() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.add(4);
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should keep the memoized hash when add changes nothing")
+		void shouldKeepMemoizedHashWhenAddChangesNothing() {
+			final BaseBitmap bitmap = new BaseBitmap(1, 2, 3);
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final long before = bitmap.getContentHash(hashFunction);
+
+			assertFalse(bitmap.add(2), "the record is already present");
+
+			assertEquals(before, bitmap.getContentHash(hashFunction));
+			assertEquals(1, hashFunction.getHashIntsCallCount(), "a no-op add must not discard the memo");
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when addAll receives an array")
+		void shouldInvalidateHashWhenAddAllReceivesArray() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.addAll(4, 5);
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when addAll receives a bitmap")
+		void shouldInvalidateHashWhenAddAllReceivesBitmap() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.addAll(new BaseBitmap(8, 9));
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when remove deletes a record")
+		void shouldInvalidateHashWhenRemoveDeletesRecord() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.remove(2);
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should keep the memoized hash when remove changes nothing")
+		void shouldKeepMemoizedHashWhenRemoveChangesNothing() {
+			final BaseBitmap bitmap = new BaseBitmap(1, 2, 3);
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			final long before = bitmap.getContentHash(hashFunction);
+
+			assertFalse(bitmap.remove(42), "the record was never present");
+
+			assertEquals(before, bitmap.getContentHash(hashFunction));
+			assertEquals(1, hashFunction.getHashIntsCallCount(), "a no-op remove must not discard the memo");
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when removeAll receives an array")
+		void shouldInvalidateHashWhenRemoveAllReceivesArray() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.removeAll(1, 3);
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when removeAll receives a bitmap")
+		void shouldInvalidateHashWhenRemoveAllReceivesBitmap() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.removeAll(new BaseBitmap(1, 2));
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when removeAll applies a predicate")
+		void shouldInvalidateHashWhenRemoveAllAppliesPredicate() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.removeAll((IntPredicate) value -> value % 2 == 0);
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when retainAll applies a predicate")
+		void shouldInvalidateHashWhenRetainAllAppliesPredicate() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.retainAll((IntPredicate) value -> value > 1);
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		@Test
+		@DisplayName("should invalidate the hash when the bitmap is cleared")
+		void shouldInvalidateHashWhenBitmapIsCleared() {
+			final BaseBitmap bitmap = seedAndHash();
+			bitmap.clear();
+			assertHashRecomputedAndCorrect(bitmap);
+		}
+
+		/**
+		 * Builds a three-record bitmap and warms its content-hash memo, so the caller's mutation is the thing that
+		 * decides whether the next {@link BaseBitmap#getContentHash} recomputes.
+		 */
+		@Nonnull
+		private BaseBitmap seedAndHash() {
+			final BaseBitmap bitmap = new BaseBitmap(1, 2, 3);
+			bitmap.getContentHash(LongHashFunction.xx3());
+			return bitmap;
+		}
+
+		/**
+		 * Asserts a mutated bitmap answers for its **current** contents and got there by walking them again rather
+		 * than replaying the memo warmed by {@link #seedAndHash()}.
+		 */
+		private void assertHashRecomputedAndCorrect(@Nonnull BaseBitmap bitmap) {
+			final CountingHashFunction hashFunction = new CountingHashFunction();
+			assertEquals(
+				hashFunction.hashIntsUncounted(bitmap.getArray()), bitmap.getContentHash(hashFunction),
+				"the content hash must describe the bitmap's current contents"
+			);
+			assertEquals(1, hashFunction.getHashIntsCallCount(), "the mutation must have forced a recomputation");
+		}
+	}
+
+	/**
+	 * {@link LongHashFunction} that records how many times {@link #hashInts(int[])} — the single entry point
+	 * {@link Bitmap#getContentHash(LongHashFunction)} uses — was actually invoked, so a test can tell a memo hit
+	 * from a recomputation. Everything else is plain delegation.
+	 */
+	private static final class CountingHashFunction extends LongHashFunction {
+		@Serial private static final long serialVersionUID = 6002348816451219923L;
+		private final LongHashFunction delegate;
+		private int hashIntsCallCount;
+
+		CountingHashFunction() {
+			this(LongHashFunction.xx3());
+		}
+
+		CountingHashFunction(@Nonnull LongHashFunction delegate) {
+			this.delegate = delegate;
+		}
+
+		int getHashIntsCallCount() {
+			return this.hashIntsCallCount;
+		}
+
+		/**
+		 * Computes the same value as {@link #hashInts(int[])} without disturbing the call count, so a test can
+		 * state its expectation without paying for it.
+		 */
+		long hashIntsUncounted(@Nonnull int[] input) {
+			return this.delegate.hashInts(input);
+		}
+
+		@Override
+		public long hashInts(int[] input) {
+			this.hashIntsCallCount++;
+			return this.delegate.hashInts(input);
+		}
+
+		@Override
+		public long hashLong(long input) {
+			return this.delegate.hashLong(input);
+		}
+
+		@Override
+		public long hashInt(int input) {
+			return this.delegate.hashInt(input);
+		}
+
+		@Override
+		public long hashShort(short input) {
+			return this.delegate.hashShort(input);
+		}
+
+		@Override
+		public long hashChar(char input) {
+			return this.delegate.hashChar(input);
+		}
+
+		@Override
+		public long hashByte(byte input) {
+			return this.delegate.hashByte(input);
+		}
+
+		@Override
+		public long hashVoid() {
+			return this.delegate.hashVoid();
+		}
+
+		@Override
+		public <T> long hash(T input, Access<T> access, long off, long len) {
+			return this.delegate.hash(input, access, off, len);
 		}
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/hierarchy/HierarchyIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/hierarchy/HierarchyIndexTest.java
@@ -25,6 +25,7 @@ package io.evitadb.index.hierarchy;
 
 import io.evitadb.api.query.order.TraversalMode;
 import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.deferred.DeferredFormula;
 import io.evitadb.exception.EvitaInvalidUsageException;
@@ -1233,13 +1234,19 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 		}
 
 		@Test
-		@DisplayName("getAllHierarchyNodesFormula memoization: same reference on second call")
-		void shouldMemoizeAllNodesFormula() {
+		@DisplayName("getAllHierarchyNodesFormula memoizes the bitmap but never the formula")
+		void shouldMemoizeAllNodesBitmapButHandOutFreshFormula() {
 			final Formula first = HierarchyIndexTest.this.hierarchyIndex
 				.getAllHierarchyNodesFormula();
 			final Formula second = HierarchyIndexTest.this.hierarchyIndex
 				.getAllHierarchyNodesFormula();
-			assertSame(first, second);
+			// a formula node carries per-query state once a plan initializes it, so an index-lifetime structure
+			// must never hand out the same instance twice - see HierarchyIndex#memoizedAllNodes
+			assertNotSame(first, second);
+			// the expensive part - the O(nodes) walk producing the bitmap - is still memoized
+			final Bitmap memoizedNodes = HierarchyIndexTest.this.hierarchyIndex.getAllHierarchyNodes();
+			assertSame(memoizedNodes, HierarchyIndexTest.this.hierarchyIndex.getAllHierarchyNodes());
+			assertSame(memoizedNodes, ((ConstantFormula) first).getDelegate());
 		}
 
 		@Test
@@ -1285,38 +1292,38 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 	class NonTransactionalModeTest {
 
 		@Test
-		@DisplayName("memoized formula reset after non-transactional addNode")
-		void shouldResetMemoizedFormulaOnAdd() {
+		@DisplayName("memoized bitmap reset after non-transactional addNode")
+		void shouldResetMemoizedBitmapOnAdd() {
 			final HierarchyIndex index = new HierarchyIndex();
 			index.addNode(1, null);
 
-			final Formula first = index.getAllHierarchyNodesFormula();
-			assertArrayEquals(new int[]{1}, first.compute().getArray());
+			final Bitmap first = index.getAllHierarchyNodes();
+			assertArrayEquals(new int[]{1}, first.getArray());
 
 			// add another node outside transaction
 			index.addNode(2, null);
 
-			final Formula second = index.getAllHierarchyNodesFormula();
-			assertArrayEquals(new int[]{1, 2}, second.compute().getArray());
-			// formula should have been refreshed
+			final Bitmap second = index.getAllHierarchyNodes();
+			assertArrayEquals(new int[]{1, 2}, second.getArray());
+			// the memoized bitmap should have been refreshed
 			assertNotSame(first, second);
 		}
 
 		@Test
-		@DisplayName("memoized formula reset after non-transactional removeNode")
-		void shouldResetMemoizedFormulaOnRemove() {
+		@DisplayName("memoized bitmap reset after non-transactional removeNode")
+		void shouldResetMemoizedBitmapOnRemove() {
 			final HierarchyIndex index = new HierarchyIndex();
 			index.addNode(1, null);
 			index.addNode(2, 1);
 
-			final Formula first = index.getAllHierarchyNodesFormula();
-			assertArrayEquals(new int[]{1, 2}, first.compute().getArray());
+			final Bitmap first = index.getAllHierarchyNodes();
+			assertArrayEquals(new int[]{1, 2}, first.getArray());
 
 			// remove node outside transaction
 			index.removeNode(2);
 
-			final Formula second = index.getAllHierarchyNodesFormula();
-			assertArrayEquals(new int[]{1}, second.compute().getArray());
+			final Bitmap second = index.getAllHierarchyNodes();
+			assertArrayEquals(new int[]{1}, second.getArray());
 			assertNotSame(first, second);
 		}
 	}


### PR DESCRIPTION
Dev-side counterpart of #1459 (which targets `master` off `release_2026-2`). Same semantic fix, plus the heap accounting that exists only on this branch, plus the ADR.

Closes #1458

## What leaked

`AbstractFormula#initialize(QueryExecutionContext)` writes the executing query's context onto every node of the plan it is part of. Three index structures memoized a `Formula` for the **lifetime of the index** and handed the same instance to successive query plans, so the first query to touch one pinned its session — and the whole catalog generation reachable from it — until the index was next written to. On a read-mostly index that is never.

Measured on decodoma production (ks02, evitaDB 2026.1.15): the post-GC live heap floor climbed **8.30 → 14.43 GB over 45 h (~139 MB/h)** against a 22 GiB maximum, never recovering.

**Read this before opening the session lifecycle:** 5,107,029 sessions were opened over the pod's life and 126 survived — **1 in 40,531**. Session close and deregistration are provably correct; this is a rare *pin*, not a lifecycle failure.

## The fix

Memoize the **bitmap** — the part that is actually expensive — and build a fresh `ConstantFormula` wrapper per call.

| Site | Change |
|---|---|
| `FilterIndex` | `memoizedAllRecordsFormula` → `memoizedAllRecords` (`Bitmap`) |
| `OwnerUniqueIndex` | memo deleted outright — `recordIds` was already the bitmap |
| `HierarchyIndex` | `memoizedAllNodeFormula` → `memoizedAllNodes` (`Bitmap`) |

`HierarchyIndex` had **no observed contamination** (0 of 101,794 instances, no main-source caller outside the class). It is converted so the shape does not survive as a template, not because it was leaking.

`OwnerUniqueIndex` losing its invalidation-on-mutation is correct: its formula always wrapped `this.recordIds`, a `TransactionalBitmap` mutated in place, so invalidation never changed the computed result — only the hash and cost captured at construction.

## Heap accounting — the part that is dev-only

`IndexHeapSize#memoizedFormulaSizeInBytes` loses all three index callers and keeps exactly one, `InvertedIndexSubSet`. Its JavaDoc claim to be "the one place a memoized formula is priced" becomes **more** accurate, so the method stays; the JavaDoc is narrowed because it described callers that no longer exist.

The three indexes stay deliberately asymmetric, and this is not an oversight:
- `HierarchyIndex` charges its bitmap **unconditionally** — it materializes a node set nothing else holds.
- `FilterIndex` charges only when `getBucketCount() > 1` — a single-bucket memo aliases the bucket's own bitmap, already charged by the tree.
- `OwnerUniqueIndex` charges **nothing** — it retains nothing.

**A pre-existing under-report surfaced.** Dropping the formula scaffolding, which was charged at an upper bound, exposed that `BaseBitmap#getHeapSizeInBytes` under-reports its own graph by about two words (~16 bytes) against a reflective walk. It predates this change and was masked by the over-charge sitting on top of it. It is a constant, not a term that grows. **Deliberately not chased here** — it is a bitmap-accounting question independent of this leak, and the non-growth assertion still pins it.

## Sweep — what was checked and left alone

- **`InvertedIndexSubSet#memoizedResult`** — the only index-lifetime subset is `FilterIndex#memoizedRangeHistogramSubSet`, whose sole consumer (`AttributeHistogramComputer`) reads `getBuckets()` and never `getFormula()`. Bitmap memoization is *not* available here — the aggregation lambda may return a lazy `DeferredFormula`, so materializing eagerly would change behaviour. Recorded as a JavaDoc invariant at the field instead.
- **`GlobalEntityIndex.GlobalIndexProxyState`** — memoizes a formula, but is built per query plan in `QueryPlanningContext`, so it is query-lifetime.
- **`EntityIndex`, `GlobalUniqueIndex`, `RangeIndex`, `InvertedIndex`, `AbstractPriceListAndCurrencyPriceIndex`** — all build a fresh formula per call already.

## Rejected: a no-op `ConstantFormula#initialize`

The cheaper option — give `ConstantFormula` the same no-op `initialize` that `EmptyFormula` and `SkipFormula` already have. Rejected because it is a per-class exemption, and this codebase has already lost that game twice; those two singletons *are* the previous rounds. The one case that would have justified it does not hold: `InvertedIndexSubSet`'s lambda returns an `OrFormula` or `DeferredFormula` in the multi-bucket case, so a `ConstantFormula` exemption protects nothing there.

Full reasoning, including the `compute(...)`-threading option that would make the invariant unrepresentable and why it is not a patch-release change, is in the ADR.

## Tests

**270 green** across `FilterIndexTest`, `UniqueIndexTest`, `UniqueIndexViewTest`, `HierarchyIndexTest`, `IndexFormulaRetentionTest`, `ContainerIndexHeapSizeTest`, `LeafIndexHeapSizeTest`.

**The test diff is not a loosening of coverage** — it is the contract change:

- **`IndexFormulaRetentionTest` (new)** reflects over the index types' fields and fails on any retained `Formula`. It **calibrates itself** against a deliberately leaky holder, so it cannot silently degrade into inspecting nothing.
- **Three tests asserted the formula reference identity being removed** and were *inverted* — they now assert successive calls return *different* formula instances over the *same* memoized bitmap.
- **Four invalidation tests moved from formula identity to bitmap identity**, because `assertNotSame` on formulas is now trivially true and those tests would otherwise have stopped testing invalidation while still passing.
- **Two heap-size tests were rewritten, not renamed.** `LeafIndexHeapSizeTest` previously asserted a step-up after `getRecordIdsFormula()`; that is now deliberately false, so it asserts the footprint is *unchanged* — which turns it into a direct guard, since a step-up there now means a memo came back. The `HierarchyIndex` one moved from a strictly-positive over-charge to a bounded signed divergence, for the `BaseBitmap` reason above.

## Notes for review

- The ADR is in **this** PR only — one record per line of work, and it documents accounting that exists only here. #1459 says so in its body.
- `HierarchyIndex#getAllHierarchyNodes()` is new public API — additive, read-only, and the exact analogue of the already-public `FilterIndex#getAllRecords()`.
- `FilterIndex#getAllRecords()` no longer round-trips through a formula. Object identity is unchanged: `AbstractFormula#compute()` memoizes `computeInternal()`, and `ConstantFormula#computeInternal()` returns `this.delegate` — so the old path already handed out this same internal bitmap.


---

## Follow-up in this PR: the per-call content hash, found and fixed

`ConstantFormula` hashes a **non-transactional** delegate's *contents* in `includeAdditionalHash`, and `AbstractFormula#initFields` computes that eagerly in the constructor. Once a filter index's value tree holds more than one bucket, the memoized all-records bitmap is a `BaseBitmap` — not a `TransactionalLayerProducer` — so every `getAllRecordsFormula()` call paid `O(records)` where the old formula memo paid it once. That is not a mere optimization either: such a formula gathers **no** transactional ids, so the content hash is its *sole* cache discriminator.

**The fix:** move the memo onto the bitmap. `Bitmap#getContentHash(LongHashFunction)` defaults to the walk; `BaseBitmap` memoizes it. Because an index hands out the same `BaseBitmap` **instance** every time, the walk happens once and every later formula reads it back — while the index still retains no `Formula`, so the invariant and `IndexFormulaRetentionTest` are untouched. Rejected alternative: a `ConstantFormula` overload taking a precomputed hash, which adds public API, needs a "no hash supplied" sentinel, and helps only the two call sites that thread it through.

Measured on a seeded `OwnerFilterIndex` (one distinct value per 10 records, so the aggregation genuinely merges buckets) — added cost per `getAllRecordsFormula()` call:

| records | bitmap memo alone | bitmap memo + content hash |
|---:|---:|---:|
| 1,000 | 1,410 ns | **68 ns** |
| 10,000 | 10,240 ns | **162 ns** |
| 100,000 | 83,396 ns | **366 ns** |
| 500,000 | 308,516 ns | **60 ns** |

The remainder no longer scales with record count — it is the allocation plus `initFields`' scalars, and the scatter across sizes says it now sits below that harness's noise floor.

**Two things worth a reviewer's eye:**
- The memo is keyed by **hash function identity**, not assumed global — `CacheEnforcingPolicy` builds its own instance from the same factory as `TransactionalDataRelatedStructure#HASH_FUNCTION`, and a memo ignoring that would answer one function's question with another's hash.
- `BaseBitmap` is `@NotThreadSafe` yet the memo is read concurrently. The guard field is written **after** the hash with volatile semantics, so a racing reader either misses the memo and recomputes an identical value or sees a fully published one. Mutation concurrent with reads was already outside the class' contract.

**Invalidation had to be exhaustive**, and a sweep confirmed it can be: no site in main sources mutates a `PersistentRoaringBitmap` in place *after* wrapping it in a `BaseBitmap` — `OrFormula#computeInternal`, `HierarchyIndex#listNodesIncludingParents`, `createAllHierarchyNodesBitmap`, `BitmapChanges#getMergedBitmap` and both sorters' `notFoundRecords` each build a fresh local and wrap it last. All nine mutators clear the memo alongside `memoizedCardinality`.

**Scope of the original exposure was narrow:** only `AttributeIsTranslator` (an `attributeIs(NULL|NOT_NULL)` filter) and `AttributeHistogramComputer` ask for the formula. `OwnerUniqueIndex` was never affected (its delegate is a `TransactionalBitmap`, so the key is its transactional id), nor was `HierarchyIndex` in practice, nor a single-bucket filter index.

**Tests:** `BaseBitmapTest.ContentHashTest` — 13 cases using a counting `LongHashFunction` delegate, so each distinguishes "answered correctly" from "answered correctly *and* recomputed": one memo-hit, one foreign-function, nine invalidation (one per mutator), two asserting a **no-op** `add`/`remove` keeps the memo.

**Heap accounting (this branch only — the release line has none).** Both figures were settled against a JOL walk rather than reasoned about, and both are counter-intuitive:
- The two new fields need **no** alignment term. A `long` must start 8-aligned and the header is 12 bytes, so the arithmetic looks like it owes 4 bytes of padding — but the JVM packs the existing `int` into that gap and the `long` lands aligned for free. Adding the term over-reported by 8 bytes per bitmap.
- The guard points at the JVM-wide `TransactionalDataRelatedStructure#HASH_FUNCTION`, which the arithmetic rightly charges nothing for but a walk charges 16 bytes — and only once the memo is populated, which is why `LeafIndexHeapSizeTest` passed **cold** and failed **warm** by exactly one object. It now sits in `IndexHeapSizeAssertions#SHARED_EMPTY_ARRAYS`, where it is the first entry a cold index never reaches.


### Follow-up: the memo's publication was wrong, and is now an atomic pair

Caught by review after the above landed. The memo held the hash in a plain `long` and its function in a `volatile` reference written afterwards as a guard — the textbook safe-publication idiom, and correct for a **single** writer. It does not make a *pair* atomic, and this memo keys on one field and answers from the other:

```
T1  memoizedContentHash = hashA
T2  memoizedContentHash = hashB
T2  guard = B
T1  guard = A            <- guard names A, value is hashB
```

A third caller matching the guard then receives a hash never computed for the function it asked for. Since a `ConstantFormula` over a non-transactional delegate gathers no transactional ids, that hash is its *sole* cache discriminator — so this is a wrong cache key, not a slow one.

Both are now held in one immutable record published by a single volatile reference write. A record's final fields are safely published even through a data race, so a reader sees either `null` or a consistent pair, and racing writers can only overwrite each other with individually-consistent ones.

Not reachable from main sources today — only `TransactionalDataRelatedStructure#HASH_FUNCTION` ever reaches `getContentHash` — but it is public interface API and the keying exists precisely for callers that bring their own function, so the guarantee has to actually hold. Re-calibrated: removing the invalidation from all nine mutators still fails all nine `ContentHashTest` invalidation tests.

Heap accounting followed the field move: the wrapper loses its `long` and keeps one reference, and the record is charged only once allocated. Neither needs the alignment term a field sum suggests — both carry a 4-byte field the JVM slots into the gap a 12-byte header leaves, so the `long` lands 8-aligned for free. That was got wrong once per object, in the opposite direction, before a JOL probe settled it.
