### PR TITLE
chore: consolidate 2026-08 dependency bumps; drop the netty override

### DIFF
--- a/.github/workflows/docker-canary.yml
+++ b/.github/workflows/docker-canary.yml
@@ -24,9 +24,10 @@ jobs:
           persist-credentials: false
 
       - name: Download a single artifact # download `evita-server.jar` artifact if the workflow we react to was successful
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          run_id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}   # cross-run download needs an explicit token
           name: evita-server.jar
           path: docker
 

--- a/.github/workflows/docker-canary.yml
+++ b/.github/workflows/docker-canary.yml
@@ -40,7 +40,7 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
           buildkitd-flags: --debug
           platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -81,17 +81,19 @@ jobs:
 
       - name: Download a JAR file to deploy # download `evita-server.jar` artifact from the dispatching run
         if: steps.inputs.outputs.source == 'workflow_artifact'
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          run_id: ${{ steps.inputs.outputs.run_id }}
+          run-id: ${{ steps.inputs.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}   # cross-run download needs an explicit token
           name: evita-server.jar
           path: docker
 
       - name: Download a version information # download `version.txt` artifact from the dispatching run
         if: steps.inputs.outputs.source == 'workflow_artifact'
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          run_id: ${{ steps.inputs.outputs.run_id }}
+          run-id: ${{ steps.inputs.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}   # cross-run download needs an explicit token
           name: version.txt
 
       # Recovery path: pull dist.zip from the release, extract evita-server.jar

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -119,7 +119,7 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
           buildkitd-flags: --debug
           platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -102,7 +102,7 @@ jobs:
           # fail loudly here rather than let the reviewer discover a missing ref mid-review
           git rev-parse --verify "refs/remotes/origin/${BASE_REF}"
 
-      - uses: anthropics/claude-code-action@1623c36729ac1cd5895198cded705a287de7db79 # v1.0.187
+      - uses: anthropics/claude-code-action@dcb57747bfceeaa1fa72638cae52295d1d853d4a # v1.0.199
         with:
           claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true

--- a/documentation/adr/2026-08-31-netty-override-removal.md
+++ b/documentation/adr/2026-08-31-netty-override-removal.md
@@ -1,0 +1,153 @@
+---
+title: Drop the netty version override instead of pinning tcnative to take netty 4.2.17
+date: 2026-08-31
+updated: 2026-08-31 14:28
+status: proposed
+kind: infrastructure
+issues: []
+prs: [1474]
+areas: [pom.xml]
+supersedes: []
+superseded-by: []
+relates: []
+---
+
+# Drop the netty version override instead of pinning tcnative to take netty 4.2.17
+
+The root `pom.xml` carried a `netty.version` property and five `netty-codec-*` `dependencyManagement`
+entries that pulled netty ahead of the version armeria depends on, so that netty security fixes could
+be picked up before armeria's next release. Both are now removed. netty resolves from armeria's own
+`netty-bom`, and the netty 4.2.17.Final bump that Dependabot proposed is deliberately not taken,
+because taking it through that override breaks every TLS-bearing external-API test.
+
+## Why
+
+The override was written to close netty advisories ahead of armeria, and it carried its own exit
+condition in a comment: *drop this override once armeria itself depends on >= 4.2.16.Final*. armeria
+1.41.0 pins netty 4.2.16.Final, so the condition was met by a routine dependency bump.
+
+The constraint that made this non-obvious is that the override was not merely redundant at that
+point — it had become **actively harmful**, and would have shipped a broken build had the next netty
+bump been applied the way every previous one was. The override pins only the `netty-codec-*`
+artifacts. `netty-codec-http` depends on `netty-handler`, which owns `SslHandler`, so raising the
+codecs silently raises `netty-handler` too. `netty-tcnative` is not a codec and is not pinned, so it
+stays on whatever armeria depends on. netty 4.2.17 expects tcnative 2.0.81.Final; armeria 1.41.0
+brings 2.0.78.Final. The result is a `netty-handler` that is three tcnative releases ahead of its
+native library, and every armeria client TLS handshake fails with `UnprocessedRequestException` /
+`StacklessClosedChannelException`.
+
+This is not visible at compile time. `mvn clean install -DskipTests` passes on the broken
+combination; only running the external-API tests surfaces it.
+
+### Previous state
+
+`netty.version` sat in `<properties>` with a comment explaining that it overrode armeria's netty to
+pick up `netty-codec-*` advisories, and that a full `netty-bom` import was deliberately avoided
+because it manages every `io.netty:*` artifact — which was observed to flip `netty-handler`'s
+mediated scope from `provided` to `runtime` in `evita_external_api_grpc_shared` and break its
+`module-info.java` (`requires io.netty.handler` needs compile-time visibility). Five
+`dependencyManagement` entries bound `netty-codec-http`, `-http2`, `-compression`, `-haproxy` and
+`-dns` to that property.
+
+That comment also asserted that *mixing patch versions within the same netty 4.2.x line is
+binary-compatible, so pinning just the affected artifacts is sufficient and safer*. For
+4.2.16 → 4.2.17 that assertion is false. It is true of the Java bytecode and false of the system as a
+whole, because the coupling that breaks travels with `netty-handler` and its native library rather
+than with the codecs.
+
+## Options considered
+
+### Option A — remove the override entirely, stay on armeria's netty (chosen)
+
+Delete the `netty.version` property and the five `netty-codec-*` entries. netty resolves uniformly
+from armeria's `netty-bom` at 4.2.16.Final with tcnative 2.0.78.Final — the combination armeria was
+tested against.
+
+- **Pros:** No version skew of any kind. Nothing to keep in sync. The exit condition the original
+  comment specified is honoured rather than quietly ignored. Removes a mechanism whose failure mode
+  is invisible until runtime.
+- **Cons:** Leaves GHSA-8c42-7qj2-3j46 unpatched until armeria ships netty >= 4.2.17, and gives up
+  the ability to close a future netty advisory ahead of armeria without recreating the override.
+
+### Option B — keep the override at 4.2.17 and pin tcnative to 2.0.81.Final (declined)
+
+Add six `dependencyManagement` entries — `netty-tcnative-classes` plus `netty-tcnative-boringssl-static`
+for each of the five platform classifiers armeria ships — so the native library moves in lockstep
+with `netty-handler`.
+
+- **Pros:** Verified to work; closes GHSA-8c42-7qj2-3j46 now.
+- **Cons:** Pins native TLS binaries ahead of what armeria was tested against, and the classifier
+  list is a hand-maintained duplicate of armeria's platform matrix.
+- **Rejected because:** a classifier-keyed pin covers only the classifiers it names. If armeria adds
+  a platform, that platform silently resolves to the *old* tcnative while `netty-handler` stays new —
+  reproducing exactly the failure being fixed, on one platform only, discoverable only by running the
+  TLS tests on that platform. Paying that for GHSA-8c42-7qj2-3j46 is a bad trade, because the
+  advisory is a flaw in netty's own `CorsHandler` and evitaDB does not use it (see below). **Revisit
+  if** a netty advisory lands that evitaDB demonstrably *does* reach and armeria has not yet shipped
+  the fix.
+
+### Option C — keep the override, pinned at 4.2.16.Final (declined)
+
+Leave the property and entries in place, set to the version armeria already supplies.
+
+- **Pros:** Smallest diff; the machinery stays ready for the next advisory.
+- **Rejected because:** it is a no-op that reads as load-bearing. Its comment would have to claim a
+  reason that no longer holds, and the next person to bump the property would hit the tcnative
+  breakage with nothing to warn them. A mechanism that does nothing but looks like it does something
+  is worse than its absence.
+
+## Decision
+
+**Chosen: Option A.** The driver is that the override's failure mode is silent at compile time and
+catastrophic at runtime, and the thing it was buying — closing netty advisories ahead of armeria — is
+not currently worth buying. Exposure to GHSA-8c42-7qj2-3j46 appears to be nil: the advisory is a
+`Vary`-header overwrite in `io.netty.handler.codec.http.cors.CorsHandler`, and evitaDB implements
+CORS itself in `io.evitadb.externalApi.http.CorsService`, an armeria `SimpleDecoratingHttpService`.
+No evitaDB code path reaches netty's `CorsHandler`.
+
+For Option B to win, a future netty advisory would have to affect a component evitaDB genuinely
+exercises, with armeria lagging. At that point the override should be recreated **including
+tcnative**, not codec-only — and this record exists so that whoever recreates it knows that.
+
+## Key technical details
+
+- The override lived in the root `pom.xml` only; no module pinned netty independently.
+- The trap is that `netty-codec-http` → `netty-handler` is a *transitive* edge, so pinning codecs
+  moves `SslHandler` without naming it. Any future partial netty pin must either include
+  `netty-tcnative-*` or avoid raising `netty-handler` at all.
+- `netty-bom` remains unsuitable as the mechanism: importing it manages every `io.netty:*` artifact
+  and was previously observed to flip `netty-handler`'s mediated scope from `provided` to `runtime`
+  in `evita_external_api_grpc_shared`, breaking its `module-info.java`.
+- Verify any netty change with `mvn dependency:tree -Dincludes=io.netty` and check that the
+  `netty-*` artifacts and `netty-tcnative-*` agree with each other, not merely with the property.
+
+## Verification
+
+`mvn clean install -DskipTests` — BUILD SUCCESS. `mvn -pl evita_test/evita_functional_tests test -P
+unitAndFunctional -Dgroups="(external_api | grpc | rest | graphql | observability) & !slow"` — 2326
+tests, 0 failures, 0 errors, 5 skipped.
+
+The four configurations were run against that same suite, changing only dependency versions:
+
+| armeria | netty | tcnative | Failures | Errors |
+|---|---|---|---|---|
+| 1.40.0 | 4.2.16.Final | 2.0.78.Final | 0 | 0 |
+| 1.41.0 | 4.2.16.Final | 2.0.78.Final | 0 | 0 |
+| 1.41.0 | 4.2.17.Final | 2.0.78.Final | 6 | **927** |
+| 1.41.0 | 4.2.17.Final | 2.0.81.Final | 0 | 0 |
+
+Rows two and three isolate netty as the sole cause; rows three and four isolate tcnative as the sole
+mechanism. The 927 errors are concentrated in the GraphQL, REST and gRPC functional tests, all with
+the same root cause: `com.linecorp.armeria.client.UnprocessedRequestException:
+io.netty.channel.StacklessClosedChannelException`, raised from
+`HttpSessionHandler.tryFailSessionPromise` under `SslHandler.channelInactive`.
+
+## Consequences & open follow-ups
+
+- **GHSA-8c42-7qj2-3j46 stays open** against `io.netty:netty-codec-http` until armeria ships netty
+  >= 4.2.17. Dependabot will keep proposing netty bumps; each one needs the tcnative check above
+  before it is taken, and a bump that only raises the codecs must not be merged on a green compile.
+- **Dependabot's netty PRs (#1424, #1472) were closed undone.** They will reappear on netty 4.2.18,
+  which is intended — the reappearing PR is the prompt to re-check whether armeria has caught up.
+- **The tcnative version skew is not detectable by the compile gate.** Any future dependency work
+  that touches the web stack needs the external-API test groups run, not just `install -DskipTests`.

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -34,6 +34,7 @@ filename date that disagrees with `date:`.
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
 | 2026-08-31 | [Gate cross-entity histogram removal on a pre-mutation condition pre-pass, not bucket membership](2026-08-31-cross-entity-histogram-removal-pre-pass.md) | fix | accepted | #1467, PR #1468, PR #1469 |
+| 2026-08-31 | [Drop the netty version override instead of pinning tcnative to take netty 4.2.17](2026-08-31-netty-override-removal.md) | infrastructure | proposed | PR #1474 |
 | 2026-08-28 | [Index caches memoize the bitmap, never the formula, because a formula node carries per-query state](2026-08-28-index-lifetime-formula-memoization.md) | fix | accepted | #1458, PR #1459, PR #1460 |
 | 2026-08-28 | [Count each evitaDB error once, at the hierarchy root, and record where it was created](2026-08-28-attributable-internal-error-metrics.md) | fix | accepted | #1461, PR #1462, PR #1463 |
 | 2026-08-24 | [Price histogram granularity is decided per accessor, not all-or-nothing across the query](2026-08-24-price-histogram-per-accessor-granularity.md) | fix | accepted | #1433, PR #1435, PR #1436 |

--- a/jacoco/pom.xml
+++ b/jacoco/pom.xml
@@ -155,7 +155,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.14</version>
+				<version>0.8.15</version>
 				<executions>
 					<execution>
 						<id>report-aggregate</id>

--- a/pom.xml
+++ b/pom.xml
@@ -139,22 +139,13 @@
 		<grpc.version>1.83.1</grpc.version>
 		<bouncyCastle.version>1.85</bouncyCastle.version>
 		<swagger.version>2.2.52</swagger.version>
-		<armeria.version>1.40.0</armeria.version>
-		<!--
-			Overrides the netty version armeria 1.40.0 itself pulls in (4.2.15.Final) to pick up
-			GHSA-558v-64gr-wgg4 / GHSA-q6cq-mhr2-jmr5 / GHSA-6jqx-86gh-f27w and the other netty-codec-*
-			advisories fixed in 4.2.16.Final, ahead of armeria's next release. Patch bump within the
-			same 4.2.x line - see the netty-codec-* overrides in dependencyManagement below for why
-			only those artifacts (not a full netty-bom import) are pinned. Drop this override (and the
-			property) once armeria itself depends on >= 4.2.16.Final.
-		-->
-		<netty.version>4.2.16.Final</netty.version>
+		<armeria.version>1.41.0</armeria.version>
 		<prometheus.version>1.8.0</prometheus.version>
 		<micrometer.version>1.17.0</micrometer.version>
 		<byteBuddy.version>1.17.8</byteBuddy.version>
 		<graphql.version>25.0</graphql.version>
 		<okhttp.version>5.4.0</okhttp.version>
-		<opentelemetry.version>1.64.0</opentelemetry.version>
+		<opentelemetry.version>1.65.0</opentelemetry.version>
 		<opentelemetry.semconv.version>1.43.0</opentelemetry.semconv.version>
 		<minio.version>8.6.0</minio.version>
 		<jol.version>0.17</jol.version>
@@ -203,41 +194,6 @@
 
 	<dependencyManagement>
 		<dependencies>
-			<!--
-				See the netty.version comment in <properties> above: overrides only the netty-codec-*
-				artifacts armeria 1.40.0 pulls in that carry an open Dependabot advisory, without a full
-				netty-bom import - importing netty-bom manages every io.netty:* artifact (incl.
-				netty-handler and netty-resolver-dns, neither of which is itself vulnerable), which was
-				observed to flip netty-handler's mediated scope from "provided" to "runtime" in
-				evita_external_api_grpc_shared and break its module-info.java (`requires io.netty.handler`
-				needs compile-time visibility). Mixing patch versions within the same netty 4.2.x line is
-				binary-compatible, so pinning just the affected artifacts is sufficient and safer.
-			-->
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-codec-http2</artifactId>
-				<version>${netty.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-codec-http</artifactId>
-				<version>${netty.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-codec-compression</artifactId>
-				<version>${netty.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-codec-haproxy</artifactId>
-				<version>${netty.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-codec-dns</artifactId>
-				<version>${netty.version}</version>
-			</dependency>
 			<dependency>
 				<groupId>com.esotericsoftware</groupId>
 				<artifactId>kryo</artifactId>
@@ -844,7 +800,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.14</version>
+				<version>0.8.15</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>


### PR DESCRIPTION
Consolidates the open Dependabot bump PRs for 2026-08 into one reviewed change, following the repository's consolidated-bump convention.

## Maven

| Dependency | Change | PR |
|---|---|---|
| `armeria.version` | 1.40.0 → 1.41.0 | #1425 |
| `opentelemetry.version` | 1.64.0 → 1.65.0 | #1427 |
| `org.jacoco:jacoco-maven-plugin` | 0.8.14 → 0.8.15 | #1426 |

## GitHub Actions

| Action | Change | PR |
|---|---|---|
| `anthropics/claude-code-action` | 1.0.187 → 1.0.199 | #1448 |
| `docker/setup-buildx-action` | 4.2.0 → 4.3.0 | #1449 |

All action pins were verified to resolve from their version tags (18/18 ✅).

## The netty override is removed

The `netty.version` property and the five `netty-codec-*` `dependencyManagement`
entries are gone. That override carried its own exit condition — *"drop this
override (and the property) once armeria itself depends on >= 4.2.16.Final"* —
and armeria 1.41.0 pins netty 4.2.16.Final, so it is met. netty now resolves
uniformly from armeria's own netty-bom (verified with `dependency:tree`: every
`io.netty:*` artifact at 4.2.16.Final, tcnative at 2.0.78.Final, no skew).

## netty 4.2.17 is deliberately not taken (#1424, #1472)

As a one-line property bump it **breaks every TLS-bearing external-API test**.
Pinning `netty-codec-*` to 4.2.17 drags `netty-handler` — which owns
`SslHandler` — to 4.2.17 as a transitive of `netty-codec-http`, while
`netty-tcnative` stays on the 2.0.78.Final armeria pins. netty 4.2.17 expects
tcnative 2.0.81.Final. Every armeria client TLS handshake then fails with
`UnprocessedRequestException` / `StacklessClosedChannelException`.

Measured on the `external_api`, `grpc`, `rest`, `graphql` and `observability`
groups — 2326 tests each run:

| armeria | netty | tcnative | Result |
|---|---|---|---|
| 1.40.0 | 4.2.16 | 2.0.78 | 0 failures, 0 errors |
| 1.41.0 | 4.2.16 | 2.0.78 | 0 failures, 0 errors |
| 1.41.0 | 4.2.17 | 2.0.78 | **6 failures, 927 errors** |
| 1.41.0 | 4.2.17 | 2.0.81 | 0 failures, 0 errors |

Pinning all six tcnative artifacts (classes plus five platform classifiers) to
2.0.81.Final does fix it, but it pins native TLS binaries ahead of what armeria
was tested against and would silently miss any platform armeria adds later.
That is not worth carrying for an advisory we do not appear to reach:
GHSA-8c42-7qj2-3j46 is a flaw in netty's own `CorsHandler`, and evitaDB
implements CORS itself in `io.evitadb.externalApi.http.CorsService` on top of
armeria. Worth revisiting when armeria ships netty >= 4.2.17.

This also corrects a claim the removed comment made — that mixing patch
versions within one netty 4.2.x line is binary-compatible, so pinning just the
affected artifacts is sufficient. For 4.2.16 → 4.2.17 that is false: the
tcnative coupling travels with `netty-handler`, not with the codecs.

## dawidd6/action-download-artifact replaced with actions/download-artifact

Second commit. Both Docker deploy workflows pulled build artifacts from another
workflow run through a third-party action; `actions/download-artifact` has
supported cross-run downloads since v4 via `run-id` + `github-token`, so the
third-party dependency is no longer needed for what these workflows do — and its
v23 release was an openly LLM-assisted rewrite the maintainer declined to vouch
for, on the path that publishes our images.

Replaced at all three call sites (canary ×1, latest ×2). The input is `run-id`
rather than `run_id`, and a `github-token` is mandatory when `run-id` is not the
current run — both workflows already declare `actions: read`. Destination paths
are unchanged: dawidd6 defaulted `path` to `./` and `actions/download-artifact`
defaults it to `$GITHUB_WORKSPACE`, so `version.txt` still lands where the
"Extract major version" step greps for it.

This supersedes #1447 (dawidd6 21 → 24).

## Held back

- `com.graphql-java:graphql-java` 25.0 → 26.0 (#1377), tracked by #1422. 26.0
  enables query-complexity limits by default (maxDepth 100, maxFieldsCount
  100000), which needs a runtime check against evitaDB's generated schemas.
  26.1 is out, so that work should target 26.1+.

## Verification

- `mvn clean install -DskipTests` — BUILD SUCCESS
- `mvn -pl evita_test/evita_functional_tests test -P unitAndFunctional -Dgroups="(external_api | grpc | rest | graphql | observability) & !slow"` — **2326 tests, 0 failures, 0 errors, 5 skipped**
- The two Docker workflows cannot be exercised locally or by CI on a PR (they
  trigger on `workflow_run` / `workflow_dispatch`), so the download-artifact
  swap is verified by inspection: inputs read from `action.yml` at the pinned
  SHA, permissions already present, destination paths traced to their consumer.
