### PR TITLE
Retire the rtk wrapper from agent instructions, and fold the fulltext relaxation consequences into its record

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -63,15 +63,15 @@ The test suite is split across four sibling modules under `evita_test/`:
 
 - **Default fast loop** — the `unitAndFunctional` profile excludes `slow`/`flaky`-tagged tests in functional_tests; the long-running and documentation modules are skipped via their own surefire config:
   ```bash
-  rtk mvn -pl evita_test/evita_functional_tests test -P unitAndFunctional
+  mvn -pl evita_test/evita_functional_tests test -P unitAndFunctional
   ```
 - **Tag-filter expressions** — pass to surefire via `-Dgroups` / `-DexcludedGroups`; JUnit 5 supports boolean expressions:
   ```bash
-  rtk mvn -pl evita_test/evita_functional_tests test -Dgroups="facet & external_api"
-  rtk mvn -pl evita_test/evita_functional_tests test -Dgroups="(query | indexing) & !slow"
+  mvn -pl evita_test/evita_functional_tests test -Dgroups="facet & external_api"
+  mvn -pl evita_test/evita_functional_tests test -Dgroups="(query | indexing) & !slow"
   ```
-- **Documentation runners** — `rtk mvn -P documentation`. The matching profile in the docs module flips its `skipTests` to `false`; the root profile sets `skipTests=true` everywhere else, so only documentation tests run.
-- **Slow / long-running tests** — `rtk mvn -P longRunning`. Same pattern as `documentation`; selects only the long-running module.
+- **Documentation runners** — `mvn -P documentation`. The matching profile in the docs module flips its `skipTests` to `false`; the root profile sets `skipTests=true` everywhere else, so only documentation tests run.
+- **Slow / long-running tests** — `mvn -P longRunning`. Same pattern as `documentation`; selects only the long-running module.
 - **Picking the right tags for a code change** — map the changed source path to layer + capability tags. For example, a change under `evita_engine/src/main/java/io/evitadb/index/facet/` calls for `(facet | indexing) & !slow`; under `evita_external_api/evita_external_api_rest/` use `rest & external_api`. The full path-to-tag mapping is documented in the `TestTags` JavaDoc and in the bulk-tagging script committed during the rollout.
 
 ## Reading test results — the false-green traps
@@ -88,7 +88,7 @@ expect, as unproven until you have read the count.
   freshly-compiled `target/classes`. After any signature / type-parameter / method change in `evita_engine`,
   reinstall it before running dependent-module tests:
   ```bash
-  rtk mvn -o -pl evita_engine install -DskipTests
+  mvn -o -pl evita_engine install -DskipTests
   ```
   Skip this and the failure surfaces as a **compile** error in the test module (e.g. `wrong number of type arguments; required 3`, `NoSuchMethodError`) that points at test code which is actually fine — the stale binary is the real cause.
 - **The local repository is not always `~/.m2` — check `MAVEN_OPTS` before you reason about what is installed.**
@@ -115,7 +115,7 @@ expect, as unproven until you have read the count.
   signatures (`AssertionUtils.assertSavepointCommitKeeps` and friends) pointing at long-running test code
   that is perfectly correct. Always use one reactor:
   ```bash
-  rtk mvn -pl evita_test/evita_functional_tests,evita_test/evita_long_running_tests test -P longRunning
+  mvn -pl evita_test/evita_functional_tests,evita_test/evita_long_running_tests test -P longRunning
   ```
   The tell is a signature in the error that exists nowhere in the source: compare the compiler's
   `declared in method` line against the current declaration **before** touching a single call site.

--- a/.claude/skills/consolidate-version-bumps/SKILL.md
+++ b/.claude/skills/consolidate-version-bumps/SKILL.md
@@ -133,9 +133,7 @@ git -C "$WT" diff --stat
 ```
 
 ### Step 6 — Build and test locally
-Use `mvn` below; if your `CLAUDE.md` configures a Maven proxy (e.g. `rtk mvn`),
-substitute it. Compile gate (compiles + test-compiles the whole reactor; catches
-API breaks):
+Compile gate (compiles + test-compiles the whole reactor; catches API breaks):
 ```shell
 mvn clean install -DskipTests            # expect exit 0
 ```

--- a/.claude/skills/wal-replay-profiling/SKILL.md
+++ b/.claude/skills/wal-replay-profiling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: wal-replay-profiling
 description: Measure evitaDB write-path (commit/transaction) performance by replaying a real production catalog's Write-Ahead Log against an embedded instance via the WalReplayBenchmark JMH harness, with async-profiler (alloc/cpu) or JMH `-prof gc`. Invoke when profiling commit latency, allocation, or GC behavior on the write path, when a production WAL export needs re-measuring, or when a profiling run produced a suspicious/empty/inconsistent result (zero-byte collapsed dump, contended-box numbers, cross-round contradiction).
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash(mvn *), Bash(rtk *), Bash(java *), Bash(git *), Bash(rg *), Bash(awk *), Bash(ps *), Bash(uptime *), Bash(free *), Bash(kill *), Bash(cd *), Bash(ls *), Bash(du *), Bash(tar *), Bash(diff *), Bash(cp *), Bash(mkdir *), AskUserQuestion
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash(mvn *), Bash(java *), Bash(git *), Bash(rg *), Bash(awk *), Bash(ps *), Bash(uptime *), Bash(free *), Bash(kill *), Bash(cd *), Bash(ls *), Bash(du *), Bash(tar *), Bash(diff *), Bash(cp *), Bash(mkdir *), AskUserQuestion
 ---
 
 # WAL-replay performance profiling
@@ -25,12 +25,12 @@ All three are in this skill directory and expect `ROOT=/www/oss/evita/evitaDB-de
 ## 1. Building
 
 ```shell
-rtk mvn clean install -P full -DskipTests
+mvn clean install -P full -DskipTests
 ```
 
 `-P full` is mandatory — `evita_test/evita_performance_tests` is not in the default reactor.
