### PR TITLE
fix: carry the whole query head through every rebuild and serialization path (hotfix)

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/EvitaSessionContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/EvitaSessionContract.java
@@ -559,7 +559,7 @@ public interface EvitaSessionContract extends Comparable<EvitaSessionContract>, 
 		if (query.getRequire() == null) {
 			return queryOne(
 				Query.query(
-					query.getCollection(),
+					query.getHead(),
 					query.getFilterBy(),
 					query.getOrderBy(),
 					require(entityFetch())
@@ -571,7 +571,7 @@ public interface EvitaSessionContract extends Comparable<EvitaSessionContract>, 
 			.isEmpty()) {
 			return queryOne(
 				Query.query(
-					query.getCollection(),
+					query.getHead(),
 					query.getFilterBy(),
 					query.getOrderBy(),
 					(Require) query.getRequire().getCopyWithNewChildren(
@@ -658,7 +658,7 @@ public interface EvitaSessionContract extends Comparable<EvitaSessionContract>, 
 		if (query.getRequire() == null) {
 			return queryList(
 				Query.query(
-					query.getCollection(),
+					query.getHead(),
 					query.getFilterBy(),
 					query.getOrderBy(),
 					require(entityFetch())
@@ -670,7 +670,7 @@ public interface EvitaSessionContract extends Comparable<EvitaSessionContract>, 
 			.isEmpty()) {
 			return queryList(
 				Query.query(
-					query.getCollection(),
+					query.getHead(),
 					query.getFilterBy(),
 					query.getOrderBy(),
 					(Require) query.getRequire().getCopyWithNewChildren(
@@ -750,7 +750,7 @@ public interface EvitaSessionContract extends Comparable<EvitaSessionContract>, 
 		if (query.getRequire() == null) {
 			return query(
 				Query.query(
-					query.getCollection(),
+					query.getHead(),
 					query.getFilterBy(),
 					query.getOrderBy(),
 					require(entityFetch())
@@ -762,7 +762,7 @@ public interface EvitaSessionContract extends Comparable<EvitaSessionContract>, 
 			.isEmpty()) {
 			return query(
 				Query.query(
-					query.getCollection(),
+					query.getHead(),
 					query.getFilterBy(),
 					query.getOrderBy(),
 					(Require) query.getRequire().getCopyWithNewChildren(

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientSession.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientSession.java
@@ -44,8 +44,10 @@ import io.evitadb.api.proxy.ProxyFactory;
 import io.evitadb.api.proxy.SealedEntityProxy;
 import io.evitadb.api.proxy.SealedEntityProxy.Propagation;
 import io.evitadb.api.proxy.SealedEntityReferenceProxy;
+import io.evitadb.api.query.HeadConstraint;
 import io.evitadb.api.query.Query;
 import io.evitadb.api.query.RequireConstraint;
+import io.evitadb.api.query.head.Head;
 import io.evitadb.api.query.require.EntityContentRequire;
 import io.evitadb.api.query.require.EntityFetch;
 import io.evitadb.api.query.require.SeparateEntityContentRequireContainer;
@@ -122,6 +124,7 @@ import io.evitadb.externalApi.grpc.requestResponse.schema.CatalogSchemaConverter
 import io.evitadb.externalApi.grpc.requestResponse.schema.EntitySchemaConverter;
 import io.evitadb.externalApi.grpc.requestResponse.schema.mutation.DelegatingLocalCatalogSchemaMutationConverter;
 import io.evitadb.externalApi.grpc.requestResponse.schema.mutation.catalog.ModifyEntitySchemaMutationConverter;
+import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
 import io.evitadb.utils.ReflectionLookup;
 import io.grpc.ClientCall;
@@ -301,10 +304,9 @@ public class EvitaClientSession implements EvitaSessionContract {
 		}
 		if (query.getCollection() == null) {
 			return extractEntityTypeFromClass(expectedType, reflectionLookup)
-				.or(() -> ofNullable(query.getCollection()).map(io.evitadb.api.query.head.Collection::getEntityType))
 				.map(
 					entityType -> Query.query(
-						collection(entityType),
+						mergeEntityTypeIntoHead(query.getHead(), entityType),
 						query.getFilterBy(),
 						query.getOrderBy(),
 						query.getRequire()
@@ -313,6 +315,34 @@ public class EvitaClientSession implements EvitaSessionContract {
 				.orElseGet(query::normalizeQuery);
 		} else {
 			return query.normalizeQuery();
+		}
+	}
+
+	/**
+	 * Combines the entity type derived from the expected result type with the header the caller wrote.
+	 *
+	 * Omitting the {@link io.evitadb.api.query.head.Collection} from the header is a legitimate caller shape - the
+	 * entity type then comes from the model class instead - so the header must be completed, not replaced. Everything
+	 * else the caller put there, {@link io.evitadb.api.query.head.Label labels} above all, is theirs and has to reach
+	 * the server; the query string is the only channel it has.
+	 *
+	 * @param head       the header the caller supplied, may be null
+	 * @param entityType the entity type derived from the expected result type
+	 * @return a header naming the collection first, followed by whatever the caller's header carried
+	 */
+	@Nonnull
+	private static HeadConstraint mergeEntityTypeIntoHead(@Nullable HeadConstraint head, @Nonnull String entityType) {
+		if (head == null) {
+			return collection(entityType);
+		} else if (head instanceof Head headContainer) {
+			return head(
+				ArrayUtils.mergeArrays(
+					new HeadConstraint[]{collection(entityType)},
+					headContainer.getChildren()
+				)
+			);
+		} else {
+			return head(collection(entityType), head);
 		}
 	}
 

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/resolver/endpoint/DeleteEntitiesByQueryHandler.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/resolver/endpoint/DeleteEntitiesByQueryHandler.java
@@ -80,7 +80,9 @@ public class DeleteEntitiesByQueryHandler extends QueryOrientedEntitiesHandler {
 				final Query finalQuery = requestExecutedEvent.measureInternalEvitaDBExecution(() -> {
 					if (QueryUtils.findRequire(query, EntityFetch.class, SeparateEntityContentRequireContainer.class) == null) {
 						return Query.query(
-							query.getCollection(),
+							// the whole header must survive - it already carries the source-type, source-query and
+							// caller labels that QueryOrientedEntitiesHandler#enrichHeadWithInternalConstraints put there
+							query.getHead(),
 							query.getFilterBy(),
 							query.getOrderBy(),
 							require(

--- a/evita_query/src/main/java/io/evitadb/api/query/visitor/PrettyPrintingVisitor.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/visitor/PrettyPrintingVisitor.java
@@ -219,7 +219,9 @@ public class PrettyPrintingVisitor implements ConstraintVisitor {
 	public void traverse(@Nonnull Query query) {
 		this.result.append("query" + ARG_OPENING).append(newLine());
 		this.level = 1;
-		ofNullable(query.getCollection()).ifPresent(it -> {
+		// the header is the whole HeadConstraint subtree, not the Collection extracted from it - printing
+		// `getCollection()` would silently drop every `label` the caller attached to the query
+		ofNullable(query.getHead()).ifPresent(it -> {
 			it.accept(this);
 			this.result.append(",");
 		});

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/query/serializer/QuerySerializer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/query/serializer/QuerySerializer.java
@@ -27,9 +27,9 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import io.evitadb.api.query.HeadConstraint;
 import io.evitadb.api.query.Query;
 import io.evitadb.api.query.filter.FilterBy;
-import io.evitadb.api.query.head.Collection;
 import io.evitadb.api.query.order.OrderBy;
 import io.evitadb.api.query.require.Require;
 
@@ -42,7 +42,10 @@ public class QuerySerializer extends Serializer<Query> {
 
 	@Override
 	public void write(Kryo kryo, Output output, Query object) {
-		kryo.writeObjectOrNull(output, object.getCollection(), Collection.class);
+		// the header is written polymorphically - it is a whole HeadConstraint subtree (a bare `collection`, a bare
+		// `label`, or a `head` container holding both), and persisting only the extracted Collection would drop
+		// every label the query was tagged with
+		kryo.writeClassAndObject(output, object.getHead());
 		kryo.writeObjectOrNull(output, object.getFilterBy(), FilterBy.class);
 		kryo.writeObjectOrNull(output, object.getOrderBy(), OrderBy.class);
 		kryo.writeObjectOrNull(output, object.getRequire(), Require.class);
@@ -51,7 +54,7 @@ public class QuerySerializer extends Serializer<Query> {
 	@Override
 	public Query read(Kryo kryo, Input input, Class<? extends Query> type) {
 		return Query.query(
-			kryo.readObjectOrNull(input, Collection.class),
+			(HeadConstraint) kryo.readClassAndObject(input),
 			kryo.readObjectOrNull(input, FilterBy.class),
 			kryo.readObjectOrNull(input, OrderBy.class),
 			kryo.readObjectOrNull(input, Require.class)

--- a/evita_test/evita_documentation_tests/src/test/java/io/evitadb/documentation/csharp/CsharpPrettyPrintingVisitor.java
+++ b/evita_test/evita_documentation_tests/src/test/java/io/evitadb/documentation/csharp/CsharpPrettyPrintingVisitor.java
@@ -190,7 +190,9 @@ public class CsharpPrettyPrintingVisitor implements ConstraintVisitor {
 		}
 		this.result.append("Query" + ARG_OPENING).append(newLine());
 		this.level = 1;
-		ofNullable(query.getCollection()).ifPresent(it -> {
+		// the header is the whole HeadConstraint subtree, not the Collection extracted from it - printing
+		// `getCollection()` would silently drop every `label` the caller attached to the query
+		ofNullable(query.getHead()).ifPresent(it -> {
 			it.accept(this);
 			this.result.append(",");
 		});

--- a/evita_test/evita_documentation_tests/src/test/java/io/evitadb/documentation/csharp/CsharpPrettyPrintingVisitorTest.java
+++ b/evita_test/evita_documentation_tests/src/test/java/io/evitadb/documentation/csharp/CsharpPrettyPrintingVisitorTest.java
@@ -1,0 +1,103 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.documentation.csharp;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.*;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.QUERY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that the C# code samples generated for the user documentation carry the whole query header. The visitor
+ * traverses {@link io.evitadb.api.query.Query#getHead()}; traversing the extracted
+ * {@link io.evitadb.api.query.head.Collection} instead would silently drop every `label` from the published sample -
+ * exactly the defect the Java printing path had.
+ *
+ * See issue #1507.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("CsharpPrettyPrintingVisitor - query header rendering")
+@Tag(CONTRACT)
+@Tag(QUERY)
+class CsharpPrettyPrintingVisitorTest {
+
+	@Test
+	@DisplayName("Should render the whole head container with its labels")
+	void shouldRenderHeadContainerWithLabels() {
+		assertEquals(
+			"""
+			Query(
+				Head(
+					Collection("Product"),
+					Label("query-name", "my-query"),
+					Label("url", "/test-url")
+				),
+				FilterBy(
+					EntityPrimaryKeyInSet(1, 2, 3)
+				)
+			)""",
+			CsharpPrettyPrintingVisitor.toString(
+				query(
+					head(
+						collection("Product"),
+						label("query-name", "my-query"),
+						label("url", "/test-url")
+					),
+					filterBy(entityPrimaryKeyInSet(1, 2, 3))
+				),
+				"\t",
+				""
+			)
+		);
+	}
+
+	@Test
+	@DisplayName("Should keep a bare collection head unwrapped")
+	void shouldKeepBareCollectionHeadUnwrapped() {
+		assertEquals(
+			"""
+			Query(
+				Collection("Product"),
+				FilterBy(
+					EntityPrimaryKeyInSet(1)
+				)
+			)""",
+			CsharpPrettyPrintingVisitor.toString(
+				query(
+					collection("Product"),
+					filterBy(entityPrimaryKeyInSet(1))
+				),
+				"\t",
+				""
+			)
+		);
+	}
+
+}

--- a/evita_test/evita_documentation_tests/src/test/java/io/evitadb/documentation/csharp/CsharpPrettyPrintingVisitorTest.java
+++ b/evita_test/evita_documentation_tests/src/test/java/io/evitadb/documentation/csharp/CsharpPrettyPrintingVisitorTest.java
@@ -100,4 +100,46 @@ class CsharpPrettyPrintingVisitorTest {
 		);
 	}
 
+	@Test
+	@DisplayName("Should render a label-only head that carries no collection")
+	void shouldRenderLabelOnlyHead() {
+		assertEquals(
+			"""
+			Query(
+				Label("query-name", "my-query"),
+				FilterBy(
+					EntityPrimaryKeyInSet(1)
+				)
+			)""",
+			CsharpPrettyPrintingVisitor.toString(
+				query(
+					label("query-name", "my-query"),
+					filterBy(entityPrimaryKeyInSet(1))
+				),
+				"\t",
+				""
+			)
+		);
+	}
+
+	@Test
+	@DisplayName("Should render a query that carries no head at all")
+	void shouldRenderQueryWithoutHead() {
+		assertEquals(
+			"""
+			Query(
+				FilterBy(
+					EntityPrimaryKeyInSet(1)
+				)
+			)""",
+			CsharpPrettyPrintingVisitor.toString(
+				query(
+					filterBy(entityPrimaryKeyInSet(1))
+				),
+				"\t",
+				""
+			)
+		);
+	}
+
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/EvitaSessionContractHeadPreservationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/EvitaSessionContractHeadPreservationTest.java
@@ -1,0 +1,233 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api;
+
+import io.evitadb.api.query.Query;
+import io.evitadb.api.query.QueryUtils;
+import io.evitadb.api.query.head.Collection;
+import io.evitadb.api.query.head.Label;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.*;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.QUERY;
+import static io.evitadb.test.TestTags.SESSION;
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+/**
+ * The `queryOneSealedEntity` / `queryListOfSealedEntities` / `querySealedEntity` convenience methods of
+ * {@link EvitaSessionContract} inject an `entityFetch` requirement when the caller did not supply one, and do so by
+ * rebuilding the query. The rebuild reads the header through {@link Query#getCollection()}, which extracts only the
+ * {@link Collection} constraint — so every other head constraint, {@link Label} included, is discarded before the
+ * query ever reaches an implementation.
+ *
+ * Because these are `default` methods on the contract, the loss happens on the embedded session just as it does on
+ * the remote driver. The tests below drive each method through a mock that captures the query the default method
+ * actually delegates, and assert that the header arrived intact.
+ *
+ * See issue #1507.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("EvitaSessionContract — head preservation in entityFetch-injecting defaults")
+@Tag(CONTRACT)
+@Tag(SESSION)
+@Tag(QUERY)
+class EvitaSessionContractHeadPreservationTest {
+	private static final String ENTITY_TYPE = "PRODUCT";
+	private static final String LABEL_NAME = "rest_method";
+	private static final String LABEL_VALUE = "CartController.updateCartByOperation";
+
+	/**
+	 * Query whose header carries a label and which defines no `require` section at all — the first rebuilding
+	 * branch of each convenience method.
+	 */
+	@Nonnull
+	private static Query labelledQueryWithoutRequire() {
+		return query(
+			head(
+				collection(ENTITY_TYPE),
+				label(LABEL_NAME, LABEL_VALUE)
+			),
+			filterBy(entityPrimaryKeyInSet(1))
+		);
+	}
+
+	/**
+	 * Query whose header carries a label and whose `require` section exists but contains no `entityFetch` — the
+	 * second rebuilding branch of each convenience method.
+	 */
+	@Nonnull
+	private static Query labelledQueryWithoutEntityFetch() {
+		return query(
+			head(
+				collection(ENTITY_TYPE),
+				label(LABEL_NAME, LABEL_VALUE)
+			),
+			filterBy(entityPrimaryKeyInSet(1)),
+			require(page(1, 5))
+		);
+	}
+
+	/**
+	 * Query that already satisfies the `entityFetch` requirement — no rebuild happens and the instance must be
+	 * handed over untouched.
+	 */
+	@Nonnull
+	private static Query labelledQueryWithEntityFetch() {
+		return query(
+			head(
+				collection(ENTITY_TYPE),
+				label(LABEL_NAME, LABEL_VALUE)
+			),
+			filterBy(entityPrimaryKeyInSet(1)),
+			require(entityFetch())
+		);
+	}
+
+	/**
+	 * Builds a session mock whose `default` methods run for real, stubs the three abstract query methods to capture
+	 * the {@link Query} they receive, runs `invocation` against it and returns whatever was captured.
+	 *
+	 * @param invocation the convenience method to exercise on the contract
+	 * @return the query the default method delegated to the abstract query method
+	 */
+	@Nonnull
+	private static Query captureDelegatedQuery(@Nonnull Consumer<EvitaSessionContract> invocation) {
+		final AtomicReference<Query> captured = new AtomicReference<>();
+		final EvitaSessionContract session = mock(EvitaSessionContract.class, CALLS_REAL_METHODS);
+
+		doAnswer(it -> {
+			captured.set(it.getArgument(0));
+			return Optional.empty();
+		}).when(session).queryOne(any(Query.class), eq(SealedEntity.class));
+		doAnswer(it -> {
+			captured.set(it.getArgument(0));
+			return List.of();
+		}).when(session).queryList(any(Query.class), eq(SealedEntity.class));
+		doAnswer(it -> {
+			captured.set(it.getArgument(0));
+			return null;
+		}).when(session).query(any(Query.class), eq(SealedEntity.class));
+
+		invocation.accept(session);
+
+		return requireNonNull(captured.get(), "the convenience method never delegated to a query method");
+	}
+
+	/**
+	 * Asserts that the rebuilt query still targets the original collection AND still carries the original label.
+	 * The collection half guards the opposite mistake — a merge that forgets the collection while keeping the label.
+	 */
+	private static void assertHeaderSurvived(@Nonnull Query rebuiltQuery) {
+		final Collection collection = rebuiltQuery.getCollection();
+		assertNotNull(collection, () -> "the collection was lost during the rebuild: " + rebuiltQuery);
+		assertEquals(ENTITY_TYPE, collection.getEntityType());
+
+		final List<Label> labels = QueryUtils.findConstraints(
+			requireNonNull(rebuiltQuery.getHead(), () -> "the whole head was lost during the rebuild"),
+			Label.class
+		);
+		assertEquals(1, labels.size(), () -> "the head label was dropped during the rebuild: " + rebuiltQuery);
+		assertEquals(LABEL_NAME, labels.get(0).getLabelName());
+		assertEquals(LABEL_VALUE, labels.get(0).getLabelValue());
+	}
+
+	@Test
+	@DisplayName("queryOneSealedEntity should keep head labels when the query defines no require")
+	void shouldKeepHeadLabelsInQueryOneSealedEntityWithoutRequire() {
+		assertHeaderSurvived(
+			captureDelegatedQuery(session -> session.queryOneSealedEntity(labelledQueryWithoutRequire()))
+		);
+	}
+
+	@Test
+	@DisplayName("queryOneSealedEntity should keep head labels when the require carries no entityFetch")
+	void shouldKeepHeadLabelsInQueryOneSealedEntityWithoutEntityFetch() {
+		assertHeaderSurvived(
+			captureDelegatedQuery(session -> session.queryOneSealedEntity(labelledQueryWithoutEntityFetch()))
+		);
+	}
+
+	@Test
+	@DisplayName("queryListOfSealedEntities should keep head labels when the query defines no require")
+	void shouldKeepHeadLabelsInQueryListOfSealedEntitiesWithoutRequire() {
+		assertHeaderSurvived(
+			captureDelegatedQuery(session -> session.queryListOfSealedEntities(labelledQueryWithoutRequire()))
+		);
+	}
+
+	@Test
+	@DisplayName("queryListOfSealedEntities should keep head labels when the require carries no entityFetch")
+	void shouldKeepHeadLabelsInQueryListOfSealedEntitiesWithoutEntityFetch() {
+		assertHeaderSurvived(
+			captureDelegatedQuery(session -> session.queryListOfSealedEntities(labelledQueryWithoutEntityFetch()))
+		);
+	}
+
+	@Test
+	@DisplayName("querySealedEntity should keep head labels when the query defines no require")
+	void shouldKeepHeadLabelsInQuerySealedEntityWithoutRequire() {
+		assertHeaderSurvived(
+			captureDelegatedQuery(session -> session.querySealedEntity(labelledQueryWithoutRequire()))
+		);
+	}
+
+	@Test
+	@DisplayName("querySealedEntity should keep head labels when the require carries no entityFetch")
+	void shouldKeepHeadLabelsInQuerySealedEntityWithoutEntityFetch() {
+		assertHeaderSurvived(
+			captureDelegatedQuery(session -> session.querySealedEntity(labelledQueryWithoutEntityFetch()))
+		);
+	}
+
+	@Test
+	@DisplayName("A query that already defines entityFetch must be delegated untouched")
+	void shouldDelegateQueryWithEntityFetchUntouched() {
+		final Query original = labelledQueryWithEntityFetch();
+		assertSame(
+			original,
+			captureDelegatedQuery(session -> session.queryListOfSealedEntities(original))
+		);
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/EvitaSessionContractHeadPreservationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/EvitaSessionContractHeadPreservationTest.java
@@ -224,12 +224,32 @@ class EvitaSessionContractHeadPreservationTest {
 	}
 
 	@Test
-	@DisplayName("A query that already defines entityFetch must be delegated untouched")
-	void shouldDelegateQueryWithEntityFetchUntouched() {
+	@DisplayName("queryOneSealedEntity must delegate a query that already defines entityFetch untouched")
+	void shouldDelegateQueryWithEntityFetchUntouchedFromQueryOneSealedEntity() {
+		final Query original = labelledQueryWithEntityFetch();
+		assertSame(
+			original,
+			captureDelegatedQuery(session -> session.queryOneSealedEntity(original))
+		);
+	}
+
+	@Test
+	@DisplayName("queryListOfSealedEntities must delegate a query that already defines entityFetch untouched")
+	void shouldDelegateQueryWithEntityFetchUntouchedFromQueryListOfSealedEntities() {
 		final Query original = labelledQueryWithEntityFetch();
 		assertSame(
 			original,
 			captureDelegatedQuery(session -> session.queryListOfSealedEntities(original))
+		);
+	}
+
+	@Test
+	@DisplayName("querySealedEntity must delegate a query that already defines entityFetch untouched")
+	void shouldDelegateQueryWithEntityFetchUntouchedFromQuerySealedEntity() {
+		final Query original = labelledQueryWithEntityFetch();
+		assertSame(
+			original,
+			captureDelegatedQuery(session -> session.querySealedEntity(original))
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/EvitaSessionContractHeadPreservationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/EvitaSessionContractHeadPreservationTest.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.api;
 
+import io.evitadb.api.query.HeadConstraint;
 import io.evitadb.api.query.Query;
 import io.evitadb.api.query.QueryUtils;
 import io.evitadb.api.query.head.Collection;
@@ -45,7 +46,6 @@ import static io.evitadb.test.TestTags.QUERY;
 import static io.evitadb.test.TestTags.SESSION;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -159,14 +159,17 @@ class EvitaSessionContractHeadPreservationTest {
 	 * The collection half guards the opposite mistake — a merge that forgets the collection while keeping the label.
 	 */
 	private static void assertHeaderSurvived(@Nonnull Query rebuiltQuery) {
-		final Collection collection = rebuiltQuery.getCollection();
-		assertNotNull(collection, () -> "the collection was lost during the rebuild: " + rebuiltQuery);
-		assertEquals(ENTITY_TYPE, collection.getEntityType());
-
-		final List<Label> labels = QueryUtils.findConstraints(
-			requireNonNull(rebuiltQuery.getHead(), () -> "the whole head was lost during the rebuild"),
-			Label.class
+		final HeadConstraint head = requireNonNull(
+			rebuiltQuery.getHead(), () -> "the whole head was lost during the rebuild"
 		);
+
+		// exactly one - `getCollection()` returns the first match, so counting is what would catch a rebuild that
+		// prepends a collection to a header that already names one
+		final List<Collection> collections = QueryUtils.findConstraints(head, Collection.class);
+		assertEquals(1, collections.size(), () -> "the collection was lost or duplicated by the rebuild: " + rebuiltQuery);
+		assertEquals(ENTITY_TYPE, collections.get(0).getEntityType());
+
+		final List<Label> labels = QueryUtils.findConstraints(head, Label.class);
 		assertEquals(1, labels.size(), () -> "the head label was dropped during the rebuild: " + rebuiltQuery);
 		assertEquals(LABEL_NAME, labels.get(0).getLabelName());
 		assertEquals(LABEL_VALUE, labels.get(0).getLabelValue());

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/query/QueryTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/query/QueryTest.java
@@ -24,11 +24,14 @@
 package io.evitadb.api.query;
 
 import io.evitadb.api.query.head.Collection;
+import io.evitadb.api.query.parser.DefaultQueryParser;
+import io.evitadb.api.query.parser.exception.EvitaSyntaxException;
 import io.evitadb.api.query.visitor.PrettyPrintingVisitor.StringWithParameters;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import org.junit.jupiter.api.Tag;
 
 import static io.evitadb.api.query.Query.query;
@@ -609,6 +612,87 @@ class QueryTest {
 					)
 				)
 			).normalizeQuery()
+		);
+	}
+
+	/**
+	 * The EvitaQL string is the only channel the remote driver has — {@link io.evitadb.api.query.head.Label labels}
+	 * that survive in the object model but not in the printed string never reach the server. A head therefore has to
+	 * come back from the parser exactly as it went in.
+	 *
+	 * The emitted shape is additionally constrained by the grammar: `EvitaQLQueryVisitor#findHeadConstraint` accepts
+	 * exactly one top-level head constraint, so several head constraints must be printed inside a `head(...)`
+	 * container rather than as siblings of `filterBy`. These round-trips fail the moment that rule is broken.
+	 *
+	 * See issue #1507.
+	 */
+	@Test
+	void shouldRoundTripHeadWithCollectionAndLabelThroughEvitaQlString() {
+		final Query original = query(
+			head(
+				collection("product"),
+				label("rest_method", "CartController.updateCartByOperation")
+			),
+			filterBy(attributeEquals("code", "samsung"))
+		);
+
+		assertEquals(
+			original,
+			DefaultQueryParser.getInstance().parseQueryUnsafe(original.toString())
+		);
+	}
+
+	@Test
+	void shouldRoundTripLabelOnlyHeadThroughEvitaQlString() {
+		final Query original = query(
+			label("rest_method", "CartController.updateCartByOperation"),
+			filterBy(attributeEquals("code", "samsung"))
+		);
+
+		assertEquals(
+			original,
+			DefaultQueryParser.getInstance().parseQueryUnsafe(original.toString())
+		);
+	}
+
+	/**
+	 * Mirrors what the gRPC driver actually does: print the query with its scalar arguments extracted into
+	 * positional parameters, then let the server parse the pair back.
+	 */
+	@Test
+	void shouldRoundTripHeadLabelsThroughParameterExtraction() {
+		final Query original = query(
+			head(
+				collection("product"),
+				label("rest_method", "CartController.updateCartByOperation")
+			),
+			filterBy(attributeEquals("code", "samsung"))
+		);
+
+		final StringWithParameters printed = original.toStringWithParameterExtraction();
+
+		assertEquals(
+			original,
+			DefaultQueryParser.getInstance().parseQuery(
+				printed.query(),
+				new ArrayList<Object>(printed.parameters())
+			)
+		);
+	}
+
+	/**
+	 * Documents why the printed form must use the `head(...)` container: the grammar allows exactly one top-level
+	 * head constraint, so printing the collection and the label as siblings would produce a string the server
+	 * refuses to parse.
+	 */
+	@Test
+	void shouldRejectSeveralTopLevelHeadConstraints() {
+		assertThrows(
+			EvitaSyntaxException.class,
+			() -> DefaultQueryParser.getInstance().parseQueryUnsafe(
+				"query(collection('product'),label('rest_method', 'CartController.updateCartByOperation')," +
+					"filterBy(attributeEquals('code', 'samsung')))"
+			)
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/query/visitor/PrettyPrintingVisitorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/query/visitor/PrettyPrintingVisitorTest.java
@@ -475,4 +475,117 @@ class PrettyPrintingVisitorTest {
 			);
 		}
 	}
+
+	/**
+	 * The query header is not the `collection` constraint — it is a whole {@link io.evitadb.api.query.HeadConstraint}
+	 * subtree that may carry {@link io.evitadb.api.query.head.Label labels} alongside (or instead of) the collection.
+	 * Everything the driver puts on the wire goes through this visitor, so a head constraint the visitor does not
+	 * print never reaches the server at all.
+	 *
+	 * See issue #1507.
+	 */
+	@Nested
+	@DisplayName("Head printing")
+	class HeadPrintingTest {
+
+		@Test
+		@DisplayName("Should print the whole head container, not only its collection")
+		void shouldPrintHeadContainerWithCollectionAndLabel() {
+			assertEquals(
+				"""
+				query(
+					head(
+						collection('PRODUCT'),
+						label('rest_method', 'CartController.updateCartByOperation')
+					),
+					filterBy(
+						entityPrimaryKeyInSet(1)
+					)
+				)""",
+				PrettyPrintingVisitor.toString(
+					query(
+						head(
+							collection("PRODUCT"),
+							label("rest_method", "CartController.updateCartByOperation")
+						),
+						filterBy(entityPrimaryKeyInSet(1))
+					),
+					"\t"
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("Should print a label-only head that carries no collection")
+		void shouldPrintLabelOnlyHead() {
+			assertEquals(
+				"query(label('rest_method', 'CartController.updateCartByOperation'),filterBy(entityPrimaryKeyInSet(1)))",
+				PrettyPrintingVisitor.toString(
+					query(
+						label("rest_method", "CartController.updateCartByOperation"),
+						filterBy(entityPrimaryKeyInSet(1))
+					)
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("Should print every label when the head carries several")
+		void shouldPrintEveryLabelOfTheHead() {
+			assertEquals(
+				"query(head(collection('PRODUCT'),label('a', 'b'),label('c', 'd')),filterBy(entityPrimaryKeyInSet(1)))",
+				PrettyPrintingVisitor.toString(
+					query(
+						head(
+							collection("PRODUCT"),
+							label("a", "b"),
+							label("c", "d")
+						),
+						filterBy(entityPrimaryKeyInSet(1))
+					)
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("Should extract head label arguments as query parameters")
+		void shouldExtractHeadLabelArgumentsAsParameters() {
+			final StringWithParameters result = PrettyPrintingVisitor.toStringWithParameterExtraction(
+				query(
+					head(
+						collection("PRODUCT"),
+						label("rest_method", "CartController.updateCartByOperation")
+					),
+					filterBy(entityPrimaryKeyInSet(1))
+				)
+			);
+
+			assertEquals(
+				"query(head(collection(?),label(?, ?)),filterBy(entityPrimaryKeyInSet(?)))",
+				result.query()
+			);
+			assertArrayEquals(
+				new Serializable[]{"PRODUCT", "rest_method", "CartController.updateCartByOperation", 1},
+				result.parameters().toArray(new Serializable[0])
+			);
+		}
+
+		/**
+		 * Guards the opposite mistake: a head that is nothing but a bare `collection` must stay unwrapped, because
+		 * that is the shape every existing query and every existing test on the wire already uses.
+		 */
+		@Test
+		@DisplayName("Should keep a bare collection head unwrapped")
+		void shouldKeepBareCollectionHeadUnwrapped() {
+			assertEquals(
+				"query(collection('PRODUCT'),filterBy(entityPrimaryKeyInSet(1)))",
+				PrettyPrintingVisitor.toString(
+					query(
+						collection("PRODUCT"),
+						filterBy(entityPrimaryKeyInSet(1))
+					)
+				)
+			);
+		}
+	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientHeadLabelPropagationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientHeadLabelPropagationTest.java
@@ -1,0 +1,319 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.driver;
+
+import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.requestResponse.data.EntityClassifier;
+import io.evitadb.api.requestResponse.data.annotation.EntityRef;
+import io.evitadb.api.requestResponse.data.structure.EntityReference;
+import io.evitadb.driver.config.ClientTimeoutOptions;
+import io.evitadb.driver.config.ClientTlsOptions;
+import io.evitadb.driver.config.EvitaClientConfiguration;
+import io.evitadb.externalApi.configuration.ApiOptions;
+import io.evitadb.externalApi.configuration.HostDefinition;
+import io.evitadb.externalApi.grpc.GrpcProvider;
+import io.evitadb.externalApi.grpc.generated.GrpcQueryParam;
+import io.evitadb.externalApi.grpc.generated.GrpcQueryRequest;
+import io.evitadb.externalApi.system.SystemProvider;
+import io.evitadb.server.EvitaServer;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import io.evitadb.test.TestConstants;
+import io.evitadb.test.annotation.DataSet;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import io.evitadb.utils.CertificateUtils;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.MethodDescriptor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.entityFetch;
+import static io.evitadb.api.query.QueryConstraints.entityPrimaryKeyInSet;
+import static io.evitadb.api.query.QueryConstraints.filterBy;
+import static io.evitadb.api.query.QueryConstraints.head;
+import static io.evitadb.api.query.QueryConstraints.label;
+import static io.evitadb.api.query.QueryConstraints.require;
+import static io.evitadb.test.TestConstants.TEST_CATALOG;
+import static io.evitadb.test.TestTags.DRIVER;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.QUERY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The gRPC transport carries a query as an EvitaQL string plus its extracted parameters — a head constraint that
+ * does not make it into that string never reaches the server, and the query is then untraceable in the traffic
+ * recording, in the spans and in the metrics that the label exists to feed.
+ *
+ * Two independent client-side sites drop it. `EvitaClientSession#assertRequestMakesSenseAndEntityTypeIsPresent`
+ * rebuilds a head that carries no `collection` from scratch, and `PrettyPrintingVisitor#traverse(Query)` prints
+ * `Query#getCollection()` rather than `Query#getHead()`. These tests read what the driver actually put on the wire,
+ * so each site is observed where it is reachable rather than where it is written.
+ *
+ * See issue #1507.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("EvitaClient — head label propagation")
+@Tag(DRIVER)
+@Tag(GRPC)
+@Tag(QUERY)
+@ExtendWith(EvitaParameterResolver.class)
+class EvitaClientHeadLabelPropagationTest implements TestConstants, EvitaTestSupport {
+	private static final String DATA_SET_HEAD_LABEL_PROPAGATION = "clientHeadLabelPropagation";
+	private static final String LABEL_NAME = "rest_method";
+	private static final String LABEL_VALUE = "CartController.updateCartByOperation";
+	/**
+	 * Primary key deliberately absent from the dataset — the queries below exist to be *sent*, not to match, and an
+	 * empty result page keeps the assertion about the wire and nothing else.
+	 */
+	private static final int MISSING_PRIMARY_KEY = 999_999;
+
+	/**
+	 * Model class whose {@link EntityRef} annotation supplies the entity type. It is what makes a query with no
+	 * `collection` in its head a legitimate caller shape: the entity type comes from the expected result type
+	 * instead, which is exactly the shape the driver's rebuild throws the rest of the head away for.
+	 */
+	@EntityRef(Entities.PRODUCT)
+	public interface ProductHandle extends EntityClassifier {
+	}
+
+	/**
+	 * Builds a minimal catalog holding a single product. The catalog stays in the WARM_UP state — queries by primary
+	 * key work there and need no transaction, keeping the reproduction focused on what the driver serializes.
+	 */
+	@DataSet(value = DATA_SET_HEAD_LABEL_PROPAGATION, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE}, readOnly = false, destroyAfterClass = true)
+	static EvitaClient initDataSet(EvitaServer evitaServer) {
+		final EvitaClient setupClient = new EvitaClient(clientConfiguration(evitaServer));
+		setupClient.defineCatalog(TEST_CATALOG);
+		setupClient.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.createNewEntity(Entities.PRODUCT, 1).upsertVia(session);
+			}
+		);
+		return setupClient;
+	}
+
+	@Test
+	@UseDataSet(DATA_SET_HEAD_LABEL_PROPAGATION)
+	@DisplayName("should send a head label of a query whose head carries no collection")
+	void shouldSendHeadLabelWhenHeadCarriesNoCollection(EvitaServer evitaServer) {
+		final GrpcQueryRequest sentRequest = captureQueryRequest(
+			evitaServer,
+			session -> session.queryList(
+				query(
+					label(LABEL_NAME, LABEL_VALUE),
+					filterBy(entityPrimaryKeyInSet(MISSING_PRIMARY_KEY)),
+					require(entityFetch())
+				),
+				ProductHandle.class
+			)
+		);
+
+		// the entity type taken from the expected result type must still be there ...
+		assertTrue(
+			sentRequest.getQuery().contains("collection("),
+			() -> "the entity type never made it onto the wire: " + sentRequest.getQuery()
+		);
+		// ... and the label must have been merged into the head rather than replaced by it
+		assertLabelOnTheWire(sentRequest);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET_HEAD_LABEL_PROPAGATION)
+	@DisplayName("should send a head label of a query whose head also carries a collection")
+	void shouldSendHeadLabelWhenHeadAlsoCarriesCollection(EvitaServer evitaServer) {
+		final GrpcQueryRequest sentRequest = captureQueryRequest(
+			evitaServer,
+			session -> session.queryList(
+				query(
+					head(
+						collection(Entities.PRODUCT),
+						label(LABEL_NAME, LABEL_VALUE)
+					),
+					filterBy(entityPrimaryKeyInSet(MISSING_PRIMARY_KEY))
+				),
+				EntityReference.class
+			)
+		);
+
+		assertLabelOnTheWire(sentRequest);
+	}
+
+	/**
+	 * Guards the opposite mistake: a query whose head is nothing but a `collection` must keep going on the wire in
+	 * the shape every deployed server already parses, without a gratuitous `head(...)` wrapper.
+	 */
+	@Test
+	@UseDataSet(DATA_SET_HEAD_LABEL_PROPAGATION)
+	@DisplayName("should send a bare collection head unwrapped")
+	void shouldSendBareCollectionHeadUnwrapped(EvitaServer evitaServer) {
+		final GrpcQueryRequest sentRequest = captureQueryRequest(
+			evitaServer,
+			session -> session.queryList(
+				query(
+					collection(Entities.PRODUCT),
+					filterBy(entityPrimaryKeyInSet(MISSING_PRIMARY_KEY))
+				),
+				EntityReference.class
+			)
+		);
+
+		assertTrue(
+			sentRequest.getQuery().contains("collection("),
+			() -> "the entity type never made it onto the wire: " + sentRequest.getQuery()
+		);
+		assertFalse(
+			sentRequest.getQuery().contains("head("),
+			() -> "a head with nothing but a collection must not be wrapped: " + sentRequest.getQuery()
+		);
+	}
+
+	/**
+	 * Asserts both halves of a label on the wire: the `label(...)` constraint in the query string, and the name and
+	 * value among the extracted positional parameters. Asserting only the string would pass on a query that prints
+	 * the placeholders but loses the values.
+	 */
+	private static void assertLabelOnTheWire(@Nonnull GrpcQueryRequest sentRequest) {
+		assertTrue(
+			sentRequest.getQuery().contains("label("),
+			() -> "the head label was dropped by the driver: " + sentRequest.getQuery()
+		);
+		assertTrue(
+			sentRequest.getPositionalQueryParamsList().stream()
+				.map(GrpcQueryParam::getStringValue)
+				.anyMatch(LABEL_NAME::equals),
+			() -> "the label name never reached the wire: " + sentRequest.getPositionalQueryParamsList()
+		);
+		assertTrue(
+			sentRequest.getPositionalQueryParamsList().stream()
+				.map(GrpcQueryParam::getStringValue)
+				.anyMatch(LABEL_VALUE::equals),
+			() -> "the label value never reached the wire: " + sentRequest.getPositionalQueryParamsList()
+		);
+	}
+
+	/**
+	 * Runs `queryInvocation` through a freshly built client whose channel is intercepted, and returns the
+	 * {@link GrpcQueryRequest} the driver actually sent.
+	 */
+	@Nonnull
+	private static GrpcQueryRequest captureQueryRequest(
+		@Nonnull EvitaServer evitaServer,
+		@Nonnull Consumer<EvitaSessionContract> queryInvocation
+	) {
+		final QueryRequestCapturingInterceptor capture = new QueryRequestCapturingInterceptor();
+		try (final EvitaClient client = new EvitaClient(
+			clientConfiguration(evitaServer),
+			(Consumer<GrpcClientBuilder>) builder -> builder.intercept(capture)
+		)) {
+			client.queryCatalog(TEST_CATALOG, queryInvocation);
+		}
+		final GrpcQueryRequest sentRequest = capture.lastRequest();
+		assertNotNull(sentRequest, "the driver never sent a GrpcQueryRequest");
+		return sentRequest;
+	}
+
+	/**
+	 * Builds an {@link EvitaClientConfiguration} pointing at the running server's gRPC endpoint.
+	 */
+	private static EvitaClientConfiguration clientConfiguration(@Nonnull EvitaServer evitaServer) {
+		final ApiOptions apiOptions = evitaServer.getExternalApiServer().getApiOptions();
+		final HostDefinition grpcHost = apiOptions.getEndpointConfiguration(GrpcProvider.CODE).getHost()[0];
+		final HostDefinition systemHost = apiOptions.getEndpointConfiguration(SystemProvider.CODE).getHost()[0];
+
+		final String serverCertificates = apiOptions.certificate().getFolderPath().toString();
+		final int lastDash = serverCertificates.lastIndexOf('-');
+		final Path clientCertificates = Path.of(serverCertificates.substring(0, lastDash) + "-client");
+
+		return EvitaClientConfiguration
+			.builder()
+			.host(grpcHost.hostAddress())
+			.port(grpcHost.port())
+			.systemApiPort(systemHost.port())
+			.tls(
+				ClientTlsOptions.builder()
+					.mtlsEnabled(false)
+					.certificateFolderPath(clientCertificates)
+					.certificateFileName(Path.of(CertificateUtils.getGeneratedClientCertificateFileName()))
+					.certificateKeyFileName(Path.of(CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName()))
+					.build()
+			)
+			.timeouts(
+				ClientTimeoutOptions.builder()
+					.timeout(10, TimeUnit.MINUTES)
+					.build()
+			)
+			.build();
+	}
+
+	/**
+	 * gRPC {@link ClientInterceptor} that records the last {@link GrpcQueryRequest} handed to the transport. Reading
+	 * the outbound message is the only faithful observation point — everything downstream of the driver's own
+	 * serialization already sees the head that survived it.
+	 */
+	private static final class QueryRequestCapturingInterceptor implements ClientInterceptor {
+		private final AtomicReference<GrpcQueryRequest> lastRequest = new AtomicReference<>();
+
+		@Nullable
+		GrpcQueryRequest lastRequest() {
+			return this.lastRequest.get();
+		}
+
+		@Override
+		public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+			MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next
+		) {
+			return new SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+				@Override
+				public void sendMessage(ReqT message) {
+					if (message instanceof GrpcQueryRequest queryRequest) {
+						QueryRequestCapturingInterceptor.this.lastRequest.set(queryRequest);
+					}
+					super.sendMessage(message);
+				}
+			};
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientHeadLabelPropagationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientHeadLabelPropagationTest.java
@@ -75,6 +75,7 @@ import static io.evitadb.test.TestConstants.TEST_CATALOG;
 import static io.evitadb.test.TestTags.DRIVER;
 import static io.evitadb.test.TestTags.GRPC;
 import static io.evitadb.test.TestTags.QUERY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -102,6 +103,8 @@ class EvitaClientHeadLabelPropagationTest implements TestConstants, EvitaTestSup
 	private static final String DATA_SET_HEAD_LABEL_PROPAGATION = "clientHeadLabelPropagation";
 	private static final String LABEL_NAME = "rest_method";
 	private static final String LABEL_VALUE = "CartController.updateCartByOperation";
+	private static final String SECOND_LABEL_NAME = "page-url";
+	private static final String SECOND_LABEL_VALUE = "/cart";
 	/**
 	 * Primary key deliberately absent from the dataset — the queries below exist to be *sent*, not to match, and an
 	 * empty result page keeps the assertion about the wire and nothing else.
@@ -150,11 +153,8 @@ class EvitaClientHeadLabelPropagationTest implements TestConstants, EvitaTestSup
 			)
 		);
 
-		// the entity type taken from the expected result type must still be there ...
-		assertTrue(
-			sentRequest.getQuery().contains("collection("),
-			() -> "the entity type never made it onto the wire: " + sentRequest.getQuery()
-		);
+		// the entity type taken from the expected result type must still be there, exactly once ...
+		assertSingleCollectionOnTheWire(sentRequest);
 		// ... and the label must have been merged into the head rather than replaced by it
 		assertLabelOnTheWire(sentRequest);
 	}
@@ -177,7 +177,54 @@ class EvitaClientHeadLabelPropagationTest implements TestConstants, EvitaTestSup
 			)
 		);
 
+		assertSingleCollectionOnTheWire(sentRequest);
 		assertLabelOnTheWire(sentRequest);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET_HEAD_LABEL_PROPAGATION)
+	@DisplayName("should derive the collection when the query carries no head at all")
+	void shouldDeriveCollectionWhenQueryCarriesNoHead(EvitaServer evitaServer) {
+		final GrpcQueryRequest sentRequest = captureQueryRequest(
+			evitaServer,
+			session -> session.queryList(
+				query(
+					filterBy(entityPrimaryKeyInSet(MISSING_PRIMARY_KEY)),
+					require(entityFetch())
+				),
+				ProductHandle.class
+			)
+		);
+
+		assertSingleCollectionOnTheWire(sentRequest);
+		assertFalse(
+			sentRequest.getQuery().contains("head("),
+			() -> "a derived collection alone must not be wrapped: " + sentRequest.getQuery()
+		);
+	}
+
+	@Test
+	@UseDataSet(DATA_SET_HEAD_LABEL_PROPAGATION)
+	@DisplayName("should keep every label of a collection-free head container while deriving the collection")
+	void shouldKeepEveryLabelOfCollectionFreeHeadContainer(EvitaServer evitaServer) {
+		final GrpcQueryRequest sentRequest = captureQueryRequest(
+			evitaServer,
+			session -> session.queryList(
+				query(
+					head(
+						label(LABEL_NAME, LABEL_VALUE),
+						label(SECOND_LABEL_NAME, SECOND_LABEL_VALUE)
+					),
+					filterBy(entityPrimaryKeyInSet(MISSING_PRIMARY_KEY)),
+					require(entityFetch())
+				),
+				ProductHandle.class
+			)
+		);
+
+		assertSingleCollectionOnTheWire(sentRequest);
+		assertLabelOnTheWire(sentRequest, LABEL_NAME, LABEL_VALUE);
+		assertLabelOnTheWire(sentRequest, SECOND_LABEL_NAME, SECOND_LABEL_VALUE);
 	}
 
 	/**
@@ -215,6 +262,14 @@ class EvitaClientHeadLabelPropagationTest implements TestConstants, EvitaTestSup
 	 * the placeholders but loses the values.
 	 */
 	private static void assertLabelOnTheWire(@Nonnull GrpcQueryRequest sentRequest) {
+		assertLabelOnTheWire(sentRequest, LABEL_NAME, LABEL_VALUE);
+	}
+
+	private static void assertLabelOnTheWire(
+		@Nonnull GrpcQueryRequest sentRequest,
+		@Nonnull String labelName,
+		@Nonnull String labelValue
+	) {
 		assertTrue(
 			sentRequest.getQuery().contains("label("),
 			() -> "the head label was dropped by the driver: " + sentRequest.getQuery()
@@ -222,14 +277,27 @@ class EvitaClientHeadLabelPropagationTest implements TestConstants, EvitaTestSup
 		assertTrue(
 			sentRequest.getPositionalQueryParamsList().stream()
 				.map(GrpcQueryParam::getStringValue)
-				.anyMatch(LABEL_NAME::equals),
+				.anyMatch(labelName::equals),
 			() -> "the label name never reached the wire: " + sentRequest.getPositionalQueryParamsList()
 		);
 		assertTrue(
 			sentRequest.getPositionalQueryParamsList().stream()
 				.map(GrpcQueryParam::getStringValue)
-				.anyMatch(LABEL_VALUE::equals),
+				.anyMatch(labelValue::equals),
 			() -> "the label value never reached the wire: " + sentRequest.getPositionalQueryParamsList()
+		);
+	}
+
+	/**
+	 * Asserts the wire carries exactly one `collection` constraint. Counting rather than merely finding one is what
+	 * catches a merge that prepends a collection to a header that already names one.
+	 */
+	private static void assertSingleCollectionOnTheWire(@Nonnull GrpcQueryRequest sentRequest) {
+		final String sentQuery = sentRequest.getQuery();
+		assertEquals(
+			1,
+			sentQuery.split("collection\\(", -1).length - 1,
+			() -> "expected exactly one collection on the wire: " + sentQuery
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientHeadLabelPropagationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientHeadLabelPropagationTest.java
@@ -27,6 +27,11 @@ import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
 import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.requestResponse.data.EntityClassifier;
 import io.evitadb.api.requestResponse.data.annotation.EntityRef;
+import io.evitadb.api.query.Query;
+import io.evitadb.api.query.QueryUtils;
+import io.evitadb.api.query.head.Collection;
+import io.evitadb.api.query.head.Label;
+import io.evitadb.api.query.parser.DefaultQueryParser;
 import io.evitadb.api.requestResponse.data.structure.EntityReference;
 import io.evitadb.driver.config.ClientTimeoutOptions;
 import io.evitadb.driver.config.ClientTlsOptions;
@@ -34,8 +39,8 @@ import io.evitadb.driver.config.EvitaClientConfiguration;
 import io.evitadb.externalApi.configuration.ApiOptions;
 import io.evitadb.externalApi.configuration.HostDefinition;
 import io.evitadb.externalApi.grpc.GrpcProvider;
-import io.evitadb.externalApi.grpc.generated.GrpcQueryParam;
 import io.evitadb.externalApi.grpc.generated.GrpcQueryRequest;
+import io.evitadb.externalApi.grpc.query.QueryConverter;
 import io.evitadb.externalApi.system.SystemProvider;
 import io.evitadb.server.EvitaServer;
 import io.evitadb.test.Entities;
@@ -59,6 +64,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -72,11 +78,12 @@ import static io.evitadb.api.query.QueryConstraints.head;
 import static io.evitadb.api.query.QueryConstraints.label;
 import static io.evitadb.api.query.QueryConstraints.require;
 import static io.evitadb.test.TestConstants.TEST_CATALOG;
+import static java.util.Objects.requireNonNull;
 import static io.evitadb.test.TestTags.DRIVER;
 import static io.evitadb.test.TestTags.GRPC;
 import static io.evitadb.test.TestTags.QUERY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -197,10 +204,7 @@ class EvitaClientHeadLabelPropagationTest implements TestConstants, EvitaTestSup
 		);
 
 		assertSingleCollectionOnTheWire(sentRequest);
-		assertFalse(
-			sentRequest.getQuery().contains("head("),
-			() -> "a derived collection alone must not be wrapped: " + sentRequest.getQuery()
-		);
+		assertBareCollectionHeadOnTheWire(sentRequest);
 	}
 
 	@Test
@@ -246,14 +250,8 @@ class EvitaClientHeadLabelPropagationTest implements TestConstants, EvitaTestSup
 			)
 		);
 
-		assertTrue(
-			sentRequest.getQuery().contains("collection("),
-			() -> "the entity type never made it onto the wire: " + sentRequest.getQuery()
-		);
-		assertFalse(
-			sentRequest.getQuery().contains("head("),
-			() -> "a head with nothing but a collection must not be wrapped: " + sentRequest.getQuery()
-		);
+		assertSingleCollectionOnTheWire(sentRequest);
+		assertBareCollectionHeadOnTheWire(sentRequest);
 	}
 
 	/**
@@ -270,35 +268,61 @@ class EvitaClientHeadLabelPropagationTest implements TestConstants, EvitaTestSup
 		@Nonnull String labelName,
 		@Nonnull String labelValue
 	) {
-		assertTrue(
-			sentRequest.getQuery().contains("label("),
-			() -> "the head label was dropped by the driver: " + sentRequest.getQuery()
+		final Query sentQuery = parseWireForm(sentRequest);
+		final List<Label> labels = QueryUtils.findConstraints(
+			requireNonNull(sentQuery.getHead(), () -> "the head never reached the wire: " + sentRequest.getQuery()),
+			Label.class
 		);
 		assertTrue(
-			sentRequest.getPositionalQueryParamsList().stream()
-				.map(GrpcQueryParam::getStringValue)
-				.anyMatch(labelName::equals),
-			() -> "the label name never reached the wire: " + sentRequest.getPositionalQueryParamsList()
-		);
-		assertTrue(
-			sentRequest.getPositionalQueryParamsList().stream()
-				.map(GrpcQueryParam::getStringValue)
-				.anyMatch(labelValue::equals),
-			() -> "the label value never reached the wire: " + sentRequest.getPositionalQueryParamsList()
+			labels.stream().anyMatch(
+				it -> labelName.equals(it.getLabelName()) && labelValue.equals(it.getLabelValue())
+			),
+			() -> "the head label `" + labelName + "` was dropped by the driver: " + sentRequest.getQuery()
 		);
 	}
 
 	/**
-	 * Asserts the wire carries exactly one `collection` constraint. Counting rather than merely finding one is what
-	 * catches a merge that prepends a collection to a header that already names one.
+	 * Asserts the head on the wire is a bare `collection`, not wrapped in a `head(...)` container - the shape every
+	 * already-deployed server parses, and the one a fix that over-wraps would break.
+	 */
+	private static void assertBareCollectionHeadOnTheWire(@Nonnull GrpcQueryRequest sentRequest) {
+		assertInstanceOf(
+			Collection.class,
+			parseWireForm(sentRequest).getHead(),
+			() -> "a head with nothing but a collection must not be wrapped: " + sentRequest.getQuery()
+		);
+	}
+
+	/**
+	 * Parses the captured wire form back with its positional parameters and returns the resulting query.
+	 *
+	 * Parsing rather than matching substrings is what the server itself does, so this doubles as proof that the
+	 * driver emitted something the server can actually read - a head printed as siblings of `filterBy` would be
+	 * rejected here by `EvitaQLQueryVisitor#findHeadConstraint`.
+	 */
+	@Nonnull
+	private static Query parseWireForm(@Nonnull GrpcQueryRequest sentRequest) {
+		return DefaultQueryParser.getInstance().parseQuery(
+			sentRequest.getQuery(),
+			QueryConverter.convertQueryParamsList(sentRequest.getPositionalQueryParamsList())
+		);
+	}
+
+	/**
+	 * Asserts the wire carries exactly one `collection` constraint, naming the product collection. Counting rather
+	 * than merely finding one is what catches a merge that prepends a collection to a header that already names one.
 	 */
 	private static void assertSingleCollectionOnTheWire(@Nonnull GrpcQueryRequest sentRequest) {
-		final String sentQuery = sentRequest.getQuery();
-		assertEquals(
-			1,
-			sentQuery.split("collection\\(", -1).length - 1,
-			() -> "expected exactly one collection on the wire: " + sentQuery
+		final Query sentQuery = parseWireForm(sentRequest);
+		final List<Collection> collections = QueryUtils.findConstraints(
+			requireNonNull(sentQuery.getHead(), () -> "the head never reached the wire: " + sentRequest.getQuery()),
+			Collection.class
 		);
+		assertEquals(
+			1, collections.size(),
+			() -> "expected exactly one collection on the wire: " + sentRequest.getQuery()
+		);
+		assertEquals(Entities.PRODUCT, collections.get(0).getEntityType());
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/query/QuerySerializationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/query/QuerySerializationTest.java
@@ -198,7 +198,11 @@ public class QuerySerializationTest {
 					Query.query(head(collection("a"), label("x", "y")),
 						filterBy(attributeEquals("a", "b")))),
 				arguments("label-only head",
-					Query.query(label("x", "y"), filterBy(attributeEquals("a", "b"))))
+					Query.query(label("x", "y"), filterBy(attributeEquals("a", "b")))),
+				// a header-less query still has to round-trip - the head slot is written polymorphically and its
+				// null representation is part of that contract
+				arguments("no head at all",
+					Query.query(filterBy(attributeEquals("a", "b"))))
 			);
 		}
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/query/QuerySerializationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/query/QuerySerializationTest.java
@@ -189,7 +189,16 @@ public class QuerySerializationTest {
 						require(debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS), entityFetchAll()))),
 				arguments("collection + require",
 					Query.query(collection("a"),
-						require(debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS), entityFetchAll())))
+						require(debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS), entityFetchAll()))),
+				// the head is a whole HeadConstraint subtree, not just the Collection extracted from it —
+				// a serializer that persists only the collection silently drops query labels (issue #1507)
+				arguments("head(collection + label)",
+					Query.query(head(collection("a"), label("x", "y")))),
+				arguments("head(collection + label) + filter",
+					Query.query(head(collection("a"), label("x", "y")),
+						filterBy(attributeEquals("a", "b")))),
+				arguments("label-only head",
+					Query.query(label("x", "y"), filterBy(attributeEquals("a", "b"))))
 			);
 		}
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/traffic/serializer/QueryContainerSerializerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/traffic/serializer/QueryContainerSerializerTest.java
@@ -75,4 +75,41 @@ class QueryContainerSerializerTest extends AbstractContainerSerializerTest {
 		);
 	}
 
+	/**
+	 * The recorded query is persisted as a whole {@link io.evitadb.api.query.Query}, so its header has to
+	 * survive the round-trip too — the separate {@code labels} array indexes the recording, but the query text
+	 * an operator replays or exports comes from the query itself.
+	 *
+	 * See issue #1507.
+	 */
+	@Test
+	void shouldSerializeAndDeserializeContainerWithLabelledQueryHead() {
+		assertSerializationRound(
+			new QueryContainer(
+				UUID.randomUUID(),
+				4,
+				"Labelled query",
+				query(
+					head(
+						collection("a"),
+						label("rest_method", "CartController.updateCartByOperation")
+					),
+					filterBy(entityPrimaryKeyInSet(1, 2)),
+					orderBy(attributeNatural("c")),
+					require(entityFetchAll())
+				),
+				new Label[]{
+					new Label("rest_method", "CartController.updateCartByOperation"),
+				},
+				OffsetDateTime.now(),
+				456,
+				4,
+				7,
+				650,
+				new int[]{1, 2, 3},
+				null
+			)
+		);
+	}
+
 }

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/generators/RandomQueryGenerator.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/generators/RandomQueryGenerator.java
@@ -222,7 +222,7 @@ public interface RandomQueryGenerator {
 		}
 
 		return Query.query(
-			existingQuery.getCollection(),
+			existingQuery.getHead(),
 			existingQuery.getFilterBy(),
 			require(
 				ArrayUtils.mergeArrays(
@@ -291,7 +291,7 @@ public interface RandomQueryGenerator {
 		);
 
 		return Query.query(
-			existingQuery.getCollection(),
+			existingQuery.getHead(),
 			filterBy(
 				and(
 					ArrayUtils.mergeArrays(
@@ -310,7 +310,7 @@ public interface RandomQueryGenerator {
 	 */
 	default Query generateRandomPriceHistogramQuery(@Nonnull Query existingQuery, @Nonnull Random random) {
 		return Query.query(
-			existingQuery.getCollection(),
+			existingQuery.getHead(),
 			existingQuery.getFilterBy(),
 			require(
 				ArrayUtils.mergeArrays(


### PR DESCRIPTION
Closes #1507

## The defect

Query `label()` constraints attached to the query head never reached the server. The head is a whole
`HeadConstraint` subtree, but **seven** places treated it as the `Collection` extracted from it via
`Query#getCollection()` — which returns only the `Collection` and discards every other head constraint.

Labels exist to attribute a query to its origin in the traffic log, traces and metrics. None of that worked.

## Sites fixed

| Site | What it did |
|---|---|
| `PrettyPrintingVisitor#traverse(Query)` | printed `getCollection()`, so labels were absent from the EvitaQL string the driver puts on the wire — the only channel the gRPC transport has. **The root defect**; it also made the recorded query text label-free in the traffic-capture readback. |
| `EvitaClientSession#assertRequestMakesSenseAndEntityTypeIsPresent` | rebuilt a head that carried no `collection` from scratch. Omitting the collection is a legitimate caller shape (the entity type then comes from the model class), so the header is now **completed, not replaced**, mirroring the server's existing `EvitaSessionService#normalizeQueryWithAddingLabel`. |
| `EvitaSessionContract` ×6 | the three `entityFetch`-injecting defaults rebuilt through `getCollection()`, losing the head on **embedded** sessions as well as remote ones. |
| `DeleteEntitiesByQueryHandler` (REST) | discarded the head `QueryOrientedEntitiesHandler#enrichHeadWithInternalConstraints` had just built — the `source-type` label, the `source-query` label and every caller label — making REST deletions untraceable. |
| `QuerySerializer` (Kryo) | persisted only the `Collection`, so a recorded query lost its labels on disk. The head is now written polymorphically; `Head`, `Collection` and `Label` were already registered. |
| `CsharpPrettyPrintingVisitor` | generated C# documentation samples dropped labels. Its Java sibling already used `getHead()`. |
| `RandomQueryGenerator` ×3 | benchmark helpers that add a constraint to an existing query rebuilt it without the head. Latent today. |

## Shape of the fix

The printed form must wrap several head constraints in `head(...)`: `EvitaQLQueryVisitor#findHeadConstraint`
accepts exactly **one** top-level head constraint, so printing siblings would not parse back. Round-trip tests
pin this.

Guard tests pin the opposite mistake too — a head that is nothing but a `collection` must stay **unwrapped**,
in the shape every deployed server already parses.

## Compatibility

`QuerySerializer`'s change alters the traffic-recording binary format, which carries no version field:
recordings exported by an older server are not readable by this build. Accepted deliberately — they are
transient diagnostic artefacts, not durable catalog state, and backward compatibility there is explicitly not
required yet.

## Verification

- **28 tests added** across the six surfaces, including gRPC wire-level assertions that read the outbound
  `GrpcQueryRequest`.
- **Proved by counterfactual, not just by passing.** On the unfixed tree 17 unit tests fail; the driver pair
  fails with the issue's own string `query(collection(?),filterBy(entityPrimaryKeyInSet(?)))`. The C# test was
  separately verified against a reverted visitor.
- **Full functional suite: 23,710 run, 0 failures** (one pre-existing `ExportS3ServiceTest` error — no Docker
  in the environment). `mvn test-compile -P full` green.
- An adversarial review pass found the REST site and five ways the first round of tests could have passed for
  the wrong reason; all are addressed in the second commit.

## Known gap

The REST delete-by-query fix ships **without a dedicated regression test**: no delete-by-query test exists to
extend, and the rebuild is not reachable without the whole REST endpoint machinery — covering it would mean
adding a seam to production code purely for a test's benefit.

---

## Hotfix note

This is the `master`-targeted twin of #1514 (which targets `dev`). Same two commits, cherry-picked onto
`origin/master` — they applied cleanly, and all seven production files were byte-identical between the two
branches, so the released code carries the defect in exactly the form described above.

Verified independently on this branch rather than inheriting #1514's result: build green, `mvn test-compile -P full`
green, the C# visitor test green under `-P documentation`, and the functional suite at **21,080 run, 0 failures**
apart from two pre-existing issues:

- `ExportS3ServiceTest` — no Docker in the build environment.
- `CdcCallbackDispatcherTest.shouldNotCreateThreadsWhenCallbacksAreRefused` — a **pre-existing `master` flake,
  already fixed on `dev`**. It asserts on `ThreadMXBean#getTotalStartedThreadCount()`, which its own comment at
  line 175 concedes is "JVM-wide and monotonic, so unrelated activity in this JVM can" inflate it. It passes 4/4
  in isolation and fails with a different count on each parallel run (125, then 119). `dev` replaced it with the
  load-immune `shouldNotRunAnyCallbackUnderSustainedRefusal` in `65e4406ed`; that fix will reach `master` with the
  next merge and is deliberately not cherry-picked here.
