### PR TITLE
fix: gate cross-entity histogram removal on the pre-mutation condition

### DIFF
--- a/documentation/adr/2026-04-23-bucketed-histogram-indexing.md
+++ b/documentation/adr/2026-04-23-bucketed-histogram-indexing.md
@@ -9,7 +9,7 @@ prs: [1136]
 areas: [evita_api/src/main/java/io/evitadb/api/requestResponse/schema, evita_engine/src/main/java/io/evitadb/index, evita_engine/src/main/java/io/evitadb/core/expression/trigger, evita_engine/src/main/java/io/evitadb/core/catalog]
 supersedes: []
 superseded-by: []
-relates: [2026-05-06-reference-histogram-statistics, 2026-05-27-range-and-multi-histogram-schema, 2026-04-23-conditional-facet-indexing]
+relates: [2026-05-06-reference-histogram-statistics, 2026-05-27-range-and-multi-histogram-schema, 2026-04-23-conditional-facet-indexing, 2026-08-31-cross-entity-histogram-removal-pre-pass]
 ---
 
 # Conditionally index per-reference attribute histograms via a dedicated HistogramIndex family

--- a/documentation/adr/2026-08-31-cross-entity-histogram-removal-pre-pass.md
+++ b/documentation/adr/2026-08-31-cross-entity-histogram-removal-pre-pass.md
@@ -1,11 +1,11 @@
 ---
 title: Gate cross-entity histogram removal on a pre-mutation condition pre-pass, not bucket membership
 date: 2026-08-31
-updated: 2026-08-31 11:20
+updated: 2026-08-31 11:48
 status: accepted
 kind: fix
 issues: [1467]
-prs: []
+prs: [1468, 1469]
 areas: [evita_engine/src/main/java/io/evitadb/index/mutation, evita_engine/src/main/java/io/evitadb/core/collection]
 supersedes: []
 superseded-by: []
@@ -147,15 +147,31 @@ format rework that can absorb the histogram rebuild.
 - **The pre-pass must stay read-only.** Every `resolveAffected` path it reaches uses
   `findReferencedTypeEntityIndex` / `getIndexByPrimaryKeyIfExists`, never a `getOrCreate…` variant.
   A future resolution path that creates an index would make the pre-pass mutate state.
-- **Bitmaps are materialised** (`new BaseBitmap(split.shouldBeIndexed().getArray())`) because the
-  mutations the pre-pass runs ahead of are about to modify the very indexes a passthrough filter plan
-  may hand back by reference.
+- **Bitmaps are materialised** (`new BaseBitmap(split.shouldBeIndexed())`) because the mutations the
+  pre-pass runs ahead of are about to modify the very indexes a passthrough filter plan may hand back
+  by reference. The copy constructor clones the compressed representation; going through `getArray()`
+  would spend an `int[]` of the full cardinality to rebuild the same bitmap.
 - **`ReevaluateExpressionMutation` identity still covers only its four core fields.** That is what
-  lets the pre-pass key its captures by the mutation itself and match them to the dispatched copy —
-  and it is why `preMutationConditionState` uses put-if-absent: a collector is constructed per root
-  entity mutation and shared by its nested invocations, so the first capture is the genuinely
-  pre-batch one. **Do not** clear that map on the dispatch path; a nested invocation would wipe the
-  enclosing one's captures before it dispatches.
+  lets the pre-pass match its captures to the dispatched copy — but it is *also* why the capture map
+  cannot be keyed by the mutation alone. The identity excludes the target entity type, while
+  `groupByTargetEntityType` emits one envelope per owner collection: two owner types declaring a
+  trigger on the same reference name, dependency type and scope produce mutations that compare equal
+  in two different envelopes, evaluated against two different collections. Keyed by the mutation
+  alone, the second envelope inherits the first collection's owner PKs, the restriction narrows to
+  empty, and a removal that should happen is suppressed — a stale histogram entry, the exact failure
+  this record exists to prevent. Hence `preMutationConditionState` is keyed by
+  `ConditionStateKey(entityType, mutation)`, covered by
+  `shouldDropContributionsInEveryOwnerCollectionSharingReferenceName`.
+- **Put-if-absent on the capture map** is deliberate: a collector is constructed per root entity
+  mutation and shared by its nested invocations, so the first capture is the genuinely pre-batch one.
+  **Do not** clear that map on the dispatch path; a nested invocation would wipe the enclosing one's
+  captures before it dispatches.
+- **Capture and dispatch read the same list.** Trigger discovery runs over the *root* batch only —
+  `popIndexImplicitMutations(localMutations)` — so the pre-pass is given exactly that list and nothing
+  can be dispatched without a captured counterpart. Widening dispatch to cover implicit local
+  mutations means widening the pre-pass in the same commit. An earlier revision of this work also
+  captured `implicitMutations.localMutations()`; that was dead weight, since no envelope derived from
+  them is ever dispatched (see *Consequences* for the gap that implies).
 - **The unrestricted fallback is unreachable in production.** `LocalMutationExecutorCollector` is the
   sole caller of `EntityCollection.applyIndexMutations` and always attaches the captured state; the
   `null` branch in `restrictToPreviouslyIndexed` exists for tests that construct a mutation directly.
@@ -184,9 +200,17 @@ format rework that can absorb the histogram rebuild.
   `null`-versus-empty contract and the mutation's identity-ignores-payload property directly. Worth
   knowing: the class's 28 pre-existing tests construct mutations without the captured state, so they
   exercise the *fallback* branch, not the guard.