-`rtk` truncates long build logs and **drops the `BUILD SUCCESS` line** — confirm by exit code and
-`target/benchmarks.jar`'s timestamp, never by grepping the log.
+A full build produces a long log that a tool harness may truncate; when the tail is missing, confirm
+by exit code and `target/benchmarks.jar`'s timestamp rather than by grepping for `BUILD SUCCESS`.
 
 To rebuild only the perf module afterwards (upstream already installed): `-o -P full package -pl evita_test/evita_performance_tests -DskipTests`.
 

--- a/.claude/skills/warmup-reindex-benchmark/SKILL.md
+++ b/.claude/skills/warmup-reindex-benchmark/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: warmup-reindex-benchmark
 description: Measure how long a full catalog reindex-and-publish takes — re-upsert every entity of a real production catalog into a fresh catalog in WARM_UP mode through the gRPC driver, then transition it to ALIVE via goLive. Reports load wall-clock, per-collection and per-upsert latency distributions, and the goLive transition separately. Invoke when asked how long publishing a dataset takes, when verifying a full reindex still completes after write-path or driver changes, when comparing ingestion throughput between two builds, or when profiling the server-side write path under a realistic bulk load.
-allowed-tools: Read, Edit, Write, Grep, Glob, Bash(mvn *), Bash(rtk *), Bash(java *), Bash(git *), Bash(rg *), Bash(awk *), Bash(sed *), Bash(ps *), Bash(uptime *), Bash(free *), Bash(kill *), Bash(pkill *), Bash(cd *), Bash(ls *), Bash(du *), Bash(df *), Bash(unzip *), Bash(python3 *), Bash(cp *), Bash(mkdir *), Bash(chmod *), Bash(grep *), Bash(tail *), Bash(head *), AskUserQuestion
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash(mvn *), Bash(java *), Bash(git *), Bash(rg *), Bash(awk *), Bash(sed *), Bash(ps *), Bash(uptime *), Bash(free *), Bash(kill *), Bash(pkill *), Bash(cd *), Bash(ls *), Bash(du *), Bash(df *), Bash(unzip *), Bash(python3 *), Bash(cp *), Bash(mkdir *), Bash(chmod *), Bash(grep *), Bash(tail *), Bash(head *), AskUserQuestion
 ---
 
 # WARM_UP reindex + goLive benchmark

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,17 @@ mvn clean install
 
 Running tests: see `.claude/rules/testing.md` for the tag taxonomy, Maven profiles, and test commands.
 
+## Git worktrees
+
+If `$HOLE_WORKTREES_DIR` is set, create git worktrees inside it:
+
+```shell
+git worktree add "$HOLE_WORKTREES_DIR/<branch>" <branch>
+```
+
+Worktrees created anywhere else exist only inside the sandbox and are lost when it exits. If the
+variable is not set, use the project's usual location.
+
 ## Libraries
 
 Prefer the libraries already in use — Kryo (binary serialization), RoaringBitmap (bitmaps), Jackson (JSON), Netty/Armeria (web server & client), gRPC-Java & GraphQL-Java (APIs), Logback (logging), Byte Buddy (runtime codegen), MinIO (S3 storage). Don't introduce an alternative for a job one of these already does without discussion.

--- a/documentation/adr/2026-08-24-fulltext-search-lucene-vs-inhouse/README.md
+++ b/documentation/adr/2026-08-24-fulltext-search-lucene-vs-inhouse/README.md
@@ -1,7 +1,7 @@
 ---
 title: Prototype an in-house fulltext core over evitaDB's bitmap algebra instead of integrating Lucene
 date: 2026-08-24
