### PR TITLE
chore: bump Maven and GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci-dev-documentation.yml
+++ b/.github/workflows/ci-dev-documentation.yml
@@ -27,7 +27,7 @@ jobs:
         persist-credentials: false
 
     - name: Setup Java JDK
-      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0  # setup JDK 17 for building
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0  # setup JDK 17 for building
       with:
          distribution: 'temurin'
          java-version: '17'

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -60,7 +60,7 @@ jobs:
         fi
 
     - name: Setup Java JDK
-      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0  # setup JDK 17 for building
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0  # setup JDK 17 for building
       with:
          distribution: 'temurin'
          java-version: '17'

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -43,7 +43,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup Java JDK
-      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0  # setup JDK 17 for building
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0  # setup JDK 17 for building
       with:
         distribution: 'temurin'
         java-version: '17'

--- a/.github/workflows/ci-performance.yml
+++ b/.github/workflows/ci-performance.yml
@@ -24,7 +24,7 @@ jobs:
         persist-credentials: false
 
     - name: Setup Java JDK
-      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0  # setup JDK 17 for building
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0  # setup JDK 17 for building
       with:
          distribution: 'temurin'
          java-version: '17'

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -149,7 +149,7 @@ jobs:
         fi
 
     - name: Setup Java JDK
-      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0  # setup JDK 17 for building
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0  # setup JDK 17 for building
       with:
         distribution: 'temurin'
         java-version: '17'

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -29,7 +29,7 @@ jobs:
           echo "Commits found: $COMMIT_COUNT"
 
       - name: Setup Java JDK   # this should setup JDK 17 but only if something was committed this day
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0  # setup JDK 17 for building
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0  # setup JDK 17 for building
         if: ${{ env.NEW_COMMIT_COUNT != '0' }}
         with:
            distribution: 'temurin'

--- a/.github/workflows/long-running-tests.yml
+++ b/.github/workflows/long-running-tests.yml
@@ -41,7 +41,7 @@ jobs:
           echo "Commits found in dev branch: $COMMIT_COUNT"
 
       - name: Setup Java JDK   # this should setup JDK 17 but only if something was committed to dev branch in the last week
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0  # setup JDK 17 for building
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0  # setup JDK 17 for building
         if: ${{ env.NEW_COMMIT_COUNT != '0' }}
         with:
            distribution: 'temurin'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Setup Java JDK
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -102,7 +102,7 @@ jobs:
           # fail loudly here rather than let the reviewer discover a missing ref mid-review
           git rev-parse --verify "refs/remotes/origin/${BASE_REF}"
 
-      - uses: anthropics/claude-code-action@dcb57747bfceeaa1fa72638cae52295d1d853d4a # v1.0.199
+      - uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 		<slf4j.version>2.0.18</slf4j.version>
 		<logback.version>1.6.1</logback.version>
 		<kryo.version>5.6.2</kryo.version>
-		<jackson.version>2.22.1</jackson.version>
+		<jackson.version>2.22.2</jackson.version>
 		<jackson.annotations.version>2.22</jackson.annotations.version>
 		<snakeyaml.version>2.6</snakeyaml.version>
 		<roaringbitmap.version>1.6.18</roaringbitmap.version>
@@ -138,13 +138,13 @@
 		<lombok.version>1.18.46</lombok.version>
 		<grpc.version>1.83.1</grpc.version>
 		<bouncyCastle.version>1.85</bouncyCastle.version>
-		<swagger.version>2.2.52</swagger.version>
+		<swagger.version>2.2.54</swagger.version>
 		<armeria.version>1.41.0</armeria.version>
 		<prometheus.version>1.8.0</prometheus.version>
 		<micrometer.version>1.17.0</micrometer.version>
 		<byteBuddy.version>1.17.8</byteBuddy.version>
 		<graphql.version>25.0</graphql.version>
-		<okhttp.version>5.4.0</okhttp.version>
+		<okhttp.version>5.5.0</okhttp.version>
 		<opentelemetry.version>1.65.0</opentelemetry.version>
 		<opentelemetry.semconv.version>1.43.0</opentelemetry.semconv.version>
 		<minio.version>8.6.0</minio.version>


### PR DESCRIPTION
Consolidates the open Dependabot bump PRs into a single commit, following the established consolidated-bump convention.

## Included

**Maven**
- `okhttp.version` 5.4.0 → 5.5.0 (#1475)
- `jackson.version` 2.22.1 → 2.22.2 (#1477)
- `swagger.version` 2.2.52 → 2.2.54 (#1478)

**GitHub Actions**
- `anthropics/claude-code-action` 1.0.199 → 1.0.210 (#1479)
- `actions/setup-java` 5.7.0 → 6.0.0 (#1480)

Dependabot updated the setup-java SHA in all 8 workflow files but left the trailing `# v5.7.0` comment stale in 7 of them; all comments corrected to `# v6.0.0`. Every Action pin (18/18 in the tree) verifies against its release tag via `tools/consolidate-version-bumps.sh verify-pins`. setup-java v6's ESM migration is documented as not user-facing breaking, the Zulu → Azul metadata API switch does not affect the `temurin` distribution used here, and the renamed `jdkFile` input is not used in these workflows.

## Held back

- **hppc 0.11.1 (#1476)** — still ships Java 21 bytecode (class-file major version 65, verified via javap), incompatible with the Java 17 baseline; the same blocker that excluded 0.11.x in July.
- **graphql-java 26.1 (#1481)** — v26 still narrows `GraphQLSchema.Builder.additionalType(s)` to `GraphQLNamedType`, breaking `evita_external_api_graphql`'s public `registerType(GraphQLType)` API, and turns on default query-complexity limits (maxDepth 100, maxFieldsCount 100000) that need a runtime check against evitaDB's generated schemas; same reasons 26.0 was held back on 2026-08-15.

## Verification

- `mvn clean install -DskipTests` — full reactor, BUILD SUCCESS
- Focused runtime tests in `evita_functional_tests`: REST/OpenAPI + JSON deserializer suites (100 tests, 0 failures) and GraphQL system queries (5 tests, 0 failures) — covering the jackson, swagger and okhttp consumers at runtime (surefire reports, not console)

After merge, the superseded Dependabot PRs (#1475, #1477, #1478, #1479, #1480) get closed with a pointer to the landed commit; #1476 and #1481 stay open with their hold-back reasons.

Ref: #1475 #1477 #1478 #1479 #1480