+- `shouldDropContributionsInEveryOwnerCollectionSharingReferenceName` pins the collection-scoped key.
+  Two owner types (`product` PK 1, `bundle` PK 7 — deliberately disjoint, so neither collection's
+  captured set can cover the other's owner by coincidence) declare a trigger on the same reference
+  name, dependency type and scope; one mutation of the referenced entity must drop both
+  contributions. With the key reduced to the mutation alone it fails on **both** catalog states —
+  `Owner PK 7 should NOT be in ungrouped histogram 'statusHistogram' ==> expected: <false> but was:
+  <true>` — confirming it discriminates rather than merely passing.
 - Regression sweep: `ConditionalBucketIndexingTest`, `ConditionalFacetIndexingTest`,
   `ConditionalBucketQueryTest`, `ReevaluateExpressionExecutorTest`, `ReferencedTypeEntityIndexTest`,
   `ReducedGroupEntityIndexTest` — 395 tests, 0 failures, 0 errors.
+  `ConditionalBucketIndexingTest` re-run after the collection-scoped key: 101 tests, 0 failures.
 
 ## Consequences & open follow-ups
 
@@ -197,6 +221,26 @@ format rework that can absorb the histogram rebuild.
   Mutations that fire none allocate nothing (the pre-pass short-circuits on an empty trigger
   collection), so the cost is confined to catalogs using `bucketedPartially`. Not measured — if
   cross-entity fan-out shows up on a write profile, this is the first thing to look at.
+- **The captured state is owner-grained, which is coarser than a contribution.** A GROUP mutation can
+  resolve several `(referencedEntityPK, groupPK)` contributions for one owner, and a condition mixing
+  a group attribute with a referenced-entity predicate may hold for only some of them. The pre-pass
+  marks the owner once, so within one owner it cannot separate a qualifying reference from a
+  non-qualifying sibling. This does **not** regress anything: `restrictToPreviouslyIndexed` returns
+  `allAffectedOwnerPKs`, `EmptyBitmap`, or their intersection — always a subset of the set removal
+  used before this change — so it can only ever suppress a removal, never authorise one. The residual
+  over-removal it fails to close is the pre-existing behaviour. Closing it means capturing per
+  contribution tuple rather than per owner, and reusing that split for additions too. Tracked as
+  #1470 (milestone 2026.3), with the fixture that can express the asymmetry.
+- **Implicit local mutations do not fire cross-entity triggers at all — pre-existing, not introduced
+  here.** `popIndexImplicitMutations` has always scanned only the root batch, so an `AttributeMutation`
+  or `ReferenceAttributeMutation` synthesised by `GENERATE_ATTRIBUTES` /
+  `GENERATE_REFERENCE_ATTRIBUTES` never reaches trigger discovery, even when it writes an attribute a
+  trigger watches. The mechanism is confirmed by reading the dispatch path; no failing case has been
+  constructed, and the `GENERATE_ATTRIBUTES` half looks benign because it only runs for a *new*
+  entity, which no owner can reference yet. The `GENERATE_REFERENCE_ATTRIBUTES` half is the one worth
+  chasing. Deliberately left out of scope here — closing it means widening dispatch, and the pre-pass
+  must widen with it or the new triggers fall straight through to unrestricted removal. Tracked as
+  #1470 (milestone 2026.3).
 - **The pre-pass evaluates a superset of triggers**, since it cannot yet know which attribute writes
   turn out to be no-ops. Cheap to tighten if it ever matters; deliberately not done, because
   narrowing it requires duplicating the executor's no-op detection before the executor runs.

--- a/documentation/adr/2026-08-31-cross-entity-histogram-removal-pre-pass.md
+++ b/documentation/adr/2026-08-31-cross-entity-histogram-removal-pre-pass.md
@@ -125,6 +125,19 @@ The cost that would flip this decision is the doubled condition evaluation. If c
 fan-out ever dominates a write-path profile, Option C becomes the answer — but only alongside a
 format rework that can absorb the histogram rebuild.
 
+The chosen guard is correct across all four condition transitions, which is the argument that it
+neither leaks nor over-removes (`V` unchanged unless stated):
+
+| old condition | new condition | remove | add | net cardinality |
+|---|---|---|---|---|
+| false | false | suppressed | no | 0 ✓ |
+| false | true | suppressed | yes | +1 ✓ |
+| true | false | yes | no | −1 ✓ |
+| true | true | yes (old `V`) | yes (new `V`) | 0 ✓ |
+
+The two `old = false` rows are the ones the membership guard got wrong: it removed where the
+contribution never existed, spending a sibling's cardinality unit.
+
 ## Key technical details
 
 - **The pre-pass** — `LocalMutationExecutorCollector.capturePreMutationConditionState`. Runs before
@@ -244,6 +257,35 @@ format rework that can absorb the histogram rebuild.
 - **The pre-pass evaluates a superset of triggers**, since it cannot yet know which attribute writes
   turn out to be no-ops. Cheap to tighten if it ever matters; deliberately not done, because
   narrowing it requires duplicating the executor's no-op detection before the executor runs.
+
+## Hypotheses ruled out — do not re-chase
+
+The investigation spent most of its time on two wrong theories. Both are the natural first guess for
+"a histogram entry disappeared", so they are recorded with the evidence that killed them.
+
+- **It is not a `TransactionalMap` / `MapChanges` bug.** Remove-then-re-add of the same key was walked
+  down both branches: created-then-removed (`existing == false`, so `removedKeys` is never touched and
+  the instance is stashed in `createdThenRemovedProducers`, released at commit) and
+  base-map-remove-then-re-add (`registerModifiedKey` plus `removedKeys.remove(key)`). Neither loses the
+  new instance. The eager `removed.removeLayer(transactionalLayer)` in `HistogramIndexOperations` is
+  redundant with what `MapChanges.put` already does, but release is documented idempotent. The
+  decisive evidence is simpler than any of that: the defect reproduces identically in `WARMING_UP`,
+  where there is no transaction at all.
+- **`HistogramIndexOperations` lines 152-158 are not the bug**, and the evidence that pointed there
+  could not have shown it. `SimpleHistogramIndex.getFilterIndex` returns
+  `this.filterIndex.isEmpty() ? null : this.filterIndex`, so a `getHistogramFilterIndex(...) == null`
+  probe **cannot distinguish "the map entry is gone" from "the entry is present but empty"**. The
+  whole `removeHistogramValue`-orphans-the-instance theory rested on reading the first meaning into an
+  ambiguous `null`. Any future probe at that seam has to disambiguate before concluding anything.
+
+The trace that settled it came from JDWP logpoints at `HistogramIndexOperations` 106 / 151 / 154,
+gated to generation 4 of seed `2095323828`. The decisive step was op 6 — `pv=3` flipping
+`INACTIVE→ACTIVE` emitted `REM raw=500 own=1` although `pv=3` had contributed nothing, because
+`pv=2` also carried `basicUnitValue = 5` and so owner 1 was already in bucket 500. From there
+`cardinality(500, owner 1)` read 1 where it should have read 2, and op 9's legitimate removal of
+`pv=2`'s contribution emptied the bucket. The same sequence then replayed on a second
+`histogramIndexes` map instance — that is trunk incorporation applying the same mutations to the
+shared catalog, not a duplicated op or a Surefire rerun.
 
 ## Related work
 

--- a/documentation/adr/2026-08-31-cross-entity-histogram-removal-pre-pass.md
+++ b/documentation/adr/2026-08-31-cross-entity-histogram-removal-pre-pass.md
@@ -1,0 +1,213 @@
+---
+title: Gate cross-entity histogram removal on a pre-mutation condition pre-pass, not bucket membership
+date: 2026-08-31
+updated: 2026-08-31 11:20
+status: accepted
+kind: fix
+issues: [1467]
+prs: []
+areas: [evita_engine/src/main/java/io/evitadb/index/mutation, evita_engine/src/main/java/io/evitadb/core/collection]
+supersedes: []
+superseded-by: []
+relates: [2026-04-23-bucketed-histogram-indexing]
+---
+
+# Cross-entity histogram removal is gated on the pre-mutation condition, captured before the batch is applied
+
+A conditional (`bucketedPartially`) reference histogram could lose an owner entirely when two of that
+owner's references carried source values that normalise to the same bucket key. The cross-entity
+re-evaluation path decided whether to remove a contribution by asking *"is this owner in that
+bucket?"*, which cannot distinguish *this* reference's contribution from a sibling's. The fix gives
+it the question it actually needs — *"did this reference contribute?"* — by evaluating the trigger's
+condition once **before** the batch's local mutations are applied and carrying the answer to the
+executor on the mutation envelope.
+
+## Why
+
+The histogram is a **multiset**. `SimpleHistogramIndex.insertValue` / `removeValue` gate the
+underlying `FilterIndex` membership bitmap on an `AttributeCardinalityIndex` counter keyed by
+`(ownerPK, value)`, so the bucket only gains or loses the owner on a `0→1` / `1→0` transition. That
+is what lets an owner with two qualifying references survive the removal of one of them, and
+[[2026-04-23-bucketed-histogram-indexing]] states the invariant explicitly: *"an owner PK appears at
+most once per bucket per histogram — enforced by the cardinality-gated insert/remove pair"*.
+
+The pairing is the whole contract, and the cross-entity path broke it. `ReevaluateExpressionExecutor`
+performs a remove-before-add for every affected owner on every dependency change, guarded by
+`histogramContainsOwner`. That guard exists to skip a removal for a contribution that was never
+created (the condition was false when the value was indexed) — but it tests membership, which is
+true as soon as **anybody's** contribution for `(value, owner)` exists. When a sibling reference
+occupies the bucket, the guard passes for a reference that contributed nothing and the removal
+decrements the sibling's cardinality unit. The counter then reads one where it should read two, and
+the next legitimate removal empties the bucket and drops the owner from the histogram outright.
+
+The constraint that made this non-obvious: the *old* condition is genuinely unavailable at the point
+of the fix. `LocalMutationExecutorCollector` deliberately runs the index-trigger phase **after** the
+container implicit-mutation phase — *"Container mutations must finish first so that storage state is
+fully consistent before cross-entity triggers read it"* — so by dispatch time every readable source,
+index and storage container alike, already reflects the post-mutation state. There is no
+pre-mutation seam on that path; one had to be built.
+
+### Previous state
+
+The local (owner-side) path had already met this problem and solved it:
+`EntityIndexLocalMutationExecutor.removeHistogramWithConditionGuard` evaluates each trigger's
+condition against pre-mutation storage and skips the removal when it is false, with a JavaDoc naming
+the failure verbatim — *"removing values would incorrectly decrement another reference's cardinality
+for the same `(value, ownerPK)` pair"*. `ReferenceIndexMutator.isValueInHistogram` sits **behind**
+that guard, so the identical membership probe there is belt-and-braces on an already-correct
+decision. Only the cross-entity path never got the treatment, because it is the one path where
+pre-mutation state is out of reach.
+
+## Options considered
+
+### Option A — read-only pre-pass, answer carried on the mutation (chosen)
+
+Evaluate the histogram conditions twice: once read-only before the batch's local mutations are
+applied (so the answer is the pre-mutation one), and once as today. The captured owners ride to the
+executor on `ReevaluateExpressionMutation.previouslyIndexedOwnerPKs`, which narrows what removal may
+touch.
+
+- **Pros:** both sides use the **same** index-backed evaluator, so old and new conditions cannot
+  disagree for any reason other than the mutation itself; no on-disk format change; the added field
+  is engine-internal, so no external API moves.
+- **Cons:** one extra condition evaluation per firing cross-entity histogram trigger; adds a phase to
+  the write-path orchestration that a future change must keep read-only; repairs nothing in catalogs
+  that have already drifted.
+
+### Option B — pre-mutation read overlay (declined)
+
+Evaluate the old condition with `AbstractExpressionIndexTrigger.evaluate(...)` against an
+`EntityStoragePartAccessor` overlay substituting `preMutationSourceValues` for the mutated entity.
+
+- **Pros:** no change to write-path phase ordering; reuses the expression evaluator the local path
+  already relies on.
+- **Rejected because:** the cross-entity path has no `EntityStoragePartAccessor` at all — the only
+  implementation is `ContainerizedLocalMutationExecutor`, which is mutation-scoped — so a read-only
+  accessor over the catalog's `DataStoreReader`s would have to be written from scratch, plus the
+  overlay, plus new accessors on `IndexMutationTarget`. Worse, it would introduce **two evaluation
+  engines for one condition** (expression evaluator for the old answer, index filter for the new),
+  whose divergence would be a fresh class of drift bug. Revisit only if a read-only storage accessor
+  appears for another reason *and* the two evaluators are proven equivalent.
+
+### Option C — re-key the histogram cardinality by contributing reference (declined)
+
+Replace the `(ownerPK, value) → count` counter with a `(ownerPK, value) → set of referencedEntityPK`,
+making insert and remove idempotent per reference and deleting the guard entirely.
+
+- **Pros:** semantically exact; removes the class of bug rather than the instance; no pre-pass, no
+  extra evaluation.
+- **Rejected because:** `HistogramCardinalityStoragePart` is a **released** on-disk format. This needs
+  a `serialVersionUID` bump plus backward-compatible readers in every configurer that registers it
+  (see the `kryo-bwc-audit` skill), and — the real blocker — existing catalogs store counts that
+  cannot be converted into attribution sets without rebuilding every histogram. Revisit if the
+  histogram storage format is being reworked for another reason and a rebuild is on the table anyway.
+
+### Option D — reconcile to the desired count (declined)
+
+Recompute, per affected `(owner, value)`, how many of the owner's references currently carry that
+source value *and* satisfy the condition, then adjust the counter to match.
+
+- **Pros:** self-healing — would repair already-drifted indexes on the next touch; no format change.
+- **Rejected because:** there is no owner→references mapping to enumerate. It would have to fan out
+  from `sourceFilterIndex.getRecordsEqualTo(V)` across every referenced entity sharing the value,
+  with a reduced-index lookup and a condition evaluation each — unbounded work on the write path.
+  Revisit if an owner→references mapping ever lands on the `ReferencedTypeEntityIndex`.
+
+## Decision
+
+**Chosen: Option A.** It is the only option that fixes the defect without either changing a released
+storage format (C), introducing a second evaluation engine for the same condition (B), or putting
+unbounded work on the write path (D). It also mirrors what the local path already does — evaluate
+the condition, then decide — which keeps one mental model for "may I remove this contribution?"
+across both paths.
+
+The cost that would flip this decision is the doubled condition evaluation. If cross-entity trigger
+fan-out ever dominates a write-path profile, Option C becomes the answer — but only alongside a
+format rework that can absorb the histogram rebuild.
+
+## Key technical details
+
+- **The pre-pass** — `LocalMutationExecutorCollector.capturePreMutationConditionState`. Runs before
+  `entityIndexUpdater.prepare(...)`, which is not cosmetic: `prepare` inserts the entity into the
+  global index and can therefore already flip a condition for a freshly created entity.
+- **Trigger discovery without side effects** —
+  `EntityIndexLocalMutationExecutor.peekIndexImplicitMutations`. It cannot read the removal branch off
+  the container (nothing has been applied), so the caller states it. The two agree *by construction*:
+  `popIndexImplicitMutations` branches on `containerAccessor.isEntityRemovedEntirely()`, which is a
+  `final` field set from `entityMutation instanceof EntityRemoveMutation` at
+  `ContainerizedLocalMutationExecutor`'s single construction site — the same expression the caller
+  evaluates. **If that flag ever becomes dynamic, the peek must take the same signal instead of
+  inferring it**: a disagreement would make the pre-pass capture a narrower trigger set than dispatch
+  fires, and the uncaptured triggers would silently fall back to unrestricted removal. The peek may
+  report a superset of the triggers that actually fire; surplus captures are never looked up.
+- **`null` versus empty is load-bearing.** `ReevaluateExpressionExecutor.evaluateHistogramConditionState`
+  returns `null` for "no histogram trigger, nothing to guard" (removal stays unrestricted) and a map
+  with a **possibly empty** bitmap for "the pre-pass ran and nobody qualified" (every removal
+  suppressed). Collapsing the two reintroduces the bug.
+- **The pre-pass must stay read-only.** Every `resolveAffected` path it reaches uses
+  `findReferencedTypeEntityIndex` / `getIndexByPrimaryKeyIfExists`, never a `getOrCreate…` variant.
+  A future resolution path that creates an index would make the pre-pass mutate state.
+- **Bitmaps are materialised** (`new BaseBitmap(split.shouldBeIndexed().getArray())`) because the
+  mutations the pre-pass runs ahead of are about to modify the very indexes a passthrough filter plan
+  may hand back by reference.
+- **`ReevaluateExpressionMutation` identity still covers only its four core fields.** That is what
+  lets the pre-pass key its captures by the mutation itself and match them to the dispatched copy —
+  and it is why `preMutationConditionState` uses put-if-absent: a collector is constructed per root
+  entity mutation and shared by its nested invocations, so the first capture is the genuinely
+  pre-batch one. **Do not** clear that map on the dispatch path; a nested invocation would wipe the
+  enclosing one's captures before it dispatches.
+- **The unrestricted fallback is unreachable in production.** `LocalMutationExecutorCollector` is the
+  sole caller of `EntityCollection.applyIndexMutations` and always attaches the captured state; the
+  `null` branch in `restrictToPreviouslyIndexed` exists for tests that construct a mutation directly.
+  A second dispatch path that skips the pre-pass would silently reintroduce the defect.
+- **`ReevaluateExpressionExecutor` stays package-private.** The pre-pass entry point is on
+  `IndexMutationExecutorRegistry`, already the package's public door for acting on an `IndexMutation`.
+- **Pre-mutation attribute capture now has one funnel** —
+  `EntityIndexLocalMutationExecutor.recordCapturedOldEntityAttributeValue`. The two capture sites
+  reached the same canonical `BigDecimal` form by different routes (a `normalizing` supplier wrapper
+  on one, a hand-written `normalizeIfBigDecimal` call on the other) with the contract written down in
+  neither; the funnel applies it once, idempotently.
+
+## Verification
+
+- `ConditionalBucketIndexingTest` — three new cases, each ~0.3 s and each run over `WARMING_UP` **and**
+  `ALIVE`. `shouldKeepSiblingContributionWhenSecondReferenceStartsQualifyingForSameBucket` (condition
+  change) and `shouldKeepSiblingContributionWhenNonQualifyingReferenceChangesItsValue` (value change,
+  the `knownOldValues` branch) both failed on both catalog states before the fix and pass after.
+  `shouldKeepQualifyingContributionWhenNonQualifyingSiblingReferenceIsRemoved` passed before and after
+   — it pins the local path's guard-before-remove ordering as a regression detector.
+- `EvitaConditionalBucketGenerationalTest#shouldSurviveGenerationalTestWithReferencedEntityAttributeExpression`
+  with `-Dtest.seed=2095323828`: failed at generation 4 in ~2 s of test time before
+  (`expected: <{5=[1]}> but was: <{}>`), runs a full 61 s interval clean after. Pinned as
+  `shouldNotSurfaceHistogramDriftForSeed2095323828`.
+- `ReevaluateExpressionExecutorTest` — new `PreMutationConditionStateTest` nested class pins the
+  `null`-versus-empty contract and the mutation's identity-ignores-payload property directly. Worth
+  knowing: the class's 28 pre-existing tests construct mutations without the captured state, so they
+  exercise the *fallback* branch, not the guard.
+- Regression sweep: `ConditionalBucketIndexingTest`, `ConditionalFacetIndexingTest`,
+  `ConditionalBucketQueryTest`, `ReevaluateExpressionExecutorTest`, `ReferencedTypeEntityIndexTest`,
+  `ReducedGroupEntityIndexTest` — 395 tests, 0 failures, 0 errors.
+
+## Consequences & open follow-ups
+
+- **Already-drifted catalogs are not repaired.** A catalog that lost histogram entries before this
+  fix keeps the wrong cardinality until the affected histograms are rebuilt. Only Option D would have
+  been self-healing, and it lost on write-path cost.
+- **The write path now pays a second condition evaluation** per firing cross-entity histogram trigger.
+  Mutations that fire none allocate nothing (the pre-pass short-circuits on an empty trigger
+  collection), so the cost is confined to catalogs using `bucketedPartially`. Not measured — if
+  cross-entity fan-out shows up on a write profile, this is the first thing to look at.
+- **The pre-pass evaluates a superset of triggers**, since it cannot yet know which attribute writes
+  turn out to be no-ops. Cheap to tighten if it ever matters; deliberately not done, because
+  narrowing it requires duplicating the executor's no-op detection before the executor runs.
+
+## Related work
+
+- [[2026-04-23-bucketed-histogram-indexing]] — introduced the cardinality-gated insert/remove pair and
+  stated the once-per-bucket invariant this record restores. The defect was a violation of that
+  record's invariant, not a change to it.
+
+## Timeline
+
+- **2026-08-31** — reproduced deterministically on `release_2026-2` (`e623f2c84`), root-caused via
+  JDWP trace of generation 4, reduced to sub-second functional tests, fixed and verified

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-08-31 | [Gate cross-entity histogram removal on a pre-mutation condition pre-pass, not bucket membership](2026-08-31-cross-entity-histogram-removal-pre-pass.md) | fix | accepted | — |
+| 2026-08-31 | [Gate cross-entity histogram removal on a pre-mutation condition pre-pass, not bucket membership](2026-08-31-cross-entity-histogram-removal-pre-pass.md) | fix | accepted | #1467, PR #1468, PR #1469 |
 | 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | accepted | #1433, PR #1435, PR #1436 |
 | 2026-08-24 | [Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers](2026-08-24-grpc-streaming-backpressure-readiness-gate.md) | fix | accepted | #1441, PR #1450, PR #1451 |
 | 2026-08-24 | [Keep the reference bundle in step with the reference collection](2026-08-24-refresh-provisional-representative-key.md) | fix | accepted | #1438, #1444, PR #1442, PR #1443 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-08-31 | [Gate cross-entity histogram removal on a pre-mutation condition pre-pass, not bucket membership](2026-08-31-cross-entity-histogram-removal-pre-pass.md) | fix | accepted | — |
 | 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | accepted | #1433, PR #1435, PR #1436 |
 | 2026-08-24 | [Pace gRPC server-streaming producers with a readiness gate, and unblock large file transfers](2026-08-24-grpc-streaming-backpressure-readiness-gate.md) | fix | accepted | #1441, PR #1450, PR #1451 |
 | 2026-08-24 | [Keep the reference bundle in step with the reference collection](2026-08-24-refresh-provisional-representative-key.md) | fix | accepted | #1438, #1444, PR #1442, PR #1443 |

--- a/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
@@ -135,6 +135,7 @@ import io.evitadb.index.mutation.IndexMutation;
 import io.evitadb.index.mutation.IndexMutationExecutor;
 import io.evitadb.index.mutation.IndexMutationExecutorRegistry;
 import io.evitadb.index.mutation.IndexMutationTarget;
+import io.evitadb.index.mutation.ReevaluateExpressionMutation;
 import io.evitadb.index.mutation.local.EntityIndexLocalMutationExecutor;
 import io.evitadb.index.mutation.storagePart.ContainerizedLocalMutationExecutor;
 import io.evitadb.index.reference.ReferenceChanges;
@@ -1538,6 +1539,38 @@ public final class EntityCollection implements
 			for (final IndexMutation mutation : entityIndexMutation.mutations()) {
 				IndexMutationExecutorRegistry.INSTANCE.dispatch(mutation, this.entityIndexCreator);
 			}
+		} finally {
+			this.entityIndexCreator.setSession(null);
+		}
+	}
+
+	/**
+	 * Read-only counterpart of {@link #applyIndexMutations} used by `LocalMutationExecutorCollector`'s pre-pass:
+	 * evaluates every histogram trigger's condition for the mutation's affected owners **without writing
+	 * anything**, so the caller can capture the pre-mutation answer before the batch is applied. The result is
+	 * handed back on the dispatched mutation as
+	 * {@link ReevaluateExpressionMutation#previouslyIndexedOwnerPKs()}; see
+	 * {@link ReevaluateExpressionExecutor#evaluateHistogramConditionState} for why the executor cannot derive it
+	 * itself.
+	 *
+	 * The session is set for the duration of the evaluation exactly as in {@link #applyIndexMutations}, because
+	 * condition evaluation goes through `evaluateFilter()` and needs a `QueryPlanningContext`.
+	 *
+	 * @param mutation the cross-entity re-evaluation signal about to be applied
+	 * @param session  active session for query evaluation, may be null during WAL replay
+	 * @return owner PKs whose condition currently holds, keyed by histogram name, or `null` when the reference
+	 *         declares no histogram trigger and there is therefore nothing to guard
+	 */
+	@Nullable
+	public Map<String, Bitmap> evaluateHistogramConditionState(
+		@Nonnull ReevaluateExpressionMutation mutation,
+		@Nullable EvitaSessionContract session
+	) {
+		this.entityIndexCreator.setSession(session);
+		try {
+			return IndexMutationExecutorRegistry.INSTANCE.evaluateHistogramConditionState(
+				mutation, this.entityIndexCreator
+			);
 		} finally {
 			this.entityIndexCreator.setSession(null);
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/collection/LocalMutationExecutorCollector.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/LocalMutationExecutorCollector.java
@@ -177,9 +177,15 @@ class LocalMutationExecutorCollector {
 	 * normalise to the same histogram bucket.
 	 *
 	 * Keying by the mutation works because {@link ReevaluateExpressionMutation}'s identity covers only the four
-	 * core fields, so the pre-pass envelope and the dispatched one compare equal. Entries are inserted with
-	 * put-if-absent semantics: when the same trigger is provoked both by the batch's own mutations and by an
-	 * implicit mutation derived from them, the earlier (truly pre-batch) capture is the correct one.
+	 * core fields, so the pre-pass envelope and the dispatched one compare equal. **The target entity type has to
+	 * be part of the key as well**, because it is deliberately *not* part of that identity: two owner entity types
+	 * that declare a trigger on the same reference name, dependency type and scope produce two envelopes carrying
+	 * mutations that compare equal, and their condition state is evaluated against different collections. Keyed by
+	 * the mutation alone, the second envelope would silently inherit the first collection's answer and suppress
+	 * removals it should perform, leaving stale histogram entries — the very failure this class exists to prevent.
+	 *
+	 * Entries are inserted with put-if-absent semantics: a collector is shared with the nested invocations spawned
+	 * for external mutations, and the first capture within one root batch is the truly pre-batch one.
 	 *
 	 * **Lifetime is what makes put-if-absent safe.** A collector is constructed per root entity mutation (see
 	 * `EntityCollection#applyMutations`) and its nested invocations — implicit and external mutations derived from
@@ -190,7 +196,22 @@ class LocalMutationExecutorCollector {
 	 *
 	 * Lazily allocated — stays null for the overwhelming majority of mutations, which fire no histogram trigger.
 	 */
-	@Nullable private Map<ReevaluateExpressionMutation, Map<String, Bitmap>> preMutationConditionState;
+	@Nullable private Map<ConditionStateKey, Map<String, Bitmap>> preMutationConditionState;
+
+	/**
+	 * Key of {@link #preMutationConditionState} — a captured condition answer belongs to one trigger *in one
+	 * target collection*, and {@link ReevaluateExpressionMutation} alone cannot express that: its identity
+	 * deliberately excludes the target entity type so that the pre-pass envelope and the dispatched one compare
+	 * equal, which means two owner entity types sharing a reference name, dependency type and scope collide.
+	 *
+	 * @param entityType target collection the state was evaluated against
+	 * @param mutation   the cross-entity re-evaluation signal the state belongs to
+	 */
+	private record ConditionStateKey(
+		@Nonnull String entityType,
+		@Nonnull ReevaluateExpressionMutation mutation
+	) {
+	}
 
 	/**
 	 * Evaluates the histogram conditions of every cross-entity trigger the supplied mutations are about to fire,
@@ -224,8 +245,9 @@ class LocalMutationExecutorCollector {
 				if (!(candidate instanceof ReevaluateExpressionMutation reevaluation)) {
 					continue;
 				}
+				final ConditionStateKey key = new ConditionStateKey(indexMutation.entityType(), reevaluation);
 				if (this.preMutationConditionState != null
-					&& this.preMutationConditionState.containsKey(reevaluation)) {
+					&& this.preMutationConditionState.containsKey(key)) {
 					// an earlier capture in this batch is the true pre-mutation state — keep it
 					continue;
 				}
@@ -238,7 +260,7 @@ class LocalMutationExecutorCollector {
 					if (this.preMutationConditionState == null) {
 						this.preMutationConditionState = CollectionUtils.createHashMap(8);
 					}
-					this.preMutationConditionState.put(reevaluation, conditionState);
+					this.preMutationConditionState.put(key, conditionState);
 				}
 			}
 		}
@@ -259,13 +281,16 @@ class LocalMutationExecutorCollector {
 		if (this.preMutationConditionState == null) {
 			return entityIndexMutation;
 		}
+		final String entityType = entityIndexMutation.entityType();
 		final IndexMutation[] mutations = entityIndexMutation.mutations();
 		IndexMutation[] enriched = null;
 		for (int i = 0; i < mutations.length; i++) {
 			if (!(mutations[i] instanceof ReevaluateExpressionMutation reevaluation)) {
 				continue;
 			}
-			final Map<String, Bitmap> conditionState = this.preMutationConditionState.get(reevaluation);
+			final Map<String, Bitmap> conditionState = this.preMutationConditionState.get(
+				new ConditionStateKey(entityType, reevaluation)
+			);
 			if (conditionState == null) {
 				continue;
 			}
@@ -446,11 +471,6 @@ class LocalMutationExecutorCollector {
 				final ImplicitMutations implicitMutations = changeCollector.popImplicitMutations(
 					localMutations, generateImplicitMutations
 				);
-				// implicit mutations can provoke triggers of their own — capture their pre-state too, before
-				// they are applied. Put-if-absent keeps an earlier (pre-batch) capture for triggers both fire.
-				capturePreMutationConditionState(
-					session, entityIndexUpdater, List.of(implicitMutations.localMutations()), false
-				);
 				// immediately apply all local mutations
 				for (final LocalMutation<?, ?> localMutation : implicitMutations.localMutations()) {
 					for (final LocalMutationExecutor executor : orderedExecutors) {
@@ -493,6 +513,11 @@ class LocalMutationExecutorCollector {
 			// so that storage state is fully consistent before cross-entity triggers read it. Index
 			// mutations are never written to WAL — they are regenerated deterministically on replay.
 			// The dispatch is synchronous and bounded by the number of affected entities.
+			//
+			// `localMutations` is deliberately the same list the condition pre-pass above was given: trigger
+			// discovery runs over the *root* batch only, so every dispatched envelope has a captured counterpart
+			// and none is left to fall back on unrestricted histogram removal. Widening this to cover implicit
+			// local mutations means widening the pre-pass with it, in the same commit.
 			final IndexImplicitMutations indexImplicit = entityIndexUpdater.popIndexImplicitMutations(localMutations);
 			for (final EntityIndexMutation indexMutation : indexImplicit.indexMutations()) {
 				// route each envelope to the target collection's thin dispatcher — bypasses

--- a/evita_engine/src/main/java/io/evitadb/core/collection/LocalMutationExecutorCollector.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/LocalMutationExecutorCollector.java
@@ -50,8 +50,11 @@ import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer.Savepoint
 import io.evitadb.core.transaction.stage.mutation.ServerEntityMutation;
 import io.evitadb.dataType.Scope;
 import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.mutation.EntityIndexMutation;
 import io.evitadb.index.mutation.IndexImplicitMutations;
+import io.evitadb.index.mutation.IndexMutation;
+import io.evitadb.index.mutation.ReevaluateExpressionMutation;
 import io.evitadb.index.mutation.local.EntityIndexLocalMutationExecutor;
 import io.evitadb.index.mutation.storagePart.ContainerizedLocalMutationExecutor;
 import io.evitadb.spi.store.catalog.header.model.EntityCollectionHeader;
@@ -59,6 +62,7 @@ import io.evitadb.spi.store.catalog.persistence.EntityCollectionPersistenceServi
 import io.evitadb.spi.store.catalog.persistence.EntityCollectionPersistenceService.EntityWithFetchCount;
 import io.evitadb.spi.store.catalog.persistence.StorageDescriptor;
 import io.evitadb.utils.Assert;
+import io.evitadb.utils.CollectionUtils;
 import lombok.RequiredArgsConstructor;
 
 import javax.annotation.Nonnull;
@@ -67,6 +71,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -160,6 +165,119 @@ class LocalMutationExecutorCollector {
 	 * by rebuilding (warm-up), or the whole in-memory transaction is discarded on failure (WAL replay).
 	 */
 	@Nullable private Savepoint savepoint;
+	/**
+	 * Per-histogram condition state captured by {@link #capturePreMutationConditionState} **before** a batch's
+	 * local mutations were applied, keyed by the {@link ReevaluateExpressionMutation} it belongs to.
+	 *
+	 * This is the only surviving witness of the pre-mutation answer: the index-trigger phase deliberately runs
+	 * after the container implicit-mutation phase, so by dispatch time every readable source already reflects the
+	 * post-mutation state. Without it, `ReevaluateExpressionExecutor`'s remove-before-add cannot distinguish
+	 * *"this reference contributed (value → owner)"* from *"somebody's contribution for (value, owner) exists"*,
+	 * and its removal consumes a sibling reference's cardinality unit whenever two of an owner's references
+	 * normalise to the same histogram bucket.
+	 *
+	 * Keying by the mutation works because {@link ReevaluateExpressionMutation}'s identity covers only the four
+	 * core fields, so the pre-pass envelope and the dispatched one compare equal. Entries are inserted with
+	 * put-if-absent semantics: when the same trigger is provoked both by the batch's own mutations and by an
+	 * implicit mutation derived from them, the earlier (truly pre-batch) capture is the correct one.
+	 *
+	 * **Lifetime is what makes put-if-absent safe.** A collector is constructed per root entity mutation (see
+	 * `EntityCollection#applyMutations`) and its nested invocations — implicit and external mutations derived from
+	 * that root — share it by design. Everything accumulated here therefore belongs to one root mutation, whose
+	 * genuine pre-state is the *first* capture; entries are never carried into a second root mutation, so a later
+	 * mutation of the same entity re-captures from scratch. Do not add a clear on the dispatch path: a nested
+	 * invocation would wipe the enclosing one's captures before it dispatches.
+	 *
+	 * Lazily allocated — stays null for the overwhelming majority of mutations, which fire no histogram trigger.
+	 */
+	@Nullable private Map<ReevaluateExpressionMutation, Map<String, Bitmap>> preMutationConditionState;
+
+	/**
+	 * Evaluates the histogram conditions of every cross-entity trigger the supplied mutations are about to fire,
+	 * and stores the answers in {@link #preMutationConditionState}. Reads only — nothing is written to any index.
+	 *
+	 * Must be called **before** `localMutations` are applied, because "the condition holds right now" is only the
+	 * pre-mutation answer for as long as nothing has been applied. Trigger identities come from
+	 * {@link EntityIndexLocalMutationExecutor#peekIndexImplicitMutations}, which may return a superset (it cannot
+	 * know which attribute writes turn out to be no-ops); a surplus entry is simply never looked up.
+	 *
+	 * Cost is one condition evaluation per firing cross-entity histogram trigger. Mutations that fire none — the
+	 * overwhelming majority — do not allocate at all: `evaluateHistogramConditionState` short-circuits on an empty
+	 * trigger collection and no map is created.
+	 *
+	 * @param session            active session for query evaluation, may be null during WAL replay
+	 * @param entityIndexUpdater the index executor of the entity being mutated
+	 * @param localMutations     the mutations about to be applied
+	 * @param entityRemoval      `true` when the batch removes the entity entirely
+	 */
+	private void capturePreMutationConditionState(
+		@Nullable EvitaSessionContract session,
+		@Nonnull EntityIndexLocalMutationExecutor entityIndexUpdater,
+		@Nonnull List<? extends LocalMutation<?, ?>> localMutations,
+		boolean entityRemoval
+	) {
+		final IndexImplicitMutations prospective = entityIndexUpdater.peekIndexImplicitMutations(
+			localMutations, entityRemoval
+		);
+		for (final EntityIndexMutation indexMutation : prospective.indexMutations()) {
+			for (final IndexMutation candidate : indexMutation.mutations()) {
+				if (!(candidate instanceof ReevaluateExpressionMutation reevaluation)) {
+					continue;
+				}
+				if (this.preMutationConditionState != null
+					&& this.preMutationConditionState.containsKey(reevaluation)) {
+					// an earlier capture in this batch is the true pre-mutation state — keep it
+					continue;
+				}
+				// null means the reference declares no histogram trigger (a facet-only trigger, say) — there is
+				// nothing to guard, and storing an empty map would wrongly suppress removals
+				final Map<String, Bitmap> conditionState = this.catalog
+					.getCollectionForEntityOrThrowException(indexMutation.entityType())
+					.evaluateHistogramConditionState(reevaluation, session);
+				if (conditionState != null) {
+					if (this.preMutationConditionState == null) {
+						this.preMutationConditionState = CollectionUtils.createHashMap(8);
+					}
+					this.preMutationConditionState.put(reevaluation, conditionState);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Returns `entityIndexMutation` with every {@link ReevaluateExpressionMutation} in it carrying the condition
+	 * state {@link #capturePreMutationConditionState} recorded for it, or the original envelope untouched when
+	 * nothing was captured (no histogram trigger fired — the common case, and allocation-free).
+	 *
+	 * @param entityIndexMutation the envelope about to be dispatched
+	 * @return the envelope to dispatch
+	 */
+	@Nonnull
+	private EntityIndexMutation attachPreMutationConditionState(
+		@Nonnull EntityIndexMutation entityIndexMutation
+	) {
+		if (this.preMutationConditionState == null) {
+			return entityIndexMutation;
+		}
+		final IndexMutation[] mutations = entityIndexMutation.mutations();
+		IndexMutation[] enriched = null;
+		for (int i = 0; i < mutations.length; i++) {
+			if (!(mutations[i] instanceof ReevaluateExpressionMutation reevaluation)) {
+				continue;
+			}
+			final Map<String, Bitmap> conditionState = this.preMutationConditionState.get(reevaluation);
+			if (conditionState == null) {
+				continue;
+			}
+			if (enriched == null) {
+				enriched = mutations.clone();
+			}
+			enriched[i] = reevaluation.withPreviouslyIndexedOwnerPKs(conditionState);
+		}
+		return enriched == null
+			? entityIndexMutation
+			: new EntityIndexMutation(entityIndexMutation.entityType(), enriched);
+	}
 
 	/**
 	 * Method fetches the full contents of the entity by its primary key from the I/O storage (taking advantage of
@@ -285,6 +403,7 @@ class LocalMutationExecutorCollector {
 			this.level++;
 
 			final List<? extends LocalMutation<?, ?>> localMutations;
+			final boolean entityRemoval;
 			if (entityMutation instanceof EntityRemoveMutation) {
 				// fetch the full entity body so the removal can be decomposed into the local mutations
 				// that actually apply it — this is required to execute the removal, not to derive conflict
@@ -293,13 +412,22 @@ class LocalMutationExecutorCollector {
 				// finer-grained write to the same entity
 				result = getFullEntityContents(changeCollector);
 				localMutations = computeLocalMutationsForEntityRemoval(result.entity());
+				entityRemoval = true;
 			} else if (entityMutation instanceof EntityUpsertMutation) {
 				localMutations = entityMutation.getLocalMutations();
-				entityIndexUpdater.prepare(localMutations);
+				entityRemoval = false;
 			} else {
 				throw new GenericEvitaInternalError(
 					"Unsupported entity mutation type: " + entityMutation.getClass().getName()
 				);
+			}
+			// Condition pre-pass: read the cross-entity histogram conditions while they still answer for the
+			// PRE-mutation state. Must precede both `prepare()` (which inserts the entity into the global index,
+			// and so can already flip a condition for a freshly created entity) and the apply loop below. See
+			// #preMutationConditionState for why the dispatched executor cannot derive this for itself.
+			capturePreMutationConditionState(session, entityIndexUpdater, localMutations, entityRemoval);
+			if (!entityRemoval) {
+				entityIndexUpdater.prepare(localMutations);
 			}
 			if (addToWAL) {
 				this.entityMutations.add(entityMutation);
@@ -317,6 +445,11 @@ class LocalMutationExecutorCollector {
 			if (!generateImplicitMutations.isEmpty()) {
 				final ImplicitMutations implicitMutations = changeCollector.popImplicitMutations(
 					localMutations, generateImplicitMutations
+				);
+				// implicit mutations can provoke triggers of their own — capture their pre-state too, before
+				// they are applied. Put-if-absent keeps an earlier (pre-batch) capture for triggers both fire.
+				capturePreMutationConditionState(
+					session, entityIndexUpdater, List.of(implicitMutations.localMutations()), false
 				);
 				// immediately apply all local mutations
 				for (final LocalMutation<?, ?> localMutation : implicitMutations.localMutations()) {
@@ -365,7 +498,7 @@ class LocalMutationExecutorCollector {
 				// route each envelope to the target collection's thin dispatcher — bypasses
 				// the full ServerEntityMutation pipeline (no storage, no WAL, no schema evolution)
 				this.catalog.getCollectionForEntityOrThrowException(indexMutation.entityType())
-					.applyIndexMutations(indexMutation, session);
+					.applyIndexMutations(attachPreMutationConditionState(indexMutation), session);
 			}
 
 			// finish the record

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/IndexMutationExecutorRegistry.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/IndexMutationExecutorRegistry.java
@@ -23,9 +23,11 @@
 
 package io.evitadb.index.mutation;
 
+import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.utils.Assert;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
@@ -92,6 +94,30 @@ public class IndexMutationExecutorRegistry {
 			() -> "No executor registered for mutation type `" + mutation.getClass().getName() + "`."
 		);
 		executor.execute(mutation, target);
+	}
+
+	/**
+	 * Read-only companion to {@link #dispatch}: evaluates the histogram conditions a
+	 * {@link ReevaluateExpressionMutation} depends on **without applying anything**, so a caller holding
+	 * pre-mutation state can capture the answer while it is still the pre-mutation one.
+	 *
+	 * It lives on the registry rather than being reached through the executor directly because
+	 * `ReevaluateExpressionExecutor` is deliberately package-private — the registry is this package's single
+	 * public door for acting on an {@link IndexMutation} against an {@link IndexMutationTarget}, and this keeps
+	 * it that way.
+	 *
+	 * @param mutation the cross-entity re-evaluation signal about to be applied
+	 * @param target   limited view of the target `EntityCollection`
+	 * @return owner PKs whose condition currently holds, keyed by histogram name, or `null` when the reference
+	 *         declares no histogram trigger
+	 * @see ReevaluateExpressionExecutor#evaluateHistogramConditionState
+	 */
+	@Nullable
+	public Map<String, Bitmap> evaluateHistogramConditionState(
+		@Nonnull ReevaluateExpressionMutation mutation,
+		@Nonnull IndexMutationTarget target
+	) {
+		return ReevaluateExpressionExecutor.evaluateHistogramConditionState(mutation, target);
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
@@ -52,6 +52,7 @@ import io.evitadb.index.ReferencedTypeEntityIndex;
 import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.bitmap.EmptyBitmap;
 import io.evitadb.index.facet.FacetGroupIndex;
 import io.evitadb.index.facet.FacetIdIndex;
 import io.evitadb.index.facet.FacetReferenceIndex;
@@ -60,6 +61,7 @@ import io.evitadb.index.invertedIndex.ValueToRecord;
 import io.evitadb.index.mutation.local.ReferenceIndexMutator;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
 import io.evitadb.utils.Assert;
+import io.evitadb.utils.CollectionUtils;
 import lombok.extern.slf4j.Slf4j;
 import io.evitadb.roaringbitmap.PersistentRoaringBitmap;
 import io.evitadb.roaringbitmap.RoaringBitmapWriter;
@@ -208,6 +210,107 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 				);
 			}
 		}
+	}
+
+	/**
+	 * Read-only pre-pass companion to {@link #execute}. Resolves the affected owners and evaluates every
+	 * histogram trigger's condition against the index state **as it stands right now**, writing nothing.
+	 *
+	 * `LocalMutationExecutorCollector` calls this before a batch's local mutations are applied, so "right now"
+	 * is the pre-mutation state, and hands the result back on
+	 * {@link ReevaluateExpressionMutation#previouslyIndexedOwnerPKs()} when the batch is finally dispatched. That
+	 * is the only way this executor can learn the *old* condition: by the time {@link #execute} runs, the
+	 * index-trigger phase deliberately sits after the container implicit-mutation phase (see
+	 * `LocalMutationExecutorCollector`), so every readable source already reflects the post-mutation state.
+	 *
+	 * The same {@link #evaluateCondition} used for the new state computes the old one, so the two sides cannot
+	 * disagree for any reason other than the mutation itself.
+	 *
+	 * **`null` versus empty is load-bearing.** `null` means *"there was nothing to guard"* — the reference
+	 * declares no histogram trigger — and lets {@link #processHistogramTriggers} keep its historical
+	 * unrestricted behaviour. A non-null map means the pre-pass genuinely ran and carries one entry per trigger,
+	 * an **empty bitmap included**: that says "no owner qualified beforehand", which must suppress every removal,
+	 * not fall back to removing them all.
+	 *
+	 * @param mutation the cross-entity re-evaluation signal about to be applied
+	 * @param target   access to the owning entity collection's schema, triggers, and indexes
+	 * @return owner PKs whose condition currently holds, keyed by histogram name, or `null` when the reference
+	 *         has no histogram triggers at all
+	 */
+	@Nullable
+	public static Map<String, Bitmap> evaluateHistogramConditionState(
+		@Nonnull ReevaluateExpressionMutation mutation,
+		@Nonnull IndexMutationTarget target
+	) {
+		final Collection<HistogramExpressionTrigger> histogramTriggers = target.getHistogramTriggers(
+			mutation.referenceName(), mutation.scope()
+		);
+		if (histogramTriggers.isEmpty()) {
+			return null;
+		}
+		final AffectedEntityResolution affected = resolveAffected(target, mutation);
+		final Bitmap allAffectedOwnerPKs = affected.allOwnerPKs();
+		final Map<String, Bitmap> result = CollectionUtils.createHashMap(histogramTriggers.size());
+		if (allAffectedOwnerPKs.isEmpty()) {
+			// no owner referenced the mutated entity yet, so no owner can have contributed — record that
+			// explicitly rather than returning null, which would re-enable unrestricted removal
+			for (final HistogramExpressionTrigger trigger : histogramTriggers) {
+				result.put(trigger.getHistogramIndexName(), EmptyBitmap.INSTANCE);
+			}
+			return result;
+		}
+		for (final HistogramExpressionTrigger trigger : histogramTriggers) {
+			final ConditionalSplit split = evaluateCondition(
+				trigger, mutation, target, affected, allAffectedOwnerPKs
+			);
+			// materialize the result — the mutations this pre-pass runs ahead of are about to modify the very
+			// indexes a passthrough filter plan may hand back by reference, and this bitmap has to survive them
+			result.put(
+				trigger.getHistogramIndexName(),
+				new BaseBitmap(split.shouldBeIndexed().getArray())
+			);
+		}
+		return result;
+	}
+
+	/**
+	 * Narrows the owners a histogram removal may touch to those that actually contributed before this batch —
+	 * the answer captured by {@link #evaluateHistogramConditionState} and carried on
+	 * {@link ReevaluateExpressionMutation#previouslyIndexedOwnerPKs()}.
+	 *
+	 * This is what makes the remove side of remove-before-add *paired*. The membership guard it supplements
+	 * (`histogramContainsOwner`) can only see that *somebody's* contribution for `(value, owner)` exists, so on
+	 * its own it will happily consume a sibling reference's cardinality unit when two of an owner's references
+	 * share a bucket key — the defect this restriction exists to prevent.
+	 *
+	 * @param allAffectedOwnerPKs all owners affected by the mutation
+	 * @param mutation            the cross-entity re-evaluation signal
+	 * @param histogramName       name of the histogram definition being processed
+	 * @return the owners whose contribution may be removed
+	 */
+	@Nonnull
+	private static Bitmap restrictToPreviouslyIndexed(
+		@Nonnull Bitmap allAffectedOwnerPKs,
+		@Nonnull ReevaluateExpressionMutation mutation,
+		@Nonnull String histogramName
+	) {
+		final Map<String, Bitmap> previouslyIndexedByHistogram = mutation.previouslyIndexedOwnerPKs();
+		if (previouslyIndexedByHistogram == null) {
+			// No pre-pass ran for this mutation, so fall back to the historical (unrestricted) behaviour. In
+			// production this is unreachable: `LocalMutationExecutorCollector` is the sole caller of
+			// `EntityCollection#applyIndexMutations` and always attaches the captured state. It is reached only
+			// by tests that construct a mutation directly. A future second dispatch path that skips the pre-pass
+			// would silently reintroduce the sibling-cardinality defect here — attach the state there too.
+			return allAffectedOwnerPKs;
+		}
+		final Bitmap previouslyIndexed = previouslyIndexedByHistogram.get(histogramName);
+		if (previouslyIndexed == null || previouslyIndexed.isEmpty()) {
+			return EmptyBitmap.INSTANCE;
+		}
+		final int[] restricted = and(
+			getRoaringBitmap(allAffectedOwnerPKs), getRoaringBitmap(previouslyIndexed)
+		).toArray();
+		return restricted.length == 0 ? EmptyBitmap.INSTANCE : new BaseBitmap(restricted);
 	}
 
 	/**
@@ -370,11 +473,16 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 			// populated — for GROUP deps from rgei.getReferencedEntityPrimaryKeys(), for PARENT deps
 			// from RTEI/RGEI traversal intersected with children bitmap.
 			final boolean canUseScopedRemoval = resolution.source() == HistogramValueSource.REFERENCED_ENTITY_ATTRIBUTE;
+			// only owners that actually contributed before this batch may have their contribution removed —
+			// removing on mere bucket membership consumes a sibling reference's cardinality unit
+			final Bitmap ownerPKsToRemove = restrictToPreviouslyIndexed(
+				allAffectedOwnerPKs, mutation, histogramName
+			);
 			if (canUseScopedRemoval) {
 				// Scoped removal: deterministic remove using known values from source FilterIndex
 				// or pre-mutation captured values when the value source attribute itself changed.
 				scopedRemoveForReferencedEntityAttribute(
-					histogramName, resolution, allAffectedOwnerPKs,
+					histogramName, resolution, ownerPKsToRemove,
 					affected, rtei, isGrouped, target, locales, mutation, scope
 				);
 				addHistogramEntries(
@@ -385,7 +493,7 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 				// REFERENCE_ATTRIBUTE path: deterministic remove+re-add using values from the
 				// reference attribute FilterIndex (same index the add path reads)
 				removeFromReferenceAttribute(
-					histogramName, resolution, allAffectedOwnerPKs, affected,
+					histogramName, resolution, ownerPKsToRemove, affected,
 					rtei, isGrouped, target, referenceName, locales
 				);
 				addHistogramEntries(
@@ -664,7 +772,7 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 			final PersistentRoaringBitmap matched = and(removePKs, groupPKs);
 
 			if (!matched.isEmpty()) {
-				// determine values to remove: known old values (value-change) or current source values (condition-change)
+				// values to remove: known old values (value-change) or current source values (condition-change)
 				final List<? extends Serializable> valuesToRemove;
 				if (knownOldValues != null) {
 					// value source changed: use pre-captured old values for deterministic removal

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
@@ -264,10 +264,13 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 				trigger, mutation, target, affected, allAffectedOwnerPKs
 			);
 			// materialize the result — the mutations this pre-pass runs ahead of are about to modify the very
-			// indexes a passthrough filter plan may hand back by reference, and this bitmap has to survive them
+			// indexes a passthrough filter plan may hand back by reference, and this bitmap has to survive them.
+			// The copy constructor clones the compressed representation when the source is roaring-backed (it
+			// always is here); going through `getArray()` would spend an int[] of the full cardinality to
+			// rebuild the same thing.
 			result.put(
 				trigger.getHistogramIndexName(),
-				new BaseBitmap(split.shouldBeIndexed().getArray())
+				new BaseBitmap(split.shouldBeIndexed())
 			);
 		}
 		return result;

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionMutation.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionMutation.java
@@ -25,6 +25,7 @@ package io.evitadb.index.mutation;
 
 import io.evitadb.core.expression.trigger.DependencyType;
 import io.evitadb.dataType.Scope;
+import io.evitadb.index.bitmap.Bitmap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -43,15 +44,31 @@ import java.util.Map;
  * histogram bucket scanning or fallback re-indexing. The map is keyed by attribute name, then by locale
  * (null for non-localized).
  *
+ * The optional `previouslyIndexedOwnerPKs` field carries, per histogram name, the owner PKs whose histogram
+ * condition held **before** any of this batch's local mutations were applied. It is captured by
+ * {@code LocalMutationExecutorCollector}'s read-only pre-pass, because by the time this mutation is dispatched
+ * every readable source — indexes and storage containers alike — already reflects the post-mutation state.
+ *
+ * Without it the removal side of the executor's remove-before-add has no way to tell *"this reference contributed
+ * (value → owner)"* from *"somebody's contribution for (value, owner) exists"*: the histogram is a multiset gated
+ * by {@code AttributeCardinalityIndex}, so removing on mere bucket membership consumes a **sibling** reference's
+ * cardinality unit whenever two of an owner's references normalise to the same bucket key. The counter then reads
+ * one where it should read two, and the next legitimate removal evicts the owner from the histogram entirely.
+ *
  * Identity (equals/hashCode) is based solely on the 4 core fields (referenceName, mutatedEntityPK,
- * dependencyType, scope) — the `preMutationSourceValues` field is excluded to preserve deduplication semantics
- * in {@code EntityIndexLocalMutationExecutor.collectEntityAttributeTriggers()}.
+ * dependencyType, scope) — the `preMutationSourceValues` and `previouslyIndexedOwnerPKs` fields are excluded to
+ * preserve deduplication semantics in {@code EntityIndexLocalMutationExecutor.collectEntityAttributeTriggers()}.
+ * That exclusion is also what lets the pre-pass key its captured state by the mutation itself: the pre-pass and
+ * dispatch copies differ only in these two payload fields and therefore compare equal.
  *
  * @param referenceName          reference with the conditional expression
  * @param mutatedEntityPK        the group/referenced entity PK that changed
  * @param dependencyType         how the mutated entity relates to the owner
  * @param scope                  scope of the expression to re-evaluate
  * @param preMutationSourceValues pre-mutation attribute values keyed by attribute name and locale, or null
+ * @param previouslyIndexedOwnerPKs owner PKs whose condition held before the batch, keyed by histogram name,
+ *                                  or null when no pre-pass ran (facet-only triggers, tests, WAL replay paths
+ *                                  without a collector)
  * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
 public record ReevaluateExpressionMutation(
@@ -59,9 +76,20 @@ public record ReevaluateExpressionMutation(
 	int mutatedEntityPK,
 	@Nonnull DependencyType dependencyType,
 	@Nonnull Scope scope,
-	@Nullable Map<String, Map<Locale, Serializable>> preMutationSourceValues
+	@Nullable Map<String, Map<Locale, Serializable>> preMutationSourceValues,
+	@Nullable Map<String, Bitmap> previouslyIndexedOwnerPKs
 ) implements IndexMutation, Serializable {
 	@Serial private static final long serialVersionUID = -1L;
+
+	public ReevaluateExpressionMutation(
+		@Nonnull String referenceName,
+		int mutatedEntityPK,
+		@Nonnull DependencyType dependencyType,
+		@Nonnull Scope scope,
+		@Nullable Map<String, Map<Locale, Serializable>> preMutationSourceValues
+	) {
+		this(referenceName, mutatedEntityPK, dependencyType, scope, preMutationSourceValues, null);
+	}
 
 	/**
 	 * Convenience factory for mutations that do not carry pre-mutation values (facet triggers,
@@ -74,7 +102,25 @@ public record ReevaluateExpressionMutation(
 		@Nonnull DependencyType dependencyType,
 		@Nonnull Scope scope
 	) {
-		return new ReevaluateExpressionMutation(referenceName, mutatedEntityPK, dependencyType, scope, null);
+		return new ReevaluateExpressionMutation(referenceName, mutatedEntityPK, dependencyType, scope, null, null);
+	}
+
+	/**
+	 * Returns a copy of this mutation carrying the supplied pre-pass condition state. Used by
+	 * {@code LocalMutationExecutorCollector} to attach the state it captured before the batch was applied,
+	 * without disturbing the mutation's identity.
+	 *
+	 * @param previouslyIndexedOwnerPKs owner PKs whose condition held before the batch, keyed by histogram name
+	 * @return a copy carrying the pre-pass state
+	 */
+	@Nonnull
+	public ReevaluateExpressionMutation withPreviouslyIndexedOwnerPKs(
+		@Nullable Map<String, Bitmap> previouslyIndexedOwnerPKs
+	) {
+		return new ReevaluateExpressionMutation(
+			this.referenceName, this.mutatedEntityPK, this.dependencyType, this.scope,
+			this.preMutationSourceValues, previouslyIndexedOwnerPKs
+		);
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/EntityIndexLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/EntityIndexLocalMutationExecutor.java
@@ -596,6 +596,45 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 	}
 
 	/**
+	 * Read-only sibling of {@link #popIndexImplicitMutations} used by `LocalMutationExecutorCollector`'s
+	 * pre-pass to learn which cross-entity triggers a batch is *about to* fire, before any of it is applied.
+	 *
+	 * Only the trigger identities matter to the caller — the envelopes it returns carry no pre-mutation values
+	 * (nothing has been captured yet) and are never dispatched. They are matched against the real envelopes
+	 * later by {@link ReevaluateExpressionMutation}'s identity, which excludes both payload fields.
+	 *
+	 * The removal branch cannot be read off the container here (nothing has been applied), so the caller states
+	 * it — and the two agree by construction, not by luck: {@link #popIndexImplicitMutations} branches on
+	 * `containerAccessor.isEntityRemovedEntirely()`, which is a `final` field
+	 * {@link io.evitadb.index.mutation.storagePart.ContainerizedLocalMutationExecutor} is built with from
+	 * `entityMutation instanceof EntityRemoveMutation` at its single construction site in `EntityCollection`.
+	 * That is the same expression the caller evaluates. **If that flag ever becomes dynamic, this peek must take
+	 * the same signal instead of inferring it** — a disagreement would make the pre-pass capture a narrower
+	 * trigger set than dispatch fires, and the uncaptured triggers would silently fall back to unrestricted
+	 * histogram removal.
+	 *
+	 * Over-firing is harmless: a trigger that turns out not to fire simply leaves an unused entry.
+	 *
+	 * @param inputMutations the local mutations about to be applied
+	 * @param entityRemoval  `true` when the batch removes the entity entirely
+	 * @return the index mutations this batch is expected to produce
+	 */
+	@Nonnull
+	public IndexImplicitMutations peekIndexImplicitMutations(
+		@Nonnull List<? extends LocalMutation<?, ?>> inputMutations,
+		boolean entityRemoval
+	) {
+		final CatalogExpressionTriggerRegistry registry = getCatalogExpressionTriggerRegistry();
+		if (registry == null) {
+			return EMPTY_INDEX_IMPLICIT_MUTATIONS;
+		}
+		final int entityPK = getPrimaryKeyToIndex(IndexType.ENTITY_INDEX, Target.NEW);
+		return entityRemoval
+			? buildRemovalMutations(registry, entityPK)
+			: buildAttributeChangeMutations(registry, entityPK, inputMutations);
+	}
+
+	/**
 	 * Prepares the necessary initial setup for the provided local mutations, ensuring
 	 * appropriate indexes and configurations are in place for further processing. This
 	 * initializes required components such as global indexes and sortable attribute compounds.
@@ -1513,17 +1552,9 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 		@Nonnull AttributeKey attributeKey,
 		@Nonnull ExistingAttributeValueSupplier supplier
 	) {
-		supplier.getAttributeValue(attributeKey).ifPresent(av -> {
-			final Serializable value = av.value();
-			if (value != null) {
-				if (this.capturedOldEntityAttributeValues == null) {
-					this.capturedOldEntityAttributeValues = CollectionUtils.createHashMap(8);
-				}
-				this.capturedOldEntityAttributeValues
-					.computeIfAbsent(attributeKey.attributeName(), k -> CollectionUtils.createHashMap(4))
-					.putIfAbsent(attributeKey.locale(), value);
-			}
-		});
+		supplier.getAttributeValue(attributeKey).ifPresent(
+			av -> recordCapturedOldEntityAttributeValue(attributeKey, av.value())
+		);
 	}
 
 	/**
@@ -1539,21 +1570,44 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 			if (!attributeNames.contains(attributeValue.key().attributeName())) {
 				continue;
 			}
-			final Serializable rawValue = attributeValue.value();
-			if (rawValue != null) {
-				// normalize BigDecimal values to match the canonical form used in indexes
-				final Serializable value = NumberUtils.normalizeIfBigDecimal(rawValue);
-				if (this.capturedOldEntityAttributeValues == null) {
-					this.capturedOldEntityAttributeValues = CollectionUtils.createHashMap(8);
-				}
-				this.capturedOldEntityAttributeValues
-					.computeIfAbsent(
-						attributeValue.key().attributeName(),
-						k -> CollectionUtils.createHashMap(4)
-					)
-					.putIfAbsent(attributeValue.key().locale(), value);
-			}
+			recordCapturedOldEntityAttributeValue(attributeValue.key(), attributeValue.value());
 		}
+	}
+
+	/**
+	 * The single write boundary of {@link #capturedOldEntityAttributeValues} — every capture site funnels
+	 * through here so the canonical form of a captured value is decided in exactly one place.
+	 *
+	 * **Why this matters.** Captured values are consumed by
+	 * {@code ReevaluateExpressionExecutor.resolvePreMutationValues}, which turns them into the `remove(oldValue,
+	 * ownerPK)` probe for a histogram bucket. That probe has to hit the same bucket key the matching insert
+	 * created, so a captured value must carry the same `BigDecimal` canonicalisation the index-write path
+	 * applies. The two capture sites reach that form by different routes —
+	 * {@link #captureOldEntityAttributeValue} is fed by a supplier already wrapped in
+	 * {@link ExistingAttributeValueSupplier#normalizing}, while {@link #captureEntityAttributeValues} walks a
+	 * raw {@link Entity} — and nothing but this method made them agree. Applying
+	 * {@link NumberUtils#normalizeIfBigDecimal} here covers both: it is idempotent, so the already-normalized
+	 * route is unaffected, and a future third capture site cannot get it wrong by omission.
+	 *
+	 * `putIfAbsent` on both levels preserves the *true* pre-mutation value when one attribute is mutated
+	 * several times within a single batch.
+	 *
+	 * @param attributeKey the attribute key identifying the captured attribute
+	 * @param rawValue     the pre-mutation value as read from storage, or `null` when the attribute was unset
+	 */
+	private void recordCapturedOldEntityAttributeValue(
+		@Nonnull AttributeKey attributeKey,
+		@Nullable Serializable rawValue
+	) {
+		if (rawValue == null) {
+			return;
+		}
+		if (this.capturedOldEntityAttributeValues == null) {
+			this.capturedOldEntityAttributeValues = CollectionUtils.createHashMap(8);
+		}
+		this.capturedOldEntityAttributeValues
+			.computeIfAbsent(attributeKey.attributeName(), k -> CollectionUtils.createHashMap(4))
+			.putIfAbsent(attributeKey.locale(), NumberUtils.normalizeIfBigDecimal(rawValue));
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ConditionalBucketIndexingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ConditionalBucketIndexingTest.java
@@ -81,6 +81,7 @@ class ConditionalBucketIndexingTest implements EvitaTestSupport, IndexingTestSup
 	private static final String ENTITY_PARAMETER_VALUE = "parameterValue";
 	private static final String ENTITY_PARAMETER = "parameter";
 	private static final String ENTITY_TAG = "tag";
+	private static final String ENTITY_BUNDLE = "bundle";
 
 	private static final String REF_PARAM_BY_GROUP_ATTR = "paramByGroupAttr";
 	private static final String REF_PARAM_BY_GROUP_ATTR_WITH_DEFAULT = "paramByGroupAttrWithDefault";
@@ -418,8 +419,19 @@ class ConditionalBucketIndexingTest implements EvitaTestSupport, IndexingTestSup
 	 */
 	@Nonnull
 	private EntityCollectionContract getProductCollection() {
+		return getCollection(ENTITY_PRODUCT);
+	}
+
+	/**
+	 * Returns the live collection of the given entity type from the test catalog.
+	 *
+	 * @param entityType the entity type whose collection is requested
+	 * @return the entity collection
+	 */
+	@Nonnull
+	private EntityCollectionContract getCollection(@Nonnull String entityType) {
 		final CatalogContract catalog = this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
-		return catalog.getCollectionForEntity(ENTITY_PRODUCT).orElseThrow();
+		return catalog.getCollectionForEntity(entityType).orElseThrow();
 	}
 
 	/**
@@ -1684,6 +1696,80 @@ class ConditionalBucketIndexingTest implements EvitaTestSupport, IndexingTestSup
 	@Nested
 	@DisplayName("Cross-entity triggers — referenced entity mutations")
 	class CrossEntityReferencedEntityTriggerTest {
+
+		@ParameterizedTest(name = "catalog state: {0}")
+		@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+		@DisplayName("Should drop contributions in every owner collection sharing a reference name")
+		void shouldDropContributionsInEveryOwnerCollectionSharingReferenceName(CatalogState state) {
+			withCatalogInState(
+				state,
+				session -> {
+					defineConditionalBucketSchema(session);
+					// a second owner type whose trigger shares the reference name, dependency type and scope
+					// with product's — the pair a ReevaluateExpressionMutation's identity cannot tell apart,
+					// so the pre-mutation condition state has to be keyed by target collection as well
+					session.defineEntitySchema(ENTITY_BUNDLE)
+						.withReferenceToEntity(
+							REF_PARAM_BY_REF_ENTITY_ATTR, ENTITY_PARAMETER_VALUE, Cardinality.ZERO_OR_MORE,
+							whichIs -> whichIs
+								.indexedForFilteringAndPartitioning()
+								.bucketed(
+									HISTOGRAM_STATUS,
+									ExpressionFactory.parse(
+										"$reference.referencedEntity?.attributes['basicUnitValue']"
+									)
+								)
+								.bucketedPartially(
+									ExpressionFactory.parse(
+										"($reference.referencedEntity.attributes['status'] ?? '') == 'ACTIVE'"
+									)
+								)
+						)
+						.updateVia(session);
+
+					session.createNewEntity(ENTITY_PARAMETER_VALUE, 1)
+						.setAttribute(ATTR_STATUS, "ACTIVE")
+						.setAttribute(ATTR_BASIC_UNIT_VALUE, new BigDecimal("50"))
+						.upsertVia(session);
+
+					// deliberately disjoint owner PKs: a set captured against one collection must not be able
+					// to cover the other collection's owner by coincidence
+					session.createNewEntity(ENTITY_PRODUCT, 1)
+						.setReference(REF_PARAM_BY_REF_ENTITY_ATTR, 1)
+						.upsertVia(session);
+					session.createNewEntity(ENTITY_BUNDLE, 7)
+						.setReference(REF_PARAM_BY_REF_ENTITY_ATTR, 1)
+						.upsertVia(session);
+				},
+				session -> {
+					final EntityCollectionContract productCollection = getProductCollection();
+					final EntityCollectionContract bundleCollection = getCollection(ENTITY_BUNDLE);
+					assertUngroupedHistogramBucketContains(
+						productCollection, REF_PARAM_BY_REF_ENTITY_ATTR,
+						HISTOGRAM_STATUS, new BigDecimal("50"), 1
+					);
+					assertUngroupedHistogramBucketContains(
+						bundleCollection, REF_PARAM_BY_REF_ENTITY_ATTR,
+						HISTOGRAM_STATUS, new BigDecimal("50"), 7
+					);
+
+					// a single mutation of the referenced entity fans out to both owner collections
+					session.getEntity(ENTITY_PARAMETER_VALUE, 1, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setAttribute(ATTR_STATUS, "INACTIVE")
+						.upsertVia(session);
+
+					// neither collection may keep a stale contribution
+					assertUngroupedHistogramNotIndexed(
+						productCollection, REF_PARAM_BY_REF_ENTITY_ATTR, HISTOGRAM_STATUS, 1
+					);
+					assertUngroupedHistogramNotIndexed(
+						bundleCollection, REF_PARAM_BY_REF_ENTITY_ATTR, HISTOGRAM_STATUS, 7
+					);
+				}
+			);
+		}
 
 		@ParameterizedTest(name = "catalog state: {0}")
 		@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ConditionalBucketIndexingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ConditionalBucketIndexingTest.java
@@ -1629,6 +1629,53 @@ class ConditionalBucketIndexingTest implements EvitaTestSupport, IndexingTestSup
 				}
 			);
 		}
+
+		@ParameterizedTest(name = "catalog state: {0}")
+		@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+		@DisplayName("Should keep qualifying contribution when non-qualifying sibling reference is removed")
+		void shouldKeepQualifyingContributionWhenNonQualifyingSiblingReferenceIsRemoved(CatalogState state) {
+			withCatalogInState(
+				state,
+				session -> {
+					defineConditionalBucketSchema(session);
+
+					// both parameter values carry the SAME histogram value, but only PV#1 qualifies -
+					// PV#2 never contributes anything to the histogram
+					session.createNewEntity(ENTITY_PARAMETER_VALUE, 1)
+						.setAttribute(ATTR_STATUS, "ACTIVE")
+						.setAttribute(ATTR_BASIC_UNIT_VALUE, new BigDecimal("50"))
+						.upsertVia(session);
+					session.createNewEntity(ENTITY_PARAMETER_VALUE, 2)
+						.setAttribute(ATTR_STATUS, "INACTIVE")
+						.setAttribute(ATTR_BASIC_UNIT_VALUE, new BigDecimal("50"))
+						.upsertVia(session);
+
+					session.createNewEntity(ENTITY_PRODUCT, 1)
+						.setReference(REF_PARAM_BY_REF_ENTITY_ATTR, 1)
+						.setReference(REF_PARAM_BY_REF_ENTITY_ATTR, 2)
+						.upsertVia(session);
+				},
+				session -> {
+					final EntityCollectionContract productCollection = getProductCollection();
+					assertUngroupedHistogramBucketContains(
+						productCollection, REF_PARAM_BY_REF_ENTITY_ATTR,
+						HISTOGRAM_STATUS, new BigDecimal("50"), 1
+					);
+
+					// dropping the reference that never contributed must not evict PV#1's contribution
+					session.getEntity(ENTITY_PRODUCT, 1, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.removeReference(REF_PARAM_BY_REF_ENTITY_ATTR, 2)
+						.upsertVia(session);
+
+					assertUngroupedHistogramBucketContains(
+						productCollection, REF_PARAM_BY_REF_ENTITY_ATTR,
+						HISTOGRAM_STATUS, new BigDecimal("50"), 1
+					);
+				}
+			);
+		}
 	}
 
 	/**
@@ -1680,6 +1727,114 @@ class ConditionalBucketIndexingTest implements EvitaTestSupport, IndexingTestSup
 						.orElseThrow()
 						.openForWrite()
 						.setAttribute(ATTR_STATUS, "ACTIVE")
+						.upsertVia(session);
+
+					assertUngroupedHistogramBucketContains(
+						productCollection, REF_PARAM_BY_REF_ENTITY_ATTR,
+						HISTOGRAM_STATUS, new BigDecimal("50"), 1
+					);
+				}
+			);
+		}
+
+		@ParameterizedTest(name = "catalog state: {0}")
+		@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+		@DisplayName("Should keep sibling contribution when a second reference starts qualifying for the same bucket")
+		void shouldKeepSiblingContributionWhenSecondReferenceStartsQualifyingForSameBucket(CatalogState state) {
+			withCatalogInState(
+				state,
+				session -> {
+					defineConditionalBucketSchema(session);
+
+					// both parameter values carry the SAME histogram value, so both land in one bucket;
+					// only the first one qualifies initially
+					session.createNewEntity(ENTITY_PARAMETER_VALUE, 1)
+						.setAttribute(ATTR_STATUS, "ACTIVE")
+						.setAttribute(ATTR_BASIC_UNIT_VALUE, new BigDecimal("50"))
+						.upsertVia(session);
+					session.createNewEntity(ENTITY_PARAMETER_VALUE, 2)
+						.setAttribute(ATTR_STATUS, "INACTIVE")
+						.setAttribute(ATTR_BASIC_UNIT_VALUE, new BigDecimal("50"))
+						.upsertVia(session);
+
+					session.createNewEntity(ENTITY_PRODUCT, 1)
+						.setReference(REF_PARAM_BY_REF_ENTITY_ATTR, 1)
+						.setReference(REF_PARAM_BY_REF_ENTITY_ATTR, 2)
+						.upsertVia(session);
+				},
+				session -> {
+					final EntityCollectionContract productCollection = getProductCollection();
+					// only PV#1 qualifies - bucket 50 holds a single contribution
+					assertUngroupedHistogramBucketContains(
+						productCollection, REF_PARAM_BY_REF_ENTITY_ATTR,
+						HISTOGRAM_STATUS, new BigDecimal("50"), 1
+					);
+
+					// PV#2 starts qualifying for the very same bucket - the bucket must now hold two
+					// contributions even though the visible membership bitmap cannot show that
+					session.getEntity(ENTITY_PARAMETER_VALUE, 2, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setAttribute(ATTR_STATUS, "ACTIVE")
+						.upsertVia(session);
+
+					assertUngroupedHistogramBucketContains(
+						productCollection, REF_PARAM_BY_REF_ENTITY_ATTR,
+						HISTOGRAM_STATUS, new BigDecimal("50"), 1
+					);
+
+					// PV#1 stops qualifying - PV#2 still does, so the product must stay in bucket 50
+					session.getEntity(ENTITY_PARAMETER_VALUE, 1, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setAttribute(ATTR_STATUS, "INACTIVE")
+						.upsertVia(session);
+
+					assertUngroupedHistogramBucketContains(
+						productCollection, REF_PARAM_BY_REF_ENTITY_ATTR,
+						HISTOGRAM_STATUS, new BigDecimal("50"), 1
+					);
+				}
+			);
+		}
+
+		@ParameterizedTest(name = "catalog state: {0}")
+		@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+		@DisplayName("Should keep sibling contribution when a non-qualifying reference changes its value")
+		void shouldKeepSiblingContributionWhenNonQualifyingReferenceChangesItsValue(CatalogState state) {
+			withCatalogInState(
+				state,
+				session -> {
+					defineConditionalBucketSchema(session);
+
+					// PV#1 qualifies for bucket 50; PV#2 shares that value but never qualifies
+					session.createNewEntity(ENTITY_PARAMETER_VALUE, 1)
+						.setAttribute(ATTR_STATUS, "ACTIVE")
+						.setAttribute(ATTR_BASIC_UNIT_VALUE, new BigDecimal("50"))
+						.upsertVia(session);
+					session.createNewEntity(ENTITY_PARAMETER_VALUE, 2)
+						.setAttribute(ATTR_STATUS, "INACTIVE")
+						.setAttribute(ATTR_BASIC_UNIT_VALUE, new BigDecimal("50"))
+						.upsertVia(session);
+
+					session.createNewEntity(ENTITY_PRODUCT, 1)
+						.setReference(REF_PARAM_BY_REF_ENTITY_ATTR, 1)
+						.setReference(REF_PARAM_BY_REF_ENTITY_ATTR, 2)
+						.upsertVia(session);
+				},
+				session -> {
+					final EntityCollectionContract productCollection = getProductCollection();
+					assertUngroupedHistogramBucketContains(
+						productCollection, REF_PARAM_BY_REF_ENTITY_ATTR,
+						HISTOGRAM_STATUS, new BigDecimal("50"), 1
+					);
+
+					// PV#2's value moves off the shared bucket; since PV#2 never contributed there,
+					// PV#1's contribution to bucket 50 must survive untouched
+					session.getEntity(ENTITY_PARAMETER_VALUE, 2, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setAttribute(ATTR_BASIC_UNIT_VALUE, new BigDecimal("60"))
 						.upsertVia(session);
 
 					assertUngroupedHistogramBucketContains(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/ReevaluateExpressionExecutorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/ReevaluateExpressionExecutorTest.java
@@ -44,6 +44,7 @@ import io.evitadb.api.requestResponse.schema.dto.ReferenceSchema;
 import io.evitadb.api.requestResponse.schema.mutation.reference.ScopedReferenceIndexType;
 import io.evitadb.core.expression.trigger.DependencyType;
 import io.evitadb.core.expression.trigger.FacetExpressionTrigger;
+import io.evitadb.core.expression.trigger.HistogramExpressionTrigger;
 import io.evitadb.dataType.Scope;
 import io.evitadb.index.EntityIndexKey;
 import io.evitadb.index.EntityIndexType;
@@ -103,6 +104,7 @@ import static io.evitadb.test.TestTags.SCHEMA;
 class ReevaluateExpressionExecutorTest {
 
 	private static final String REFERENCE_NAME = "parameterValues";
+	private static final String HISTOGRAM_NAME = "basicUnitValueHistogram";
 	private static final String GROUP_ENTITY_TYPE = "parameterGroup";
 	private static final String REFERENCED_ENTITY_TYPE = "parameterValue";
 	private static final String ENTITY_TYPE = "product";
@@ -1762,6 +1764,135 @@ class ReevaluateExpressionExecutorTest {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Pins the contract of the read-only pre-pass that `LocalMutationExecutorCollector` runs before a batch is
+	 * applied. Its result becomes {@link ReevaluateExpressionMutation#previouslyIndexedOwnerPKs()}, which is what
+	 * stops the executor's remove-before-add from consuming a **sibling** reference's histogram cardinality unit
+	 * when two of an owner's references normalise to the same bucket key.
+	 *
+	 * The `null`-versus-empty distinction asserted here is load-bearing and easy to lose in a refactor of the
+	 * mutation record: `null` means "no histogram trigger, nothing to guard" and restores unrestricted removal,
+	 * whereas an **empty bitmap** means "nobody qualified beforehand" and must suppress every removal.
+	 */
+	@Nested
+	@DisplayName("Pre-pass condition capture")
+	class PreMutationConditionStateTest {
+
+		@Test
+		@DisplayName("returns null when the reference declares no histogram trigger")
+		void shouldReturnNullWhenNoHistogramTriggerExists() {
+			final AffectedReferenceGroup group = new AffectedReferenceGroup(3, 1, new BaseBitmap(100, 200));
+			final TestTarget testTarget = createTestTarget(
+				new AffectedEntityResolution(List.of(group)), ReferenceIndexType.FOR_FILTERING
+			);
+			final IndexMutationTarget target = testTarget.target();
+			when(target.getHistogramTriggers(REFERENCE_NAME, Scope.LIVE))
+				.thenReturn(Collections.emptyList());
+
+			assertNull(
+				ReevaluateExpressionExecutor.evaluateHistogramConditionState(
+					ReevaluateExpressionMutation.withoutOldValues(
+						REFERENCE_NAME, 3, DependencyType.REFERENCED_ENTITY_ATTRIBUTE, Scope.LIVE
+					),
+					target
+				),
+				"no histogram trigger means there is nothing to guard - the executor must keep removing freely"
+			);
+		}
+
+		@Test
+		@DisplayName("returns an empty bitmap - not null - when no owner is affected yet")
+		void shouldReturnEmptyBitmapWhenNoOwnerIsAffected() {
+			// no resolution indexes are set up, so resolveAffected finds no owner at all
+			final TestTarget testTarget = createTestTarget(
+				AffectedEntityResolution.EMPTY, ReferenceIndexType.FOR_FILTERING
+			);
+			final IndexMutationTarget target = testTarget.target();
+			// build the trigger first - Mockito rejects a mock() / when() nested inside another when()
+			final HistogramExpressionTrigger trigger = unconditionalHistogramTrigger();
+			when(target.getHistogramTriggers(REFERENCE_NAME, Scope.LIVE))
+				.thenReturn(List.of(trigger));
+
+			final Map<String, Bitmap> conditionState =
+				ReevaluateExpressionExecutor.evaluateHistogramConditionState(
+					ReevaluateExpressionMutation.withoutOldValues(
+						REFERENCE_NAME, 3, DependencyType.REFERENCED_ENTITY_ATTRIBUTE, Scope.LIVE
+					),
+					target
+				);
+
+			assertNotNull(conditionState, "the pre-pass ran, so it must report its answer rather than null");
+			assertTrue(
+				conditionState.get(HISTOGRAM_NAME).isEmpty(),
+				"nobody contributed beforehand, so every removal must be suppressed"
+			);
+		}
+
+		@Test
+		@DisplayName("reports the owners whose condition holds before the batch")
+		void shouldReportOwnersWhoseConditionHoldsBeforeTheBatch() {
+			final AffectedReferenceGroup group = new AffectedReferenceGroup(3, 1, new BaseBitmap(100, 200));
+			final TestTarget testTarget = createTestTarget(
+				new AffectedEntityResolution(List.of(group)), ReferenceIndexType.FOR_FILTERING
+			);
+			final IndexMutationTarget target = testTarget.target();
+			// build the trigger first - Mockito rejects a mock() / when() nested inside another when()
+			final HistogramExpressionTrigger trigger = unconditionalHistogramTrigger();
+			when(target.getHistogramTriggers(REFERENCE_NAME, Scope.LIVE))
+				.thenReturn(List.of(trigger));
+
+			final Map<String, Bitmap> conditionState =
+				ReevaluateExpressionExecutor.evaluateHistogramConditionState(
+					ReevaluateExpressionMutation.withoutOldValues(
+						REFERENCE_NAME, 3, DependencyType.REFERENCED_ENTITY_ATTRIBUTE, Scope.LIVE
+					),
+					target
+				);
+
+			assertNotNull(conditionState);
+			assertArrayEquals(
+				new int[]{100, 200},
+				conditionState.get(HISTOGRAM_NAME).getArray(),
+				"an unconditional trigger qualifies every affected owner"
+			);
+			// the pre-pass must not have touched a single index
+			verify(target, never()).getOrCreateIndexByPrimaryKey(anyInt());
+		}
+
+		@Test
+		@DisplayName("captured state survives on the mutation without changing its identity")
+		void shouldCarryCapturedStateWithoutChangingIdentity() {
+			final ReevaluateExpressionMutation bare = ReevaluateExpressionMutation.withoutOldValues(
+				REFERENCE_NAME, 3, DependencyType.REFERENCED_ENTITY_ATTRIBUTE, Scope.LIVE
+			);
+			final ReevaluateExpressionMutation enriched = bare.withPreviouslyIndexedOwnerPKs(
+				Map.of(HISTOGRAM_NAME, new BaseBitmap(100))
+			);
+
+			assertEquals(
+				bare, enriched,
+				"identity must ignore the payload - the collector keys its captures by the mutation itself"
+			);
+			assertEquals(bare.hashCode(), enriched.hashCode());
+			assertNull(bare.previouslyIndexedOwnerPKs());
+			assertArrayEquals(
+				new int[]{100}, enriched.previouslyIndexedOwnerPKs().get(HISTOGRAM_NAME).getArray()
+			);
+		}
+
+		/**
+		 * A histogram trigger with no `FilterBy`, so `evaluateCondition` short-circuits to "every affected owner
+		 * qualifies" and the test asserts the capture plumbing rather than the query engine.
+		 */
+		@Nonnull
+		private HistogramExpressionTrigger unconditionalHistogramTrigger() {
+			final HistogramExpressionTrigger trigger = mock(HistogramExpressionTrigger.class);
+			when(trigger.getHistogramIndexName()).thenReturn(HISTOGRAM_NAME);
+			when(trigger.hasFilterByConstraint()).thenReturn(false);
+			return trigger;
+		}
 	}
 
 	/**

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/api/EvitaConditionalBucketGenerationalTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/api/EvitaConditionalBucketGenerationalTest.java
@@ -661,6 +661,28 @@ class EvitaConditionalBucketGenerationalTest implements EvitaTestSupport, TimeBo
 		logFinished(finalState);
 	}
 
+	/**
+	 * Re-invokes [#shouldSurviveGenerationalTestWithReferencedEntityAttributeExpression] with the
+	 * deterministic seed pinned to the CI failure, mirroring
+	 * [#shouldNotSurfaceHistogramDriftForSeedMinus1128235571].
+	 *
+	 * This seed fails at **generation 4**, within ~2s, so a 5-minute interval is far more than enough
+	 * and the time-bounded driver short-circuits on the first assertion failure. Generation 4 reaches
+	 * the defect through an owner that references two parameter values whose `basicUnitValue` both
+	 * normalise to bucket `500`: a condition flip on the second one made the executor remove on mere
+	 * bucket membership and consume the first one's cardinality unit. The fast equivalent lives in
+	 * `ConditionalBucketIndexingTest` (`shouldKeepSiblingContributionWhen…`); this pins the exact
+	 * reported sequence.
+	 */
+	@Test
+	@Tag(SLOW)
+	@DisplayName("Generative seed 2095323828 must not surface conditional histogram drift")
+	void shouldNotSurfaceHistogramDriftForSeed2095323828() {
+		shouldSurviveGenerationalTestWithReferencedEntityAttributeExpression(
+			new GenerationalTestInput(/* intervalInMinutes */ 5, /* randomSeed */ 2095323828)
+		);
+	}
+
 	// --- Focused test for conditional histogram stale evaluateFilter after group attribute change ---
 
 	@org.junit.jupiter.api.Test


### PR DESCRIPTION
Ref: #1467 (the `dev` PR carries the closing keyword)

Counterpart to the `dev` PR — same change, both branches were byte-identical in
every seam this touches.

## The defect

The histogram is a **multiset**: `SimpleHistogramIndex.insertValue` / `removeValue` gate the
underlying `FilterIndex` membership bitmap on an `AttributeCardinalityIndex` counter keyed by
`(ownerPK, value)`, so the bucket only gains or loses the owner on a `0->1` / `1->0` transition.
ADR `2026-04-23-bucketed-histogram-indexing` states the invariant: *"an owner PK appears at most once
per bucket per histogram — enforced by the cardinality-gated insert/remove pair"*.

`ReevaluateExpressionExecutor` broke the pairing. Its remove-before-add was guarded by
`histogramContainsOwner`, which tests bucket **membership** — true as soon as *anybody's*
contribution for `(value, owner)` exists — where it needs to answer *"did **this** reference
contribute?"*. When two of an owner's references normalise to the same bucket key, the guard passes
for a reference that contributed nothing and the removal consumes the **sibling's** cardinality unit.
The counter then reads `1` where it should read `2`, and the next legitimate removal empties the
bucket and drops the owner from the histogram outright.

The owner-side path was never affected — `removeHistogramWithConditionGuard` already evaluates the
condition first, and its JavaDoc names this exact failure. Only the cross-entity path lacked the
guard, because it is the one path where pre-mutation state is out of reach:
`LocalMutationExecutorCollector` deliberately runs the index-trigger phase *after* the container
implicit-mutation phase, so by dispatch time every readable source already reflects the post-mutation
state.

## The fix

Capture the answer before it is lost. `LocalMutationExecutorCollector` evaluates the histogram
conditions **read-only, before a batch is applied**, and carries the result on
`ReevaluateExpressionMutation.previouslyIndexedOwnerPKs`; the executor removes only owners in it.
Both sides use the **same** index-backed evaluator, so old and new conditions cannot disagree for any
reason other than the mutation itself.

Resulting transition table (`V` unchanged unless stated):

| old cond | new cond | remove | add | net cardinality |
|---|---|---|---|---|
| false | false | suppressed | no | 0 |
| false | true | suppressed | yes | +1 |
| true | false | yes | no | -1 |
| true | true | yes (old V) | yes (new V) | 0 |

Rejected alternatives, with concrete blockers, are in the ADR: re-keying the cardinality by
contributing reference (released Kryo format + an unconvertible counts->sets migration) and
reconciling to a desired count (unbounded write-path fan-out, no owner->references mapping exists).

## Verification

- **`ConditionalBucketIndexingTest`** — 3 new cases, ~0.3 s each, run over `WARMING_UP` **and** `ALIVE`:
  - `shouldKeepSiblingContributionWhenSecondReferenceStartsQualifyingForSameBucket` (condition change)
    — failed on both states before, passes after
  - `shouldKeepSiblingContributionWhenNonQualifyingReferenceChangesItsValue` (value change, the
    `knownOldValues` branch) — failed on both states before, passes after
  - `shouldKeepQualifyingContributionWhenNonQualifyingSiblingReferenceIsRemoved` — **passed before and
    after**; kept as a regression detector pinning the local path's guard-before-remove ordering
- **Seed gate** — `EvitaConditionalBucketGenerationalTest` with `-Dtest.seed=2095323828` failed at
  generation 4 in ~2 s of test time (`expected: <{5=[1]}> but was: <{}>`); now runs a full 61 s
  interval clean. Pinned as `shouldNotSurfaceHistogramDriftForSeed2095323828`.
- **Sweep** — 399 tests, 0 failures, 0 errors across `ConditionalBucketIndexingTest`,
  `ConditionalFacetIndexingTest`, `ConditionalBucketQueryTest`, `ReevaluateExpressionExecutorTest`,
  `ReferencedTypeEntityIndexTest`, `ReducedGroupEntityIndexTest`.

## Reviewer notes

- **`ReevaluateExpressionExecutorTest`'s 28 pre-existing tests do not exercise the new guard.** They
  construct mutations without the captured state, so they take the permissive fallback branch. The new
  `PreMutationConditionStateTest` nested class pins the guard and the load-bearing `null`-vs-empty
  distinction directly.
- **This stops new drift; it does not repair catalogs that already drifted.** Those histograms need
  rebuilding. Only the rejected reconcile option would have been self-healing.
- **Write-path cost is one extra condition evaluation per firing cross-entity histogram trigger**,
  unmeasured. Mutations that fire none allocate nothing. Recorded in the ADR with a concrete trigger
  for revisiting.