-updated: 2026-09-02 11:40
+updated: 2026-09-02 12:25
 status: partially-implemented
 kind: feature
 issues: [258, 1454]

--- a/documentation/adr/2026-08-24-fulltext-search-lucene-vs-inhouse/prototypes/query-design.md
+++ b/documentation/adr/2026-08-24-fulltext-search-lucene-vs-inhouse/prototypes/query-design.md
@@ -640,8 +640,9 @@ nothing says what the twenty is — whereas a child carries an **introducing wor
 meaning a name: `textMatches("jacket", relaxUntil(20))` can be read aloud. A positional argument
 is therefore only fine where the parent's own name gives it context (the text in `textMatches`,
 the number in `limit`); everything else gets its own word. It is the same principle that decided
-R2 against R1 in §5.1 and by which the relaxation ADR rejects string mini-grammars à la
-`"3<90%"` — an expression whose meaning cannot be read off does not belong in the language.
+R2 against R1 in §5.1 and by which [`../README.md`](../README.md) ("Rejected outright") rejects
+string mini-grammars à la `"3<90%"` — an expression whose meaning cannot be read off does not
+belong in the language.
 
 V1 remains as a legitimate **shortened form for P1**, so that the prototype does not pay the toll
 of the full DSL surface before the core is measured. V2 (weights in the filter) remains recorded
@@ -2121,6 +2122,20 @@ each rung again (`index.cpp:4062`); we would have it as an intermediate result.
 
 What remains open: the name of the constraint, the interaction with the prefetch path and whether it goes into
 F1 at all — probably not, to be decided after the P1 measurement.
+
+Consequences for the implementation, beyond the three rules above. **Equal document frequencies need a
+deterministic tie-break** (term order will do) — the ladder is built from a frequency ordering, and where that
+ordering is not total the level choice stops being a function of index state plus query alone, which is exactly
+the property a WAL-replayed replica relies on to reach the same answer. **The floor is a trigger, not a
+target**: dropping a single term only enlarges the set, and it may overshoot N by orders of magnitude, so the
+constraint promises "at least N when it can", never "about N". **And the decision has a stated expiry** — the
+whole cost argument rests on the intersection pass leaving its intermediates behind, so if the fulltext formula
+is ever fused into one streaming operator for other reasons, the free ladder is gone and the static policy of
+the Lucene family (the `minimum_should_match` ladder, in a typed shape rather than the string grammar rejected
+above) becomes the honest fallback. That is the trigger for revisiting this decision, and the criteria that would
+detect it: relaxation adds no measurable cost to queries already above the floor, a relaxed response's facets,
+histogram, page and total count all describe the same chosen level, and a replayed WAL produces an identical
+level choice on every node.
 
 **Q17 — the scoring composition of suggest (new, from the sponsor's review, §10.1).** The default signal is
 the cardinality of the postings after intersection with the must-match filter; popularised relevance (what


### PR DESCRIPTION
Three documentation commits, no code.

**Drop the retired `rtk` wrapper from the agent instructions.** The `rtk` Maven proxy no longer exists, so every instruction telling an agent to run `rtk mvn` pointed at a missing binary. All twelve call sites become plain `mvn`, and `Bash(rtk *)` leaves the two skills that allowed it — including `warmup-reindex-benchmark`, which is recent enough that an earlier pass at this had not seen it. The truncated-log warning in `wal-replay-profiling` is rewritten rather than deleted: confirming a build by exit code and jar timestamp instead of grepping for `BUILD SUCCESS` is still the right advice, it just is not `rtk` doing the truncating.

**Record where sandbox git worktrees must live.** A worktree created outside `$HOLE_WORKTREES_DIR` exists only inside the sandbox and disappears with it, taking the branch checkout along.

**Fold the relaxation consequences into Q16 and close its dangling reference.** The adaptive-relaxation decision was recorded twice — once in `2026-08-24-fulltext-search-lucene-vs-inhouse/` (the `README.md` decision row dated 2026-08-14, plus Q14 and Q16 in `prototypes/query-design.md`) and once in a standalone file that never landed in git. Q16 already carried the argument; three consequences lived only in the standalone and are added under it as a closing block:

- equal document frequencies need a deterministic tie-break, or the level choice stops being a function of index state plus query and a WAL-replayed replica can pick a different one
- the floor is a trigger, not a target: one dropped term can overshoot `N` by orders of magnitude
- the decision expires if the conjunction is ever fused into a streaming operator, since the free ladder is the whole cost argument — with the criteria that would detect it

This also repoints the `query-design.md` reference to "the relaxation ADR", which pointed at that never-committed file, to the *Rejected outright* table in the record where the string mini-grammar argument actually lives. One line of work, one record, per `.claude/rules/adr.md`.

Ref: #258