### PR TITLE
test: cover cross-reference facet propagation and reference re-sort on id assignment

### DIFF
--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReferenceIndexingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReferenceIndexingTest.java
@@ -37,6 +37,9 @@ import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
 import io.evitadb.api.requestResponse.schema.Cardinality;
 import io.evitadb.core.Evita;
 import io.evitadb.index.EntityIndex;
+import io.evitadb.index.facet.FacetGroupIndex;
+import io.evitadb.index.facet.FacetIdIndex;
+import io.evitadb.index.facet.FacetReferenceIndex;
 import io.evitadb.test.Entities;
 import io.evitadb.test.EvitaTestSupport;
 import io.evitadb.test.EvitaTestSupport.TestPaths;
@@ -829,6 +832,190 @@ class ReferenceIndexingTest implements EvitaTestSupport, IndexingTestSupport {
 					assertArrayEquals(new int[]{1, 2, 4}, getAllCategories(session));
 					session.deleteEntityAndItsHierarchy(Entities.CATEGORY, 1);
 					assertArrayEquals(new int[]{2}, getAllCategories(session));
+				}
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cross-reference facet propagation")
+	class CrossReferenceFacetPropagationTest {
+
+		/**
+		 * Asserts that the facet of `facetReferenceName`/`facetPK` is registered for `ownerPK` in the passed index.
+		 *
+		 * @param index              the index to inspect - deliberately any index, not only the global one
+		 * @param facetReferenceName name of the reference the facet belongs to
+		 * @param facetPK            primary key of the faceted entity
+		 * @param ownerPK            primary key of the entity owning the reference
+		 */
+		private void assertFacetPresent(
+			@Nonnull EntityIndex index,
+			@Nonnull String facetReferenceName,
+			int facetPK,
+			int ownerPK
+		) {
+			final FacetReferenceIndex facetReferenceIndex = index.getFacetingEntities().get(facetReferenceName);
+			assertNotNull(
+				facetReferenceIndex,
+				"FacetReferenceIndex for `" + facetReferenceName + "` must exist in " + index.getIndexKey()
+			);
+			final FacetGroupIndex facetGroupIndex = facetReferenceIndex.getFacetsInGroup(null);
+			assertNotNull(facetGroupIndex, "Ungrouped FacetGroupIndex must exist in " + index.getIndexKey());
+			final FacetIdIndex facetIdIndex = facetGroupIndex.getFacetIdIndex(facetPK);
+			assertNotNull(
+				facetIdIndex,
+				"FacetIdIndex for facet PK " + facetPK + " must exist in " + index.getIndexKey()
+			);
+			assertTrue(
+				facetIdIndex.getRecords().contains(ownerPK),
+				"Entity " + ownerPK + " must be registered as a facet of `" + facetReferenceName + ":" + facetPK +
+					"` in " + index.getIndexKey()
+			);
+		}
+
+		/**
+		 * Asserts that no facet of `facetReferenceName` is registered in the passed index at all.
+		 *
+		 * @param index              the index to inspect
+		 * @param facetReferenceName name of the reference that must not be faceted
+		 */
+		private void assertNoFacetOfReference(@Nonnull EntityIndex index, @Nonnull String facetReferenceName) {
+			assertNull(
+				index.getFacetingEntities().get(facetReferenceName),
+				"Reference `" + facetReferenceName + "` is not faceted and must not be registered in "
+					+ index.getIndexKey()
+			);
+		}
+
+		@Test
+		@DisplayName("Should index faceted reference into reduced index of its non-faceted sibling")
+		void shouldIndexFacetedReferenceIntoReducedIndexOfNonFacetedSibling() {
+			// This pins the cross-reference fan-out for the one entity shape nothing else in the suite covers:
+			// an indexed but *non-faceted* reference living next to an indexed *faceted* one. The fan-out is what
+			// carries the faceted `category` into the reduced index of the non-faceted `brand`, and it is skipped
+			// whenever the mutated reference cannot be faceted at all - so this asserts the skip does not reach
+			// the case where the mutated reference *is* faceted.
+			ReferenceIndexingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema(Entities.CATEGORY).updateVia(session);
+					session.defineEntitySchema(Entities.BRAND).updateVia(session);
+					session.upsertEntity(session.createNewEntity(Entities.CATEGORY, 1));
+					session.upsertEntity(session.createNewEntity(Entities.BRAND, 1));
+
+					session
+						.defineEntitySchema(Entities.PRODUCT)
+						// indexed, but deliberately NOT faceted
+						.withReferenceToEntity(
+							Entities.BRAND,
+							Entities.BRAND,
+							Cardinality.ZERO_OR_ONE,
+							whichIs -> whichIs.indexedForFilteringAndPartitioning()
+						)
+						// indexed AND faceted sibling sitting on the very same entity
+						.withReferenceToEntity(
+							Entities.CATEGORY,
+							Entities.CATEGORY,
+							Cardinality.ZERO_OR_MORE,
+							whichIs -> whichIs.indexedForFilteringAndPartitioning().faceted()
+						)
+						.updateVia(session);
+
+					// establish the non-faceted sibling first, so that it is already present in the reference
+					// container by the time the faceted reference is inserted and fans out across it
+					session.upsertEntity(
+						session.createNewEntity(Entities.PRODUCT, 1).setReference(Entities.BRAND, 1)
+					);
+					session.getEntity(Entities.PRODUCT, 1, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setReference(Entities.CATEGORY, 1)
+						.upsertVia(session);
+
+					final CatalogContract catalog =
+						ReferenceIndexingTest.this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+					final EntityCollectionContract productCollection =
+						catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+
+					final EntityIndex brandIndex = getReferencedEntityIndex(productCollection, Entities.BRAND, 1);
+					assertNotNull(brandIndex, "Reduced index of the non-faceted `brand` reference must exist");
+					// the faceted category must have been propagated into the non-faceted sibling's reduced index
+					assertFacetPresent(brandIndex, Entities.CATEGORY, 1, 1);
+					// ...while the non-faceted brand itself must not be registered as a facet anywhere
+					assertNoFacetOfReference(brandIndex, Entities.BRAND);
+
+					final EntityIndex categoryIndex =
+						getReferencedEntityIndex(productCollection, Entities.CATEGORY, 1);
+					assertNotNull(categoryIndex, "Reduced index of the faceted `category` reference must exist");
+					assertNoFacetOfReference(categoryIndex, Entities.BRAND);
+
+					// the global index keeps the faceted reference and only that one
+					final EntityIndex globalIndex = getGlobalIndex(productCollection);
+					assertNotNull(globalIndex);
+					assertFacetPresent(globalIndex, Entities.CATEGORY, 1, 1);
+					assertNoFacetOfReference(globalIndex, Entities.BRAND);
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("Should back-fill an existing faceted reference into a later non-faceted sibling's index")
+		void shouldBackFillExistingFacetedReferenceIntoLaterNonFacetedSiblingIndex() {
+			// The reverse order of the test above, and it exercises a different mechanism. Here the faceted
+			// `category` already exists when the non-faceted `brand` is added, so the brand's reduced index is
+			// created *after* the facet — and it is `ReferenceIndexMutator#indexAllFacets`, reached from the
+			// direct path via `indexAllExistingData`, that has to back-fill the existing category facet into it.
+			// That scan is skipped when the entity schema declares no faceted reference at all, so this pins that
+			// the skip does not reach the case where one does.
+			ReferenceIndexingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema(Entities.CATEGORY).updateVia(session);
+					session.defineEntitySchema(Entities.BRAND).updateVia(session);
+					session.upsertEntity(session.createNewEntity(Entities.CATEGORY, 1));
+					session.upsertEntity(session.createNewEntity(Entities.BRAND, 1));
+
+					session
+						.defineEntitySchema(Entities.PRODUCT)
+						.withReferenceToEntity(
+							Entities.BRAND,
+							Entities.BRAND,
+							Cardinality.ZERO_OR_ONE,
+							whichIs -> whichIs.indexedForFilteringAndPartitioning()
+						)
+						.withReferenceToEntity(
+							Entities.CATEGORY,
+							Entities.CATEGORY,
+							Cardinality.ZERO_OR_MORE,
+							whichIs -> whichIs.indexedForFilteringAndPartitioning().faceted()
+						)
+						.updateVia(session);
+
+					// faceted reference first - the brand's reduced index does not exist yet
+					session.upsertEntity(
+						session.createNewEntity(Entities.PRODUCT, 1).setReference(Entities.CATEGORY, 1)
+					);
+					final CatalogContract catalog =
+						ReferenceIndexingTest.this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+					final EntityCollectionContract productCollection =
+						catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+					assertNull(
+						getReferencedEntityIndex(productCollection, Entities.BRAND, 1),
+						"Brand reduced index must not exist before the brand reference is added"
+					);
+
+					// adding the non-faceted sibling creates its reduced index, which must be back-filled
+					session.getEntity(Entities.PRODUCT, 1, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setReference(Entities.BRAND, 1)
+						.upsertVia(session);
+
+					final EntityIndex brandIndex = getReferencedEntityIndex(productCollection, Entities.BRAND, 1);
+					assertNotNull(brandIndex, "Reduced index of the non-faceted `brand` reference must exist");
+					assertFacetPresent(brandIndex, Entities.CATEGORY, 1, 1);
+					assertNoFacetOfReference(brandIndex, Entities.BRAND);
 				}
 			);
 		}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/spi/store/catalog/persistence/storageParts/entity/ReferencesStoragePartTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/spi/store/catalog/persistence/storageParts/entity/ReferencesStoragePartTest.java
@@ -29,6 +29,7 @@ import io.evitadb.api.requestResponse.data.Droppable;
 import io.evitadb.api.requestResponse.data.ReferenceContract;
 import io.evitadb.api.requestResponse.data.ReferenceContract.GroupEntityReference;
 import io.evitadb.api.requestResponse.data.ReferencesEditor.ReferencesBuilder;
+import io.evitadb.api.requestResponse.data.mutation.reference.ComparableReferenceKey;
 import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
 import io.evitadb.api.requestResponse.data.structure.Reference;
 import io.evitadb.api.requestResponse.data.structure.ReferenceAttributes;
@@ -199,7 +200,7 @@ class ReferencesStoragePartTest {
 			() -> MissingReferenceBehavior.ACCEPT_INTERNAL_KEY
 		);
 
-		final Map<?, ?> assignedKeys = part.assignMissingIdsAndSort();
+		final Map<ComparableReferenceKey, ReferenceKey> assignedKeys = part.assignMissingIdsAndSort();
 		assertEquals(1, assignedKeys.size(), "Exactly one reference had a missing internal primary key");
 
 		final ReferenceContract[] references = part.getReferencesAsCollection().toArray(new ReferenceContract[0]);
@@ -220,11 +221,15 @@ class ReferencesStoragePartTest {
 	}
 
 	@Test
-	@DisplayName("should keep order without re-sorting when appended references are numbered in place")
+	@DisplayName("should keep order when appended references are numbered in place")
 	void shouldKeepOrderWhenAppendedReferencesAreNumberedInPlace() {
 		// the counterpart of the test above and the ordinary path: every inserted reference is numbered in array
 		// order from a monotonically growing counter, so the container leaves the assignment loop already sorted
-		// and the re-sort is skipped. The observable outcome must be identical either way.
+		// and the guarded `Arrays.sort` runs as a no-op. The guard itself (`lupkBefore != lastUsedPrimaryKey`) is
+		// still true here - it only asks whether *any* id was assigned, not whether that assignment disturbed the
+		// ordering. The shape that genuinely skips the sort is the insertion of a reference already carrying a
+		// known positive internal key: it flips `unassignedPrimaryKeys` without triggering a single assignment,
+		// and it is not what this test covers. The observable outcome must be identical either way.
 		final io.evitadb.spi.store.catalog.persistence.storageParts.entity.ReferencesStoragePart part =
 			new io.evitadb.spi.store.catalog.persistence.storageParts.entity.ReferencesStoragePart(
 				3, 10,

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/spi/store/catalog/persistence/storageParts/entity/ReferencesStoragePartTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/spi/store/catalog/persistence/storageParts/entity/ReferencesStoragePartTest.java
@@ -174,6 +174,98 @@ class ReferencesStoragePartTest {
 	}
 
 	@Test
+	@DisplayName("should re-sort when an assigned id overtakes an already numbered duplicate")
+	void shouldReSortWhenAssignedIdOvertakesAlreadyNumberedDuplicate() {
+		// `assignMissingIdsAndSort` only re-sorts when the assignment actually disturbed the ordering. This is
+		// the shape where it genuinely does: a brand new reference sorts *before* its already numbered duplicates
+		// (its internal primary key is still negative), but the id it receives is drawn from the counter and is
+		// therefore *higher* than theirs - so the container comes out of the assignment loop unsorted.
+		final io.evitadb.spi.store.catalog.persistence.storageParts.entity.ReferencesStoragePart part =
+			new io.evitadb.spi.store.catalog.persistence.storageParts.entity.ReferencesStoragePart(
+				2, 10,
+				new Reference[]{
+					newRef("B", 1, 1, null, false),
+					newRef("D", 1, 4, null, false),
+					newRef("D", 1, 6, null, false),
+					newRef("E", 1, 7, null, false)
+				},
+				128
+			);
+
+		// inserted at the head of the `D` cluster, because -3 precedes both 4 and 6
+		part.replaceOrAddReference(
+			new ReferenceKey("D", 1, -3),
+			existing -> newRef("D", 1, -3, null, false),
+			() -> MissingReferenceBehavior.ACCEPT_INTERNAL_KEY
+		);
+
+		final Map<?, ?> assignedKeys = part.assignMissingIdsAndSort();
+		assertEquals(1, assignedKeys.size(), "Exactly one reference had a missing internal primary key");
+
+		final ReferenceContract[] references = part.getReferencesAsCollection().toArray(new ReferenceContract[0]);
+		assertEquals(5, references.length);
+		// the whole container must be sorted again - the newly numbered reference now belongs behind its duplicates
+		for (int i = 1; i < references.length; i++) {
+			assertTrue(
+				ReferenceKey.FULL_COMPARATOR.compare(
+					references[i - 1].getReferenceKey(), references[i].getReferenceKey()
+				) < 0,
+				"References must stay sorted, but `" + references[i - 1].getReferenceKey() +
+					"` is followed by `" + references[i].getReferenceKey() + "`"
+			);
+		}
+		// the assigned id continues the container's own counter
+		assertEquals(11, references[3].getReferenceKey().internalPrimaryKey());
+		assertEquals("D", references[3].getReferenceName());
+	}
+
+	@Test
+	@DisplayName("should keep order without re-sorting when appended references are numbered in place")
+	void shouldKeepOrderWhenAppendedReferencesAreNumberedInPlace() {
+		// the counterpart of the test above and the ordinary path: every inserted reference is numbered in array
+		// order from a monotonically growing counter, so the container leaves the assignment loop already sorted
+		// and the re-sort is skipped. The observable outcome must be identical either way.
+		final io.evitadb.spi.store.catalog.persistence.storageParts.entity.ReferencesStoragePart part =
+			new io.evitadb.spi.store.catalog.persistence.storageParts.entity.ReferencesStoragePart(
+				3, 10,
+				new Reference[]{
+					newRef("A", 1, 1, null, false),
+					newRef("C", 1, 2, null, false)
+				},
+				128
+			);
+
+		part.replaceOrAddReference(
+			new ReferenceKey("B", 5, -1),
+			existing -> newRef("B", 5, -1, null, false),
+			() -> MissingReferenceBehavior.ACCEPT_INTERNAL_KEY
+		);
+		part.replaceOrAddReference(
+			new ReferenceKey("B", 2, -2),
+			existing -> newRef("B", 2, -2, null, false),
+			() -> MissingReferenceBehavior.ACCEPT_INTERNAL_KEY
+		);
+
+		assertEquals(2, part.assignMissingIdsAndSort().size());
+
+		final ReferenceContract[] references = part.getReferencesAsCollection().toArray(new ReferenceContract[0]);
+		assertEquals(4, references.length);
+		for (int i = 1; i < references.length; i++) {
+			assertTrue(
+				ReferenceKey.FULL_COMPARATOR.compare(
+					references[i - 1].getReferenceKey(), references[i].getReferenceKey()
+				) < 0,
+				"References must stay sorted, but `" + references[i - 1].getReferenceKey() +
+					"` is followed by `" + references[i].getReferenceKey() + "`"
+			);
+			assertTrue(
+				references[i].getReferenceKey().isKnownInternalPrimaryKey(),
+				"Every reference must end up with a terminal internal primary key"
+			);
+		}
+	}
+
+	@Test
 	@DisplayName("should replace existing reference when internal key known and keep order")
 	void shouldReplaceExistingReferenceWhenInternalKeyKnownAndMaintainOrder() {
 		final io.evitadb.spi.store.catalog.persistence.storageParts.entity.ReferencesStoragePart part = new io.evitadb.spi.store.catalog.persistence.storageParts.entity.ReferencesStoragePart(


### PR DESCRIPTION
Adds regression coverage for three reference-indexing behaviours that had none. **Test-only — no production code is touched.**

## What is covered

`ReferenceIndexingTest` → new `Cross-reference facet propagation` nested class:

- **`shouldIndexFacetedReferenceIntoReducedIndexOfNonFacetedSibling`** — an indexed but *non-faceted* reference living beside an indexed *faceted* one on the same entity. The faceted reference must be registered in the reduced index of the non-faceted sibling; the non-faceted one must be registered nowhere.
- **`shouldBackFillExistingFacetedReferenceIntoLaterNonFacetedSiblingIndex`** — the reverse order, where the sibling's reduced index is created only *after* the faceted reference already exists, so `ReferenceIndexMutator#indexAllFacets` has to back-fill it.

`ReferencesStoragePartTest`:

- **`shouldReSortWhenAssignedIdOvertakesAlreadyNumberedDuplicate`** — the one `assignMissingIdsAndSort` shape where the re-sort genuinely fires: a new reference whose negative internal key sorts it *ahead* of its already numbered duplicates, while the key drawn for it from the container's counter is *higher* than theirs.
- **`shouldKeepOrderWhenAppendedReferencesAreNumberedInPlace`** — its counterpart, the ordinary case where assignment walks the array in order from a monotonic counter and the container leaves the loop already sorted.

## Why these shapes

Nothing in the suite combined a non-faceted indexed reference with a faceted sibling on one entity: `ReferenceIndexingTest`'s two-reference schema makes both faceted, its non-faceted references sit on single-reference entities, `ConditionalFacetIndexingTest` is faceted throughout, and `IndexInvariantsTest`'s reference is faceted. The two mechanisms are distinct — one is the cross-reference fan-out, the other is the create-time back-fill — and each test isolates one of them.

## Verification

`mvn -pl evita_test/evita_functional_tests test -Dtest='ReferenceIndexingTest,ReferencesStoragePartTest'` → **42 tests, 0 failures** on this branch's base.

Each test was **sabotage-verified**: the behaviour it pins was deliberately broken and the test confirmed to fail, and to fail *only* for the mechanism it targets — inverting the facet-propagation decision fails the two indexing tests, and disabling the container re-sort fails the storage-part test with `References must stay sorted, but `D: 1/11` is followed by `D: 1/4``.