### PR TITLE
fix: stop counting transaction conflicts as internal engine errors

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/exception/ConflictingCatalogCommutativeMutationException.java
+++ b/evita_api/src/main/java/io/evitadb/api/exception/ConflictingCatalogCommutativeMutationException.java
@@ -24,6 +24,7 @@
 package io.evitadb.api.exception;
 
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictKey;
+import io.evitadb.exception.NotMonitored;
 
 import javax.annotation.Nonnull;
 import java.io.Serial;
@@ -54,8 +55,16 @@ import java.io.Serial;
  * bugs where business logic assumptions (like "never go below zero") might be violated by
  * blindly applying deltas without validating current state.
  *
+ * **Monitoring:**
+ * The type carries its own {@link NotMonitored} marker rather than relying on the one on
+ * {@link ConflictingCatalogMutationException}. The marker is not
+ * {@link java.lang.annotation.Inherited}, and the error-monitoring agent evaluates it against the
+ * concrete runtime class, so dropping it here would put commutative conflicts back into
+ * `io_evitadb_errors_total` under their own label.
+ *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
  */
+@NotMonitored
 public class ConflictingCatalogCommutativeMutationException extends ConflictingCatalogMutationException {
     @Serial
     private static final long serialVersionUID = 401973444573552277L;

--- a/evita_api/src/main/java/io/evitadb/api/exception/ConflictingCatalogMutationException.java
+++ b/evita_api/src/main/java/io/evitadb/api/exception/ConflictingCatalogMutationException.java
@@ -27,6 +27,7 @@ package io.evitadb.api.exception;
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictKey;
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictResolution;
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictResolutionLayer;
+import io.evitadb.exception.NotMonitored;
 import lombok.Getter;
 
 import javax.annotation.Nonnull;
@@ -58,8 +59,16 @@ import java.io.Serial;
  * "name" on entity 1 doesn't conflict with modifying attribute "price" on the same entity,
  * allowing higher concurrency than whole-entity locking would provide.
  *
+ * **Monitoring:**
+ * The type is marked {@link NotMonitored}: a conflict is a benign, expected outcome of concurrent
+ * writers, not an engine fault. Counting it would move `io_evitadb_errors_total` and, through the
+ * same counter, raise the `EVITA_DB_INTERNAL_ERRORS` health signal. Conflicts are tracked instead
+ * through `TransactionConflictEvent` (`io_evitadb_transaction_transaction_conflict_total`), which
+ * also breaks them down by conflict policy, resolution layer and conflict scope.
+ *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
  */
+@NotMonitored
 public class ConflictingCatalogMutationException extends TransactionException {
 	@Serial private static final long serialVersionUID = 4792726509766583503L;
 	/**


### PR DESCRIPTION
Ref: #1490

Hotfix twin of the `dev` PR. The issue is closed by the `dev` PR so the fix is not marked done until it is on the mainline.

## What

Adds `@NotMonitored` to `ConflictingCatalogMutationException` and to
`ConflictingCatalogCommutativeMutationException`.

## Why

A transaction conflict was being counted as a genuine engine fault. Every construction moved
`io_evitadb_errors_total{error_type="ConflictingCatalogMutationException"}`, and
`ObservabilityProbesDetector.checkEvitaErrors` reads the very same counter
(`ObservabilityManager.EVITA_ERRORS`), so each conflict also raised the `EVITA_DB_INTERNAL_ERRORS`
signal.

A conflict is an expected, recoverable outcome of concurrent writers. The engine already says so in
one place — `AbstractTransactionStage.handleException` deliberately special-cases it to `debug`
instead of `error` — and it already has a dedicated, better-labelled counter,
`io_evitadb_transaction_transaction_conflict_total`, carrying `conflictPolicy`, `resolutionLayer`
and `conflictScope`. That metric shipped in v2026.2.4 but never opted the exception out of error
monitoring, so conflicts were counted twice: once correctly, once as an internal error.

## Why both classes

`NotMonitored` is not `@Inherited`, and `ObservabilityManager.MONITORED_ERROR_TYPES` evaluates it
against the concrete runtime class. Annotating only the parent would leave commutative conflicts
counted under their own label.

## Accepted cost

Both types lose `ErrorOriginLogger` stack-trace coverage, since the same gate at
`ObservabilityManager:218` sits ahead of the metric, the counter and the origin logger. Acceptable:
the conflict path already emits a dedicated metric with finer labels plus a log line carrying the
conflict key, catalog version and resolved policy.

## Verification

- `mvn -pl evita_api -am compile` — BUILD SUCCESS.
- `javap -v` confirms both classes carry `NotMonitored` under `RuntimeVisibleAnnotations`, which is
  what the runtime `isAnnotationPresent` gate requires (`CLASS` retention would compile and then
  silently opt nothing out).

## Not in this PR

Two findings surfaced while diagnosing this; both are written up on #1490 and deliberately left out
of a one-line metric fix:

1. `GlobalExceptionHandlerInterceptor:120` maps a conflict to gRPC `INTERNAL` (13) and logs it at
   `ERROR`. The canonical code is `ABORTED` (10), which client retry policies treat as retryable.
2. `TransactionConflictEvent`'s javadoc claims conflicts are a subset of
   `TransactionFinished(resolution=ROLLBACK)`. They are disjoint — a conflicted transaction reports
   `COMMIT`, because `SessionRegistry.reportTransactionResolution` reads session-side
   `isRollbackOnly()` and fires before the conflict stage runs.
