### PR TITLE
Refuse to publish a warm-up schema change that fails validation

### DIFF
--- a/.claude/rules/durability-model.md
+++ b/.claude/rules/durability-model.md
@@ -53,6 +53,13 @@ never published must not take the files the last published record still names.
 advances repeatedly during a load; there is no single end-of-load publication. In `ALIVE`, publication may be
 deferred to a checkpoint (`checkpointCoordinator`), so bytes can sit unpublished for a while by design.
 
+*Which flushes run* is the separate question, and the answer is not "all of them". A collection-level schema
+operation flushes mid-session only while the catalog schema validates (`Catalog#flushMidSessionIfSchemaValid`) —
+a schema half-built across several steps is legitimate, so the publication waits for the session close rather
+than refusing. Nothing is lost by the wait: the changes stay in the data store buffer, and the session close
+publishes them once the schema is whole. So read the sentence above as "a flush that runs, publishes", never as
+"every DDL operation reaches the disk".
+
 **A catalog whose *in-memory* state is broken is recovered completely by reload.** The disk was never damaged, so
 reload lands on the last published state — a full recovery, not damage limitation. Say that to the operator.
 Telling them "the persisted state is incomplete" when it is merely *older* sends them looking for corruption

--- a/documentation/adr/2026-07-18-paged-index-corruption-and-flush-failure-boundary/README.md
+++ b/documentation/adr/2026-07-18-paged-index-corruption-and-flush-failure-boundary/README.md
@@ -1,7 +1,7 @@
 ---
 title: Publish the previous flush's page baseline before collecting; fail fast on stale twins and suspend the catalog rather than retrying a failed flush
 date: 2026-07-18
-updated: 2026-09-04 07:15
+updated: 2026-09-08 13:10
 status: accepted
 kind: fix
 issues: []
@@ -9,7 +9,7 @@ prs: [1293, 1284]
 areas: [evita_engine/index, evita_engine/store, evita_engine/core/transaction, evita_engine/core/session]
 supersedes: []
 superseded-by: []
-relates: [2026-07-10-more-optimized-data-structures, 2026-07-27-write-path-performance-tuning, 2026-09-03-content-sized-value-tree-columns, 2026-09-04-millisecond-temporal-precision]
+relates: [2026-07-10-more-optimized-data-structures, 2026-07-27-write-path-performance-tuning, 2026-09-03-content-sized-value-tree-columns, 2026-09-04-millisecond-temporal-precision, 2026-09-08-warm-up-invalid-schema-refuses-to-publish]
 ---
 
 # Paged-index corruption on warm-up flush, and the failure boundary for a failed flush

--- a/documentation/adr/2026-08-26-warm-up-per-entity-mutation-atomicity.md
+++ b/documentation/adr/2026-08-26-warm-up-per-entity-mutation-atomicity.md
@@ -1,7 +1,7 @@
 ---
 title: Make every warm-up entity write atomic through a thread-local savepoint whose participants journal their own absolute inverses, unconditionally
 date: 2026-08-26
-updated: 2026-09-03 22:50
+updated: 2026-09-08 13:10
 status: accepted
 kind: feature
 issues: [1432]
@@ -9,7 +9,7 @@ prs: [1494]
 areas: [evita_engine/core/transaction/memory, evita_engine/core/collection, evita_engine/core/buffer, evita_engine/index]
 supersedes: []
 superseded-by: []
-relates: [2026-07-10-more-optimized-data-structures, 2026-07-31-bulk-ingest-write-path]
+relates: [2026-07-10-more-optimized-data-structures, 2026-07-31-bulk-ingest-write-path, 2026-09-08-warm-up-invalid-schema-refuses-to-publish]
 ---
 
 # Per-entity mutation atomicity in WARM_UP — a savepoint the structures journal into

--- a/documentation/adr/2026-09-06-go-live-session-drain.md
+++ b/documentation/adr/2026-09-06-go-live-session-drain.md
@@ -1,7 +1,7 @@
 ---
 title: The engine-level go-live drains its catalog's sessions itself, and publishes the ALIVE bootstrap only behind that drain
 date: 2026-09-06
-updated: 2026-09-06 18:05
+updated: 2026-09-08 13:10
 status: accepted
 kind: fix
 issues: [1495]
@@ -9,7 +9,7 @@ prs: []
 areas: [evita_engine/src/main/java/io/evitadb/core/session, evita_engine/src/main/java/io/evitadb/core/catalog, evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators]
 supersedes: []
 superseded-by: []
-relates: [2026-09-03-content-sized-value-tree-columns]
+relates: [2026-09-03-content-sized-value-tree-columns, 2026-09-08-warm-up-invalid-schema-refuses-to-publish]
 ---
 
 # The go-live operator owns the catalog's quiescence, and `Catalog#goLive()` is the boundary it must beat

--- a/documentation/adr/2026-09-08-warm-up-invalid-schema-refuses-to-publish.md
+++ b/documentation/adr/2026-09-08-warm-up-invalid-schema-refuses-to-publish.md
@@ -1,11 +1,11 @@
 ---
 title: A warm-up schema change refused by validation raises the unpublishable barrier, so the catalog deactivates and recovers by reload rather than by an undo
 date: 2026-09-08
-updated: 2026-09-08 14:45
+updated: 2026-09-09 04:50
 status: accepted
 kind: fix
 issues: [1466]
-prs: []
+prs: [1520]
 areas: [evita_engine/src/main/java/io/evitadb/core/session, evita_engine/src/main/java/io/evitadb/core/catalog, evita_engine/src/main/java/io/evitadb/core/transaction/engine, evita_api/src/main/java/io/evitadb/api]
 supersedes: []
 superseded-by: []
@@ -246,17 +246,19 @@ is paired with a control that pushes the *same* schema element through legitimat
 so an empty assertion cannot pass because the reopened schema was read wrongly.
 
 **Every refusal additionally asserts that the barrier was raised**, by waiting for the deactivation it schedules
-to be reported on the system change stream (`assertRefusalRaisesTheBarrier`). Without that, each of these tests
-would also pass against a refusal thrown by a *pre-flight* check — which leaves the catalog untouched and makes
-every assertion about the reopened schema hold trivially. The distinction is one edit away from mattering:
-`SetAttributeSchemaAcceleratedMutation` deliberately does not run the accelerator's own applicability check, and
-the sibling `CreateAttributeSchemaMutation` does.
+to be reported on the system change stream (`CatalogUnpublishableBarrierAssertions#assertRefusalRaisesTheBarrier`,
+extracted from `WarmUpRefusedSchemaPersistenceTest` into its own class once `AttributeFilterAcceleratorRefusalTest`
+needed it too — see *Timeline*). Without that, each of these tests would also pass against a refusal thrown by a
+*pre-flight* check — which leaves the catalog untouched and makes every assertion about the reopened schema hold
+trivially. The distinction is one edit away from mattering: `SetAttributeSchemaAcceleratedMutation` deliberately
+does not run the accelerator's own applicability check, and the sibling `CreateAttributeSchemaMutation` does.
 `Recovery#shouldDeactivateTheCatalogAndHandBackTheLastPublishedStateOnActivation` covers the whole story: an
 entity written by a session that closed successfully survives the recovery, and one written by the refused session
 does not.
 
 `AttributeFilterAcceleratorRefusalTest#shouldRefuseAnAcceleratorDeclaredOnAnAttributeWithNoFilterIndex` was a
-characterisation asserting the wrong outcome deliberately; it now asserts `Set.of()`.
+characterisation asserting the wrong outcome deliberately; it now asserts `Set.of()` and, like every case above,
+asserts the barrier explicitly rather than relying on the exception type alone.
 
 `MidSessionPublication` covers the two cases the barrier cannot reach, and both were written as failing tests
 before the gates existed: a session that applies the offending mutation and *then* defines another collection
@@ -321,3 +323,10 @@ beside it.
   chosen over the publication-route gate, implemented
 - **2026-09-08** — adversarial review found two publications upstream of the barrier that the implementation did
   not cover; both reproduced, both gated, this record corrected
+- **2026-09-08** — PR #1520 opened; Copilot and `claude[bot]` review found a stale `@link` parameter type on
+  `Catalog#markUnpublishable`'s javadoc (fixed) and that
+  `AttributeFilterAcceleratorRefusalTest#shouldRefuseAnAcceleratorDeclaredOnAnAttributeWithNoFilterIndex` checked
+  disk state without asserting the barrier itself — exactly the gap this record's own *Verification* section
+  already named as "one edit away from mattering". The barrier-assertion machinery was extracted from
+  `WarmUpRefusedSchemaPersistenceTest` into `CatalogUnpublishableBarrierAssertions` so both test classes share it,
+  and the flagged test now asserts the barrier too. Full functional suite re-run green after both fixes.

--- a/documentation/adr/2026-09-08-warm-up-invalid-schema-refuses-to-publish.md
+++ b/documentation/adr/2026-09-08-warm-up-invalid-schema-refuses-to-publish.md
@@ -1,0 +1,210 @@
+---
+title: A warm-up schema change refused by validation raises the unpublishable barrier, so the catalog deactivates and recovers by reload rather than by an undo
+date: 2026-09-08
+updated: 2026-09-08 13:10
+status: accepted
+kind: fix
+issues: [1466]
+prs: []
+areas: [evita_engine/src/main/java/io/evitadb/core/session, evita_engine/src/main/java/io/evitadb/core/catalog, evita_engine/src/main/java/io/evitadb/core/transaction/engine, evita_api/src/main/java/io/evitadb/api]
+supersedes: []
+superseded-by: []
+relates: [2026-07-18-paged-index-corruption-and-flush-failure-boundary, 2026-08-26-warm-up-per-entity-mutation-atomicity, 2026-09-06-go-live-session-drain]
+---
+
+# A warm-up schema change refused by validation raises the unpublishable barrier
+
+When catalog-schema validation refuses a schema change in a `WARMING_UP` catalog, the catalog now raises the
+unpublishable barrier that `2026-07-18-paged-index-corruption-and-flush-failure-boundary` introduced for failed
+flushes. Every route that would write a bootstrap record refuses from that moment on, the catalog is handed over
+for deactivation, and activating it again loads the last state it published — the one written by the last session
+that closed successfully. Nothing is undone in memory, because nothing can be.
+
+## Why
+
+A schema change that fails `CatalogSchema#validate()` was refused to the caller and still reached the disk, and
+the reopened catalog loaded it without complaint. An operator was left holding a catalog whose schema the engine
+itself would have rejected — for instance an attribute carrying a filter accelerator with no filter index behind
+it, or a managed reference to an entity type that does not exist.
+
+The constraint that made this non-obvious is that **validation cannot move earlier**. A schema is routinely built
+across several steps whose intermediate states are legitimately invalid — a reflected reference declared before
+the reference it reflects is the worked example, pinned by
+`AttributeFilterAcceleratorRefusalTest#shouldAllowSchemaChangeWithUnresolvedReflectedReference`. Validation
+therefore runs on the whole graph, once, when a session closes, and by then the change is applied.
+
+### Previous state
+
+`EvitaSession#closeInternal`'s warm-up branch already validated *before* it flushed, so the refused session
+performed no write of its own — the code even carried a comment naming #1466 as the residual gap. What it could
+not do was un-apply the change: `EntityCollection#updateSchema` had already exchanged the schema into every
+collection the change reached, run the structural work that goes with it, and trapped an `EntitySchemaStoragePart`
+in the data-store buffer.
+
+So the poisoned state survived on the running catalog, and the next publisher wrote it. A counterfactual
+measurement — suppressing the shutdown flush and reopening — established who those publishers were:
+
+| bystander between the refusal and the close | shutdown flush on | shutdown flush suppressed |
+|---|---|---|
+| none | poison persists | clean |
+| a **read-only** `queryCatalog` session | poison persists | **poison persists** |
+| a data-only `updateCatalog` session | poison persists | **poison persists** |
+
+The second row is the one that shaped the decision: `closeInternal` takes the warm-up branch for *every* session
+regardless of its traits, so a session that wrote nothing at all republished the refused schema. Any fix that
+enumerates publishers has to find that one, and the first draft of this work did not.
+
+## Options considered
+
+### Option A — raise the unpublishable barrier (chosen)
+
+One call at the refusal site. `Catalog#markUnpublishableDueToInvalidSchema` records the cause and schedules
+deactivation; every publication route already consults the barrier, and `Catalog#terminateInternally` already
+skips its flush when it is set.
+
+- **Pros:** complete by construction rather than by enumeration — a publication route added later is covered
+  without being found. Reuses a mechanism that already exists, is already tested, and whose operator story
+  (deactivate, then activate again) is already a documented API. Recovery lands on a state that is consistent by
+  construction, because it was published by a session that completed.
+- **Cons:** everything written since the last session close is discarded, and the client has to call
+  `EvitaContract#activateCatalog`. Makes deactivation a routine path, which raises the stakes on #1497.
+
+### Option B — validate at every publication route (declined)
+
+Add an unconditional `getSchema().validate()` beside `assertPublishable()` in `Catalog#flush()`,
+`terminateInternally()`, `goLive()` and `replace()`, defer the three opportunistic mid-session publications, and
+stop read-only sessions from flushing in warm-up.
+
+- **Pros:** no data loss and no downtime — the client repairs the schema and continues the import.
+- **Cons:** four gates, three deferrals and a session-traits guard, all of which have to stay exhaustive.
+- **Rejected because:** the repair path was never sound. The exchange's side effects have already run —
+  `initRootNodes`, `usageRegistry.alignWith`, the trigger-registry rebuild — and a corrective mutation exchanges
+  again on top of them rather than reversing them; nothing shows the composition equals what a clean path would
+  have produced. Its safety also rested on enumerating publishers, and the enumeration was already incomplete
+  once (the read-only session above). Worth revisiting only if warm-up ever gains an undo that spans collections.
+
+### Option C — refresh the schema in place from the last bootstrap pointer (declined)
+
+Leave the catalog running and reload only the schema from the last published record.
+
+- **Pros:** the leanest recovery imaginable — no deactivation, no data loss, no client action.
+- **Rejected because:** unsound twice over. `EntityCollection#updateSchema` puts an `EntitySchemaStoragePart`
+  into the data-store buffer in a `finally`, so the invalid part is already trapped and the next flush publishes
+  it regardless of what the in-memory schema says; and automatic schema evolution means entities already in
+  memory may depend on the evolved schema that the refresh would drop.
+
+### Option D — validate a candidate graph before exchanging (declined)
+
+Build the post-mutation schemas as values, validate, and exchange only if the result validates.
+
+- **Pros:** no poison ever, so no barrier, no loss and no reload.
+- **Rejected because:** legitimately-invalid intermediate states are a supported feature (see *Why*), so the
+  check would have to be allowed to fail without refusing the change — which makes it not a check. Holding the
+  mutation pending until the graph validates is deferred schema application: a feature that changes the semantics
+  of every schema mutation, not a fix. Worth revisiting only if the schema API ever gains an explicit
+  "apply this batch atomically" boundary.
+
+## Decision
+
+**Chosen: Option A.** The drivers were completeness and provable recovery, and the barrier wins on both: it is
+one flag that every publication route already reads, and reload is the only recovery whose result can be argued
+about at all. Option B lost on the second driver rather than the first — enumeration is fragile, but the deciding
+point is that its "repair and continue" story assumed an undo that does not exist.
+
+Two properties of the chosen mechanism are deliberate. The barrier is raised through
+`Catalog#markUnpublishableDueToInvalidSchema` rather than `markUnpublishable`, because the latter's message is
+written for a failed flush and reads as an engine fault, while this is a rejected user change with a named cause;
+the seam for exactly this was already documented on `recordUnpublishableCause`. And nothing is undone in memory:
+the catalog keeps serving until the deactivation lands, and the state it lands on comes from disk.
+
+For the option to be revisited, warm-up would have to gain an undo that spans entity collections — which is what
+`2026-08-26-warm-up-per-entity-mutation-atomicity` deliberately did not build, and whose journal explicitly
+forbids partial replay.
+
+## Key technical details
+
+- **The refusal site is the only one.** `CatalogSchema#validate()` has exactly one engine call site —
+  `EvitaSession#validateCatalogSchema`, reached from `closeInternal`. The hard stop is therefore *automatically*
+  limited to post-exchange failures: the pre-flight refusals (`verifyEntitySchemaMutationsApplicable`,
+  `verifyNoAcceleratorAddedToNonEmptyCollection`, the mutations' own asserts) are untouched and keep refusing
+  cleanly, so an ordinary schema typo never costs a reload. A future change that adds a second `validate()` call
+  site must decide deliberately whether it also raises the barrier.
+- **Only the warm-up branch.** `validateCatalogSchema` is also called transactionally, where it marks the
+  transaction rollback-only and the state unwinds properly. Nothing changed there.
+- **Two shutdown defects were fixed in passing**, both pre-existing and both made routine by this change, since
+  a client that reacts to the refusal by shutting down now has a lifecycle mutation in flight while the engine
+  closes:
+  - `EngineTransactionManager#close()` joined the pending engine mutations and let their *failure* propagate,
+    skipping `enginePersistenceService::close` — so the engine's folder lock stayed held and the next start died
+    with `FolderAlreadyUsedException` against a process that had already exited. The wait is now completion-only.
+  - `updateEngineStateAfterEngineMutation` dereferenced `Evita#getEngineState()`, which `Evita#closeCatalogs`
+    clears *before* draining the mutations still in flight. It now refuses with `InstanceTerminatedException`,
+    ahead of the write-ahead log append, so nothing of the refused mutation is durable.
+- **Whether a restart finds the catalog `INACTIVE` is a race, and both outcomes are correct.** The deactivation
+  is scheduled rather than run inline, so a process that shuts down promptly after the refusal may exit before it
+  lands - in which case nothing is persisted and the catalog comes back loaded. When it does land first, the
+  `INACTIVE` state IS persisted and the restarted engine leaves the catalog unloaded until it is activated. Both
+  sides read the same bootstrap record, so the guarantee is unaffected; only the operator's next step differs.
+  Nothing was added to make shutdown wait for the deactivation: `scheduleDeactivation` already treats a
+  deactivation that does not complete as acceptable ("the catalog stays refusing, which is the property that
+  matters"), and blocking shutdown on work that shutdown makes moot would buy predictability with availability.
+  Any test that reopens after a refusal must tolerate both sides - see
+  `WarmUpRefusedSchemaPersistenceTest#reopenAndReadSchema`.
+- **Deactivation settles in two steps, and the second is observable only by retry.** The catalog reads `INACTIVE`
+  once the engine-state update lands, but the lifecycle mutation releases its conflict key when it finalizes a
+  moment later; an activation issued in between is refused with `ConflictingEngineMutationException`. That is the
+  engine's "another lifecycle operation is still in flight" signal, and a client reacting instantly to the
+  deactivation has to retry. `WarmUpRefusedSchemaPersistenceTest#activateOnceTheDeactivationSettles` documents it.
+
+## Verification
+
+The full functional suite runs green: **23,717 tests, 0 failures**, the only error being `ExportS3ServiceTest`,
+which needs a Docker environment this workstation does not provide.
+
+`WarmUpRefusedSchemaPersistenceTest` (new, 5 tests) proves the guarantee on **two independent validation rules** —
+the attribute filter-accelerator rule and the managed-reference rule — so it is pinned to the warm-up write path
+rather than to one validator. Each refusal is asserted on its message, not merely on the exception type, and each
+is paired with a control that pushes the *same* schema element through legitimately and finds it after a reopen,
+so an empty assertion cannot pass because the reopened schema was read wrongly.
+`Recovery#shouldDeactivateTheCatalogAndHandBackTheLastPublishedStateOnActivation` covers the whole story: an
+entity written by a session that closed successfully survives the recovery, and one written by the refused session
+does not.
+
+`AttributeFilterAcceleratorRefusalTest#shouldRefuseAnAcceleratorDeclaredOnAnAttributeWithNoFilterIndex` was a
+characterisation asserting the wrong outcome deliberately; it now asserts `Set.of()`.
+
+**Counterfactual:** with the single `markUnpublishableDueToInvalidSchema` call removed and everything else
+unchanged, all four guards fail — the two repros (`expected: <[]> but was: <[SUBSTRING_SEARCH]>` and
+`expected: <false> but was: <true>`), the characterisation flip, and the recovery test (`stayed at WARMING_UP
+instead of reaching INACTIVE`) — while the other 21 tests in the two classes still pass. The folder-lock fix has
+its own counterfactual: before it, the reopen in every repro died with `FolderAlreadyUsedException`.
+
+## Consequences & open follow-ups
+
+- **Catalogs already poisoned on disk are not covered, and deliberately will not be.** After a reload the version
+  gate in `EvitaSession#validateCatalogSchema` skips validation, so such a catalog keeps loading; the next
+  schema-changing session is what catches it. Validating at load was considered and declined — deactivating an
+  operator's catalog at startup for a pre-existing condition is a worse upgrade experience than the condition.
+- **The loss window is one session.** Warm-up publishes when a session closes, so a client running a single
+  long import session loses that whole session's work to one invalid schema change. This is the trade the phase
+  already makes, and it is now stated in `CatalogState.WARMING_UP` and in
+  `documentation/user/en/deep-dive/bulk-vs-incremental-indexing.md`, both of which previously claimed the
+  catalog should be discarded and rebuilt from scratch.
+- **#1497 (deactivate and drop have no undo) matters more now**, because deactivation went from a rare
+  consequence of a flush failure to the ordinary answer to a schema typo.
+
+## Related work
+
+- `2026-07-18-paged-index-corruption-and-flush-failure-boundary` — introduced the unpublishable barrier and its
+  deactivation for failed and cancelled flushes. This record adds a fourth cause to it and gives that cause its
+  own operator message.
+- `2026-08-26-warm-up-per-entity-mutation-atomicity` — the per-entity savepoint whose journal forbids partial
+  replay. It is the reason a schema-level undo is not merely unimplemented but out of reach, which is what makes
+  Option B's repair path unsound.
+- `2026-09-06-go-live-session-drain` — the other lifecycle path that quiesces sessions before publishing; both
+  records concern what may reach the disk while a catalog changes state.
+
+## Timeline
+
+- **2026-09-08** — reproduction written, publishers identified by counterfactual measurement, barrier design
+  chosen over the publication-route gate, implemented

--- a/documentation/adr/2026-09-08-warm-up-invalid-schema-refuses-to-publish.md
+++ b/documentation/adr/2026-09-08-warm-up-invalid-schema-refuses-to-publish.md
@@ -1,7 +1,7 @@
 ---
 title: A warm-up schema change refused by validation raises the unpublishable barrier, so the catalog deactivates and recovers by reload rather than by an undo
 date: 2026-09-08
-updated: 2026-09-09 04:50
+updated: 2026-09-10 11:20
 status: accepted
 kind: fix
 issues: [1466]
@@ -239,10 +239,10 @@ forbids partial replay.
 The full functional suite runs green: **23,717 tests, 0 failures**, the only error being `ExportS3ServiceTest`,
 which needs a Docker environment this workstation does not provide.
 
-`WarmUpRefusedSchemaPersistenceTest` (new, 7 tests) proves the guarantee on **two independent validation rules** —
-the attribute filter-accelerator rule and the managed-reference rule — so it is pinned to the warm-up write path
-rather than to one validator. Each refusal is asserted on its message, not merely on the exception type, and each
-is paired with a control that pushes the *same* schema element through legitimately and finds it after a reopen,
+`WarmUpRefusedSchemaPersistenceTest` (new, 14 tests) proves the guarantee on **three independent validation
+rules** — the attribute filter-accelerator rule, the managed-reference rule and the reflected-reference rule — so
+it is pinned to the warm-up write path rather than to one validator. Each refusal is asserted on its message, not
+merely on the exception type, and each is paired with a control that pushes the *same* schema element through legitimately and finds it after a reopen,
 so an empty assertion cannot pass because the reopened schema was read wrongly.
 
 **Every refusal additionally asserts that the barrier was raised**, by waiting for the deactivation it schedules
@@ -259,6 +259,29 @@ does not.
 `AttributeFilterAcceleratorRefusalTest#shouldRefuseAnAcceleratorDeclaredOnAnAttributeWithNoFilterIndex` was a
 characterisation asserting the wrong outcome deliberately; it now asserts `Set.of()` and, like every case above,
 asserts the barrier explicitly rather than relying on the exception type alone.
+
+`InterlinkedCollectionRemoval` covers the **removal** direction, which reaches the same validation from the
+opposite side: an additive change declares something the catalog cannot satisfy, a removal takes away what an
+existing declaration relied on. It is the case an operator meets by accident — dropping one half of a circular
+product/category link, where the product owns the reference and the category reflects it — and it carries one
+hazard the additive cases do not, because a removal parks the collection's data file for retirement. The tests
+therefore assert the catalog folder as well as the schema: a refused removal must leave every data file the
+published bootstrap record still names, and the one-session control must see both retirements released. **The
+control is the part that matters most**, because without it every refusal above would also be satisfied by an
+engine that simply refused to drop a referenced collection at all: dropping *both* sides inside one session
+succeeds, in either order, and neither order validates halfway through. That is the same tolerance
+`flushMidSessionIfSchemaValid` grants a reflected reference declared before its target, and it makes "both sides
+of a circular link must be dropped in the same session" the operator-facing rule.
+
+**One of these tests is calibrated and four are not, and the comments at the site say which.** Measured by
+disabling the `isSchemaValid()` guard: only
+`shouldNotPublishTheHalfTornPairWhenTheSameSessionThenDefinesAnotherCollection` fails (the reopened catalog then
+holds `[CATEGORY, BRAND]` — the removal published and the product collection is gone from the disk). The
+removal-only refusals pass either way, because a mid-session flush on that path is a no-op for a second,
+independent reason: `Catalog#flush` derives `changeOccurred` from the catalog schema version, and `updateSchema`
+exchanges that version only *after* `removeEntitySchema` has returned, so at the moment of the flush no version
+has moved and the removed collection is already out of the map that would report one. The guard bites only once
+something else in the session supplies a change.
 
 `MidSessionPublication` covers the two cases the barrier cannot reach, and both were written as failing tests
 before the gates existed: a session that applies the offending mutation and *then* defines another collection
@@ -305,6 +328,13 @@ beside it.
   added upstream of the session close will not be covered by anything here. The chokepoints were chosen to make
   that unlikely — the operator is the single funnel for go-live, and `flushMidSessionIfSchemaValid` is the single
   helper the three DDL flushes now share — but this is the part of the design a later change can silently break.
+- **On the removal path the schema gate is not the only thing holding, and the second mechanism is accidental.**
+  `Catalog#flush`'s `changeOccurred` check makes the mid-session flush a no-op immediately after
+  `Catalog#removeEntitySchema`, because the catalog schema version is exchanged only after it returns. That is a
+  belt beside the braces today, but it is not a designed guarantee, and reordering the exchange would remove it
+  without any test noticing — only
+  `InterlinkedCollectionRemoval#shouldNotPublishTheHalfTornPairWhenTheSameSessionThenDefinesAnotherCollection`
+  covers the schema gate itself on this path.
 
 ## Related work
 
@@ -330,3 +360,9 @@ beside it.
   already named as "one edit away from mattering". The barrier-assertion machinery was extracted from
   `WarmUpRefusedSchemaPersistenceTest` into `CatalogUnpublishableBarrierAssertions` so both test classes share it,
   and the flagged test now asserts the barrier too. Full functional suite re-run green after both fixes.
+- **2026-09-10** — the removal direction was found uncovered while answering a question about
+  `Catalog#flushMidSessionIfSchemaValid`: measured, dropping one half of a circular product/category link
+  deactivates the catalog, and dropping both halves inside one session succeeds in either order. Neither shape
+  had a test. `InterlinkedCollectionRemoval` added (5 tests), including the folder assertions for the parked
+  data-file retirements and the calibration note recording which of them the `isSchemaValid()` guard actually
+  holds up.

--- a/documentation/adr/2026-09-08-warm-up-invalid-schema-refuses-to-publish.md
+++ b/documentation/adr/2026-09-08-warm-up-invalid-schema-refuses-to-publish.md
@@ -1,7 +1,7 @@
 ---
 title: A warm-up schema change refused by validation raises the unpublishable barrier, so the catalog deactivates and recovers by reload rather than by an undo
 date: 2026-09-08
-updated: 2026-09-08 13:10
+updated: 2026-09-08 14:45
 status: accepted
 kind: fix
 issues: [1466]
@@ -17,8 +17,13 @@ relates: [2026-07-18-paged-index-corruption-and-flush-failure-boundary, 2026-08-
 When catalog-schema validation refuses a schema change in a `WARMING_UP` catalog, the catalog now raises the
 unpublishable barrier that `2026-07-18-paged-index-corruption-and-flush-failure-boundary` introduced for failed
 flushes. Every route that would write a bootstrap record refuses from that moment on, the catalog is handed over
-for deactivation, and activating it again loads the last state it published — the one written by the last session
-that closed successfully. Nothing is undone in memory, because nothing can be.
+for deactivation, and activating it again loads the last state it published. Nothing is undone in memory, because
+nothing can be.
+
+**The barrier alone is not the whole fix, and the first implementation of this decision was wrong about that.**
+Validation runs when a session closes, so the barrier is raised at the close — and anything that publishes
+*earlier in that same session* gets there first. Two such publications exist, and each needed a gate of its own
+ahead of the barrier: the warm-up flush that collection-level DDL runs inline, and go-live.
 
 ## Why
 
@@ -59,15 +64,19 @@ enumerates publishers has to find that one, and the first draft of this work did
 ### Option A — raise the unpublishable barrier (chosen)
 
 One call at the refusal site. `Catalog#markUnpublishableDueToInvalidSchema` records the cause and schedules
-deactivation; every publication route already consults the barrier, and `Catalog#terminateInternally` already
-skips its flush when it is set.
+deactivation; every publication route already consults the barrier before writing, and
+`Catalog#terminateInternally` already skips its flush when it is set. The consulting is what costs nothing to
+extend — the option's weakness is *when* the barrier gets raised, not which routes read it.
 
-- **Pros:** complete by construction rather than by enumeration — a publication route added later is covered
-  without being found. Reuses a mechanism that already exists, is already tested, and whose operator story
-  (deactivate, then activate again) is already a documented API. Recovery lands on a state that is consistent by
-  construction, because it was published by a session that completed.
-- **Cons:** everything written since the last session close is discarded, and the client has to call
+- **Pros:** for every publication *after* it is raised, complete by construction rather than by enumeration — a
+  route added later is covered without being found. Reuses a mechanism that already exists, is already tested, and
+  whose operator story (deactivate, then activate again) is already a documented API. Recovery lands on a state
+  that is consistent by construction, because it was published by a session that completed.
+- **Cons:** everything written since the last publication is discarded, and the client has to call
   `EvitaContract#activateCatalog`. Makes deactivation a routine path, which raises the stakes on #1497.
+  **And its completeness is temporal, not total:** it says nothing about publications that happen before it is
+  raised, which is the whole of the mid-session problem below. This was missed in the first implementation and
+  found by adversarial review — see *Verification*.
 
 ### Option B — validate at every publication route (declined)
 
@@ -82,6 +91,11 @@ stop read-only sessions from flushing in warm-up.
   again on top of them rather than reversing them; nothing shows the composition equals what a clean path would
   have produced. Its safety also rested on enumerating publishers, and the enumeration was already incomplete
   once (the read-only session above). Worth revisiting only if warm-up ever gains an undo that spans collections.
+- **But one part of it was necessary anyway, and declining the option as a whole hid that.** Option B's
+  "defer the three opportunistic mid-session publications" is not an alternative to the barrier — it addresses a
+  case the barrier cannot reach at all, because those publications happen before the barrier exists. It is
+  implemented here, in the narrower form described under *Key technical details*. A rejected option is rejected
+  as a whole design; that is not licence to drop the problems it was the only option to name.
 
 ### Option C — refresh the schema in place from the last bootstrap pointer (declined)
 
@@ -103,13 +117,24 @@ Build the post-mutation schemas as values, validate, and exchange only if the re
   mutation pending until the graph validates is deferred schema application: a feature that changes the semantics
   of every schema mutation, not a fix. Worth revisiting only if the schema API ever gains an explicit
   "apply this batch atomically" boundary.
+- **Not to be confused with `flushMidSessionIfSchemaValid`**, which is also a validity check that is allowed to
+  fail without refusing. The difference is what it gates: that one gates a **publication**, which is always safe
+  to postpone, while this option gates the **mutation**, which is not — postponing the mutation changes what the
+  caller's next read sees.
 
 ## Decision
 
-**Chosen: Option A.** The drivers were completeness and provable recovery, and the barrier wins on both: it is
-one flag that every publication route already reads, and reload is the only recovery whose result can be argued
-about at all. Option B lost on the second driver rather than the first — enumeration is fragile, but the deciding
-point is that its "repair and continue" story assumed an undo that does not exist.
+**Chosen: Option A, plus the one piece of Option B that answers a different question.** The drivers were
+completeness and provable recovery. Reload is the only recovery whose result can be argued about at all, so
+Option A wins the second outright; Option B lost it, because its "repair and continue" story assumed an undo that
+does not exist.
+
+On completeness the honest statement is narrower than the first version of this record claimed. The barrier makes
+every publication *downstream of the refusal* refuse, without those routes having to be enumerated. It does
+nothing for publications upstream of it, and two exist. Those are handled by two explicit gates, and those gates
+**are** an enumeration — a route added ahead of the barrier in future will need finding, exactly the fragility
+Option B was rejected for. The mitigation is that both gates sit at chokepoints (see below), not that the problem
+is gone.
 
 Two properties of the chosen mechanism are deliberate. The barrier is raised through
 `Catalog#markUnpublishableDueToInvalidSchema` rather than `markUnpublishable`, because the latter's message is
@@ -123,23 +148,67 @@ forbids partial replay.
 
 ## Key technical details
 
-- **The refusal site is the only one.** `CatalogSchema#validate()` has exactly one engine call site —
-  `EvitaSession#validateCatalogSchema`, reached from `closeInternal`. The hard stop is therefore *automatically*
-  limited to post-exchange failures: the pre-flight refusals (`verifyEntitySchemaMutationsApplicable`,
-  `verifyNoAcceleratorAddedToNonEmptyCollection`, the mutations' own asserts) are untouched and keep refusing
-  cleanly, so an ordinary schema typo never costs a reload. A future change that adds a second `validate()` call
-  site must decide deliberately whether it also raises the barrier.
+- **Only the close-time refusal raises the barrier.** Before this change `CatalogSchema#validate()` had exactly
+  one engine call site — `EvitaSession#validateCatalogSchema`, reached from `closeInternal` — which is why the
+  hard stop is limited to post-exchange failures: the pre-flight refusals
+  (`verifyEntitySchemaMutationsApplicable`, `verifyNoAcceleratorAddedToNonEmptyCollection`, the mutations' own
+  asserts) are untouched and keep refusing cleanly, so an ordinary schema typo never costs a reload. This change
+  adds two more call sites, and **neither of them may be turned into a refusal**:
+  - `Catalog#isSchemaValid()`, behind `Catalog#flushMidSessionIfSchemaValid()`. The three warm-up DDL flushes
+    (`createEntitySchema`, `removeEntitySchema`, `doReplaceEntityCollectionInternal`) publish inline while the
+    session is still open. They now publish only when the schema validates, and **skip silently otherwise** — they
+    must not refuse, because a schema that does not validate mid-session is not an error. Skipping loses nothing:
+    the changes stay in the data store buffer and the session close publishes them, after validating.
+  - `MakeCatalogAliveMutationOperator`, ahead of its flush. This one *does* raise the barrier, because go-live is
+    the end of warm-up and there is no later close to defer to. It sits in the operator rather than in
+    `EvitaSession#goLiveAndCloseWithProgress` because all three go-live entry points funnel through the operator,
+    and because the session-driven path terminates its session through `executeTerminationSteps` rather than
+    through `closeInternal` — so the close-time validation never runs for the session that calls it.
+- **`validate()` refuses in two vocabularies, and only one of them is a `SchemaAlteringException`.** A rule it
+  evaluates throws that type; a getter it *reaches* on a schema it cannot resolve simply refuses to answer, with a
+  plain `EvitaInvalidUsageException` — `ReflectedReferenceSchema#isIndexedInScope` throwing "the reflected
+  reference is not available", which `EntitySchema#validate` walks straight into. This is not a hypothesis:
+  catching only the narrow type in `Catalog#isSchemaValid` turned a legitimate intermediate state into a failed
+  DDL operation and cost **17 tests** in the full suite. All three sites — `isSchemaValid`, the warm-up close and
+  the go-live operator — therefore catch `EvitaInvalidUsageException`, and
+  `Catalog#markUnpublishableDueToInvalidSchema` takes that type. `EvitaInternalError` is a sibling of that class,
+  not a subtype, so an engine bug uncovered by the walk still surfaces.
+  **Only the `isSchemaValid` half of that is demonstrated.** Whether a schema can still be in the getter-refusing
+  shape at the *close*, where the barrier is raised, was not shown: every attempt to construct one met a
+  schema-altering refusal first, and narrowing the close-time catch back leaves the whole class green. The wide
+  catch is kept at the two barrier sites anyway, because the outcomes are asymmetric — a bare refusal slipping
+  past a narrow catch publishes exactly the state the barrier exists to stop, while catching one that did not need
+  catching costs a deactivation of a catalog whose schema was already exchanged and whose operation already
+  failed, which is what this design does everywhere else.
 - **Only the warm-up branch.** `validateCatalogSchema` is also called transactionally, where it marks the
   transaction rollback-only and the state unwinds properly. Nothing changed there.
-- **Two shutdown defects were fixed in passing**, both pre-existing and both made routine by this change, since
-  a client that reacts to the refusal by shutting down now has a lifecycle mutation in flight while the engine
-  closes:
+- **A family of shutdown defects was fixed in passing**, all pre-existing and all made routine by this change,
+  since a client that reacts to the refusal by shutting down now has a lifecycle mutation in flight while the
+  engine closes. They share one shape: `Evita#closeCatalogs` clears the engine state *before* draining the
+  mutations still in flight, so every in-flight lifecycle mutation fails at its completion updater, and whatever
+  that updater was going to do is skipped.
   - `EngineTransactionManager#close()` joined the pending engine mutations and let their *failure* propagate,
     skipping `enginePersistenceService::close` — so the engine's folder lock stayed held and the next start died
     with `FolderAlreadyUsedException` against a process that had already exited. The wait is now completion-only.
-  - `updateEngineStateAfterEngineMutation` dereferenced `Evita#getEngineState()`, which `Evita#closeCatalogs`
-    clears *before* draining the mutations still in flight. It now refuses with `InstanceTerminatedException`,
-    ahead of the write-ahead log append, so nothing of the refused mutation is durable.
+  - `updateEngineStateAfterEngineMutation` dereferenced the cleared state. It now refuses with
+    `InstanceTerminatedException`, ahead of the write-ahead log append, so **the mutation leaves no engine-level
+    trace** — no WAL entry and no engine bootstrap record, which is what makes reporting it as failed accurate.
+    It is *not* a claim that the mutation had no effect: the operator's work phase ran first and may already have
+    published at the catalog level, `Catalog#goLive()`'s ALIVE bootstrap record being the clear case. Those
+    effects are durable and stay durable, and the catalog reloads from its own bootstrap record whatever the
+    engine recorded. The first version of this record said "nothing of the refused mutation is durable", which is
+    the wider claim and false; the adversarial review caught it.
+  - **Three operators stranded a real `Catalog` on that same path**, which is the defect the second bullet's fix
+    made visible rather than fixed. Deactivation, creation and removal each hold the only reference to a real
+    catalog while the engine state holds an `UnusableCatalog` placeholder — and `UnusableCatalog#terminate()` only
+    flips a flag, so the shutdown pass that walked the engine state released nothing. A completion updater that
+    threw then skipped the real catalog's `terminate()` entirely, leaving *its* folder lock held: the same
+    `FolderAlreadyUsedException`, one level down from the one the first bullet fixed.
+    `SetCatalogStateMutationOperator` (both branches), `CreateCatalogMutationOperator` and
+    `RemoveCatalogSchemaMutationOperator` now release the catalog whether or not the state update lands. The
+    removal path deliberately releases the handles **without** wiping the folder — the removal did not commit, the
+    engine state still names that folder, and deleting a file the published record still reaches is the one act
+    that damages a catalog for real (`.claude/rules/durability-model.md`).
 - **Whether a restart finds the catalog `INACTIVE` is a race, and both outcomes are correct.** The deactivation
   is scheduled rather than run inline, so a process that shuts down promptly after the refusal may exit before it
   lands - in which case nothing is persisted and the catalog comes back loaded. When it does land first, the
@@ -155,17 +224,33 @@ forbids partial replay.
   moment later; an activation issued in between is refused with `ConflictingEngineMutationException`. That is the
   engine's "another lifecycle operation is still in flight" signal, and a client reacting instantly to the
   deactivation has to retry. `WarmUpRefusedSchemaPersistenceTest#activateOnceTheDeactivationSettles` documents it.
+- **The conflict key can refuse the deactivation itself, so `scheduleDeactivation` now retries it.** The catalog
+  raises the barrier from inside `Catalog#flush`'s failure handler, which the go-live operator calls while its own
+  lifecycle mutation is still finalizing — so the deactivation the barrier schedules races the very mutation that
+  triggered it and is refused. It was previously logged and dropped, which left a catalog that refused everything
+  and could only be cleared by a restart: safe, but flatly contradicting the recovery this record promises. Five
+  attempts, 200 ms apart, wait out a key whose holder is already finalizing. Exhausting them keeps the old
+  behaviour and the old message, because the safety property never depended on the deactivation landing. The
+  returned `Progress` is now observed too — a deactivation accepted and then failing while being applied used to
+  leave the catalog refusing with nothing in the log to say why.
 
 ## Verification
 
 The full functional suite runs green: **23,717 tests, 0 failures**, the only error being `ExportS3ServiceTest`,
 which needs a Docker environment this workstation does not provide.
 
-`WarmUpRefusedSchemaPersistenceTest` (new, 5 tests) proves the guarantee on **two independent validation rules** —
+`WarmUpRefusedSchemaPersistenceTest` (new, 7 tests) proves the guarantee on **two independent validation rules** —
 the attribute filter-accelerator rule and the managed-reference rule — so it is pinned to the warm-up write path
 rather than to one validator. Each refusal is asserted on its message, not merely on the exception type, and each
 is paired with a control that pushes the *same* schema element through legitimately and finds it after a reopen,
 so an empty assertion cannot pass because the reopened schema was read wrongly.
+
+**Every refusal additionally asserts that the barrier was raised**, by waiting for the deactivation it schedules
+to be reported on the system change stream (`assertRefusalRaisesTheBarrier`). Without that, each of these tests
+would also pass against a refusal thrown by a *pre-flight* check — which leaves the catalog untouched and makes
+every assertion about the reopened schema hold trivially. The distinction is one edit away from mattering:
+`SetAttributeSchemaAcceleratedMutation` deliberately does not run the accelerator's own applicability check, and
+the sibling `CreateAttributeSchemaMutation` does.
 `Recovery#shouldDeactivateTheCatalogAndHandBackTheLastPublishedStateOnActivation` covers the whole story: an
 entity written by a session that closed successfully survives the recovery, and one written by the refused session
 does not.
@@ -173,11 +258,28 @@ does not.
 `AttributeFilterAcceleratorRefusalTest#shouldRefuseAnAcceleratorDeclaredOnAnAttributeWithNoFilterIndex` was a
 characterisation asserting the wrong outcome deliberately; it now asserts `Set.of()`.
 
+`MidSessionPublication` covers the two cases the barrier cannot reach, and both were written as failing tests
+before the gates existed: a session that applies the offending mutation and *then* defines another collection
+(the refused reference was on disk — `expected: <false> but was: <true>`), and one that calls `goLiveAndClose`
+(no exception was raised at all, and the catalog went ALIVE carrying the invalid schema).
+
+**Both were found by adversarial review after this decision had already been implemented and its tests were
+green.** The first implementation had five tests passing and a full suite of 23,717 green, and was wrong: it
+asserted the barrier's completeness without testing anything upstream of the barrier. The review that found it was
+asked specifically to attack completeness — "is there any route that writes a bootstrap record in WARMING_UP that
+does not consult the barrier?" — which is the question the record itself should have provoked.
+
 **Counterfactual:** with the single `markUnpublishableDueToInvalidSchema` call removed and everything else
-unchanged, all four guards fail — the two repros (`expected: <[]> but was: <[SUBSTRING_SEARCH]>` and
+unchanged, all four of the close-time guards fail — the two repros (`expected: <[]> but was: <[SUBSTRING_SEARCH]>` and
 `expected: <false> but was: <true>`), the characterisation flip, and the recovery test (`stayed at WARMING_UP
 instead of reaching INACTIVE`) — while the other 21 tests in the two classes still pass. The folder-lock fix has
 its own counterfactual: before it, the reopen in every repro died with `FolderAlreadyUsedException`.
+
+The barrier assertion has one of its own, and it isolates cleanly. With only the `scheduleDeactivation()` call
+removed — so the barrier is still raised and still stops every publication — exactly the five tests that assert
+it fail, all on `Catalog 'testCatalog' was never reported as having settled into 'INACTIVE'`, while the two
+controls pass. That is the assertion carrying its own weight rather than riding on the persistence assertions
+beside it.
 
 ## Consequences & open follow-ups
 
@@ -192,6 +294,15 @@ its own counterfactual: before it, the reopen in every repro died with `FolderAl
   catalog should be discarded and rebuilt from scratch.
 - **#1497 (deactivate and drop have no undo) matters more now**, because deactivation went from a rare
   consequence of a flush failure to the ordinary answer to a schema typo.
+- **`.claude/rules/durability-model.md`'s "In `WARM_UP` every flush publishes" is no longer unconditionally
+  true.** A warm-up DDL flush is skipped when the schema does not currently validate. The rule's *point* survives
+  untouched — a flush that does run still publishes, and there is still no deferred checkpoint in warm-up — but
+  the sentence now carries a qualifier saying which flushes run, because anyone reasoning "warm-up flushed,
+  therefore it is durable" needs to know about the gate.
+- **The two gates ahead of the barrier are an enumeration, and enumerations rot.** A future publication route
+  added upstream of the session close will not be covered by anything here. The chokepoints were chosen to make
+  that unlikely — the operator is the single funnel for go-live, and `flushMidSessionIfSchemaValid` is the single
+  helper the three DDL flushes now share — but this is the part of the design a later change can silently break.
 
 ## Related work
 
@@ -208,3 +319,5 @@ its own counterfactual: before it, the reopen in every repro died with `FolderAl
 
 - **2026-09-08** — reproduction written, publishers identified by counterfactual measurement, barrier design
   chosen over the publication-route gate, implemented
+- **2026-09-08** — adversarial review found two publications upstream of the barrier that the implementation did
+  not cover; both reproduced, both gated, this record corrected

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-09-08 | [A warm-up schema change refused by validation raises the unpublishable barrier, so the catalog deactivates and recovers by reload rather than by an undo](2026-09-08-warm-up-invalid-schema-refuses-to-publish.md) | fix | accepted | #1466 |
+| 2026-09-08 | [A warm-up schema change refused by validation raises the unpublishable barrier, so the catalog deactivates and recovers by reload rather than by an undo](2026-09-08-warm-up-invalid-schema-refuses-to-publish.md) | fix | accepted | #1466, PR #1520 |
 | 2026-09-07 | [Equalized histograms bucket on the quantile function and report a kernel density, not a per-bucket ratio](2026-09-07-equalized-histogram-density-and-quantile-bucketing.md) | fix | accepted | #1501 |
 | 2026-09-07 | [A storage part declares which kind of data it holds, at registration, in a closed enum](2026-09-07-storage-part-classification.md) | feature | accepted | #1500 |
 | 2026-09-06 | [The engine-level go-live drains its catalog's sessions itself, and publishes the ALIVE bootstrap only behind that drain](2026-09-06-go-live-session-drain.md) | fix | accepted | #1495 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-09-08 | [A warm-up schema change refused by validation raises the unpublishable barrier, so the catalog deactivates and recovers by reload rather than by an undo](2026-09-08-warm-up-invalid-schema-refuses-to-publish.md) | fix | accepted | #1466 |
 | 2026-09-07 | [Equalized histograms bucket on the quantile function and report a kernel density, not a per-bucket ratio](2026-09-07-equalized-histogram-density-and-quantile-bucketing.md) | fix | accepted | #1501 |
 | 2026-09-07 | [A storage part declares which kind of data it holds, at registration, in a closed enum](2026-09-07-storage-part-classification.md) | feature | accepted | #1500 |
 | 2026-09-06 | [The engine-level go-live drains its catalog's sessions itself, and publishes the ALIVE bootstrap only behind that drain](2026-09-06-go-live-session-drain.md) | fix | accepted | #1495 |

--- a/documentation/user/en/deep-dive/bulk-vs-incremental-indexing.md
+++ b/documentation/user/en/deep-dive/bulk-vs-incremental-indexing.md
@@ -13,6 +13,7 @@ Bulk indexing is used for rapid indexing of large volumes of source data from an
 1. Only a single client (single session) can be open at a time.
 2. There are no transactions - a group of writes cannot be committed or discarded as a unit. A *single* entity write is still atomic on its own, so an error part-way through one leaves nothing behind (see [Atomicity of individual writes](#atomicity-of-individual-writes)).
 3. All changes to indexes are kept in memory and written when the session closes; in case of a database crash, all changes are lost.
+4. A failure that cannot be reverted returns the catalog to the last state it published and makes it inactive (see [Failures that cannot be reverted](#failures-that-cannot-be-reverted)).
 
 <Note type="info">
 
@@ -37,6 +38,26 @@ The failing call throws an exception and the session stays usable. You may catch
 In the ALIVE phase the enclosing transaction is untouched by the failure: every entity written before the failing one remains valid, and you may commit afterwards — the commit publishes exactly the entities that succeeded. Rolling back still discards everything, as usual.
 
 One thing is deliberately not rewound: the primary key drawn for a failed entity is not returned to the pool. Primary key sequences guarantee uniqueness, not contiguity, so a reverted write leaves a harmless gap in the numbering.
+
+## Failures that cannot be reverted
+
+A [single failed write](#atomicity-of-individual-writes) is reverted on its own and costs you nothing beyond that one entity. Some failures reach further than one entity, and the bulk indexing phase answers all of them the same way — by returning the catalog to the last state it published.
+
+Three failures behave like this:
+
+- **A schema change refused by validation.** The catalog schema is validated as a whole when a session closes, because a schema is routinely built across several steps whose intermediate states are allowed not to validate — a reflected reference may be declared before the reference it reflects, for instance. By the time the refusal is known, the change has already been applied to every entity collection it touches.
+- **A failure while writing the collected changes** at session close.
+- **A failed revert of a single entity write**, where the revert itself throws.
+
+In each case the catalog stops accepting writes and stops publishing, and the engine moves it to the *inactive* state (see [Control Engine](../use/api/control-engine.md)). <LS to="j">Activating it again with the `activateCatalog` method of <SourceClass>evita_api/src/main/java/io/evitadb/api/EvitaContract.java</SourceClass> loads</LS><LS to="e,r,g,c">Activating it again loads</LS> the last published state from disk — the one written by the last session that closed successfully. Its schema and its indexes are consistent with each other, because that state was published by a session that completed. Everything written after it has to be replayed.
+
+### Why the recovery is this coarse
+
+The bulk indexing phase earns its speed by leaving out the machinery a narrower recovery would need.
+
+There is no transaction to roll back. A schema change is applied to each entity collection separately, together with the structural work it implies — root nodes for an entity that becomes hierarchical, reference indexes, capability registries — and only then is the catalog validated as a whole. Sending a corrective schema change afterwards repeats that work on top of what already ran rather than reversing it, and nothing guarantees the result matches what a clean path would have produced. Reloading the last published state is the only recovery that is consistent by construction.
+
+It also costs less than it may appear. Nothing written since the last session close was durable in the first place, so what the reload discards is exactly the work you had not yet checkpointed. How large that is, is the trade-off described at the top of this chapter: frequent session closes make each failure cheap and the import slower, while a single long session makes the import as fast as possible and each failure expensive.
 
 ## Full reindex of the live catalog
 

--- a/documentation/user/en/deep-dive/bulk-vs-incremental-indexing.md
+++ b/documentation/user/en/deep-dive/bulk-vs-incremental-indexing.md
@@ -12,7 +12,7 @@ Bulk indexing is used for rapid indexing of large volumes of source data from an
 
 1. Only a single client (single session) can be open at a time.
 2. There are no transactions - a group of writes cannot be committed or discarded as a unit. A *single* entity write is still atomic on its own, so an error part-way through one leaves nothing behind (see [Atomicity of individual writes](#atomicity-of-individual-writes)).
-3. All changes to indexes are kept in memory and written when the session closes; in case of a database crash, all changes are lost.
+3. All changes to indexes are kept in memory and written when the session closes; in case of a database crash, everything written since the last session close is lost.
 4. A failure that cannot be reverted returns the catalog to the last state it published and makes it inactive (see [Failures that cannot be reverted](#failures-that-cannot-be-reverted)).
 
 <Note type="info">
@@ -49,7 +49,9 @@ Three failures behave like this:
 - **A failure while writing the collected changes** at session close.
 - **A failed revert of a single entity write**, where the revert itself throws.
 
-In each case the catalog stops accepting writes and stops publishing, and the engine moves it to the *inactive* state (see [Control Engine](../use/api/control-engine.md)). <LS to="j">Activating it again with the `activateCatalog` method of <SourceClass>evita_api/src/main/java/io/evitadb/api/EvitaContract.java</SourceClass> loads</LS><LS to="e,r,g,c">Activating it again loads</LS> the last published state from disk — the one written by the last session that closed successfully. Its schema and its indexes are consistent with each other, because that state was published by a session that completed. Everything written after it has to be replayed.
+In each case the catalog stops accepting writes and stops publishing. That refusal is what protects the data on disk, and it holds from the moment the failure is detected. The engine then moves the catalog to the *inactive* state (see [Control Engine](../use/api/control-engine.md)). <LS to="j">Activating it again with the `activateCatalog` method of <SourceClass>evita_api/src/main/java/io/evitadb/api/EvitaContract.java</SourceClass> loads</LS><LS to="e,r,g,c">Activating it again loads</LS> the last published state from disk — the newest state that reached the disk, which a session close writes and a collection-level schema operation may write again mid-session. Its schema and its indexes are consistent with each other, because nothing is published unless the schema validates. Everything written after it has to be replayed.
+
+Moving a catalog to the inactive state is itself an engine-level operation, and one such operation is refused while another is in flight for the same catalog. Where the engine cannot complete the move, the catalog is left refusing every write and every publication, and restarting the engine loads the same published state that activating it would have. The server log says which of the two happened.
 
 ### Why the recovery is this coarse
 

--- a/documentation/user/en/use/api/control-engine.md
+++ b/documentation/user/en/use/api/control-engine.md
@@ -53,7 +53,7 @@ The following operations are supported at the engine level:
     <dt>Set mutability</dt>
     <dd>Allows you to switch a particular catalog between `read-only` and `read-write` mode. When a catalog is in `read-only` mode, no newly created session is allowed to be created in `read-write` mode and make changes in the catalog. This engine mutation doesn't affect currently opened `read-write` sessions, nor does it force their closure.</dd>
     <dt>Set catalog state</dt>
-    <dd>Allows you to load or unload catalog contents to/from memory. Catalogs in an "active" state contain all their crucial data in memory and can be queried and updated. The "inactive" catalogs, on the other hand, lie dormant in persistent storage and don't consume any system resources, but also cannot be queried or updated.</dd>
+    <dd>Allows you to load or unload catalog contents to/from memory. Catalogs in an "active" state contain all their crucial data in memory and can be queried and updated. The "inactive" catalogs, on the other hand, lie dormant in persistent storage and don't consume any system resources, but also cannot be queried or updated. The engine also makes a catalog inactive on its own when a failure during [bulk indexing](../../deep-dive/bulk-vs-incremental-indexing.md#failures-that-cannot-be-reverted) cannot be reverted - activating it again loads the last state the catalog published.</dd>
 </dl>
 
 <Note type="info">

--- a/documentation/user/en/use/api/write-data.md
+++ b/documentation/user/en/use/api/write-data.md
@@ -42,9 +42,12 @@ The client can both write and
 query the written data, but no other client can open another session because the consistency of the data could not be
 guaranteed for them. The goal here is to index hundreds or thousands of entities per second.
 
-If the database crashes during this initial bulk indexing, the state and consistency of the data must be considered
-corrupted, and the entire catalog should be dumped and rebuilt from scratch. Since there is no client other than the
-one writing the data, we can afford to do this.
+If the database crashes during this initial bulk indexing, or a failure occurs that this phase cannot revert, the
+catalog returns to the last state it published - the one written by the last session that closed successfully - and
+everything written after it has to be replayed. Since there is no client other than the one writing the data, we can
+afford to recover this way. See
+[Failures that cannot be reverted](../../deep-dive/bulk-vs-incremental-indexing.md#failures-that-cannot-be-reverted)
+for the failures this covers, what happens to the catalog, and why the recovery is this coarse.
 
 A *single* failed write is a different matter: even during bulk indexing, each `upsertEntity` / `deleteEntity` is
 **atomic on its own**, so a call that fails part-way through is reverted completely and leaves no half-applied index

--- a/documentation/user/en/use/api/write-data.md
+++ b/documentation/user/en/use/api/write-data.md
@@ -43,7 +43,7 @@ query the written data, but no other client can open another session because the
 guaranteed for them. The goal here is to index hundreds or thousands of entities per second.
 
 If the database crashes during this initial bulk indexing, or a failure occurs that this phase cannot revert, the
-catalog returns to the last state it published - the one written by the last session that closed successfully - and
+catalog returns to the last state it published - the newest state that reached the disk - and
 everything written after it has to be replayed. Since there is no client other than the one writing the data, we can
 afford to recover this way. See
 [Failures that cannot be reverted](../../deep-dive/bulk-vs-incremental-indexing.md#failures-that-cannot-be-reverted)

--- a/evita_api/src/main/java/io/evitadb/api/CatalogState.java
+++ b/evita_api/src/main/java/io/evitadb/api/CatalogState.java
@@ -80,10 +80,14 @@ public enum CatalogState {
 	 *
 	 * A failure the phase cannot revert - a schema change refused by validation, a flush that fails or is cancelled
 	 * after collecting its changes, a per-entity rollback that itself throws - is answered by returning the catalog to
-	 * the last state it published, which is the one written by the last session that closed successfully. The catalog
-	 * refuses every further write and every further publication, is moved to {@link #INACTIVE}, and has to be
-	 * activated again through {@link EvitaContract#activateCatalog(String)}; activation loads that published state
-	 * from disk. Everything written since then has to be replayed.
+	 * the last state it published - the newest one that reached the disk, which a session close writes and a
+	 * collection-level schema operation may write again mid-session. The catalog
+	 * refuses every further write and every further publication from that moment on, so nothing untrustworthy can
+	 * reach the disk. It is then moved to {@link #INACTIVE} and has to be activated again through
+	 * {@link EvitaContract#activateCatalog(String)}, which loads that published state from disk; everything written
+	 * since then has to be replayed. Where the engine cannot complete that move - it is a lifecycle operation of its
+	 * own, and one is refused while another is in flight for the same catalog - the refusal is what remains, and the
+	 * catalog is reloaded by restarting the engine instead. The state that comes back is the same either way.
 	 *
 	 * The recovery is deliberately this coarse, because the phase buys its speed by not keeping the machinery a
 	 * narrower one would need. There is no transaction to roll back, and a schema change is applied to every entity

--- a/evita_api/src/main/java/io/evitadb/api/CatalogState.java
+++ b/evita_api/src/main/java/io/evitadb/api/CatalogState.java
@@ -71,9 +71,28 @@ public enum CatalogState {
 	 * This state has several limitations but also advantages.
 	 *
 	 * This state requires single threaded access - this means only single thread can read/write data to the catalog
-	 * in this state. No transaction are allowed in this state and there are no guarantees on consistency of the catalog
-	 * if any of the WRITE operations fails. If any error is encountered while writing to the catalog in this state it is
-	 * strongly recommended discarding entire catalog contents and starts filling it from the scratch.
+	 * in this state. No transactions are allowed: a group of writes cannot be committed or discarded as a unit, and
+	 * index changes reach the disk only when the session closes.
+	 *
+	 * A single entity write is nevertheless atomic on its own. A call that fails part-way through is reverted
+	 * completely and the session stays usable, so a rejected entity can be skipped or retried and the import simply
+	 * continues.
+	 *
+	 * A failure the phase cannot revert - a schema change refused by validation, a flush that fails or is cancelled
+	 * after collecting its changes, a per-entity rollback that itself throws - is answered by returning the catalog to
+	 * the last state it published, which is the one written by the last session that closed successfully. The catalog
+	 * refuses every further write and every further publication, is moved to {@link #INACTIVE}, and has to be
+	 * activated again through {@link EvitaContract#activateCatalog(String)}; activation loads that published state
+	 * from disk. Everything written since then has to be replayed.
+	 *
+	 * The recovery is deliberately this coarse, because the phase buys its speed by not keeping the machinery a
+	 * narrower one would need. There is no transaction to roll back, and a schema change is applied to every entity
+	 * collection it touches - together with the structural work that goes with it - before the catalog as a whole is
+	 * validated, so a corrective change would repeat that work rather than reverse it. Reloading the last published
+	 * state is therefore the only recovery that is consistent by construction, and it discards nothing that was
+	 * durable: the phase publishes when a session closes, so what is lost is exactly the work the client had not yet
+	 * checkpointed. How much that is, is the client's own trade-off between import throughput and the cost of
+	 * repeating a block.
 	 *
 	 * Writing to the catalog in this phase is much faster than with transactional access. Operations are executed in bulk,
 	 * transactional logic is disabled and doesn't slow down the writing process.

--- a/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
@@ -2658,8 +2658,8 @@ public final class Catalog
 	 * This is the **public entry point** for all three: it raises the barrier and reports it in the operator's own
 	 * terms. A caller that has already reported its situation accurately - the message here would contradict it -
 	 * raises the same barrier through {@link #recordUnpublishableCause(Throwable)} instead, and a warm-up schema
-	 * change refused by validation takes {@link #markUnpublishableDueToInvalidSchema(SchemaAlteringException)},
-	 * which is that pattern with a message of its own.
+	 * change refused by validation takes {@link #markUnpublishableDueToInvalidSchema}, which is that pattern with a
+	 * message of its own.
 	 *
 	 * @param cause the warm-up failure that made the in-memory state unpublishable
 	 */

--- a/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
@@ -2642,9 +2642,11 @@ public final class Catalog
 	 * FUTURE publication derives a record from state that can no longer be trusted - see
 	 * `.claude/rules/durability-model.md`.
 	 *
-	 * This is the **public entry point**: it raises the barrier and reports it in the operator's own terms. A caller
-	 * that has already reported its situation accurately - the message here would contradict it - raises the same
-	 * barrier through {@link #recordUnpublishableCause(Throwable)} instead.
+	 * This is the **public entry point** for all three: it raises the barrier and reports it in the operator's own
+	 * terms. A caller that has already reported its situation accurately - the message here would contradict it -
+	 * raises the same barrier through {@link #recordUnpublishableCause(Throwable)} instead, and a warm-up schema
+	 * change refused by validation takes {@link #markUnpublishableDueToInvalidSchema(SchemaAlteringException)},
+	 * which is that pattern with a message of its own.
 	 *
 	 * @param cause the warm-up failure that made the in-memory state unpublishable
 	 */
@@ -2654,6 +2656,39 @@ public final class Catalog
 				"Catalog `{}` can no longer persist changes and will be deactivated. Its stored data is intact at the " +
 					"version of the last successful flush; everything written since then must be replayed after the " +
 					"catalog is activated again.",
+				getName(), cause
+			);
+		}
+	}
+
+	/**
+	 * Reports that a schema change refused by {@link CatalogSchemaContract#validate()} has left this WARMING_UP
+	 * catalog holding a schema the engine itself would refuse to accept, so no bootstrap record may be derived from
+	 * it. Raises the same barrier as {@link #markUnpublishable(Throwable)} and reports it in the terms of THIS
+	 * situation, which is a rejected user change rather than an engine failure.
+	 *
+	 * The catalog schema is validated as a whole, once, when a warm-up session closes - intermediate states that do
+	 * not validate are legitimate, so nothing can be checked earlier. By the time the refusal is known, the change is
+	 * already applied: `EntityCollection#updateSchema` has exchanged the schema in every collection the change
+	 * reached, run the structural work that goes with it (root nodes, capability usage, trigger registries), and
+	 * trapped an `EntitySchemaStoragePart` for it. Warm-up has no undo that spans those collections, and a corrective
+	 * mutation would exchange again ON TOP of that work rather than reverse it - so the in-memory catalog cannot be
+	 * argued back into a state worth publishing.
+	 *
+	 * **Nothing on disk is damaged.** The last bootstrap record still names a complete, correct state, and the
+	 * deactivation this schedules is what lets the operator get back to it: activating the catalog again loads
+	 * exactly that state, with a schema that validates. What is lost is everything written since - which was never
+	 * durable, warm-up publishing only when a session closes.
+	 *
+	 * @param cause the validation failure that refused the schema change
+	 */
+	public void markUnpublishableDueToInvalidSchema(@Nonnull SchemaAlteringException cause) {
+		if (recordUnpublishableCause(cause)) {
+			log.error(
+				"Catalog `{}` holds a schema that failed validation and cannot be un-applied in the warm-up " +
+					"phase, so it will be deactivated. Its stored data is intact at the version of the last " +
+					"successfully closed session; activating the catalog again loads exactly that state, and " +
+					"everything written since then has to be replayed once the schema change is corrected.",
 				getName(), cause
 			);
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
@@ -56,6 +56,7 @@ import io.evitadb.api.configuration.StorageOptions;
 import io.evitadb.api.exception.CatalogNotAliveException;
 import io.evitadb.api.exception.CollectionNotFoundException;
 import io.evitadb.api.exception.ConcurrentSchemaUpdateException;
+import io.evitadb.api.exception.ConflictingEngineMutationException;
 import io.evitadb.api.exception.InvalidMutationException;
 import io.evitadb.api.exception.InvalidSchemaMutationException;
 import io.evitadb.api.exception.SchemaAlteringException;
@@ -136,6 +137,7 @@ import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.dataType.PaginatedList;
 import io.evitadb.dataType.Scope;
 import io.evitadb.dataType.set.LazyHashSet;
+import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.function.Functions;
 import io.evitadb.index.CatalogIndex;
@@ -193,6 +195,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -248,6 +251,14 @@ public final class Catalog
 	 * therefore does not exist yet. Three zeroes is the truthful reading of that state, not a missing measurement.
 	 */
 	private static final SessionStatistics NO_ACTIVE_SESSIONS = new SessionStatistics(0, 0, 0);
+	/**
+	 * How many times {@link #attemptDeactivation(int)} issues the deactivation mutation before giving up, and how
+	 * long it waits between attempts. Sized for the one thing that refuses it - a lifecycle mutation for this same
+	 * catalog still holding the conflict key - which releases the key as it finalizes, so the window to wait out is
+	 * the tail of another mutation rather than anything open-ended.
+	 */
+	private static final int DEACTIVATION_ATTEMPTS = 5;
+	private static final long DEACTIVATION_RETRY_DELAY_MILLIS = 200L;
 
 	@Getter private final long id = TransactionalObjectVersion.SEQUENCE.nextId();
 	/**
@@ -418,11 +429,13 @@ public final class Catalog
 	 */
 	private long lastPersistedSchemaVersion;
 	/**
-	 * The failure that made this catalog's in-memory state impossible to publish - a warm-up flush or rollback, or
-	 * a {@link #goLive()} that threw after publishing its ALIVE bootstrap record - or `null` while the catalog can
-	 * still be persisted. Set by {@link #recordUnpublishableCause(Throwable)}, whose public entry point is
-	 * {@link #markUnpublishable(Throwable)}, and never cleared - a catalog recovers by being reloaded from disk,
-	 * not by this field going back to `null`.
+	 * The failure that made this catalog's in-memory state impossible to publish - a warm-up flush or rollback, a
+	 * {@link #goLive()} that threw after publishing its ALIVE bootstrap record, or a warm-up schema change refused
+	 * by validation - or `null` while the catalog can still be persisted. Set by
+	 * {@link #recordUnpublishableCause(Throwable)} through one of two public entry points:
+	 * {@link #markUnpublishable(Throwable)} for the engine failures, {@link #markUnpublishableDueToInvalidSchema}
+	 * for the refused schema change. Never cleared - a catalog recovers by being reloaded from disk, not by this
+	 * field going back to `null`.
 	 *
 	 * Holds the cause atomically so the FIRST failure wins - it is the one that explains every refusal after it -
 	 * and so that the deactivation it schedules is issued exactly once. Written from more than one thread: the
@@ -2678,17 +2691,24 @@ public final class Catalog
 	 * **Nothing on disk is damaged.** The last bootstrap record still names a complete, correct state, and the
 	 * deactivation this schedules is what lets the operator get back to it: activating the catalog again loads
 	 * exactly that state, with a schema that validates. What is lost is everything written since - which was never
-	 * durable, warm-up publishing only when a session closes.
+	 * durable. A warm-up catalog publishes when a session closes and again whenever a collection-level schema
+	 * operation flushes mid-session, so the state that comes back is the newest one that reached the disk rather
+	 * than the newest closed session.
+	 *
+	 * The parameter is the whole {@link EvitaInvalidUsageException} family rather than
+	 * {@link SchemaAlteringException} alone, because `validate()` refuses in both vocabularies: a rule it evaluates
+	 * throws the schema-altering kind, while a getter it reaches on a half-built schema simply refuses to answer.
+	 * Both mean the same thing here - the schema as it stands is not acceptable and cannot be un-applied.
 	 *
 	 * @param cause the validation failure that refused the schema change
 	 */
-	public void markUnpublishableDueToInvalidSchema(@Nonnull SchemaAlteringException cause) {
+	public void markUnpublishableDueToInvalidSchema(@Nonnull EvitaInvalidUsageException cause) {
 		if (recordUnpublishableCause(cause)) {
 			log.error(
 				"Catalog `{}` holds a schema that failed validation and cannot be un-applied in the warm-up " +
-					"phase, so it will be deactivated. Its stored data is intact at the version of the last " +
-					"successfully closed session; activating the catalog again loads exactly that state, and " +
-					"everything written since then has to be replayed once the schema change is corrected.",
+					"phase, so it will be deactivated. Its stored data is intact at the last version it published; " +
+					"activating the catalog again loads exactly that state, and everything written since then has " +
+					"to be replayed once the schema change is corrected.",
 				getName(), cause
 			);
 		}
@@ -2723,13 +2743,64 @@ public final class Catalog
 	}
 
 	/**
+	 * Tells whether the catalog schema as it currently stands would survive
+	 * {@link CatalogSchemaContract#validate()}.
+	 *
+	 * Exists for the publications that happen while a warm-up session is **still open**, which the barrier cannot
+	 * help with: the barrier is raised when a session closes and validation refuses it, so anything publishing
+	 * earlier in that same session publishes before there is a barrier to consult. Those callers ask this instead.
+	 *
+	 * It is deliberately a question rather than an assertion. A schema that does not validate mid-session is not an
+	 * error - building one across several steps whose intermediate states do not validate is supported, a reflected
+	 * reference declared before the reference it reflects being the worked example. The caller therefore skips its
+	 * publication and leaves the decision to the session close, which is the point at which the state is final.
+	 *
+	 * **The catch is {@link EvitaInvalidUsageException}, not {@link SchemaAlteringException}, and the difference is
+	 * load-bearing.** `validate()` does not report every refusal in the schema-altering vocabulary: walking a
+	 * half-built schema reaches getters that refuse to answer at all, and `ReflectedReferenceSchema#isIndexedInScope`
+	 * throwing "the reflected reference is not available" for a reflected reference whose target is not wired yet is
+	 * exactly the intermediate state this method exists to tolerate. Catching only the narrower type turned that
+	 * legitimate state into a failed DDL operation. {@link io.evitadb.exception.EvitaInternalError} stays outside
+	 * the catch deliberately - an engine bug uncovered by the walk must still surface.
+	 *
+	 * @return true when the current catalog schema validates
+	 */
+	private boolean isSchemaValid() {
+		try {
+			getSchema().validate();
+			return true;
+		} catch (EvitaInvalidUsageException ex) {
+			return false;
+		}
+	}
+
+	/**
+	 * Performs the warm-up flush that a collection-level DDL operation runs while its session is still open, unless
+	 * the catalog schema would be refused by validation as it currently stands.
+	 *
+	 * Skipping is not a lost write. The changes stay in the data store buffer and are published by the session
+	 * close, which validates first - so a schema that is merely half-built at this moment still reaches the disk,
+	 * while one that is still invalid when the session closes reaches nothing.
+	 */
+	private void flushMidSessionIfSchemaValid() {
+		if (!isSchemaValid()) {
+			return;
+		}
+		// TOBEDONE #409 - we should execute all schema operations in asynchronous manner
+		final ProgressingFuture<Void> flushFuture = this.flush();
+		flushFuture.execute(ProgressingFuture.unrejectableExecutor(this.transactionalExecutor));
+		flushFuture.join();
+	}
+
+	/**
 	 * Tells whether this catalog may still publish its in-memory state.
 	 *
 	 * Exists for the one caller that must NOT throw on a barrier it finds set - {@link #terminateInternally()} skips
 	 * the flush loop and the header write, and then goes on to release every resource. Everything else uses
 	 * {@link #assertPublishable()}.
 	 *
-	 * @return true when no warm-up failure has made this catalog's state unpublishable
+	 * @return true when nothing - neither a warm-up engine failure nor a schema change refused by validation - has
+	 *         made this catalog's state unpublishable
 	 */
 	public boolean isPublishable() {
 		return this.unpublishableCause.get() == null;
@@ -2742,7 +2813,8 @@ public final class Catalog
 	 * replace path) and the next root entity mutation, so a bulk load that can never be saved stops at once instead
 	 * of pouring in more work. Termination deliberately does not call this - see {@link #isPublishable()}.
 	 *
-	 * @throws CatalogUnpublishableException when a warm-up failure has made this catalog's state unpublishable
+	 * @throws CatalogUnpublishableException when something - a warm-up engine failure, or a schema change refused
+	 *                                       by validation - has made this catalog's state unpublishable
 	 */
 	public void assertPublishable() {
 		final Throwable cause = this.unpublishableCause.get();
@@ -2761,29 +2833,103 @@ public final class Catalog
 	 * deactivation closes exactly the sessions that thread is running under.
 	 *
 	 * The barrier set by {@link #recordUnpublishableCause(Throwable)} is what protects the window until this lands:
-	 * every publication route and every further mutation already refuses. Failure to deactivate is therefore logged
-	 * rather than propagated - the catalog stays refusing, which is the property that matters.
+	 * every publication route and every further mutation already refuses. A refusal by the conflict key is waited
+	 * out ({@link #attemptDeactivation(int)}); any other failure, and an exhausted retry, are logged rather than
+	 * propagated - the catalog stays refusing, which is the property that matters.
 	 */
 	private void scheduleDeactivation() {
+		this.scheduler.execute(() -> attemptDeactivation(1));
+	}
+
+	/**
+	 * Issues one attempt at the deactivation mutation, re-scheduling itself while another lifecycle mutation for
+	 * this catalog still holds the conflict key.
+	 *
+	 * The conflict is transient by construction - the key is released when the mutation holding it finalizes - and
+	 * the case is not hypothetical: {@link #markUnpublishable(Throwable)} is called from the go-live operator's own
+	 * flush failure handler, which runs while that operator's mutation is still finalizing. Waiting the key out is
+	 * the difference between a catalog an operator can reactivate and one that needs the engine restarted, and it
+	 * costs nothing to wait: the barrier is already raised, so the catalog refuses every write and every flush for
+	 * the whole retry window.
+	 *
+	 * When the attempts run out, the catalog stays published and refusing. That is safe rather than merely
+	 * tolerable - nothing untrustworthy can be published from it - but it is a state only a restart clears.
+	 *
+	 * @param attempt 1-based number of this attempt
+	 */
+	private void attemptDeactivation(int attempt) {
 		final String catalogName = getName();
-		this.scheduler.execute(
-			() -> {
-				try {
-					// an engine that is already shutting down terminates this catalog anyway, and issuing a lifecycle
-					// mutation into a closing engine would only trade a clean shutdown for a logged failure
-					if (!this.evita.isActive()) {
-						return;
-					}
-					this.evita.deactivateCatalogWithProgress(catalogName);
-				} catch (RuntimeException ex) {
-					log.error(
-						"Failed to deactivate catalog `{}` after it became unpublishable. It keeps refusing every write " +
-							"and every flush, so no untrustworthy state can be published; restart the engine to reload it.",
-						catalogName, ex
-					);
-				}
+		try {
+			// an engine that is already shutting down terminates this catalog anyway, and issuing a lifecycle
+			// mutation into a closing engine would only trade a clean shutdown for a logged failure
+			if (!this.evita.isActive()) {
+				return;
 			}
+			this.evita.deactivateCatalogWithProgress(catalogName)
+				.onCompletion()
+				// the mutation is accepted on this thread but applied elsewhere, so a failure past acceptance
+				// surfaces only on this stage - without it a deactivation that failed while being applied would
+				// leave the catalog refusing everything with nothing in the log to say why
+				.whenComplete((__, failure) -> {
+					if (failure != null) {
+						handleFailedDeactivation(catalogName, failure, attempt);
+					}
+				});
+		} catch (RuntimeException ex) {
+			handleFailedDeactivation(catalogName, ex, attempt);
+		}
+	}
+
+	/**
+	 * Decides what a failed deactivation attempt earns: another attempt when a lifecycle conflict refused it and
+	 * attempts remain, a log record otherwise.
+	 *
+	 * The conflict is looked for down the cause chain rather than on the exception itself, because the refusal is
+	 * raised at submission but may reach here through the returned progress instead - and a wrapped conflict that
+	 * went unrecognised would silently cost the retry rather than fail loudly.
+	 *
+	 * @param catalogName name of the catalog that could not be deactivated
+	 * @param failure     what stopped it
+	 * @param attempt     1-based number of the attempt that failed
+	 */
+	private void handleFailedDeactivation(@Nonnull String catalogName, @Nonnull Throwable failure, int attempt) {
+		if (attempt < DEACTIVATION_ATTEMPTS && isLifecycleConflict(failure)) {
+			this.scheduler.schedule(
+				() -> attemptDeactivation(attempt + 1),
+				DEACTIVATION_RETRY_DELAY_MILLIS, TimeUnit.MILLISECONDS
+			);
+			return;
+		}
+		// Silent during shutdown: the engine going down under the deactivation fails it by construction, the
+		// catalog is being terminated anyway, and the advice the message carries - restart to reload - is
+		// precisely what is already happening.
+		if (!this.evita.isActive()) {
+			return;
+		}
+		log.error(
+			"Failed to deactivate catalog `{}` after it became unpublishable. It keeps refusing every write " +
+				"and every flush, so no untrustworthy state can be published; restart the engine to reload it.",
+			catalogName, failure
 		);
+	}
+
+	/**
+	 * Tells whether the passed failure is the engine refusing a lifecycle mutation because another one for the same
+	 * catalog is still in flight.
+	 *
+	 * @param failure the failure to classify; must not be null
+	 * @return true when a {@link ConflictingEngineMutationException} appears anywhere in its cause chain
+	 */
+	private static boolean isLifecycleConflict(@Nonnull Throwable failure) {
+		for (Throwable current = failure; current != null; current = current.getCause()) {
+			if (current instanceof ConflictingEngineMutationException) {
+				return true;
+			}
+			if (current.getCause() == current) {
+				break;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -3223,10 +3369,7 @@ public final class Catalog
 		entitySchemaUpdated(newCollection.getSchema());
 		// when the catalog is in WARM-UP state we need to execute immediate flush when collection is created
 		if (transaction == null) {
-			// TOBEDONE #409 - we should execute all schema operations in asynchronous manner
-			final ProgressingFuture<Void> flushFuture = this.flush();
-			flushFuture.execute(ProgressingFuture.unrejectableExecutor(this.transactionalExecutor));
-			flushFuture.join();
+			flushMidSessionIfSchemaValid();
 		}
 		return newSchema;
 	}
@@ -3273,10 +3416,7 @@ public final class Catalog
 		}
 		// when the catalog is in WARM-UP state we need to execute immediate flush when collection is removed
 		if (transaction == null) {
-			// TOBEDONE #409 - we should execute all schema operations in asynchronous manner
-			final ProgressingFuture<Void> flushFuture = this.flush();
-			flushFuture.execute(ProgressingFuture.unrejectableExecutor(this.transactionalExecutor));
-			flushFuture.join();
+			flushMidSessionIfSchemaValid();
 		}
 		return result;
 	}
@@ -3455,10 +3595,7 @@ public final class Catalog
 				}
 			}
 			// store catalog with a new file pointer
-			// TOBEDONE #409 - we should execute all schema operations in asynchronous manner
-			final ProgressingFuture<Void> flushFuture = this.flush();
-			flushFuture.execute(ProgressingFuture.unrejectableExecutor(this.transactionalExecutor));
-			flushFuture.join();
+			flushMidSessionIfSchemaValid();
 		} else {
 			// update managed reference entity types and groups that target renamed entity
 			for (EntityCollection otherCollection : this.entityCollections.values()) {

--- a/evita_engine/src/main/java/io/evitadb/core/session/EvitaSession.java
+++ b/evita_engine/src/main/java/io/evitadb/core/session/EvitaSession.java
@@ -1914,7 +1914,7 @@ public final class EvitaSession implements EvitaInternalSessionContract {
 							// revalidates - so validating after the flush would report a refusal about a schema that
 							// is already on disk and from then on permanent
 							validateCatalogSchema(this.catalog);
-						} catch (SchemaAlteringException ex) {
+						} catch (EvitaInvalidUsageException ex) {
 							// keeping THIS session from writing is not enough. The exchange stays in the
 							// running catalog - EntityCollection#updateSchema has already swapped it into
 							// every collection the change reached - so every later publisher would write
@@ -1924,7 +1924,21 @@ public final class EvitaSession implements EvitaInternalSessionContract {
 							// collections, so the barrier is raised instead: it refuses every publication
 							// route at once and hands the catalog over for deactivation, after which
 							// activating it again loads the last published state - whose schema validates,
-							// because it was published by a session that closed successfully
+							// because it was published by a session that closed successfully.
+							//
+							// Caught as the whole EvitaInvalidUsageException family rather than as
+							// SchemaAlteringException. validate() refuses in two vocabularies: a rule it evaluates
+							// throws the schema-altering kind, while a getter it reaches on a schema it cannot
+							// resolve simply refuses to answer - ReflectedReferenceSchema#isIndexedInScope throwing
+							// "the reflected reference is not available" is the demonstrated case, and it is what
+							// Catalog#isSchemaValid had to widen its own catch for. Whether a schema can still be
+							// in that shape HERE, at the close, was not demonstrated: every attempt to build one
+							// met a schema-altering refusal first. The wide catch is kept anyway, because the two
+							// outcomes are not symmetric - a bare refusal that slipped past a narrow catch would
+							// publish exactly the state this guard exists to stop, while the cost of catching one
+							// that did not need catching is a deactivation of a catalog whose schema was already
+							// exchanged and whose operation already failed, which is the answer this design gives
+							// everywhere else
 							this.catalog.markUnpublishableDueToInvalidSchema(ex);
 							throw ex;
 						}

--- a/evita_engine/src/main/java/io/evitadb/core/session/EvitaSession.java
+++ b/evita_engine/src/main/java/io/evitadb/core/session/EvitaSession.java
@@ -1906,16 +1906,28 @@ public final class EvitaSession implements EvitaInternalSessionContract {
 					);
 					final ProgressingFuture<Void> flushFuture;
 					try {
-						// the schema is validated BEFORE anything is written, unlike in the transactional branch
-						// below where the enclosing transaction can still be marked rollback-only after the fact.
-						// A warm-up flush has no such undo: it persists the schema exactly as it stands, and
-						// a reopened catalog is past the version gate in validateCatalogSchema and so never
-						// revalidates - so validating after the flush would report a refusal about a schema that
-						// is already on disk and from then on permanent. This keeps the refused session from
-						// performing the write it is refused for; it does not un-exchange the schema, which
-						// EntityCollection#updateSchema has already swapped into the running catalog and which
-						// Catalog#terminate still flushes on shutdown - that residual gap is tracked as #1466
-						validateCatalogSchema(this.catalog);
+						try {
+							// the schema is validated BEFORE anything is written, unlike in the transactional branch
+							// below where the enclosing transaction can still be marked rollback-only after the fact.
+							// A warm-up flush has no such undo: it persists the schema exactly as it stands, and
+							// a reopened catalog is past the version gate in validateCatalogSchema and so never
+							// revalidates - so validating after the flush would report a refusal about a schema that
+							// is already on disk and from then on permanent
+							validateCatalogSchema(this.catalog);
+						} catch (SchemaAlteringException ex) {
+							// keeping THIS session from writing is not enough. The exchange stays in the
+							// running catalog - EntityCollection#updateSchema has already swapped it into
+							// every collection the change reached - so every later publisher would write
+							// it: the shutdown flush in Catalog#terminateInternally, and any subsequent
+							// session close, a read-only one included, since this branch is taken for
+							// every session regardless of its traits. Warm-up has no undo spanning those
+							// collections, so the barrier is raised instead: it refuses every publication
+							// route at once and hands the catalog over for deactivation, after which
+							// activating it again loads the last published state - whose schema validates,
+							// because it was published by a session that closed successfully
+							this.catalog.markUnpublishableDueToInvalidSchema(ex);
+							throw ex;
+						}
 						// building the warm-up flush future pops the trapped changes SYNCHRONOUSLY
 						// (Catalog.flush -> EntityCollection.createFlushFuture -> popTrappedChanges); a throw
 						// here (e.g. a corrupted index serialized at close) must complete the close future

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/EngineTransactionManager.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/EngineTransactionManager.java
@@ -25,6 +25,7 @@ package io.evitadb.core.transaction.engine;
 
 
 import io.evitadb.api.exception.ConflictingEngineMutationException;
+import io.evitadb.api.exception.InstanceTerminatedException;
 import io.evitadb.api.exception.InvalidMutationException;
 import io.evitadb.api.exception.TransactionTimedOutException;
 import io.evitadb.api.requestResponse.mutation.EngineMutation;
@@ -493,11 +494,15 @@ public class EngineTransactionManager implements Closeable {
 	 * underlying persistence service is properly closed to prevent resource leaks.
 	 */
 	public void close() {
-		// wait for all engine level tasks to complete
+		// wait for all engine level tasks to complete - for their COMPLETION, not for their success. A mutation still
+		// in flight when the engine goes down fails by construction (`Evita#closeCatalogs` clears the engine state
+		// before this runs, so the state update below it has nothing to build on), and propagating that failure here
+		// would skip the release below and leave the engine's folder lock held - which the next start reports as
+		// `FolderAlreadyUsedException` against a process that has already exited
 		CompletableFuture.allOf(
 			this.currentCatalogMutations.values()
 				.stream()
-				.map(it -> it.onCompletion().toCompletableFuture())
+				.map(it -> it.onCompletion().toCompletableFuture().exceptionally(ex -> null))
 				.toArray(CompletableFuture[]::new)
 		).join();
 		// close the engine executor
@@ -807,6 +812,17 @@ public class EngineTransactionManager implements Closeable {
 	private void updateEngineStateAfterEngineMutation(@Nonnull EngineStateUpdater engineStateUpdater) {
 		this.engineStateLock.lock();
 		try {
+			// `Evita#closeCatalogs` clears the engine state before draining the mutations still in flight, so
+			// a mutation that reaches here during shutdown has nothing to build its next state on. Refusing by
+			// name rather than dereferencing the null keeps the operator's log readable, and refusing HERE -
+			// ahead of the write-ahead log append below - keeps the refusal honest, because nothing of this
+			// mutation is durable yet
+			final ExpandedEngineState currentEngineState = this.evita.getEngineState();
+			//noinspection ConstantValue
+			if (currentEngineState == null) {
+				throw new InstanceTerminatedException("instance");
+			}
+
 			final long nextStateVersion = this.lastStoredEngineStateVersion + 1;
 
 			// Build the next in-memory engine state up-front. The persistence-layer
@@ -822,7 +838,7 @@ public class EngineTransactionManager implements Closeable {
 			// is left for the following commit rather than being forgotten below without having been pruned.
 			final Set<CatalogFolderId> drainedFolders = Set.copyOf(this.folderContext.getDrainedFolders());
 			final ExpandedEngineState mutatedEngineState = engineStateUpdater.apply(
-				nextStateVersion, this.evita.getEngineState()
+				nextStateVersion, currentEngineState
 			);
 			final ExpandedEngineState nextEngineState = drainedFolders.isEmpty() ?
 				mutatedEngineState :

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/EngineTransactionManager.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/EngineTransactionManager.java
@@ -492,6 +492,11 @@ public class EngineTransactionManager implements Closeable {
 	/**
 	 * Closes the transaction manager and releases all resources associated with it. This method ensures that the
 	 * underlying persistence service is properly closed to prevent resource leaks.
+	 *
+	 * It waits for every engine mutation still in flight to reach **completion**, which is not the same as reaching
+	 * success: a mutation caught by the shutdown fails by construction, and its failure neither propagates out of
+	 * this method nor delays the release below. That is a contract rather than an implementation detail - letting a
+	 * failure escape the wait is precisely what leaves the engine's folder lock held for the life of the process.
 	 */
 	public void close() {
 		// wait for all engine level tasks to complete - for their COMPLETION, not for their success. A mutation still
@@ -788,13 +793,23 @@ public class EngineTransactionManager implements Closeable {
 	 * to derive the next engine state, and updates the engine with the new state.
 	 *
 	 * @param engineStateUpdater a function that modifies the current engine state and returns the updated state; must not be null
+	 * @throws InstanceTerminatedException when the engine has already been shut down and its state cleared, so
+	 *                                     there is no state left for the mutation to build on
 	 */
 	private void updateEngineStateBeforeEngineMutation(@Nonnull EngineStateUpdater engineStateUpdater) {
 		this.engineStateLock.lock();
 		try {
+			// same refusal as in `updateEngineStateAfterEngineMutation`, and for the same reason: the transition
+			// phase of a mutation submitted as the engine goes down finds the state already cleared, and refusing
+			// by name reads in an operator's log where a `NullPointerException` does not
+			final ExpandedEngineState currentEngineState = this.evita.getEngineState();
+			//noinspection ConstantValue
+			if (currentEngineState == null) {
+				throw new InstanceTerminatedException("instance");
+			}
 			this.evita.setNextEngineState(
 				engineStateUpdater.apply(
-					this.lastStoredEngineStateVersion + 1, this.evita.getEngineState()
+					this.lastStoredEngineStateVersion + 1, currentEngineState
 				)
 			);
 		} finally {
@@ -808,15 +823,25 @@ public class EngineTransactionManager implements Closeable {
 	 * observers about the change.
 	 *
 	 * @param engineStateUpdater A function that takes the current engine state and returns an updated version of it.
+	 * @throws InstanceTerminatedException when the engine has already been shut down and its state cleared, so
+	 *                                     there is no state left for the mutation to build on
 	 */
 	private void updateEngineStateAfterEngineMutation(@Nonnull EngineStateUpdater engineStateUpdater) {
 		this.engineStateLock.lock();
 		try {
 			// `Evita#closeCatalogs` clears the engine state before draining the mutations still in flight, so
 			// a mutation that reaches here during shutdown has nothing to build its next state on. Refusing by
-			// name rather than dereferencing the null keeps the operator's log readable, and refusing HERE -
-			// ahead of the write-ahead log append below - keeps the refusal honest, because nothing of this
-			// mutation is durable yet
+			// name rather than dereferencing the null keeps the operator's log readable.
+			//
+			// **The refusal is about the ENGINE record, and claims nothing wider.** Refusing ahead of the append
+			// below means no write-ahead-log entry and no engine bootstrap record - this mutation leaves no
+			// engine-level trace, which is what makes reporting it as failed accurate. It is emphatically NOT a
+			// claim that the mutation had no effect: the operator's work phase ran before this callback and may
+			// already have published at the CATALOG level - `Catalog#goLive()` writes the ALIVE bootstrap record
+			// and `CreateCatalogMutationOperator` creates and completes the folder, both before the completion
+			// updater reaches here. Those effects are durable and stay durable, and a catalog whose own bootstrap
+			// record says ALIVE reloads ALIVE whatever the engine did or did not record. What the operator is
+			// being told is that the ENGINE did not record the transition, and that is exactly true
 			final ExpandedEngineState currentEngineState = this.evita.getEngineState();
 			//noinspection ConstantValue
 			if (currentEngineState == null) {

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/CatalogTerminationHelper.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/CatalogTerminationHelper.java
@@ -1,0 +1,80 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.transaction.engine.operators;
+
+import io.evitadb.api.CatalogContract;
+import org.slf4j.Logger;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Releases a catalog's resources on behalf of an engine mutation operator that can no longer act on a failure.
+ *
+ * **The guarantee is that a best-effort release never propagates**, and it is the same argument at every call
+ * site. Either the operation has already committed - so an exception escaping the release would report a failure
+ * for work that succeeded - or the operation failed and its own exception is the one the caller must be told
+ * about. What is left in both cases is releasing the handles the catalog's persistence service holds into the
+ * storage folder, and that is best-effort by nature.
+ *
+ * The catch is deliberately {@link Throwable} rather than {@link Exception}: an `Error` escaping a release
+ * performed in a `finally` would replace the failure the caller is in the middle of reporting.
+ *
+ * Centralised because three operators need it and the control flow above is the part that must not drift between
+ * them. What legitimately differs is the **message** - each operator tells the operator-facing consequence of its
+ * own path - so the message travels in from the call site, and so does the caller's {@link Logger}, keeping every
+ * warning attributed to the operator that issued it rather than to this class.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+final class CatalogTerminationHelper {
+
+	private CatalogTerminationHelper() {
+		throw new UnsupportedOperationException("This is a static helper class, no instances are allowed.");
+	}
+
+	/**
+	 * Terminates the passed catalog, logging a failure rather than propagating it.
+	 *
+	 * @param log             logger of the operator issuing the release, so the warning keeps its origin; must not
+	 *                        be null
+	 * @param catalog         catalog whose resources are to be released; must not be null
+	 * @param catalogName     name to report the catalog under, which is the name it answered to rather than the one
+	 *                        it holds; must not be null
+	 * @param failureMessage  SLF4J pattern warned on failure, carrying exactly one `{}` for the catalog name and
+	 *                        naming the consequence of the leak on this particular path; must not be null
+	 */
+	static void terminateQuietly(
+		@Nonnull Logger log,
+		@Nonnull CatalogContract catalog,
+		@Nonnull String catalogName,
+		@Nonnull String failureMessage
+	) {
+		try {
+			catalog.terminate();
+		} catch (Throwable terminationFailure) {
+			log.warn(failureMessage, catalogName, terminationFailure);
+		}
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/CreateCatalogMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/CreateCatalogMutationOperator.java
@@ -38,6 +38,7 @@ import io.evitadb.core.transaction.engine.AbstractEngineStateUpdater;
 import io.evitadb.core.transaction.engine.EngineStateUpdater;
 import io.evitadb.spi.store.engine.model.CatalogFolderId;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
@@ -56,6 +57,7 @@ import java.util.function.Consumer;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
  */
+@Slf4j
 @RequiredArgsConstructor
 public class CreateCatalogMutationOperator
 	implements EngineMutationOperator<CommitVersions, CreateCatalogSchemaMutation> {
@@ -145,21 +147,45 @@ public class CreateCatalogMutationOperator
 					// anyway.
 					CreateCatalogMutationOperator.this.folderContext.completeFolder(catalogName, catalogFolder);
 
-					completionEngineStateUpdater.accept(
-						new AbstractEngineStateUpdater(transactionId, mutation) {
-							@Override
-							public ExpandedEngineState apply(
-								long version,
-								@Nonnull ExpandedEngineState expandedEngineState
-							) {
-								return ExpandedEngineState
-									.builder(expandedEngineState)
-									.withVersion(version)
-									.withCatalog(theCatalog)
-									.build();
+					// The engine state is the only place that will ever hold a reference to the catalog just
+					// created, so a failed install strands the instance: nothing can reach it afterwards to close
+					// it, and the lock it holds on its storage folder stays held for the life of the process.
+					// Shutdown is what makes this reachable - `Evita#closeCatalogs` clears the engine state before
+					// draining the mutations still in flight. The folder is deliberately left where it is: the
+					// create never committed, and an unreferenced, marker-complete folder is what boot
+					// classification reports and leaves alone.
+					boolean installedIntoEngineState = false;
+					try {
+						completionEngineStateUpdater.accept(
+							new AbstractEngineStateUpdater(transactionId, mutation) {
+								@Override
+								public ExpandedEngineState apply(
+									long version,
+									@Nonnull ExpandedEngineState expandedEngineState
+								) {
+									return ExpandedEngineState
+										.builder(expandedEngineState)
+										.withVersion(version)
+										.withCatalog(theCatalog)
+										.build();
+								}
+							}
+						);
+						installedIntoEngineState = true;
+					} finally {
+						if (!installedIntoEngineState) {
+							try {
+								theCatalog.terminate();
+							} catch (Throwable terminationFailure) {
+								log.warn(
+									"Failed to terminate catalog `{}` after the engine refused to record its " +
+										"creation - the handles its persistence service holds into the storage " +
+										"folder stay open until the server is restarted.",
+									catalogName, terminationFailure
+								);
 							}
 						}
-					);
+					}
 					// Emit the host event AFTER the engine state has been updated so the catalog's
 					// settled state (typically WARMING_UP for a freshly-created catalog) is observable
 					// by HOST-area subscribers strictly after the underlying mutation.

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/MakeCatalogAliveMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/MakeCatalogAliveMutationOperator.java
@@ -148,9 +148,11 @@ public class MakeCatalogAliveMutationOperator implements EngineMutationOperator<
 					// (a) The flush failed: `Catalog#flush` has already called `markUnpublishable` and scheduled a
 					// deactivation, so the restored catalog serves readers while every write and every flush refuses
 					// with `CatalogUnpublishableException` - which is what happens after any other warm-up flush
-					// failure - and the deactivation settles the name. Should that mutation lose the conflict-key race
-					// against this operation's own finalization it is logged and not retried, and the catalog then
-					// stays published and refusing, which is the property `Catalog#scheduleDeactivation` guarantees.
+					// failure - and the deactivation settles the name. That mutation loses the conflict-key race
+					// against this operation's own finalization, which is exactly the case `Catalog#scheduleDeactivation`
+					// retries: the key is released as this operation finalizes and a later attempt takes it. Should
+					// every attempt lose it, the failure is logged and the catalog stays published and refusing, which
+					// is the property that method guarantees whether or not the deactivation ever lands.
 					// (b) The ALIVE bootstrap is published but the new instance never reached `aliveCatalog`, and two
 					// failures land in it. `goLive()` itself threw past `persistenceService.goLive(1L)`: its own catch
 					// has already recorded the unpublishable cause and scheduled the deactivation, so the restored
@@ -263,6 +265,23 @@ public class MakeCatalogAliveMutationOperator implements EngineMutationOperator<
 				// CALIBRATION - the give-up path of this drain is swept by `LongRunningCatalogGoLiveDrainTimeoutTest`;
 				// `SessionRegistry#DRAIN_GIVE_UP_TIMEOUT_MILLIS` carries the full statement.
 				sessionRegistry.ifPresent(it -> it.closeAllActiveSessionsAndSuspend(SuspendOperation.REJECT));
+
+				// A warm-up catalog whose schema does not validate must not go live, and this is the last place that
+				// can say so: the flush below publishes, and `goLive()` after it publishes the ALIVE bootstrap
+				// record. An ordinary warm-up session close refuses exactly this state - but the session-driven
+				// go-live never reaches that check, because `EvitaSession#goLiveAndCloseWithProgress` terminates its
+				// own session through `executeTerminationSteps` rather than through `closeInternal`, where the
+				// validation lives. All three go-live entry points funnel through this operator, so the check sits
+				// here, ahead of the first publication, and raises the same barrier an ordinary close would.
+				// caught as the whole `EvitaInvalidUsageException` family for the same reason, and with the same
+				// caveat, as the warm-up close in `EvitaSession#closeInternal`: `validate()` refuses in two
+				// vocabularies, and only the narrower one is a `SchemaAlteringException`
+				try {
+					theCatalog.getSchema().validate();
+				} catch (EvitaInvalidUsageException ex) {
+					theCatalog.markUnpublishableDueToInvalidSchema(ex);
+					throw ex;
+				}
 
 				final CatalogGoesLiveEvent event = new CatalogGoesLiveEvent(catalogName);
 				return new ProgressingFuture<>(

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/ModifyCatalogSchemaNameMutationOperator.java
@@ -94,6 +94,13 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 	 * wrappers a nested future adds, and finite so a self-referencing chain cannot hang the failure path.
 	 */
 	private static final int MAX_INSPECTED_CAUSE_DEPTH = 32;
+	/**
+	 * Warned when releasing a catalog whose failed handover left its persistence service open fails - see
+	 * {@link CatalogTerminationHelper#terminateQuietly} for why the failure is not propagated.
+	 */
+	private static final String TERMINATION_FAILURE = "Failed to terminate catalog `{}` after declaring it " +
+		"unusable - the handles its persistence service holds into the storage folder stay open until the " +
+		"server is restarted, and a later attempt to delete that folder may be refused as a result.";
 
 	private final CatalogFolderContext folderContext;
 
@@ -302,14 +309,18 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 					// Guarded rather than caught, so the already-closed windows do not log a warning about
 					// handles that are not held.
 					if (!catalogToBeReplacedWith.isTerminated()) {
-						terminateQuietly(catalogToBeReplacedWith, catalogNameToBeReplacedWith);
+						CatalogTerminationHelper.terminateQuietly(
+							log, catalogToBeReplacedWith, catalogNameToBeReplacedWith, TERMINATION_FAILURE
+						);
 					}
 					// The *replacement* service, which is what leaks when the handover succeeded and the commit
 					// failed: `replaceWith` opened it and handed it to a catalog the commit never published, so
 					// nothing else holds a reference that would ever close it.
 					final CatalogContract replacement = replacementCatalog.get();
 					if (replacement != null && !replacement.isTerminated()) {
-						terminateQuietly(replacement, catalogNameToBeReplaced);
+						CatalogTerminationHelper.terminateQuietly(
+							log, replacement, catalogNameToBeReplaced, TERMINATION_FAILURE
+						);
 					}
 				}
 			}
@@ -712,26 +723,6 @@ public class ModifyCatalogSchemaNameMutationOperator implements EngineMutationOp
 			current = cause == current ? null : cause;
 		}
 		return false;
-	}
-
-	/**
-	 * Terminates a catalog whose failed handover left its persistence service open, reporting a refusal rather
-	 * than propagating it.
-	 *
-	 * @param catalog     catalog to release
-	 * @param catalogName name to report it under, which is the name it answered to rather than the one it holds
-	 */
-	private static void terminateQuietly(@Nonnull CatalogContract catalog, @Nonnull String catalogName) {
-		try {
-			catalog.terminate();
-		} catch (Throwable terminationFailure) {
-			log.warn(
-				"Failed to terminate catalog `{}` after declaring it unusable - the handles its persistence " +
-					"service holds into the storage folder stay open until the server is restarted, and a " +
-					"later attempt to delete that folder may be refused as a result.",
-				catalogName, terminationFailure
-			);
-		}
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/RemoveCatalogSchemaMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/RemoveCatalogSchemaMutationOperator.java
@@ -66,6 +66,13 @@ import java.util.function.Consumer;
 @Slf4j
 @RequiredArgsConstructor
 public class RemoveCatalogSchemaMutationOperator implements EngineMutationOperator<Void, RemoveCatalogSchemaMutation> {
+	/**
+	 * Warned when releasing the removed catalog's resources fails - see
+	 * {@link CatalogTerminationHelper#terminateQuietly} for why the failure is not propagated. Held handles matter
+	 * more here than elsewhere, because they are what makes the folder wipe below fail on Windows.
+	 */
+	private static final String TERMINATION_FAILURE = "Failed to terminate removed catalog `{}` - its handles " +
+		"stay open until the process ends, which may cause the folder wipe to be refused and retried at boot.";
 	private final CatalogFolderContext folderContext;
 
 	@Nonnull
@@ -156,7 +163,9 @@ public class RemoveCatalogSchemaMutationOperator implements EngineMutationOperat
 							// `terminate()` gets the same treatment for the same reason: the `finally` below only
 							// guarantees the host event, so an exception escaping here would still surface a failure
 							// for a drop that has already committed - and would additionally skip the wipe.
-							terminateQuietly(catalogToRemove, catalogName);
+							CatalogTerminationHelper.terminateQuietly(
+								log, catalogToRemove, catalogName, TERMINATION_FAILURE
+							);
 							RemoveCatalogSchemaMutationOperator.this.folderContext.deleteRetiredFolder(folderToReclaim);
 						} finally {
 							// Emit the host event AFTER the catalog has been fully removed from the live
@@ -174,7 +183,9 @@ public class RemoveCatalogSchemaMutationOperator implements EngineMutationOperat
 						// catalog and nothing else can ever close it. Shutdown is what makes this reachable -
 						// `Evita#closeCatalogs` clears the engine state before draining the mutations still in
 						// flight, and the placeholder it terminated on its way through releases nothing.
-						terminateQuietly(catalogToRemove, catalogName);
+						CatalogTerminationHelper.terminateQuietly(
+							log, catalogToRemove, catalogName, TERMINATION_FAILURE
+						);
 					}
 				}
 				return null;
@@ -217,29 +228,6 @@ public class RemoveCatalogSchemaMutationOperator implements EngineMutationOperat
 				.withRetiredFolder(catalogName, folderToReclaim)
 				.build()
 		);
-	}
-
-	/**
-	 * Terminates the catalog being removed, logging a failure rather than propagating it.
-	 *
-	 * Neither call site can act on a failure. On the committed path the removal has already happened, so an
-	 * exception escaping here would report a failure for an operation that succeeded - and would additionally skip
-	 * the wipe. On the uncommitted path the exception the caller must see is the one that failed the commit. What
-	 * is left in both cases is releasing the handles, which is best-effort by nature.
-	 *
-	 * @param catalog     catalog whose resources are to be released
-	 * @param catalogName name of the catalog, for the log record
-	 */
-	private static void terminateQuietly(@Nonnull CatalogContract catalog, @Nonnull String catalogName) {
-		try {
-			catalog.terminate();
-		} catch (Throwable terminationFailure) {
-			log.warn(
-				"Failed to terminate removed catalog `{}` - its handles stay open until the process " +
-					"ends, which may cause the folder wipe to be refused and retried at boot.",
-				catalogName, terminationFailure
-			);
-		}
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/RemoveCatalogSchemaMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/RemoveCatalogSchemaMutationOperator.java
@@ -120,53 +120,62 @@ public class RemoveCatalogSchemaMutationOperator implements EngineMutationOperat
 
 				theFuture.updateProgress(1);
 
-				completionEngineStateUpdater.accept(
-					new AbstractEngineStateUpdater(transactionId, mutation) {
-						@Override
-						public ExpandedEngineState apply(long version, @Nonnull ExpandedEngineState expandedEngineState) {
-							return ExpandedEngineState
-								.builder(expandedEngineState)
-								.withVersion(version)
-								.withoutCatalog(catalogToRemove)
-								// The tombstone is what makes the wipe optional. Dropping the binding leaves a
-								// folder nothing references, and an unreferenced folder is deliberately never
-								// destroyed - that rule is what protects an operator's hand-placed directory - so
-								// without this entry a wipe the operating system refuses would leave the data
-								// behind permanently, with nothing recording that it was meant to go.
-								.withRetiredFolder(catalogName, folderToReclaim)
-								.build();
-						}
-					}
-				);
-
-				// Wrap the destructive side-effects in try-finally so the host event fires even
-				// if the wipe throws (e.g. transient I/O failure). The engine state has already advanced
-				// through the live view at this point — fire the host event regardless so HOST subscribers
-				// do not miss the removal.
+				boolean removalCommitted = false;
 				try {
-					evita.removeCatalogSessionRegistryIfPresent(catalogName);
-					// Close first, wipe second, and let the wipe fail: the removal is already committed, so
-					// propagating a filesystem error here would report a failure for an operation that
-					// succeeded, and would do it precisely on the platform where a reader holding the
-					// directory open makes the wipe fail - the second Windows failure this design removes.
-					// `terminate()` gets the same treatment for the same reason: the `finally` below only
-					// guarantees the host event, so an exception escaping here would still surface a failure
-					// for a drop that has already committed - and would additionally skip the wipe.
-					try {
-						catalogToRemove.terminate();
-					} catch (RuntimeException ex) {
-						log.warn(
-							"Failed to terminate removed catalog `{}` - its handles stay open until the process " +
-								"ends, which may cause the folder wipe below to be refused and retried at boot.",
-							catalogName, ex
-						);
-					}
-					RemoveCatalogSchemaMutationOperator.this.folderContext.deleteRetiredFolder(folderToReclaim);
+					completionEngineStateUpdater.accept(
+						new AbstractEngineStateUpdater(transactionId, mutation) {
+							@Override
+							public ExpandedEngineState apply(long version, @Nonnull ExpandedEngineState expandedEngineState) {
+								return ExpandedEngineState
+									.builder(expandedEngineState)
+									.withVersion(version)
+									.withoutCatalog(catalogToRemove)
+									// The tombstone is what makes the wipe optional. Dropping the binding leaves a
+									// folder nothing references, and an unreferenced folder is deliberately never
+									// destroyed - that rule is what protects an operator's hand-placed directory - so
+									// without this entry a wipe the operating system refuses would leave the data
+									// behind permanently, with nothing recording that it was meant to go.
+									.withRetiredFolder(catalogName, folderToReclaim)
+									.build();
+							}
+						}
+					);
+					removalCommitted = true;
 				} finally {
-					// Emit the host event AFTER the catalog has been fully removed from the live
-					// view so HOST-area subscribers can deregister endpoints / clean up
-					// caches that referenced the now-gone catalog.
-					evita.notifyCatalogRemovedFromLiveView(catalogName);
+					if (removalCommitted) {
+						// Wrap the destructive side-effects in try-finally so the host event fires even
+						// if the wipe throws (e.g. transient I/O failure). The engine state has already advanced
+						// through the live view at this point — fire the host event regardless so HOST subscribers
+						// do not miss the removal.
+						try {
+							evita.removeCatalogSessionRegistryIfPresent(catalogName);
+							// Close first, wipe second, and let the wipe fail: the removal is already committed, so
+							// propagating a filesystem error here would report a failure for an operation that
+							// succeeded, and would do it precisely on the platform where a reader holding the
+							// directory open makes the wipe fail - the second Windows failure this design removes.
+							// `terminate()` gets the same treatment for the same reason: the `finally` below only
+							// guarantees the host event, so an exception escaping here would still surface a failure
+							// for a drop that has already committed - and would additionally skip the wipe.
+							terminateQuietly(catalogToRemove, catalogName);
+							RemoveCatalogSchemaMutationOperator.this.folderContext.deleteRetiredFolder(folderToReclaim);
+						} finally {
+							// Emit the host event AFTER the catalog has been fully removed from the live
+							// view so HOST-area subscribers can deregister endpoints / clean up
+							// caches that referenced the now-gone catalog.
+							evita.notifyCatalogRemovedFromLiveView(catalogName);
+						}
+					} else {
+						// **The removal did not commit, so only the handles are released - never the folder.**
+						// The engine state still binds this catalog's name to that folder, and deleting a folder
+						// the published state still reaches is the one act that damages a catalog for real (see
+						// `.claude/rules/durability-model.md`); a restart reloads the catalog from it. The
+						// instance itself is another matter: the transition updater put a `BEING_DELETED`
+						// placeholder behind the name, so this operator holds the only reference to the real
+						// catalog and nothing else can ever close it. Shutdown is what makes this reachable -
+						// `Evita#closeCatalogs` clears the engine state before draining the mutations still in
+						// flight, and the placeholder it terminated on its way through releases nothing.
+						terminateQuietly(catalogToRemove, catalogName);
+					}
 				}
 				return null;
 			}
@@ -208,6 +217,29 @@ public class RemoveCatalogSchemaMutationOperator implements EngineMutationOperat
 				.withRetiredFolder(catalogName, folderToReclaim)
 				.build()
 		);
+	}
+
+	/**
+	 * Terminates the catalog being removed, logging a failure rather than propagating it.
+	 *
+	 * Neither call site can act on a failure. On the committed path the removal has already happened, so an
+	 * exception escaping here would report a failure for an operation that succeeded - and would additionally skip
+	 * the wipe. On the uncommitted path the exception the caller must see is the one that failed the commit. What
+	 * is left in both cases is releasing the handles, which is best-effort by nature.
+	 *
+	 * @param catalog     catalog whose resources are to be released
+	 * @param catalogName name of the catalog, for the log record
+	 */
+	private static void terminateQuietly(@Nonnull CatalogContract catalog, @Nonnull String catalogName) {
+		try {
+			catalog.terminate();
+		} catch (Throwable terminationFailure) {
+			log.warn(
+				"Failed to terminate removed catalog `{}` - its handles stay open until the process " +
+					"ends, which may cause the folder wipe to be refused and retried at boot.",
+				catalogName, terminationFailure
+			);
+		}
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/SetCatalogStateMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/SetCatalogStateMutationOperator.java
@@ -112,18 +112,31 @@ public class SetCatalogStateMutationOperator implements EngineMutationOperator<V
 				Collections.singletonList(evita.loadCatalogInternal(catalogName, readOnly)),
 				(progressingFuture, loadedCatalog) -> {
 					final CatalogContract installed = loadedCatalog.iterator().next();
-					completionEngineStateUpdater.accept(
-						new AbstractEngineStateUpdater(transactionId, mutation) {
-							@Override
-							public ExpandedEngineState apply(long version, @Nonnull ExpandedEngineState expandedEngineState) {
-								return ExpandedEngineState
-									.builder(expandedEngineState)
-									.withVersion(version)
-									.withCatalog(installed)
-									.build();
+					// The engine state is the only place that will ever hold a reference to the catalog just
+					// loaded, so failing to install it strands the instance: nobody can reach it afterwards to
+					// close it, and the folder lock it took on load stays held for the life of the process.
+					// Shutdown makes that reachable - `Evita#closeCatalogs` clears the engine state before
+					// draining the mutations still in flight - so terminating here is the only release there is.
+					boolean installedIntoEngineState = false;
+					try {
+						completionEngineStateUpdater.accept(
+							new AbstractEngineStateUpdater(transactionId, mutation) {
+								@Override
+								public ExpandedEngineState apply(long version, @Nonnull ExpandedEngineState expandedEngineState) {
+									return ExpandedEngineState
+										.builder(expandedEngineState)
+										.withVersion(version)
+										.withCatalog(installed)
+										.build();
+								}
 							}
+						);
+						installedIntoEngineState = true;
+					} finally {
+						if (!installedIntoEngineState) {
+							terminateQuietly(installed, catalogName);
 						}
-					);
+					}
 					// Emit the host event AFTER the engine state has been updated so the host
 					// event lands strictly after the underlying mutation in the system CDC stream.
 					evita.notifyCatalogStateSettled(catalogName, installed.getCatalogState());
@@ -139,51 +152,78 @@ public class SetCatalogStateMutationOperator implements EngineMutationOperator<V
 					// while it is being deactivated is served against a catalog about to be terminated.
 					evita.suspendCatalogSessions(catalogName, SuspendOperation.REJECT);
 
-					completionEngineStateUpdater.accept(
-						new AbstractEngineStateUpdater(transactionId, mutation) {
-							@Override
-							public ExpandedEngineState apply(long version, @Nonnull ExpandedEngineState expandedEngineState) {
-								return ExpandedEngineState
-									.builder(expandedEngineState)
-									.withVersion(version)
-									.withCatalog(
-										SetCatalogStateMutationOperator.this.folderContext.createUnusableCatalog(
-											catalogName, CatalogState.INACTIVE,
-											CatalogInactiveException::new
+					// The teardown below has to run even when the engine state update fails, and shutdown makes
+					// that reachable: `Evita#closeCatalogs` clears the engine state before draining the mutations
+					// still in flight. What that shutdown pass terminated on its way through is the
+					// `UnusableCatalog` placeholder the transition phase installed, whose `terminate()` only flips
+					// a flag - the real `Catalog` is held by this operator and by nothing else. Letting the failure
+					// skip the block below therefore leaves the real catalog's folder lock held for the life of
+					// the process, and the next `Evita` opened over the same directory fails with
+					// `FolderAlreadyUsedException`.
+					boolean engineStateTransitioned = false;
+					try {
+						completionEngineStateUpdater.accept(
+							new AbstractEngineStateUpdater(transactionId, mutation) {
+								@Override
+								public ExpandedEngineState apply(long version, @Nonnull ExpandedEngineState expandedEngineState) {
+									return ExpandedEngineState
+										.builder(expandedEngineState)
+										.withVersion(version)
+										.withCatalog(
+											SetCatalogStateMutationOperator.this.folderContext.createUnusableCatalog(
+												catalogName, CatalogState.INACTIVE,
+												CatalogInactiveException::new
+											)
 										)
-									)
-									.build();
+										.build();
+								}
+							}
+						);
+						engineStateTransitioned = true;
+					} finally {
+						// Wrap the destructive side-effects in try-finally so the host event fires
+						// even if `theCatalog.terminate()` throws — the engine state has already
+						// transitioned to INACTIVE and HOST subscribers must observe that
+						// transition regardless of downstream cleanup failures.
+						try {
+							evita.removeCatalogSessionRegistryIfPresent(catalogName);
+							terminateQuietly(theCatalog, catalogName);
+						} finally {
+							// Emit the host event AFTER the engine state and the live `Catalog`
+							// resources have been torn down so subscribers see the INACTIVE settlement
+							// strictly after the mutation in the system CDC stream. Only when the state
+							// actually transitioned, though: announcing a settlement the engine state never
+							// took would misinform every subscriber.
+							if (engineStateTransitioned) {
+								evita.notifyCatalogStateSettled(catalogName, CatalogState.INACTIVE);
 							}
 						}
-					);
-
-					// Wrap the destructive side-effects in try-finally so the host event fires
-					// even if `theCatalog.terminate()` throws — the engine state has already
-					// transitioned to INACTIVE and HOST subscribers must observe that
-					// transition regardless of downstream cleanup failures.
-					try {
-						evita.removeCatalogSessionRegistryIfPresent(catalogName);
-						// Logged rather than propagated: the state transition has already committed, so an
-						// exception escaping here would report a failure for an operation that succeeded. The
-						// `finally` below guarantees only that the host event fires, not that the caller is
-						// told the truth about the outcome.
-						try {
-							theCatalog.terminate();
-						} catch (RuntimeException ex) {
-							log.warn(
-								"Failed to terminate catalog `{}` while deactivating it - its handles stay open " +
-									"until the process ends.",
-								catalogName, ex
-							);
-						}
-					} finally {
-						// Emit the host event AFTER the engine state and the live `Catalog`
-						// resources have been torn down so subscribers see the INACTIVE settlement
-						// strictly after the mutation in the system CDC stream.
-						evita.notifyCatalogStateSettled(catalogName, CatalogState.INACTIVE);
 					}
 					return null;
 				}
+			);
+		}
+	}
+
+	/**
+	 * Terminates the passed catalog, logging a failure rather than propagating it.
+	 *
+	 * Both call sites are past the point where reporting would help. Either the state transition has already
+	 * committed - so an exception escaping here would report a failure for an operation that succeeded - or the
+	 * transition failed and its own exception is the one the caller must be told about. What is left in both cases
+	 * is releasing the catalog's handles, and that is best-effort by nature.
+	 *
+	 * @param catalog     catalog whose resources are to be released
+	 * @param catalogName name of the catalog, for the log record
+	 */
+	private static void terminateQuietly(@Nonnull CatalogContract catalog, @Nonnull String catalogName) {
+		try {
+			catalog.terminate();
+		} catch (Throwable terminationFailure) {
+			log.warn(
+				"Failed to terminate catalog `{}` while changing its state - the handles its persistence " +
+					"service holds into the storage folder stay open until the server is restarted.",
+				catalogName, terminationFailure
 			);
 		}
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/SetCatalogStateMutationOperator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/engine/operators/SetCatalogStateMutationOperator.java
@@ -60,6 +60,13 @@ import java.util.function.Consumer;
 @Slf4j
 @RequiredArgsConstructor
 public class SetCatalogStateMutationOperator implements EngineMutationOperator<Void, SetCatalogStateMutation> {
+	/**
+	 * Warned when releasing the catalog's resources fails - see
+	 * {@link CatalogTerminationHelper#terminateQuietly} for why the failure is not propagated.
+	 */
+	private static final String TERMINATION_FAILURE = "Failed to terminate catalog `{}` while changing its " +
+		"state - the handles its persistence service holds into the storage folder stay open until the server " +
+		"is restarted.";
 	private final CatalogFolderContext folderContext;
 
 	@Nonnull
@@ -134,7 +141,7 @@ public class SetCatalogStateMutationOperator implements EngineMutationOperator<V
 						installedIntoEngineState = true;
 					} finally {
 						if (!installedIntoEngineState) {
-							terminateQuietly(installed, catalogName);
+							CatalogTerminationHelper.terminateQuietly(log, installed, catalogName, TERMINATION_FAILURE);
 						}
 					}
 					// Emit the host event AFTER the engine state has been updated so the host
@@ -187,7 +194,9 @@ public class SetCatalogStateMutationOperator implements EngineMutationOperator<V
 						// transition regardless of downstream cleanup failures.
 						try {
 							evita.removeCatalogSessionRegistryIfPresent(catalogName);
-							terminateQuietly(theCatalog, catalogName);
+							CatalogTerminationHelper.terminateQuietly(
+								log, theCatalog, catalogName, TERMINATION_FAILURE
+							);
 						} finally {
 							// Emit the host event AFTER the engine state and the live `Catalog`
 							// resources have been torn down so subscribers see the INACTIVE settlement
@@ -201,29 +210,6 @@ public class SetCatalogStateMutationOperator implements EngineMutationOperator<V
 					}
 					return null;
 				}
-			);
-		}
-	}
-
-	/**
-	 * Terminates the passed catalog, logging a failure rather than propagating it.
-	 *
-	 * Both call sites are past the point where reporting would help. Either the state transition has already
-	 * committed - so an exception escaping here would report a failure for an operation that succeeded - or the
-	 * transition failed and its own exception is the one the caller must be told about. What is left in both cases
-	 * is releasing the catalog's handles, and that is best-effort by nature.
-	 *
-	 * @param catalog     catalog whose resources are to be released
-	 * @param catalogName name of the catalog, for the log record
-	 */
-	private static void terminateQuietly(@Nonnull CatalogContract catalog, @Nonnull String catalogName) {
-		try {
-			catalog.terminate();
-		} catch (Throwable terminationFailure) {
-			log.warn(
-				"Failed to terminate catalog `{}` while changing its state - the handles its persistence " +
-					"service holds into the storage folder stay open until the server is restarted.",
-				catalogName, terminationFailure
 			);
 		}
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/AttributeFilterAcceleratorRefusalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/AttributeFilterAcceleratorRefusalTest.java
@@ -939,32 +939,40 @@ class AttributeFilterAcceleratorRefusalTest implements EvitaTestSupport {
 				}
 			);
 
-			final InvalidSchemaMutationException exception = assertThrows(
-				InvalidSchemaMutationException.class,
-				() -> AttributeFilterAcceleratorRefusalTest.this.evita.updateCatalog(
-					TEST_CATALOG,
-					session -> {
-						session.updateEntitySchema(
-							new ModifyEntitySchemaMutation(
-								Entities.PRODUCT,
-								new SetAttributeSchemaAcceleratedMutation(
-									ATTRIBUTE_CODE,
-									new ScopedAttributeFilterAccelerators(
-										Scope.LIVE, AttributeFilterAccelerator.SUBSTRING_SEARCH
+			// the barrier is asserted explicitly, not merely the exception: `SetAttributeSchemaAcceleratedMutation`
+			// deliberately skips its own pre-flight applicability check today (its sibling
+			// `CreateAttributeSchemaMutation` already has one), so a refusal here is confirmed post-exchange rather
+			// than assumed - see CatalogUnpublishableBarrierAssertions
+			final InvalidSchemaMutationException exception =
+				CatalogUnpublishableBarrierAssertions.assertRefusalRaisesTheBarrier(
+					AttributeFilterAcceleratorRefusalTest.this.evita, TEST_CATALOG,
+					InvalidSchemaMutationException.class,
+					() -> AttributeFilterAcceleratorRefusalTest.this.evita.updateCatalog(
+						TEST_CATALOG,
+						session -> {
+							session.updateEntitySchema(
+								new ModifyEntitySchemaMutation(
+									Entities.PRODUCT,
+									new SetAttributeSchemaAcceleratedMutation(
+										ATTRIBUTE_CODE,
+										new ScopedAttributeFilterAccelerators(
+											Scope.LIVE, AttributeFilterAccelerator.SUBSTRING_SEARCH
+										)
 									)
 								)
-							)
-						);
-					}
-				)
-			);
+							);
+						}
+					)
+				);
 			// asserted on the message rather than on the type alone: the collection-emptiness refusal throws the
 			// same exception, and it would satisfy a bare assertThrows while proving something else entirely
 			assertTrue(exception.getMessage().contains(AttributeFilterAccelerator.SUBSTRING_SEARCH.name()));
 			assertTrue(exception.getMessage().contains("no filter index"));
 
 			// reopening over the same storage directory is the only honest way to ask what the refused session
-			// actually left behind - the in-memory catalog would answer for a schema that was never written
+			// actually left behind - the in-memory catalog would answer for a schema that was never written. The
+			// barrier assertion above already waited for the deactivation to settle, so unlike the general case
+			// `reopenOverTheSameStorage` documents, this reopen is not racing it
 			AttributeFilterAcceleratorRefusalTest.this.reopenOverTheSameStorage();
 
 			AttributeFilterAcceleratorRefusalTest.this.evita.queryCatalog(
@@ -975,9 +983,9 @@ class AttributeFilterAcceleratorRefusalTest implements EvitaTestSupport {
 					// `EntityCollection#updateSchema` has already performed on the running catalog. What keeps that
 					// exchange off the disk is the unpublishable barrier the refusal raises: warm-up catalog
 					// termination consults it and skips its flush, as does every other route that would write a
-					// bootstrap record. The reopened catalog therefore carries the schema of the last session that
-					// closed successfully. See WarmUpRefusedSchemaPersistenceTest for the same guarantee proven on a
-					// second, unrelated validation rule
+					// bootstrap record. The reopened catalog therefore carries the newest state that reached the
+					// disk. See WarmUpRefusedSchemaPersistenceTest for the same guarantee proven on a second,
+					// unrelated validation rule
 					assertEquals(
 						Set.of(),
 						session.getEntitySchemaOrThrow(Entities.PRODUCT)

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/AttributeFilterAcceleratorRefusalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/AttributeFilterAcceleratorRefusalTest.java
@@ -26,7 +26,6 @@ package io.evitadb.api.functional.schema;
 import io.evitadb.api.TransactionContract.CommitBehavior;
 import io.evitadb.api.CatalogState;
 import io.evitadb.api.configuration.EvitaConfiguration;
-import io.evitadb.api.exception.ConflictingEngineMutationException;
 import io.evitadb.api.exception.InvalidSchemaMutationException;
 import io.evitadb.api.requestResponse.schema.AttributeFilterAccelerator;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
@@ -55,7 +54,6 @@ import static io.evitadb.test.TestTags.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Guards the refusal that protects users from a silently-incomplete substring index.
@@ -91,13 +89,6 @@ class AttributeFilterAcceleratorRefusalTest implements EvitaTestSupport {
 	/** The attribute the reflected reference excludes from inheritance, which is what makes it hold a filter. */
 	private static final String ATTRIBUTE_NOT_INHERITED = "notInherited";
 	private static final int CATEGORY_PK = 1;
-	/**
-	 * Upper bound on how long the catalog is retried for after a reopen finds it deactivated. Generous on purpose:
-	 * the retry returns on the first attempt the engine accepts, so the bound is only ever paid by a genuine hang.
-	 */
-	private static final long ACTIVATION_BUDGET_MILLIS = 30_000L;
-	/** Backoff between two attempts at an activation the engine refuses while another lifecycle step is in flight. */
-	private static final long RETRY_BACKOFF_MILLIS = 20L;
 
 	private TestPaths paths;
 	private Evita evita;
@@ -1064,39 +1055,8 @@ class AttributeFilterAcceleratorRefusalTest implements EvitaTestSupport {
 		// futures it created, so the state read below is the settled one
 		this.evita.waitUntilFullyInitialized();
 		if (this.evita.getCatalogState(TEST_CATALOG).orElse(null) == CatalogState.INACTIVE) {
-			activateWithConflictRetry();
+			CatalogUnpublishableBarrierAssertions.activateWithConflictRetry(this.evita, TEST_CATALOG);
 		}
-	}
-
-	/**
-	 * Activates the test catalog, retrying while the engine reports that another lifecycle operation for it is still
-	 * in flight.
-	 *
-	 * This is a **retry of a refused operation**, not a poll for a condition: the deactivation's engine-state update
-	 * lands before the lifecycle mutation carrying it releases its conflict key, and no seam exposes that release.
-	 */
-	private void activateWithConflictRetry() {
-		final long deadline = System.currentTimeMillis() + ACTIVATION_BUDGET_MILLIS;
-		RuntimeException lastConflict;
-		do {
-			try {
-				this.evita.activateCatalog(TEST_CATALOG);
-				return;
-			} catch (RuntimeException ex) {
-				if (!(ex instanceof ConflictingEngineMutationException)
-					&& !(ex.getCause() instanceof ConflictingEngineMutationException)) {
-					throw ex;
-				}
-				lastConflict = ex;
-				try {
-					Thread.sleep(RETRY_BACKOFF_MILLIS);
-				} catch (InterruptedException interruption) {
-					Thread.currentThread().interrupt();
-					fail("Interrupted while retrying an engine operation refused by a lifecycle conflict.");
-				}
-			}
-		} while (System.currentTimeMillis() < deadline);
-		fail("Catalog `" + TEST_CATALOG + "` could not be activated: " + lastConflict.getMessage());
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/AttributeFilterAcceleratorRefusalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/AttributeFilterAcceleratorRefusalTest.java
@@ -961,19 +961,16 @@ class AttributeFilterAcceleratorRefusalTest implements EvitaTestSupport {
 			AttributeFilterAcceleratorRefusalTest.this.evita.queryCatalog(
 				TEST_CATALOG,
 				session -> {
-					// the refusal above precedes the refused session's own write - a warming-up close validates
-					// before `Catalog#flush` - but it cannot take back the schema exchange that
-					// `EntityCollection#updateSchema` has already performed on the running catalog, and warm-up
-					// catalog termination flushes whatever sits in memory without consulting the same rule. So a
-					// clean shutdown still writes the orphan out, and the reopened catalog is past the schema
-					// version gate that decides whether to validate at all, which is why it loads without
-					// complaint. Asserted rather than left to be discovered: closing the gap needs an undo for a
-					// warm-up schema exchange, which does not exist today, and validating each
-					// `updateEntitySchema` batch instead would refuse the legitimate sequence of declaring the
-					// accelerator in one call and the filterability that licenses it in the next. Tracked as #1466 -
-					// flip this assertion to `Set.of()` when that issue is closed
+					// the refusal precedes the refused session's own write - a warming-up close validates before
+					// `Catalog#flush` - and it cannot take back the schema exchange that
+					// `EntityCollection#updateSchema` has already performed on the running catalog. What keeps that
+					// exchange off the disk is the unpublishable barrier the refusal raises: warm-up catalog
+					// termination consults it and skips its flush, as does every other route that would write a
+					// bootstrap record. The reopened catalog therefore carries the schema of the last session that
+					// closed successfully. See WarmUpRefusedSchemaPersistenceTest for the same guarantee proven on a
+					// second, unrelated validation rule
 					assertEquals(
-						Set.of(AttributeFilterAccelerator.SUBSTRING_SEARCH),
+						Set.of(),
 						session.getEntitySchemaOrThrow(Entities.PRODUCT)
 							.getAttribute(ATTRIBUTE_CODE).orElseThrow()
 							.getAcceleratorsInScope(Scope.LIVE)

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/AttributeFilterAcceleratorRefusalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/AttributeFilterAcceleratorRefusalTest.java
@@ -24,7 +24,9 @@
 package io.evitadb.api.functional.schema;
 
 import io.evitadb.api.TransactionContract.CommitBehavior;
+import io.evitadb.api.CatalogState;
 import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.exception.ConflictingEngineMutationException;
 import io.evitadb.api.exception.InvalidSchemaMutationException;
 import io.evitadb.api.requestResponse.schema.AttributeFilterAccelerator;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
@@ -53,6 +55,7 @@ import static io.evitadb.test.TestTags.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Guards the refusal that protects users from a silently-incomplete substring index.
@@ -88,6 +91,13 @@ class AttributeFilterAcceleratorRefusalTest implements EvitaTestSupport {
 	/** The attribute the reflected reference excludes from inheritance, which is what makes it hold a filter. */
 	private static final String ATTRIBUTE_NOT_INHERITED = "notInherited";
 	private static final int CATEGORY_PK = 1;
+	/**
+	 * Upper bound on how long the catalog is retried for after a reopen finds it deactivated. Generous on purpose:
+	 * the retry returns on the first attempt the engine accepts, so the bound is only ever paid by a genuine hang.
+	 */
+	private static final long ACTIVATION_BUDGET_MILLIS = 30_000L;
+	/** Backoff between two attempts at an activation the engine refuses while another lifecycle step is in flight. */
+	private static final long RETRY_BACKOFF_MILLIS = 20L;
 
 	private TestPaths paths;
 	private Evita evita;
@@ -955,8 +965,7 @@ class AttributeFilterAcceleratorRefusalTest implements EvitaTestSupport {
 
 			// reopening over the same storage directory is the only honest way to ask what the refused session
 			// actually left behind - the in-memory catalog would answer for a schema that was never written
-			AttributeFilterAcceleratorRefusalTest.this.evita.close();
-			AttributeFilterAcceleratorRefusalTest.this.evita = new Evita(configuration());
+			AttributeFilterAcceleratorRefusalTest.this.reopenOverTheSameStorage();
 
 			AttributeFilterAcceleratorRefusalTest.this.evita.queryCatalog(
 				TEST_CATALOG,
@@ -1028,6 +1037,58 @@ class AttributeFilterAcceleratorRefusalTest implements EvitaTestSupport {
 				);
 			}
 		);
+	}
+
+	/**
+	 * Closes the running instance and opens a fresh one over the same storage directory, leaving the catalog loaded
+	 * and queryable however the previous instance shut down.
+	 *
+	 * The refusal under test raises the unpublishable barrier, and the barrier schedules a deactivation - so whether
+	 * this test's `close()` outruns that deactivation is a race, and both outcomes are correct. When the
+	 * deactivation lands first the `INACTIVE` state is persisted and the reopened engine leaves the catalog
+	 * unloaded; when the close wins, the catalog comes back loaded. Both sides read the same bootstrap record, which
+	 * is the state under assertion, so the reopen simply has to tolerate either.
+	 */
+	private void reopenOverTheSameStorage() {
+		this.evita.close();
+		this.evita = new Evita(configuration());
+		// deterministic rather than a wait: the constructor schedules the initial catalog load and this joins the
+		// futures it created, so the state read below is the settled one
+		this.evita.waitUntilFullyInitialized();
+		if (this.evita.getCatalogState(TEST_CATALOG).orElse(null) == CatalogState.INACTIVE) {
+			activateWithConflictRetry();
+		}
+	}
+
+	/**
+	 * Activates the test catalog, retrying while the engine reports that another lifecycle operation for it is still
+	 * in flight.
+	 *
+	 * This is a **retry of a refused operation**, not a poll for a condition: the deactivation's engine-state update
+	 * lands before the lifecycle mutation carrying it releases its conflict key, and no seam exposes that release.
+	 */
+	private void activateWithConflictRetry() {
+		final long deadline = System.currentTimeMillis() + ACTIVATION_BUDGET_MILLIS;
+		RuntimeException lastConflict;
+		do {
+			try {
+				this.evita.activateCatalog(TEST_CATALOG);
+				return;
+			} catch (RuntimeException ex) {
+				if (!(ex instanceof ConflictingEngineMutationException)
+					&& !(ex.getCause() instanceof ConflictingEngineMutationException)) {
+					throw ex;
+				}
+				lastConflict = ex;
+				try {
+					Thread.sleep(RETRY_BACKOFF_MILLIS);
+				} catch (InterruptedException interruption) {
+					Thread.currentThread().interrupt();
+					fail("Interrupted while retrying an engine operation refused by a lifecycle conflict.");
+				}
+			}
+		} while (System.currentTimeMillis() < deadline);
+		fail("Catalog `" + TEST_CATALOG + "` could not be activated: " + lastConflict.getMessage());
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/CatalogUnpublishableBarrierAssertions.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/CatalogUnpublishableBarrierAssertions.java
@@ -1,0 +1,203 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.schema;
+
+import io.evitadb.api.CatalogState;
+import io.evitadb.api.requestResponse.cdc.ChangeCaptureContent;
+import io.evitadb.api.requestResponse.cdc.ChangeCapturePublisher;
+import io.evitadb.api.requestResponse.cdc.ChangeSystemCapture;
+import io.evitadb.api.requestResponse.cdc.ChangeSystemCaptureRequest;
+import io.evitadb.api.requestResponse.cdc.HostSystemEvent;
+import io.evitadb.core.Evita;
+import org.junit.jupiter.api.function.Executable;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Asserts that a refused catalog-lifecycle mutation raised the unpublishable barrier, observed as the catalog
+ * settling into a given {@link CatalogState} on the system change stream.
+ *
+ * **This is what keeps a refusal test from passing for the wrong reason.** A guarantee built on the barrier rests
+ * on catalog-schema validation having already exchanged the invalid schema into the running catalog before it
+ * refuses - see {@code Catalog#markUnpublishableDueToInvalidSchema}. A refusal from a *pre-flight* check instead
+ * throws the same exception type with a similar message and leaves the catalog untouched, which would make every
+ * assertion about a reopened schema hold trivially, because nothing was ever exchanged. Deactivation is the
+ * barrier's observable consequence ({@code Catalog#recordUnpublishableCause} schedules it), so waiting for it is
+ * what tells the two refusals apart.
+ *
+ * Shared by {@link WarmUpRefusedSchemaPersistenceTest} and {@link AttributeFilterAcceleratorRefusalTest}, which
+ * both pin refusals of {@code SetAttributeSchemaAcceleratedMutation} - a mutation that deliberately skips its own
+ * pre-flight applicability check today, one edit away from gaining one.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+final class CatalogUnpublishableBarrierAssertions {
+
+	/**
+	 * Upper bound on how long the deactivation a refusal schedules is waited for. Generous on purpose - a latch
+	 * returns the instant the work completes, so the bound is only ever paid by a genuine hang, and a loaded
+	 * machine can only push a positive wait toward expiry (`.claude/rules/testing.md`).
+	 */
+	private static final long AWAIT_BUDGET_MILLIS = 30_000L;
+
+	private CatalogUnpublishableBarrierAssertions() {
+		throw new UnsupportedOperationException("This is a static helper class, no instances are allowed.");
+	}
+
+	/**
+	 * Runs an action expected to be refused, and asserts that the refusal raised the unpublishable barrier.
+	 *
+	 * @param evita             the running instance the catalog under test lives in; must not be null
+	 * @param catalogName       name of the catalog the refusal is expected to deactivate; must not be null
+	 * @param expectedException type the refusal is expected to throw; must not be null
+	 * @param refusedAction     the action whose refusal is under test; must not be null
+	 * @return the exception the action was refused with; never null
+	 */
+	@Nonnull
+	static <T extends RuntimeException> T assertRefusalRaisesTheBarrier(
+		@Nonnull Evita evita,
+		@Nonnull String catalogName,
+		@Nonnull Class<T> expectedException,
+		@Nonnull Executable refusedAction
+	) {
+		// registered BEFORE the action, so the deactivation it schedules cannot settle into a stream nobody is
+		// subscribed to
+		final CatalogState inactive = CatalogState.INACTIVE;
+		try (final SettledStateLatch deactivation = subscribeToSettledState(evita, catalogName, inactive)) {
+			final T exception = assertThrows(expectedException, refusedAction);
+			deactivation.await();
+			return exception;
+		}
+	}
+
+	/**
+	 * Subscribes to the system change stream and returns a latch that opens when the engine reports the named
+	 * catalog as having settled into the given state.
+	 *
+	 * The deactivation a refusal schedules is asynchronous by design - it runs on the engine's scheduler because it
+	 * has to close the very sessions the refusing thread is running under - so a test that asks what happened next
+	 * has to wait for it. This is the transition announcing itself rather than the test guessing when to look:
+	 * {@code Evita#notifyCatalogStateSettled} emits a {@link HostSystemEvent.CatalogInstalledIntoLiveView} from the
+	 * deactivation operator's own completion phase. **Register before triggering the deactivation**, or the event
+	 * fires into a stream nobody is subscribed to.
+	 *
+	 * @param evita         the running instance the catalog under test lives in; must not be null
+	 * @param catalogName   name of the catalog to watch; must not be null
+	 * @param expectedState the settled state to wait for; must not be null
+	 * @return the subscription, which closes the underlying publisher and carries the latch; never null
+	 */
+	@Nonnull
+	static SettledStateLatch subscribeToSettledState(
+		@Nonnull Evita evita,
+		@Nonnull String catalogName,
+		@Nonnull CatalogState expectedState
+	) {
+		final ChangeCapturePublisher<ChangeSystemCapture> publisher = evita.registerSystemChangeCapture(
+			ChangeSystemCaptureRequest.builder()
+				.sinceVersion(evita.getEngineState().version() + 1)
+				.content(ChangeCaptureContent.BODY)
+				.hostArea()
+				.build()
+		);
+		final SettledStateLatch latch = new SettledStateLatch(publisher, catalogName, expectedState);
+		publisher.subscribe(latch);
+		return latch;
+	}
+
+	/**
+	 * A {@link Flow.Subscriber} over the system change stream that opens a latch when the named catalog is reported
+	 * as having settled into one particular state.
+	 */
+	static final class SettledStateLatch implements Flow.Subscriber<ChangeSystemCapture>, AutoCloseable {
+		private final ChangeCapturePublisher<ChangeSystemCapture> publisher;
+		private final String catalogName;
+		private final CatalogState expectedState;
+		private final CountDownLatch latch = new CountDownLatch(1);
+
+		SettledStateLatch(
+			@Nonnull ChangeCapturePublisher<ChangeSystemCapture> publisher,
+			@Nonnull String catalogName,
+			@Nonnull CatalogState expectedState
+		) {
+			this.publisher = publisher;
+			this.catalogName = catalogName;
+			this.expectedState = expectedState;
+		}
+
+		@Override
+		public void onSubscribe(@Nonnull Flow.Subscription subscription) {
+			subscription.request(Long.MAX_VALUE);
+		}
+
+		@Override
+		public void onNext(@Nonnull ChangeSystemCapture item) {
+			if (item.body() instanceof HostSystemEvent.CatalogInstalledIntoLiveView installed
+				&& this.catalogName.equals(installed.catalogName())
+				&& installed.observedState() == this.expectedState) {
+				this.latch.countDown();
+			}
+		}
+
+		@Override
+		public void onError(@Nonnull Throwable throwable) {
+			// nothing to do - a stream that fails leaves the latch closed and `await` reports the timeout, which
+			// carries the same verdict with a message that names the state the test was waiting for
+		}
+
+		@Override
+		public void onComplete() {
+			// see `onError` - a stream that ends without the event is indistinguishable from one that never
+			// delivered it, and both are the same test failure
+		}
+
+		/**
+		 * Blocks until the expected state is reported, failing the test when it is not reported in time.
+		 */
+		void await() {
+			try {
+				if (!this.latch.await(AWAIT_BUDGET_MILLIS, TimeUnit.MILLISECONDS)) {
+					fail(
+						"Catalog `" + this.catalogName + "` was never reported as having settled into `" +
+							this.expectedState + "`."
+					);
+				}
+			} catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				fail("Interrupted while waiting for catalog `" + this.catalogName + "` to settle.");
+			}
+		}
+
+		@Override
+		public void close() {
+			this.publisher.close();
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/CatalogUnpublishableBarrierAssertions.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/CatalogUnpublishableBarrierAssertions.java
@@ -24,6 +24,7 @@
 package io.evitadb.api.functional.schema;
 
 import io.evitadb.api.CatalogState;
+import io.evitadb.api.exception.ConflictingEngineMutationException;
 import io.evitadb.api.requestResponse.cdc.ChangeCaptureContent;
 import io.evitadb.api.requestResponse.cdc.ChangeCapturePublisher;
 import io.evitadb.api.requestResponse.cdc.ChangeSystemCapture;
@@ -66,6 +67,8 @@ final class CatalogUnpublishableBarrierAssertions {
 	 * machine can only push a positive wait toward expiry (`.claude/rules/testing.md`).
 	 */
 	private static final long AWAIT_BUDGET_MILLIS = 30_000L;
+	/** Backoff between two attempts at an operation the engine refuses while another one is still in flight. */
+	private static final long RETRY_BACKOFF_MILLIS = 20L;
 
 	private CatalogUnpublishableBarrierAssertions() {
 		throw new UnsupportedOperationException("This is a static helper class, no instances are allowed.");
@@ -129,6 +132,59 @@ final class CatalogUnpublishableBarrierAssertions {
 		final SettledStateLatch latch = new SettledStateLatch(publisher, catalogName, expectedState);
 		publisher.subscribe(latch);
 		return latch;
+	}
+
+	/**
+	 * Activates the named catalog, retrying while the engine reports that another lifecycle operation for it is
+	 * still in flight.
+	 *
+	 * The retry is not optional. A deactivation settles in two steps: the engine-state update lands - which is what
+	 * {@link SettledStateLatch} observes - and the lifecycle mutation carrying it releases its conflict key a moment
+	 * later, as it finalizes. An activation issued in between is refused with
+	 * {@link ConflictingEngineMutationException}, the engine's "another lifecycle operation for this catalog is
+	 * still in flight" signal, which is a transient rather than a failure worth failing the test over.
+	 *
+	 * This is a **retry of a refused operation**, not a poll for a condition, which is why it is a loop and stays
+	 * one: the conflict key is released as the deactivation mutation finalizes and no seam exposes that moment, so
+	 * there is nothing to latch on. A slow machine widens the window this rides out rather than shortening it.
+	 *
+	 * Shared rather than duplicated per test class because both callers ride the **same** engine race, so the
+	 * classification of what counts as a transient and the budget it is ridden out over have to stay identical -
+	 * two copies drifting apart would leave one of them failing on a conflict the other still tolerates.
+	 *
+	 * @param evita       the running instance the catalog lives in; must not be null
+	 * @param catalogName name of the catalog to activate; must not be null
+	 */
+	static void activateWithConflictRetry(@Nonnull Evita evita, @Nonnull String catalogName) {
+		final long deadline = System.currentTimeMillis() + AWAIT_BUDGET_MILLIS;
+		RuntimeException lastConflict;
+		do {
+			try {
+				evita.activateCatalog(catalogName);
+				return;
+			} catch (RuntimeException ex) {
+				if (!(ex instanceof ConflictingEngineMutationException)
+					&& !(ex.getCause() instanceof ConflictingEngineMutationException)) {
+					throw ex;
+				}
+				lastConflict = ex;
+				backOffBeforeRetry();
+			}
+		} while (System.currentTimeMillis() < deadline);
+		fail("Catalog `" + catalogName + "` could not be activated: " + lastConflict.getMessage());
+	}
+
+	/**
+	 * Waits out one backoff interval between two attempts at an operation the engine currently refuses, turning an
+	 * interrupt into a test failure rather than a silent early return.
+	 */
+	private static void backOffBeforeRetry() {
+		try {
+			Thread.sleep(RETRY_BACKOFF_MILLIS);
+		} catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			fail("Interrupted while retrying an engine operation refused by a lifecycle conflict.");
+		}
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/WarmUpRefusedSchemaPersistenceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/WarmUpRefusedSchemaPersistenceTest.java
@@ -25,7 +25,6 @@ package io.evitadb.api.functional.schema;
 
 import io.evitadb.api.CatalogState;
 import io.evitadb.api.configuration.EvitaConfiguration;
-import io.evitadb.api.exception.ConflictingEngineMutationException;
 import io.evitadb.api.exception.InvalidSchemaMutationException;
 import io.evitadb.api.requestResponse.schema.AttributeFilterAccelerator;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
@@ -125,14 +124,6 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 	private static final int PUBLISHED_PRODUCT_PK = 1;
 	/** Primary key of the entity written by the session whose close is refused, and which therefore never publishes. */
 	private static final int DISCARDED_PRODUCT_PK = 2;
-	/**
-	 * Upper bound on how long any single asynchronous catalog lifecycle step is waited for. Generous on purpose -
-	 * a latch returns the instant the work completes, so the bound is only ever paid by a genuine hang, and a
-	 * loaded machine can only push a positive wait toward expiry (`.claude/rules/testing.md`).
-	 */
-	private static final long AWAIT_BUDGET_MILLIS = 30_000L;
-	/** Backoff between two attempts at an operation the engine refuses while another one is still in flight. */
-	private static final long RETRY_BACKOFF_MILLIS = 20L;
 
 	private TestPaths paths;
 	private Evita evita;
@@ -768,7 +759,9 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 
 			// the deactivation has settled by now - `assertRefusalRaisesTheBarrier` waited for it - but the
 			// lifecycle mutation carrying it releases its conflict key only as it finalizes, a moment later
-			WarmUpRefusedSchemaPersistenceTest.this.activateWithConflictRetry();
+			CatalogUnpublishableBarrierAssertions.activateWithConflictRetry(
+				WarmUpRefusedSchemaPersistenceTest.this.evita, TEST_CATALOG
+			);
 
 			WarmUpRefusedSchemaPersistenceTest.this.evita.queryCatalog(
 				TEST_CATALOG,
@@ -787,52 +780,6 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 					);
 				}
 			);
-		}
-	}
-
-	/**
-	 * Activates the test catalog, retrying while the engine reports that another lifecycle operation for it is
-	 * still in flight.
-	 *
-	 * The retry is not optional. A deactivation settles in two steps: the engine-state update lands - which is what
-	 * {@link CatalogUnpublishableBarrierAssertions.SettledStateLatch} observes - and the lifecycle mutation carrying
-	 * it releases its conflict key a moment later, as it finalizes. An activation issued in between is refused with
-	 * {@link ConflictingEngineMutationException}, the engine's "another lifecycle operation for this catalog is
-	 * still in flight" signal, which is a transient rather than a failure worth failing the test over.
-	 *
-	 * This is a **retry of a refused operation**, not a poll for a condition, which is why it is a loop and stays
-	 * one: the conflict key is released as the deactivation mutation finalizes and no seam exposes that moment, so
-	 * there is nothing to latch on. A slow machine widens the window this rides out rather than shortening it.
-	 */
-	private void activateWithConflictRetry() {
-		final long deadline = System.currentTimeMillis() + AWAIT_BUDGET_MILLIS;
-		RuntimeException lastConflict;
-		do {
-			try {
-				this.evita.activateCatalog(TEST_CATALOG);
-				return;
-			} catch (RuntimeException ex) {
-				if (!(ex instanceof ConflictingEngineMutationException)
-					&& !(ex.getCause() instanceof ConflictingEngineMutationException)) {
-					throw ex;
-				}
-				lastConflict = ex;
-				backOffBeforeRetry();
-			}
-		} while (System.currentTimeMillis() < deadline);
-		fail("Catalog `" + TEST_CATALOG + "` could not be activated: " + lastConflict.getMessage());
-	}
-
-	/**
-	 * Waits out one backoff interval between two attempts at an operation the engine currently refuses, turning an
-	 * interrupt into a test failure rather than a silent early return.
-	 */
-	private void backOffBeforeRetry() {
-		try {
-			Thread.sleep(RETRY_BACKOFF_MILLIS);
-		} catch (InterruptedException ex) {
-			Thread.currentThread().interrupt();
-			fail("Interrupted while retrying an engine operation refused by a lifecycle conflict.");
 		}
 	}
 
@@ -890,7 +837,7 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 		// unloaded; when the close wins, the catalog comes back loaded. Both sides read the same bootstrap record -
 		// the newest state that reached the disk - which is the state under assertion
 		if (this.evita.getCatalogState(TEST_CATALOG).orElse(null) == CatalogState.INACTIVE) {
-			activateWithConflictRetry();
+			CatalogUnpublishableBarrierAssertions.activateWithConflictRetry(this.evita, TEST_CATALOG);
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/WarmUpRefusedSchemaPersistenceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/WarmUpRefusedSchemaPersistenceTest.java
@@ -38,6 +38,7 @@ import io.evitadb.api.requestResponse.schema.mutation.reference.CreateReferenceS
 import io.evitadb.core.Evita;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.dataType.Scope;
+import io.evitadb.spi.store.catalog.persistence.CatalogPersistenceService;
 import io.evitadb.test.Entities;
 import io.evitadb.test.EvitaTestSupport;
 import org.junit.jupiter.api.AfterEach;
@@ -48,7 +49,12 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static io.evitadb.test.TestTags.ATTRIBUTE;
 import static io.evitadb.test.TestTags.ENGINE;
@@ -75,9 +81,16 @@ import static org.junit.jupiter.api.Assertions.fail;
  * {@code Catalog#markUnpublishableDueToInvalidSchema}.
  *
  * The guarantee is not specific to one validation rule - {@code SealedCatalogSchema#validate()} fans out to every
- * entity and reference schema, so every rule reachable from there has the same exposure. Two independent rules are
- * therefore exercised below: the attribute filter-accelerator rule (the cheapest one to trigger from a raw mutation)
- * and the reference rule that requires a managed referenced entity type to exist.
+ * entity and reference schema, so every rule reachable from there has the same exposure. Three independent rules are
+ * therefore exercised below: the attribute filter-accelerator rule (the cheapest one to trigger from a raw mutation),
+ * the reference rule that requires a managed referenced entity type to exist, and the reflected-reference rule that
+ * requires the reference it reflects to resolve.
+ *
+ * The refusals also come from both directions, because the exposure does. An *additive* change declares something the
+ * catalog cannot satisfy; a *removal* takes away what an existing declaration relied on, and it reaches the same
+ * validation from the other side - see {@link InterlinkedCollectionRemoval}. Removal carries one hazard the additive
+ * cases do not: it parks the collection's data file for retirement, so a publication that should not have happened
+ * would not merely write a schema, it would unlink a file the previous bootstrap record still names.
  *
  * Each refusal is asserted on its **message**, never on the exception type alone - several unrelated refusals throw
  * `InvalidSchemaMutationException` and would satisfy a bare `assertThrows` while proving something else. And each
@@ -106,6 +119,8 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 	private static final String REFERENCE_CATEGORY = "category";
 	/** A reference name deliberately never declared, so a reflected reference to it cannot resolve. */
 	private static final String NON_EXISTING_REFERENCE_NAME = "nonExistingReference";
+	/** Primary key of the single category the interlinked pair is wired through. */
+	private static final int CATEGORY_PK = 1;
 	/** Primary key of the entity written by a session that closes successfully, and therefore publishes. */
 	private static final int PUBLISHED_PRODUCT_PK = 1;
 	/** Primary key of the entity written by the session whose close is refused, and which therefore never publishes. */
@@ -407,6 +422,212 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 	}
 
 	@Nested
+	@DisplayName("removal of one side of an interlinked pair")
+	class InterlinkedCollectionRemoval {
+
+		@Test
+		@Tag(REFERENCE)
+		@DisplayName("should not persist the removal of the collection a reflected reference targets")
+		void shouldNotPersistTheRemovalOfTheCollectionAReflectedReferenceTargets() {
+			// removal reaches the same `validate()` fan-out as every additive case above, but from the other side:
+			// nothing was declared, the target of an existing declaration was taken away. `Catalog#removeEntitySchema`
+			// drops the collection from the live schema accessor BEFORE it asks `flushMidSessionIfSchemaValid`, so the
+			// mid-session publication is skipped and the refusal lands on the session close.
+			//
+			// CALIBRATION - this case does NOT pin the skip, and must not be read as doing so. Measured by disabling
+			// the `isSchemaValid()` guard: this test still passes, because a mid-session flush here is a no-op for a
+			// second, independent reason. `Catalog#flush` derives `changeOccurred` from the CATALOG schema version,
+			// and `updateSchema` exchanges that version only after `removeEntitySchema` has returned - so at the
+			// moment of the flush no version has moved and the removed collection is already out of the map that
+			// would report one. The sibling that does pin the skip is
+			// `shouldNotPublishTheHalfTornPairWhenTheSameSessionThenDefinesAnotherCollection`, where the later
+			// collection definition supplies the change the flush needs
+			WarmUpRefusedSchemaPersistenceTest.this.defineInterlinkedProductAndCategory();
+			final List<String> dataFilesBefore =
+				WarmUpRefusedSchemaPersistenceTest.this.listCollectionDataFileNames();
+			assertEquals(
+				2, dataFilesBefore.size(),
+				() -> "Both collections must have a data file before the removal, but was: " + dataFilesBefore
+			);
+
+			final InvalidSchemaMutationException exception =
+				CatalogUnpublishableBarrierAssertions.assertRefusalRaisesTheBarrier(
+					WarmUpRefusedSchemaPersistenceTest.this.evita, TEST_CATALOG,
+					InvalidSchemaMutationException.class,
+					() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+						TEST_CATALOG,
+						session -> {
+							session.deleteCollection(Entities.PRODUCT);
+						}
+					)
+				);
+			assertTrue(
+				exception.getMessage().contains(REFERENCE_REFLECTED_PRODUCTS),
+				() -> "The refusal must name the reflected reference left without a target, but was: " +
+					exception.getMessage()
+			);
+
+			WarmUpRefusedSchemaPersistenceTest.this.reopenCatalog();
+			assertEquals(
+				Set.of(Entities.CATEGORY, Entities.PRODUCT),
+				WarmUpRefusedSchemaPersistenceTest.this.readEntityTypes(),
+				"A removal the close refuses must not survive that close"
+			);
+			// the durability half, which the schema assertion above cannot see: the removal also parked the
+			// collection's data file for retirement, and a round that never publishes must DROP that retirement -
+			// the file is still named by the bootstrap record this very reopen followed
+			assertEquals(
+				dataFilesBefore,
+				WarmUpRefusedSchemaPersistenceTest.this.listCollectionDataFileNames(),
+				"A refused removal must not unlink the data file the published bootstrap record still names"
+			);
+		}
+
+		@Test
+		@Tag(REFERENCE)
+		@DisplayName("should not persist the removal of the collection a managed reference targets")
+		void shouldNotPersistTheRemovalOfTheCollectionAManagedReferenceTargets() {
+			// the mirror order, and a different rule: dropping the reflecting side leaves the ordinary managed
+			// reference on the other side pointing at an entity type that is no longer in the catalog schema, which
+			// `ReferenceSchema#validate` refuses rather than `ReflectedReferenceSchema#validate`
+			WarmUpRefusedSchemaPersistenceTest.this.defineInterlinkedProductAndCategory();
+
+			final InvalidSchemaMutationException exception =
+				CatalogUnpublishableBarrierAssertions.assertRefusalRaisesTheBarrier(
+					WarmUpRefusedSchemaPersistenceTest.this.evita, TEST_CATALOG,
+					InvalidSchemaMutationException.class,
+					() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+						TEST_CATALOG,
+						session -> {
+							session.deleteCollection(Entities.CATEGORY);
+						}
+					)
+				);
+			assertTrue(
+				exception.getMessage().contains(Entities.CATEGORY),
+				() -> "The refusal must name the entity type that is gone, but was: " + exception.getMessage()
+			);
+
+			WarmUpRefusedSchemaPersistenceTest.this.reopenCatalog();
+			assertEquals(
+				Set.of(Entities.CATEGORY, Entities.PRODUCT),
+				WarmUpRefusedSchemaPersistenceTest.this.readEntityTypes(),
+				"A removal the close refuses must not survive that close, whichever side of the pair it dropped"
+			);
+		}
+
+		@Test
+		@Tag(REFERENCE)
+		@DisplayName("should not publish the half-torn pair when the same session then defines another collection")
+		void shouldNotPublishTheHalfTornPairWhenTheSameSessionThenDefinesAnotherCollection() {
+			// this is the case `flushMidSessionIfSchemaValid` exists for, and the one where skipping the flush is
+			// load-bearing rather than merely tidy. A mid-session publication here would write a bootstrap record
+			// naming a catalog header the removed collection is no longer in, AND release the retirement parked for
+			// its data file - unlinking a file the previous record still named. The barrier raised at the close
+			// afterwards cannot take either of those back.
+			//
+			// CALIBRATED: disabling the `isSchemaValid()` guard in `Catalog#flushMidSessionIfSchemaValid` fails this
+			// test, and the reopened catalog then holds `[CATEGORY, BRAND]` - the removal published and the product
+			// collection is gone from the disk. Re-measure that if the guard or `Catalog#flush`'s change detection is
+			// ever reworked; the sibling cases above pass either way and will not notice
+			WarmUpRefusedSchemaPersistenceTest.this.defineInterlinkedProductAndCategory();
+			final List<String> dataFilesBefore =
+				WarmUpRefusedSchemaPersistenceTest.this.listCollectionDataFileNames();
+
+			CatalogUnpublishableBarrierAssertions.assertRefusalRaisesTheBarrier(
+				WarmUpRefusedSchemaPersistenceTest.this.evita, TEST_CATALOG,
+				InvalidSchemaMutationException.class,
+				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.deleteCollection(Entities.PRODUCT);
+						// the mid-session publication, in the very same session as the removal that broke the schema
+						session.defineEntitySchema(Entities.BRAND)
+							.withoutGeneratedPrimaryKey()
+							.updateVia(session);
+					}
+				)
+			);
+
+			WarmUpRefusedSchemaPersistenceTest.this.reopenCatalog();
+			assertEquals(
+				Set.of(Entities.CATEGORY, Entities.PRODUCT),
+				WarmUpRefusedSchemaPersistenceTest.this.readEntityTypes(),
+				"A collection defined after the removal must not publish the half-torn pair with it"
+			);
+			// the assertion is that nothing was UNLINKED, not that the folder came back unchanged. The collection
+			// this session defined created its own data file on the way, and that file survives the refusal - no
+			// published bootstrap record names it, which makes it inert dead space that costs disk and never
+			// correctness (`.claude/rules/durability-model.md`). An unlink is the other direction, and is real damage
+			assertTrue(
+				WarmUpRefusedSchemaPersistenceTest.this.listCollectionDataFileNames()
+					.containsAll(dataFilesBefore),
+				() -> "A collection defined after the removal must not release the retirement the removal parked, " +
+					"but the folder no longer holds all of " + dataFilesBefore
+			);
+		}
+
+		@Test
+		@Tag(REFERENCE)
+		@DisplayName("should persist the removal of both interlinked collections made in one session")
+		void shouldPersistTheRemovalOfBothInterlinkedCollectionsMadeInOneSession() {
+			assertBothSidesCanBeRemovedInOneSession(Entities.PRODUCT, Entities.CATEGORY);
+		}
+
+		@Test
+		@Tag(REFERENCE)
+		@DisplayName("should persist the removal of both interlinked collections dropped in the opposite order")
+		void shouldPersistTheRemovalOfBothInterlinkedCollectionsDroppedInTheOppositeOrder() {
+			assertBothSidesCanBeRemovedInOneSession(Entities.CATEGORY, Entities.PRODUCT);
+		}
+
+		/**
+		 * The control for the three refusals above, and the guarantee they must not be read as contradicting: a
+		 * circular pair CAN be dismantled, provided both removals happen inside one session.
+		 *
+		 * Neither order validates halfway through - whichever side goes first leaves the other one dangling - so this
+		 * passes only because the skipped mid-session publication defers the decision to the close, by which point the
+		 * schema is whole again. Without the control, every assertion above would also be satisfied by an engine that
+		 * simply refused to drop a referenced collection at all.
+		 *
+		 * @param first  entity type to drop first; must not be null
+		 * @param second entity type to drop second; must not be null
+		 */
+		private void assertBothSidesCanBeRemovedInOneSession(@Nonnull String first, @Nonnull String second) {
+			WarmUpRefusedSchemaPersistenceTest.this.defineInterlinkedProductAndCategory();
+			assertEquals(
+				2, WarmUpRefusedSchemaPersistenceTest.this.listCollectionDataFileNames().size(),
+				"Both collections must have a data file before the removal"
+			);
+
+			WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.deleteCollection(first);
+					session.deleteCollection(second);
+				}
+			);
+			assertEquals(
+				CatalogState.WARMING_UP,
+				WarmUpRefusedSchemaPersistenceTest.this.evita.getCatalogState(TEST_CATALOG).orElse(null),
+				"A session that leaves the schema whole must close without raising the barrier"
+			);
+
+			WarmUpRefusedSchemaPersistenceTest.this.reopenCatalog();
+			assertEquals(
+				Set.of(),
+				WarmUpRefusedSchemaPersistenceTest.this.readEntityTypes(),
+				"Both removals must survive the close that publishes them"
+			);
+			assertEquals(
+				List.of(),
+				WarmUpRefusedSchemaPersistenceTest.this.listCollectionDataFileNames(),
+				"The record that superseded the pair must release both parked retirements"
+			);
+		}
+	}
+
+	@Nested
 	@DisplayName("publication that happens before the session closes")
 	class MidSessionPublication {
 
@@ -642,6 +863,23 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 	 */
 	@Nonnull
 	private EntitySchemaContract reopenAndReadSchema() {
+		reopenCatalog();
+		return this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				return session.getEntitySchemaOrThrow(Entities.PRODUCT);
+			}
+		);
+	}
+
+	/**
+	 * Closes the running instance and opens a fresh one over the same storage directory, so that everything read
+	 * afterwards comes from the disk rather than from a catalog that never wrote it.
+	 *
+	 * Separate from {@link #reopenAndReadSchema()} because a removal has no product schema to read back - the whole
+	 * point of the assertion is which collections exist at all.
+	 */
+	private void reopenCatalog() {
 		this.evita.close();
 		this.evita = new Evita(configuration());
 		// deterministic rather than a wait: the constructor schedules the initial catalog load and this joins the
@@ -654,12 +892,90 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 		if (this.evita.getCatalogState(TEST_CATALOG).orElse(null) == CatalogState.INACTIVE) {
 			activateWithConflictRetry();
 		}
+	}
+
+	/**
+	 * Reads the entity types the currently open catalog holds.
+	 *
+	 * @return the entity types; never null
+	 */
+	@Nonnull
+	private Set<String> readEntityTypes() {
 		return this.evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
-				return session.getEntitySchemaOrThrow(Entities.PRODUCT);
+				return session.getAllEntityTypes();
 			}
 		);
+	}
+
+	/**
+	 * Defines a circular product/category pair: an ordinary managed reference from the product to the category, and a
+	 * reflected reference on the category mirroring it back. One entity is written into each, so that both collections
+	 * own a data file the assertions below can look for.
+	 *
+	 * Both directions matter to the tests that use this. Dropping the product leaves the category's reflected
+	 * reference without the reference it reflects; dropping the category leaves the product's managed reference
+	 * without the entity type it names. Neither half of the pair can be dropped on its own.
+	 */
+	private void defineInterlinkedProductAndCategory() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.CATEGORY)
+					.withoutGeneratedPrimaryKey()
+					.updateVia(session);
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withReferenceToEntity(
+						REFERENCE_CATEGORY, Entities.CATEGORY, Cardinality.ZERO_OR_ONE,
+						whichIs -> whichIs.indexedForFilteringAndPartitioning()
+					)
+					.updateVia(session);
+			}
+		);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.getEntitySchemaOrThrow(Entities.CATEGORY)
+					.openForWrite()
+					.withReflectedReferenceToEntity(
+						REFERENCE_REFLECTED_PRODUCTS, Entities.PRODUCT, REFERENCE_CATEGORY,
+						whichIs -> whichIs.withAttributesInherited()
+					)
+					.updateVia(session);
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, CATEGORY_PK));
+				session.upsertEntity(
+					session.createNewEntity(Entities.PRODUCT, PUBLISHED_PRODUCT_PK)
+						.setReference(REFERENCE_CATEGORY, CATEGORY_PK)
+				);
+			}
+		);
+	}
+
+	/**
+	 * Lists the entity-collection data files the catalog folder currently holds, by file name.
+	 *
+	 * This is the only way to tell a removal that published from one that was refused - both leave the same catalog
+	 * behind in memory. A removal does not unlink the collection's data file: the file is still named by the
+	 * bootstrap record a reload would follow, so the unlink is parked and released only by the record that supersedes
+	 * it ({@code DefaultCatalogPersistenceService#retireDataFile}). A round that never publishes must therefore drop
+	 * the retirement, and a round that publishes must honour it.
+	 *
+	 * @return the data-file names, sorted; never null
+	 */
+	@Nonnull
+	private List<String> listCollectionDataFileNames() {
+		try (final Stream<Path> storageContent = Files.walk(this.paths.storage())) {
+			return storageContent
+				.filter(Files::isRegularFile)
+				.map(it -> it.getFileName().toString())
+				.filter(it -> it.endsWith(CatalogPersistenceService.ENTITY_COLLECTION_FILE_SUFFIX))
+				.sorted()
+				.toList();
+		} catch (IOException ex) {
+			return fail("Catalog storage folder `" + this.paths.storage() + "` could not be listed.", ex);
+		}
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/WarmUpRefusedSchemaPersistenceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/WarmUpRefusedSchemaPersistenceTest.java
@@ -34,12 +34,7 @@ import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.api.requestResponse.schema.mutation.attribute.ScopedAttributeFilterAccelerators;
 import io.evitadb.api.requestResponse.schema.mutation.attribute.SetAttributeSchemaAcceleratedMutation;
 import io.evitadb.api.requestResponse.schema.mutation.catalog.ModifyEntitySchemaMutation;
-import io.evitadb.api.requestResponse.cdc.ChangeCaptureContent;
-import io.evitadb.api.requestResponse.cdc.ChangeCapturePublisher;
-import io.evitadb.api.requestResponse.cdc.ChangeSystemCapture;
-import io.evitadb.api.requestResponse.cdc.ChangeSystemCaptureRequest;
 import io.evitadb.api.requestResponse.schema.mutation.reference.CreateReferenceSchemaMutation;
-import io.evitadb.api.requestResponse.cdc.HostSystemEvent;
 import io.evitadb.core.Evita;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.dataType.Scope;
@@ -51,13 +46,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import javax.annotation.Nonnull;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Flow;
-import java.util.concurrent.TimeUnit;
 
 import static io.evitadb.test.TestTags.ATTRIBUTE;
 import static io.evitadb.test.TestTags.ENGINE;
@@ -67,7 +58,6 @@ import static io.evitadb.test.TestTags.SCHEMA;
 import static io.evitadb.test.TestTags.STORAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -161,7 +151,8 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 			// mutation has to be submitted raw. Every other route into the schema (gRPC, REST, GraphQL, the WAL)
 			// carries mutations the same way, which is what makes this the shape worth pinning
 			final InvalidSchemaMutationException exception =
-				WarmUpRefusedSchemaPersistenceTest.this.assertRefusalRaisesTheBarrier(
+				CatalogUnpublishableBarrierAssertions.assertRefusalRaisesTheBarrier(
+					WarmUpRefusedSchemaPersistenceTest.this.evita, TEST_CATALOG,
 					InvalidSchemaMutationException.class,
 					() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
 						TEST_CATALOG,
@@ -252,7 +243,8 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 			WarmUpRefusedSchemaPersistenceTest.this.defineProductWithPlainAttribute();
 
 			final InvalidSchemaMutationException exception =
-				WarmUpRefusedSchemaPersistenceTest.this.assertRefusalRaisesTheBarrier(
+				CatalogUnpublishableBarrierAssertions.assertRefusalRaisesTheBarrier(
+					WarmUpRefusedSchemaPersistenceTest.this.evita, TEST_CATALOG,
 					InvalidSchemaMutationException.class,
 					() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
 						TEST_CATALOG,
@@ -341,7 +333,8 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 			// the barrier - see the comment at `EvitaSession#closeInternal` for what does and does not
 			WarmUpRefusedSchemaPersistenceTest.this.defineProductWithPlainAttribute();
 
-			WarmUpRefusedSchemaPersistenceTest.this.assertRefusalRaisesTheBarrier(
+			CatalogUnpublishableBarrierAssertions.assertRefusalRaisesTheBarrier(
+				WarmUpRefusedSchemaPersistenceTest.this.evita, TEST_CATALOG,
 				EvitaInvalidUsageException.class,
 				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
 					TEST_CATALOG,
@@ -426,7 +419,8 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 			// publication: `Catalog#createEntitySchema` runs a full flush inline and joins it while still in warm-up
 			WarmUpRefusedSchemaPersistenceTest.this.defineProductWithPlainAttribute();
 
-			WarmUpRefusedSchemaPersistenceTest.this.assertRefusalRaisesTheBarrier(
+			CatalogUnpublishableBarrierAssertions.assertRefusalRaisesTheBarrier(
+				WarmUpRefusedSchemaPersistenceTest.this.evita, TEST_CATALOG,
 				InvalidSchemaMutationException.class,
 				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
 					TEST_CATALOG,
@@ -469,7 +463,8 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 			// the barrier here is raised by the go-live operator, and the deactivation it schedules races that same
 			// operator's finalization for the catalog's conflict key - so awaiting it also pins the retry in
 			// `Catalog#attemptDeactivation`
-			WarmUpRefusedSchemaPersistenceTest.this.assertRefusalRaisesTheBarrier(
+			CatalogUnpublishableBarrierAssertions.assertRefusalRaisesTheBarrier(
+				WarmUpRefusedSchemaPersistenceTest.this.evita, TEST_CATALOG,
 				InvalidSchemaMutationException.class,
 				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
 					TEST_CATALOG,
@@ -522,7 +517,8 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 			// collection that already holds entities is refused by a pre-flight check instead, before any exchange
 			// happens, so it would leave nothing to recover FROM and the test would pass without proving anything
 			final InvalidSchemaMutationException exception =
-				WarmUpRefusedSchemaPersistenceTest.this.assertRefusalRaisesTheBarrier(
+				CatalogUnpublishableBarrierAssertions.assertRefusalRaisesTheBarrier(
+					WarmUpRefusedSchemaPersistenceTest.this.evita, TEST_CATALOG,
 					InvalidSchemaMutationException.class,
 					() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
 						TEST_CATALOG,
@@ -574,70 +570,12 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 	}
 
 	/**
-	 * Runs an action expected to be refused, and asserts that the refusal raised the unpublishable barrier.
-	 *
-	 * **This is what keeps the tests below from passing for the wrong reason.** The guarantee they assert rests on
-	 * the barrier, and the barrier is raised only by the catalog-schema validation that runs once the schema has
-	 * already been exchanged into the running catalog. A refusal from a pre-flight check instead - the accelerator
-	 * rule has one for non-empty collections, and {@code SetAttributeSchemaAcceleratedMutation} is one edit away
-	 * from gaining another - throws the same exception type with a similar message and leaves the catalog untouched.
-	 * Every assertion about the reopened schema would then hold trivially, because nothing was ever exchanged.
-	 * Deactivation is the barrier's observable consequence ({@code Catalog#recordUnpublishableCause} schedules it),
-	 * so waiting for it is what tells the two refusals apart.
-	 *
-	 * @param expectedException type the refusal is expected to throw; must not be null
-	 * @param refusedAction     the action whose refusal is under test; must not be null
-	 * @return the exception the action was refused with; never null
-	 */
-	@Nonnull
-	private <T extends RuntimeException> T assertRefusalRaisesTheBarrier(
-		@Nonnull Class<T> expectedException,
-		@Nonnull Executable refusedAction
-	) {
-		// registered BEFORE the action, so the deactivation it schedules cannot settle into a stream nobody is
-		// subscribed to
-		try (final SettledStateLatch deactivation = subscribeToSettledState(CatalogState.INACTIVE)) {
-			final T exception = assertThrows(expectedException, refusedAction);
-			deactivation.await();
-			return exception;
-		}
-	}
-
-	/**
-	 * Subscribes to the system change stream and returns a latch that opens when the engine reports the test catalog
-	 * as having settled into the given state.
-	 *
-	 * The deactivation a refusal schedules is asynchronous by design - it runs on the engine's scheduler because it
-	 * has to close the very sessions the refusing thread is running under - so a test that asks what happened next
-	 * has to wait for it. This is the transition announcing itself rather than the test guessing when to look:
-	 * `Evita#notifyCatalogStateSettled` emits a {@link HostSystemEvent.CatalogInstalledIntoLiveView} from the
-	 * deactivation operator's own completion phase. **Register before triggering the deactivation**, or the event
-	 * fires into a stream nobody is subscribed to.
-	 *
-	 * @param expectedState the settled state to wait for; must not be null
-	 * @return the subscription, which closes the underlying publisher and carries the latch; never null
-	 */
-	@Nonnull
-	private SettledStateLatch subscribeToSettledState(@Nonnull CatalogState expectedState) {
-		final ChangeCapturePublisher<ChangeSystemCapture> publisher = this.evita.registerSystemChangeCapture(
-			ChangeSystemCaptureRequest.builder()
-				.sinceVersion(this.evita.getEngineState().version() + 1)
-				.content(ChangeCaptureContent.BODY)
-				.hostArea()
-				.build()
-		);
-		final SettledStateLatch latch = new SettledStateLatch(publisher, expectedState);
-		publisher.subscribe(latch);
-		return latch;
-	}
-
-	/**
 	 * Activates the test catalog, retrying while the engine reports that another lifecycle operation for it is
 	 * still in flight.
 	 *
 	 * The retry is not optional. A deactivation settles in two steps: the engine-state update lands - which is what
-	 * {@link SettledStateLatch} observes - and the lifecycle mutation carrying it releases its conflict key a
-	 * moment later, as it finalizes. An activation issued in between is refused with
+	 * {@link CatalogUnpublishableBarrierAssertions.SettledStateLatch} observes - and the lifecycle mutation carrying
+	 * it releases its conflict key a moment later, as it finalizes. An activation issued in between is refused with
 	 * {@link ConflictingEngineMutationException}, the engine's "another lifecycle operation for this catalog is
 	 * still in flight" signal, which is a transient rather than a failure worth failing the test over.
 	 *
@@ -674,72 +612,6 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 		} catch (InterruptedException ex) {
 			Thread.currentThread().interrupt();
 			fail("Interrupted while retrying an engine operation refused by a lifecycle conflict.");
-		}
-	}
-
-	/**
-	 * A {@link Flow.Subscriber} over the system change stream that opens a latch when the test catalog is reported
-	 * as having settled into one particular state.
-	 */
-	private static final class SettledStateLatch implements Flow.Subscriber<ChangeSystemCapture>, AutoCloseable {
-		private final ChangeCapturePublisher<ChangeSystemCapture> publisher;
-		private final CatalogState expectedState;
-		private final CountDownLatch latch = new CountDownLatch(1);
-
-		SettledStateLatch(
-			@Nonnull ChangeCapturePublisher<ChangeSystemCapture> publisher,
-			@Nonnull CatalogState expectedState
-		) {
-			this.publisher = publisher;
-			this.expectedState = expectedState;
-		}
-
-		@Override
-		public void onSubscribe(@Nonnull Flow.Subscription subscription) {
-			subscription.request(Long.MAX_VALUE);
-		}
-
-		@Override
-		public void onNext(@Nonnull ChangeSystemCapture item) {
-			if (item.body() instanceof HostSystemEvent.CatalogInstalledIntoLiveView installed
-				&& TEST_CATALOG.equals(installed.catalogName())
-				&& installed.observedState() == this.expectedState) {
-				this.latch.countDown();
-			}
-		}
-
-		@Override
-		public void onError(@Nonnull Throwable throwable) {
-			// nothing to do - a stream that fails leaves the latch closed and `await` reports the timeout, which
-			// carries the same verdict with a message that names the state the test was waiting for
-		}
-
-		@Override
-		public void onComplete() {
-			// see `onError` - a stream that ends without the event is indistinguishable from one that never
-			// delivered it, and both are the same test failure
-		}
-
-		/**
-		 * Blocks until the expected state is reported, failing the test when it is not reported in time.
-		 */
-		void await() {
-			try {
-				if (!this.latch.await(AWAIT_BUDGET_MILLIS, TimeUnit.MILLISECONDS)) {
-					fail(
-						"Catalog `" + TEST_CATALOG + "` was never reported as having settled into `" +
-							this.expectedState + "`."
-					);
-				}
-			} catch (InterruptedException ex) {
-				Thread.currentThread().interrupt();
-				fail("Interrupted while waiting for catalog `" + TEST_CATALOG + "` to settle.");
-			}
-		}
-
-		@Override
-		public void close() {
-			this.publisher.close();
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/WarmUpRefusedSchemaPersistenceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/WarmUpRefusedSchemaPersistenceTest.java
@@ -34,8 +34,14 @@ import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.api.requestResponse.schema.mutation.attribute.ScopedAttributeFilterAccelerators;
 import io.evitadb.api.requestResponse.schema.mutation.attribute.SetAttributeSchemaAcceleratedMutation;
 import io.evitadb.api.requestResponse.schema.mutation.catalog.ModifyEntitySchemaMutation;
+import io.evitadb.api.requestResponse.cdc.ChangeCaptureContent;
+import io.evitadb.api.requestResponse.cdc.ChangeCapturePublisher;
+import io.evitadb.api.requestResponse.cdc.ChangeSystemCapture;
+import io.evitadb.api.requestResponse.cdc.ChangeSystemCaptureRequest;
 import io.evitadb.api.requestResponse.schema.mutation.reference.CreateReferenceSchemaMutation;
+import io.evitadb.api.requestResponse.cdc.HostSystemEvent;
 import io.evitadb.core.Evita;
+import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.dataType.Scope;
 import io.evitadb.test.Entities;
 import io.evitadb.test.EvitaTestSupport;
@@ -45,9 +51,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import javax.annotation.Nonnull;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
 
 import static io.evitadb.test.TestTags.ATTRIBUTE;
 import static io.evitadb.test.TestTags.ENGINE;
@@ -100,14 +110,24 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 	private static final String REFERENCE_BRAND = "brand";
 	/** An entity type deliberately never defined in the catalog, so a managed reference to it cannot validate. */
 	private static final String NON_EXISTING_ENTITY_TYPE = "nonExistingEntityType";
+	/** Name of the reflected reference declared on the category collection. */
+	private static final String REFERENCE_REFLECTED_PRODUCTS = "productsInCategory";
+	/** Name of the reference on the product collection that the reflected reference above points at. */
+	private static final String REFERENCE_CATEGORY = "category";
+	/** A reference name deliberately never declared, so a reflected reference to it cannot resolve. */
+	private static final String NON_EXISTING_REFERENCE_NAME = "nonExistingReference";
 	/** Primary key of the entity written by a session that closes successfully, and therefore publishes. */
 	private static final int PUBLISHED_PRODUCT_PK = 1;
 	/** Primary key of the entity written by the session whose close is refused, and which therefore never publishes. */
 	private static final int DISCARDED_PRODUCT_PK = 2;
-	/** Upper bound on how long any single asynchronous catalog lifecycle step is waited for. */
-	private static final long AWAIT_BUDGET_MILLIS = 10_000L;
-	/** Interval between two observations while waiting for such a step. */
-	private static final long POLL_INTERVAL_MILLIS = 20L;
+	/**
+	 * Upper bound on how long any single asynchronous catalog lifecycle step is waited for. Generous on purpose -
+	 * a latch returns the instant the work completes, so the bound is only ever paid by a genuine hang, and a
+	 * loaded machine can only push a positive wait toward expiry (`.claude/rules/testing.md`).
+	 */
+	private static final long AWAIT_BUDGET_MILLIS = 30_000L;
+	/** Backoff between two attempts at an operation the engine refuses while another one is still in flight. */
+	private static final long RETRY_BACKOFF_MILLIS = 20L;
 
 	private TestPaths paths;
 	private Evita evita;
@@ -140,25 +160,26 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 			// the builder cannot express this state at all - it refuses the chain while assembling it - so the
 			// mutation has to be submitted raw. Every other route into the schema (gRPC, REST, GraphQL, the WAL)
 			// carries mutations the same way, which is what makes this the shape worth pinning
-			final InvalidSchemaMutationException exception = assertThrows(
-				InvalidSchemaMutationException.class,
-				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
-					TEST_CATALOG,
-					session -> {
-						session.updateEntitySchema(
-							new ModifyEntitySchemaMutation(
-								Entities.PRODUCT,
-								new SetAttributeSchemaAcceleratedMutation(
-									ATTRIBUTE_CODE,
-									new ScopedAttributeFilterAccelerators(
-										Scope.LIVE, AttributeFilterAccelerator.SUBSTRING_SEARCH
+			final InvalidSchemaMutationException exception =
+				WarmUpRefusedSchemaPersistenceTest.this.assertRefusalRaisesTheBarrier(
+					InvalidSchemaMutationException.class,
+					() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+						TEST_CATALOG,
+						session -> {
+							session.updateEntitySchema(
+								new ModifyEntitySchemaMutation(
+									Entities.PRODUCT,
+									new SetAttributeSchemaAcceleratedMutation(
+										ATTRIBUTE_CODE,
+										new ScopedAttributeFilterAccelerators(
+											Scope.LIVE, AttributeFilterAccelerator.SUBSTRING_SEARCH
+										)
 									)
 								)
-							)
-						);
-					}
-				)
-			);
+							);
+						}
+					)
+				);
 			assertTrue(
 				exception.getMessage().contains(AttributeFilterAccelerator.SUBSTRING_SEARCH.name()),
 				() -> "The refusal must name the accelerator it refuses, but was: " + exception.getMessage()
@@ -230,25 +251,26 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 			// warm-up write path, not of the accelerator rule that first exposed it
 			WarmUpRefusedSchemaPersistenceTest.this.defineProductWithPlainAttribute();
 
-			final InvalidSchemaMutationException exception = assertThrows(
-				InvalidSchemaMutationException.class,
-				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
-					TEST_CATALOG,
-					session -> {
-						session.updateEntitySchema(
-							new ModifyEntitySchemaMutation(
-								Entities.PRODUCT,
-								new CreateReferenceSchemaMutation(
-									REFERENCE_BRAND, null, null, Cardinality.ZERO_OR_ONE,
-									NON_EXISTING_ENTITY_TYPE, true,
-									null, false,
-									false, false
+			final InvalidSchemaMutationException exception =
+				WarmUpRefusedSchemaPersistenceTest.this.assertRefusalRaisesTheBarrier(
+					InvalidSchemaMutationException.class,
+					() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+						TEST_CATALOG,
+						session -> {
+							session.updateEntitySchema(
+								new ModifyEntitySchemaMutation(
+									Entities.PRODUCT,
+									new CreateReferenceSchemaMutation(
+										REFERENCE_BRAND, null, null, Cardinality.ZERO_OR_ONE,
+										NON_EXISTING_ENTITY_TYPE, true,
+										null, false,
+										false, false
+									)
 								)
-							)
-						);
-					}
-				)
-			);
+							);
+						}
+					)
+				);
 			// pinned to the wording of the rule under test, not merely to the exception type:
 			// `CreateReferenceSchemaMutation` has refusals of its own that throw the same type, and a bare
 			// `assertThrows` would accept any of them
@@ -305,6 +327,178 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 	}
 
 	@Nested
+	@DisplayName("refused by the unresolved reflected-reference rule")
+	class ReflectedReferenceRule {
+
+		@Test
+		@Tag(REFERENCE)
+		@DisplayName("should not persist a reflected reference whose target reference does not exist")
+		void shouldNotPersistAReflectedReferenceWhoseTargetReferenceDoesNotExist() {
+			// a THIRD rule from the same `validate()` fan-out, on the reflected-reference machinery this time - the
+			// part of the schema whose validation reaches getters that can refuse to answer at all. Asserted on
+			// `EvitaInvalidUsageException` because that is the family the refusal belongs to; measured, it arrives
+			// as the `SchemaAlteringException` subtype, so this case does NOT on its own justify the wide catch at
+			// the barrier - see the comment at `EvitaSession#closeInternal` for what does and does not
+			WarmUpRefusedSchemaPersistenceTest.this.defineProductWithPlainAttribute();
+
+			WarmUpRefusedSchemaPersistenceTest.this.assertRefusalRaisesTheBarrier(
+				EvitaInvalidUsageException.class,
+				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.defineEntitySchema(Entities.CATEGORY)
+							.withoutGeneratedPrimaryKey()
+							.withReflectedReferenceToEntity(
+								REFERENCE_REFLECTED_PRODUCTS, Entities.PRODUCT, NON_EXISTING_REFERENCE_NAME,
+								whichIs -> whichIs.withAttributesInherited()
+							)
+							.updateVia(session);
+					}
+				)
+			);
+
+			final EntitySchemaContract reopenedSchema =
+				WarmUpRefusedSchemaPersistenceTest.this.reopenAndReadSchema();
+			assertFalse(
+				reopenedSchema.getReference(REFERENCE_REFLECTED_PRODUCTS).isPresent(),
+				"The refused reflected reference must not survive the close that follows the refusal"
+			);
+		}
+
+		@Test
+		@Tag(REFERENCE)
+		@DisplayName("should persist a reflected reference whose target reference exists")
+		void shouldPersistAReflectedReferenceWhoseTargetReferenceExists() {
+			// the control for the case above - the same reflected reference, against a target that resolves
+			WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema(Entities.CATEGORY)
+						.withoutGeneratedPrimaryKey()
+						.updateVia(session);
+					session.defineEntitySchema(Entities.PRODUCT)
+						.withoutGeneratedPrimaryKey()
+						.withReferenceToEntity(
+							REFERENCE_CATEGORY, Entities.CATEGORY, Cardinality.ZERO_OR_ONE,
+							whichIs -> whichIs.indexedForFilteringAndPartitioning()
+						)
+						.updateVia(session);
+				}
+			);
+			WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntitySchemaOrThrow(Entities.CATEGORY)
+						.openForWrite()
+						.withReflectedReferenceToEntity(
+							REFERENCE_REFLECTED_PRODUCTS, Entities.PRODUCT, REFERENCE_CATEGORY,
+							whichIs -> whichIs.withAttributesInherited()
+						)
+						.updateVia(session);
+				}
+			);
+
+			WarmUpRefusedSchemaPersistenceTest.this.reopenAndReadSchema();
+			WarmUpRefusedSchemaPersistenceTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(
+						session.getEntitySchemaOrThrow(Entities.CATEGORY)
+							.getReference(REFERENCE_REFLECTED_PRODUCTS).isPresent(),
+						"An accepted reflected reference must survive the reopen - otherwise the assertion above " +
+							"proves nothing"
+					);
+				}
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("publication that happens before the session closes")
+	class MidSessionPublication {
+
+		@Test
+		@Tag(REFERENCE)
+		@DisplayName("should not persist the refused schema when the same session then defines another collection")
+		void shouldNotPersistTheRefusedSchemaWhenTheSameSessionThenDefinesAnotherCollection() {
+			// the barrier is raised when the session CLOSES, so anything that publishes EARLIER in the same session
+			// publishes the refused schema before there is a barrier to stop it. Creating a collection is such a
+			// publication: `Catalog#createEntitySchema` runs a full flush inline and joins it while still in warm-up
+			WarmUpRefusedSchemaPersistenceTest.this.defineProductWithPlainAttribute();
+
+			WarmUpRefusedSchemaPersistenceTest.this.assertRefusalRaisesTheBarrier(
+				InvalidSchemaMutationException.class,
+				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.updateEntitySchema(
+							new ModifyEntitySchemaMutation(
+								Entities.PRODUCT,
+								new CreateReferenceSchemaMutation(
+									REFERENCE_BRAND, null, null, Cardinality.ZERO_OR_ONE,
+									NON_EXISTING_ENTITY_TYPE, true,
+									null, false,
+									false, false
+								)
+							)
+						);
+						// the mid-session publication, in the very same session as the offending mutation
+						session.defineEntitySchema(Entities.CATEGORY)
+							.withoutGeneratedPrimaryKey()
+							.updateVia(session);
+					}
+				)
+			);
+
+			final EntitySchemaContract reopenedSchema = WarmUpRefusedSchemaPersistenceTest.this.reopenAndReadSchema();
+			assertFalse(
+				reopenedSchema.getReference(REFERENCE_BRAND).isPresent(),
+				"A collection defined after the offending mutation must not publish the refused schema with it"
+			);
+		}
+
+		@Test
+		@Tag(REFERENCE)
+		@DisplayName("should not publish the refused schema when the same session goes live")
+		void shouldNotPublishTheRefusedSchemaWhenTheSameSessionGoesLive() {
+			// `goLiveAndClose` closes the session through its own termination path rather than through
+			// `EvitaSession#closeInternal`, so the catalog-schema validation that guards an ordinary warm-up close
+			// does not run for the session that calls it
+			WarmUpRefusedSchemaPersistenceTest.this.defineProductWithPlainAttribute();
+
+			// the barrier here is raised by the go-live operator, and the deactivation it schedules races that same
+			// operator's finalization for the catalog's conflict key - so awaiting it also pins the retry in
+			// `Catalog#attemptDeactivation`
+			WarmUpRefusedSchemaPersistenceTest.this.assertRefusalRaisesTheBarrier(
+				InvalidSchemaMutationException.class,
+				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.updateEntitySchema(
+							new ModifyEntitySchemaMutation(
+								Entities.PRODUCT,
+								new CreateReferenceSchemaMutation(
+									REFERENCE_BRAND, null, null, Cardinality.ZERO_OR_ONE,
+									NON_EXISTING_ENTITY_TYPE, true,
+									null, false,
+									false, false
+								)
+							)
+						);
+						session.goLiveAndClose();
+					}
+				)
+			);
+
+			final EntitySchemaContract reopenedSchema = WarmUpRefusedSchemaPersistenceTest.this.reopenAndReadSchema();
+			assertFalse(
+				reopenedSchema.getReference(REFERENCE_BRAND).isPresent(),
+				"Going live must not publish a schema the engine would refuse to accept"
+			);
+		}
+	}
+
+	@Nested
 	@DisplayName("recovery from the refusal")
 	class Recovery {
 
@@ -327,26 +521,27 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 			// The managed-reference rule is the one used here rather than the accelerator rule: an accelerator on a
 			// collection that already holds entities is refused by a pre-flight check instead, before any exchange
 			// happens, so it would leave nothing to recover FROM and the test would pass without proving anything
-			final InvalidSchemaMutationException exception = assertThrows(
-				InvalidSchemaMutationException.class,
-				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
-					TEST_CATALOG,
-					session -> {
-						session.createNewEntity(Entities.PRODUCT, DISCARDED_PRODUCT_PK).upsertVia(session);
-						session.updateEntitySchema(
-							new ModifyEntitySchemaMutation(
-								Entities.PRODUCT,
-								new CreateReferenceSchemaMutation(
-									REFERENCE_BRAND, null, null, Cardinality.ZERO_OR_ONE,
-									NON_EXISTING_ENTITY_TYPE, true,
-									null, false,
-									false, false
+			final InvalidSchemaMutationException exception =
+				WarmUpRefusedSchemaPersistenceTest.this.assertRefusalRaisesTheBarrier(
+					InvalidSchemaMutationException.class,
+					() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+						TEST_CATALOG,
+						session -> {
+							session.createNewEntity(Entities.PRODUCT, DISCARDED_PRODUCT_PK).upsertVia(session);
+							session.updateEntitySchema(
+								new ModifyEntitySchemaMutation(
+									Entities.PRODUCT,
+									new CreateReferenceSchemaMutation(
+										REFERENCE_BRAND, null, null, Cardinality.ZERO_OR_ONE,
+										NON_EXISTING_ENTITY_TYPE, true,
+										null, false,
+										false, false
+									)
 								)
-							)
-						);
-					}
-				)
-			);
+							);
+						}
+					)
+				);
 			assertTrue(
 				exception.getMessage().contains(NON_EXISTING_ENTITY_TYPE)
 					&& exception.getMessage().contains("is not present in catalog"),
@@ -354,14 +549,16 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 					+ exception.getMessage()
 			);
 
-			WarmUpRefusedSchemaPersistenceTest.this.activateOnceTheDeactivationSettles();
+			// the deactivation has settled by now - `assertRefusalRaisesTheBarrier` waited for it - but the
+			// lifecycle mutation carrying it releases its conflict key only as it finalizes, a moment later
+			WarmUpRefusedSchemaPersistenceTest.this.activateWithConflictRetry();
 
 			WarmUpRefusedSchemaPersistenceTest.this.evita.queryCatalog(
 				TEST_CATALOG,
 				session -> {
 					assertFalse(
 						session.getEntitySchemaOrThrow(Entities.PRODUCT).getReference(REFERENCE_BRAND).isPresent(),
-						"Activation must hand back the schema of the last session that closed successfully"
+						"Activation must hand back the schema of the last state the catalog published"
 					);
 					assertTrue(
 						session.getEntity(Entities.PRODUCT, PUBLISHED_PRODUCT_PK).isPresent(),
@@ -377,48 +574,76 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 	}
 
 	/**
-	 * Waits until the test catalog reaches the given state, failing the test when it does not do so within a bounded
-	 * budget.
+	 * Runs an action expected to be refused, and asserts that the refusal raised the unpublishable barrier.
 	 *
-	 * The deactivation a refusal schedules is asynchronous by design - it runs on the engine's scheduler because it
-	 * has to close the very sessions the refusing thread is running under - so a test that asks what happened next
-	 * has to wait for it rather than assume it has already happened.
+	 * **This is what keeps the tests below from passing for the wrong reason.** The guarantee they assert rests on
+	 * the barrier, and the barrier is raised only by the catalog-schema validation that runs once the schema has
+	 * already been exchanged into the running catalog. A refusal from a pre-flight check instead - the accelerator
+	 * rule has one for non-empty collections, and {@code SetAttributeSchemaAcceleratedMutation} is one edit away
+	 * from gaining another - throws the same exception type with a similar message and leaves the catalog untouched.
+	 * Every assertion about the reopened schema would then hold trivially, because nothing was ever exchanged.
+	 * Deactivation is the barrier's observable consequence ({@code Catalog#recordUnpublishableCause} schedules it),
+	 * so waiting for it is what tells the two refusals apart.
 	 *
-	 * @param expectedState the state to wait for; must not be null
+	 * @param expectedException type the refusal is expected to throw; must not be null
+	 * @param refusedAction     the action whose refusal is under test; must not be null
+	 * @return the exception the action was refused with; never null
 	 */
-	private void awaitCatalogState(@Nonnull CatalogState expectedState) {
-		final long deadline = System.currentTimeMillis() + AWAIT_BUDGET_MILLIS;
-		CatalogState observedState = null;
-		while (System.currentTimeMillis() < deadline) {
-			observedState = this.evita.getCatalogState(TEST_CATALOG).orElse(null);
-			if (observedState == expectedState) {
-				return;
-			}
-			pauseBriefly();
+	@Nonnull
+	private <T extends RuntimeException> T assertRefusalRaisesTheBarrier(
+		@Nonnull Class<T> expectedException,
+		@Nonnull Executable refusedAction
+	) {
+		// registered BEFORE the action, so the deactivation it schedules cannot settle into a stream nobody is
+		// subscribed to
+		try (final SettledStateLatch deactivation = subscribeToSettledState(CatalogState.INACTIVE)) {
+			final T exception = assertThrows(expectedException, refusedAction);
+			deactivation.await();
+			return exception;
 		}
-		fail(
-			"Catalog `" + TEST_CATALOG + "` stayed at `" + observedState + "` instead of reaching `" +
-				expectedState + "`."
-		);
 	}
 
 	/**
-	 * Waits out the deactivation a refusal schedules and then activates the catalog again.
+	 * Subscribes to the system change stream and returns a latch that opens when the engine reports the test catalog
+	 * as having settled into the given state.
 	 *
-	 * Two waits are folded together on purpose. The catalog reaching {@link CatalogState#INACTIVE} says the
-	 * deactivation's engine-state update has landed, but the lifecycle mutation carrying it releases its conflict
-	 * key only once it finalizes, a moment later. An activation issued in between is refused with
-	 * {@link ConflictingEngineMutationException} - the engine's "another lifecycle operation for this catalog is
-	 * still in flight" signal, and a transient rather than a failure worth failing the test over.
+	 * The deactivation a refusal schedules is asynchronous by design - it runs on the engine's scheduler because it
+	 * has to close the very sessions the refusing thread is running under - so a test that asks what happened next
+	 * has to wait for it. This is the transition announcing itself rather than the test guessing when to look:
+	 * `Evita#notifyCatalogStateSettled` emits a {@link HostSystemEvent.CatalogInstalledIntoLiveView} from the
+	 * deactivation operator's own completion phase. **Register before triggering the deactivation**, or the event
+	 * fires into a stream nobody is subscribed to.
+	 *
+	 * @param expectedState the settled state to wait for; must not be null
+	 * @return the subscription, which closes the underlying publisher and carries the latch; never null
 	 */
-	private void activateOnceTheDeactivationSettles() {
-		awaitCatalogState(CatalogState.INACTIVE);
-		activateWithConflictRetry();
+	@Nonnull
+	private SettledStateLatch subscribeToSettledState(@Nonnull CatalogState expectedState) {
+		final ChangeCapturePublisher<ChangeSystemCapture> publisher = this.evita.registerSystemChangeCapture(
+			ChangeSystemCaptureRequest.builder()
+				.sinceVersion(this.evita.getEngineState().version() + 1)
+				.content(ChangeCaptureContent.BODY)
+				.hostArea()
+				.build()
+		);
+		final SettledStateLatch latch = new SettledStateLatch(publisher, expectedState);
+		publisher.subscribe(latch);
+		return latch;
 	}
 
 	/**
 	 * Activates the test catalog, retrying while the engine reports that another lifecycle operation for it is
 	 * still in flight.
+	 *
+	 * The retry is not optional. A deactivation settles in two steps: the engine-state update lands - which is what
+	 * {@link SettledStateLatch} observes - and the lifecycle mutation carrying it releases its conflict key a
+	 * moment later, as it finalizes. An activation issued in between is refused with
+	 * {@link ConflictingEngineMutationException}, the engine's "another lifecycle operation for this catalog is
+	 * still in flight" signal, which is a transient rather than a failure worth failing the test over.
+	 *
+	 * This is a **retry of a refused operation**, not a poll for a condition, which is why it is a loop and stays
+	 * one: the conflict key is released as the deactivation mutation finalizes and no seam exposes that moment, so
+	 * there is nothing to latch on. A slow machine widens the window this rides out rather than shortening it.
 	 */
 	private void activateWithConflictRetry() {
 		final long deadline = System.currentTimeMillis() + AWAIT_BUDGET_MILLIS;
@@ -433,41 +658,88 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 					throw ex;
 				}
 				lastConflict = ex;
-				pauseBriefly();
+				backOffBeforeRetry();
 			}
 		} while (System.currentTimeMillis() < deadline);
 		fail("Catalog `" + TEST_CATALOG + "` could not be activated: " + lastConflict.getMessage());
 	}
 
 	/**
-	 * Waits until the test catalog is out of every transitional state and returns the state it settled in.
-	 *
-	 * @return the settled state; never null
+	 * Waits out one backoff interval between two attempts at an operation the engine currently refuses, turning an
+	 * interrupt into a test failure rather than a silent early return.
 	 */
-	@Nonnull
-	private CatalogState awaitSettledCatalogState() {
-		final long deadline = System.currentTimeMillis() + AWAIT_BUDGET_MILLIS;
-		CatalogState observedState = null;
-		while (System.currentTimeMillis() < deadline) {
-			observedState = this.evita.getCatalogState(TEST_CATALOG).orElse(null);
-			if (observedState != null && !observedState.isTransitional()) {
-				return observedState;
-			}
-			pauseBriefly();
+	private void backOffBeforeRetry() {
+		try {
+			Thread.sleep(RETRY_BACKOFF_MILLIS);
+		} catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			fail("Interrupted while retrying an engine operation refused by a lifecycle conflict.");
 		}
-		fail("Catalog `" + TEST_CATALOG + "` stayed transitional at `" + observedState + "`.");
-		throw new IllegalStateException("unreachable");
 	}
 
 	/**
-	 * Sleeps for one polling interval, turning an interrupt into a test failure rather than a silent early return.
+	 * A {@link Flow.Subscriber} over the system change stream that opens a latch when the test catalog is reported
+	 * as having settled into one particular state.
 	 */
-	private void pauseBriefly() {
-		try {
-			Thread.sleep(POLL_INTERVAL_MILLIS);
-		} catch (InterruptedException ex) {
-			Thread.currentThread().interrupt();
-			fail("Interrupted while waiting for an asynchronous catalog lifecycle step to settle.");
+	private static final class SettledStateLatch implements Flow.Subscriber<ChangeSystemCapture>, AutoCloseable {
+		private final ChangeCapturePublisher<ChangeSystemCapture> publisher;
+		private final CatalogState expectedState;
+		private final CountDownLatch latch = new CountDownLatch(1);
+
+		SettledStateLatch(
+			@Nonnull ChangeCapturePublisher<ChangeSystemCapture> publisher,
+			@Nonnull CatalogState expectedState
+		) {
+			this.publisher = publisher;
+			this.expectedState = expectedState;
+		}
+
+		@Override
+		public void onSubscribe(@Nonnull Flow.Subscription subscription) {
+			subscription.request(Long.MAX_VALUE);
+		}
+
+		@Override
+		public void onNext(@Nonnull ChangeSystemCapture item) {
+			if (item.body() instanceof HostSystemEvent.CatalogInstalledIntoLiveView installed
+				&& TEST_CATALOG.equals(installed.catalogName())
+				&& installed.observedState() == this.expectedState) {
+				this.latch.countDown();
+			}
+		}
+
+		@Override
+		public void onError(@Nonnull Throwable throwable) {
+			// nothing to do - a stream that fails leaves the latch closed and `await` reports the timeout, which
+			// carries the same verdict with a message that names the state the test was waiting for
+		}
+
+		@Override
+		public void onComplete() {
+			// see `onError` - a stream that ends without the event is indistinguishable from one that never
+			// delivered it, and both are the same test failure
+		}
+
+		/**
+		 * Blocks until the expected state is reported, failing the test when it is not reported in time.
+		 */
+		void await() {
+			try {
+				if (!this.latch.await(AWAIT_BUDGET_MILLIS, TimeUnit.MILLISECONDS)) {
+					fail(
+						"Catalog `" + TEST_CATALOG + "` was never reported as having settled into `" +
+							this.expectedState + "`."
+					);
+				}
+			} catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				fail("Interrupted while waiting for catalog `" + TEST_CATALOG + "` to settle.");
+			}
+		}
+
+		@Override
+		public void close() {
+			this.publisher.close();
 		}
 	}
 
@@ -500,11 +772,14 @@ class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
 	private EntitySchemaContract reopenAndReadSchema() {
 		this.evita.close();
 		this.evita = new Evita(configuration());
+		// deterministic rather than a wait: the constructor schedules the initial catalog load and this joins the
+		// futures it created, so the state read below is the settled one
+		this.evita.waitUntilFullyInitialized();
 		// a refusal schedules a deactivation, and whether that lands before the close is a race this test must not
 		// depend on. When it does land, the INACTIVE state is persisted and the reopened engine leaves the catalog
 		// unloaded; when the close wins, the catalog comes back loaded. Both sides read the same bootstrap record -
-		// the one published by the last session that closed successfully - which is the state under assertion
-		if (awaitSettledCatalogState() == CatalogState.INACTIVE) {
+		// the newest state that reached the disk - which is the state under assertion
+		if (this.evita.getCatalogState(TEST_CATALOG).orElse(null) == CatalogState.INACTIVE) {
 			activateWithConflictRetry();
 		}
 		return this.evita.queryCatalog(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/WarmUpRefusedSchemaPersistenceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/schema/WarmUpRefusedSchemaPersistenceTest.java
@@ -1,0 +1,528 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.schema;
+
+import io.evitadb.api.CatalogState;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.exception.ConflictingEngineMutationException;
+import io.evitadb.api.exception.InvalidSchemaMutationException;
+import io.evitadb.api.requestResponse.schema.AttributeFilterAccelerator;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.api.requestResponse.schema.mutation.attribute.ScopedAttributeFilterAccelerators;
+import io.evitadb.api.requestResponse.schema.mutation.attribute.SetAttributeSchemaAcceleratedMutation;
+import io.evitadb.api.requestResponse.schema.mutation.catalog.ModifyEntitySchemaMutation;
+import io.evitadb.api.requestResponse.schema.mutation.reference.CreateReferenceSchemaMutation;
+import io.evitadb.core.Evita;
+import io.evitadb.dataType.Scope;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static io.evitadb.test.TestTags.SCHEMA;
+import static io.evitadb.test.TestTags.STORAGE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Guards #1466 - a schema change refused by catalog-schema validation in a `WARMING_UP` catalog must not reach the
+ * disk, and must not load silently on the next open.
+ *
+ * The refusal alone does not achieve that, because the refusal and the write are performed by different actors.
+ * {@code EvitaSession#closeInternal} validates before it flushes, so the refused session performs no write of its
+ * own - but by then {@link io.evitadb.core.collection.EntityCollection#updateSchema} has already exchanged the
+ * invalid schema into the running catalog and put an {@code EntitySchemaStoragePart} into the data-store buffer, and
+ * warm-up has no undo for that exchange. Every later publisher would therefore write it out:
+ * {@code Catalog#terminateInternally} on an ordinary {@code Evita#close()}, and any subsequent session close, a
+ * read-only one included. What stops all of them at once is the unpublishable barrier the refusal raises - see
+ * {@code Catalog#markUnpublishableDueToInvalidSchema}.
+ *
+ * The guarantee is not specific to one validation rule - {@code SealedCatalogSchema#validate()} fans out to every
+ * entity and reference schema, so every rule reachable from there has the same exposure. Two independent rules are
+ * therefore exercised below: the attribute filter-accelerator rule (the cheapest one to trigger from a raw mutation)
+ * and the reference rule that requires a managed referenced entity type to exist.
+ *
+ * Each refusal is asserted on its **message**, never on the exception type alone - several unrelated refusals throw
+ * `InvalidSchemaMutationException` and would satisfy a bare `assertThrows` while proving something else. And each
+ * case is paired with a control that pushes the *same* schema element through legitimately and finds it on the far
+ * side of a reopen, so an empty assertion cannot pass merely because the reopened schema was read wrongly. The
+ * reopen is load-bearing twice over: it is the only honest way to ask what reached the disk, and it fails outright
+ * if the close that precedes it did not release the engine's folder lock.
+ *
+ * {@link AttributeFilterAcceleratorRefusalTest} pins the same accelerator case from the schema API's side.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Schema refused in warm-up must not reach the disk")
+@Tag(ENGINE)
+@Tag(STORAGE)
+@Tag(SCHEMA)
+class WarmUpRefusedSchemaPersistenceTest implements EvitaTestSupport {
+
+	private static final String ATTRIBUTE_CODE = "code";
+	private static final String REFERENCE_BRAND = "brand";
+	/** An entity type deliberately never defined in the catalog, so a managed reference to it cannot validate. */
+	private static final String NON_EXISTING_ENTITY_TYPE = "nonExistingEntityType";
+	/** Primary key of the entity written by a session that closes successfully, and therefore publishes. */
+	private static final int PUBLISHED_PRODUCT_PK = 1;
+	/** Primary key of the entity written by the session whose close is refused, and which therefore never publishes. */
+	private static final int DISCARDED_PRODUCT_PK = 2;
+	/** Upper bound on how long any single asynchronous catalog lifecycle step is waited for. */
+	private static final long AWAIT_BUDGET_MILLIS = 10_000L;
+	/** Interval between two observations while waiting for such a step. */
+	private static final long POLL_INTERVAL_MILLIS = 20L;
+
+	private TestPaths paths;
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() {
+		this.paths = createTestPaths("WarmUpRefusedSchemaPersistence");
+		this.evita = new Evita(configuration());
+		this.evita.defineCatalog(TEST_CATALOG);
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (this.evita != null && this.evita.isActive()) {
+			this.evita.close();
+		}
+		cleanupTestPaths(this.paths);
+	}
+
+	@Nested
+	@DisplayName("refused by the attribute filter-accelerator rule")
+	class AcceleratorRule {
+
+		@Test
+		@Tag(ATTRIBUTE)
+		@DisplayName("should not persist an accelerator declared on an attribute with no filter index")
+		void shouldNotPersistAnAcceleratorDeclaredOnAnAttributeWithNoFilterIndex() {
+			WarmUpRefusedSchemaPersistenceTest.this.defineProductWithPlainAttribute();
+
+			// the builder cannot express this state at all - it refuses the chain while assembling it - so the
+			// mutation has to be submitted raw. Every other route into the schema (gRPC, REST, GraphQL, the WAL)
+			// carries mutations the same way, which is what makes this the shape worth pinning
+			final InvalidSchemaMutationException exception = assertThrows(
+				InvalidSchemaMutationException.class,
+				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.updateEntitySchema(
+							new ModifyEntitySchemaMutation(
+								Entities.PRODUCT,
+								new SetAttributeSchemaAcceleratedMutation(
+									ATTRIBUTE_CODE,
+									new ScopedAttributeFilterAccelerators(
+										Scope.LIVE, AttributeFilterAccelerator.SUBSTRING_SEARCH
+									)
+								)
+							)
+						);
+					}
+				)
+			);
+			assertTrue(
+				exception.getMessage().contains(AttributeFilterAccelerator.SUBSTRING_SEARCH.name()),
+				() -> "The refusal must name the accelerator it refuses, but was: " + exception.getMessage()
+			);
+			assertTrue(
+				exception.getMessage().contains("no filter index"),
+				() -> "The refusal must name the missing filter index, but was: " + exception.getMessage()
+			);
+
+			final EntitySchemaContract reopenedSchema = WarmUpRefusedSchemaPersistenceTest.this.reopenAndReadSchema();
+			assertEquals(
+				Set.of(),
+				reopenedSchema.getAttribute(ATTRIBUTE_CODE).orElseThrow().getAcceleratorsInScope(Scope.LIVE),
+				"The refused accelerator must not survive the close that follows the refusal"
+			);
+		}
+
+		@Test
+		@Tag(ATTRIBUTE)
+		@DisplayName("should persist an accelerator the same route accepts")
+		void shouldPersistAnAcceleratorTheSameRouteAccepts() {
+			// the control for the case above: the very same raw mutation, on an attribute that *is* filterable, must
+			// come back from a reopen. Without it an empty accelerator set would also be the answer to a schema that
+			// was read wrongly, or to an attribute that never carried the declaration in the first place
+			WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema(Entities.PRODUCT)
+						.withoutGeneratedPrimaryKey()
+						.withAttribute(ATTRIBUTE_CODE, String.class, AttributeSchemaEditor::filterable)
+						.updateVia(session);
+				}
+			);
+			WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.updateEntitySchema(
+						new ModifyEntitySchemaMutation(
+							Entities.PRODUCT,
+							new SetAttributeSchemaAcceleratedMutation(
+								ATTRIBUTE_CODE,
+								new ScopedAttributeFilterAccelerators(
+									Scope.LIVE, AttributeFilterAccelerator.SUBSTRING_SEARCH
+								)
+							)
+						)
+					);
+				}
+			);
+
+			final EntitySchemaContract reopenedSchema = WarmUpRefusedSchemaPersistenceTest.this.reopenAndReadSchema();
+			assertEquals(
+				Set.of(AttributeFilterAccelerator.SUBSTRING_SEARCH),
+				reopenedSchema.getAttribute(ATTRIBUTE_CODE).orElseThrow().getAcceleratorsInScope(Scope.LIVE),
+				"An accepted accelerator must survive the reopen - otherwise the assertion above proves nothing"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("refused by the managed-reference rule")
+	class ManagedReferenceRule {
+
+		@Test
+		@Tag(REFERENCE)
+		@DisplayName("should not persist a managed reference to an entity type that does not exist")
+		void shouldNotPersistAManagedReferenceToAnEntityTypeThatDoesNotExist() {
+			// a second, entirely unrelated rule from the same `validate()` fan-out - the defect is a property of the
+			// warm-up write path, not of the accelerator rule that first exposed it
+			WarmUpRefusedSchemaPersistenceTest.this.defineProductWithPlainAttribute();
+
+			final InvalidSchemaMutationException exception = assertThrows(
+				InvalidSchemaMutationException.class,
+				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.updateEntitySchema(
+							new ModifyEntitySchemaMutation(
+								Entities.PRODUCT,
+								new CreateReferenceSchemaMutation(
+									REFERENCE_BRAND, null, null, Cardinality.ZERO_OR_ONE,
+									NON_EXISTING_ENTITY_TYPE, true,
+									null, false,
+									false, false
+								)
+							)
+						);
+					}
+				)
+			);
+			// pinned to the wording of the rule under test, not merely to the exception type:
+			// `CreateReferenceSchemaMutation` has refusals of its own that throw the same type, and a bare
+			// `assertThrows` would accept any of them
+			assertTrue(
+				exception.getMessage().contains(NON_EXISTING_ENTITY_TYPE)
+					&& exception.getMessage().contains("is not present in catalog"),
+				() -> "The refusal must name the missing entity type, but was: " + exception.getMessage()
+			);
+
+			final EntitySchemaContract reopenedSchema = WarmUpRefusedSchemaPersistenceTest.this.reopenAndReadSchema();
+			assertFalse(
+				reopenedSchema.getReference(REFERENCE_BRAND).isPresent(),
+				"The refused reference must not survive the close that follows the refusal"
+			);
+		}
+
+		@Test
+		@Tag(REFERENCE)
+		@DisplayName("should persist a managed reference the same route accepts")
+		void shouldPersistAManagedReferenceTheSameRouteAccepts() {
+			// the control for the case above - the same raw mutation against an entity type that does exist
+			WarmUpRefusedSchemaPersistenceTest.this.defineProductWithPlainAttribute();
+			WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema(Entities.BRAND)
+						.withoutGeneratedPrimaryKey()
+						.updateVia(session);
+				}
+			);
+			WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.updateEntitySchema(
+						new ModifyEntitySchemaMutation(
+							Entities.PRODUCT,
+							new CreateReferenceSchemaMutation(
+								REFERENCE_BRAND, null, null, Cardinality.ZERO_OR_ONE,
+								Entities.BRAND, true,
+								null, false,
+								false, false
+							)
+						)
+					);
+				}
+			);
+
+			final EntitySchemaContract reopenedSchema = WarmUpRefusedSchemaPersistenceTest.this.reopenAndReadSchema();
+			assertTrue(
+				reopenedSchema.getReference(REFERENCE_BRAND).isPresent(),
+				"An accepted reference must survive the reopen - otherwise the assertion above proves nothing"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("recovery from the refusal")
+	class Recovery {
+
+		@Test
+		@Tag(MANAGEMENT)
+		@DisplayName("should deactivate the catalog and hand back the last published state on activation")
+		void shouldDeactivateTheCatalogAndHandBackTheLastPublishedStateOnActivation() {
+			// published, because the session that wrote them closed successfully: the schema and one entity
+			WarmUpRefusedSchemaPersistenceTest.this.defineProductWithPlainAttribute();
+			WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(Entities.PRODUCT, PUBLISHED_PRODUCT_PK).upsertVia(session);
+				}
+			);
+
+			// never published: a second entity, and then the schema change this session's close refuses. Both are
+			// applied in memory - the refusal comes from validating the whole schema at close - and neither reaches
+			// the disk, which is exactly the trade the recovery makes.
+			// The managed-reference rule is the one used here rather than the accelerator rule: an accelerator on a
+			// collection that already holds entities is refused by a pre-flight check instead, before any exchange
+			// happens, so it would leave nothing to recover FROM and the test would pass without proving anything
+			final InvalidSchemaMutationException exception = assertThrows(
+				InvalidSchemaMutationException.class,
+				() -> WarmUpRefusedSchemaPersistenceTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.createNewEntity(Entities.PRODUCT, DISCARDED_PRODUCT_PK).upsertVia(session);
+						session.updateEntitySchema(
+							new ModifyEntitySchemaMutation(
+								Entities.PRODUCT,
+								new CreateReferenceSchemaMutation(
+									REFERENCE_BRAND, null, null, Cardinality.ZERO_OR_ONE,
+									NON_EXISTING_ENTITY_TYPE, true,
+									null, false,
+									false, false
+								)
+							)
+						);
+					}
+				)
+			);
+			assertTrue(
+				exception.getMessage().contains(NON_EXISTING_ENTITY_TYPE)
+					&& exception.getMessage().contains("is not present in catalog"),
+				() -> "The recovery must be driven by the catalog-schema validation refusal, but was: "
+					+ exception.getMessage()
+			);
+
+			WarmUpRefusedSchemaPersistenceTest.this.activateOnceTheDeactivationSettles();
+
+			WarmUpRefusedSchemaPersistenceTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertFalse(
+						session.getEntitySchemaOrThrow(Entities.PRODUCT).getReference(REFERENCE_BRAND).isPresent(),
+						"Activation must hand back the schema of the last session that closed successfully"
+					);
+					assertTrue(
+						session.getEntity(Entities.PRODUCT, PUBLISHED_PRODUCT_PK).isPresent(),
+						"An entity written by a session that closed successfully must survive the recovery"
+					);
+					assertFalse(
+						session.getEntity(Entities.PRODUCT, DISCARDED_PRODUCT_PK).isPresent(),
+						"An entity written by the refused session must not survive it - it was never published"
+					);
+				}
+			);
+		}
+	}
+
+	/**
+	 * Waits until the test catalog reaches the given state, failing the test when it does not do so within a bounded
+	 * budget.
+	 *
+	 * The deactivation a refusal schedules is asynchronous by design - it runs on the engine's scheduler because it
+	 * has to close the very sessions the refusing thread is running under - so a test that asks what happened next
+	 * has to wait for it rather than assume it has already happened.
+	 *
+	 * @param expectedState the state to wait for; must not be null
+	 */
+	private void awaitCatalogState(@Nonnull CatalogState expectedState) {
+		final long deadline = System.currentTimeMillis() + AWAIT_BUDGET_MILLIS;
+		CatalogState observedState = null;
+		while (System.currentTimeMillis() < deadline) {
+			observedState = this.evita.getCatalogState(TEST_CATALOG).orElse(null);
+			if (observedState == expectedState) {
+				return;
+			}
+			pauseBriefly();
+		}
+		fail(
+			"Catalog `" + TEST_CATALOG + "` stayed at `" + observedState + "` instead of reaching `" +
+				expectedState + "`."
+		);
+	}
+
+	/**
+	 * Waits out the deactivation a refusal schedules and then activates the catalog again.
+	 *
+	 * Two waits are folded together on purpose. The catalog reaching {@link CatalogState#INACTIVE} says the
+	 * deactivation's engine-state update has landed, but the lifecycle mutation carrying it releases its conflict
+	 * key only once it finalizes, a moment later. An activation issued in between is refused with
+	 * {@link ConflictingEngineMutationException} - the engine's "another lifecycle operation for this catalog is
+	 * still in flight" signal, and a transient rather than a failure worth failing the test over.
+	 */
+	private void activateOnceTheDeactivationSettles() {
+		awaitCatalogState(CatalogState.INACTIVE);
+		activateWithConflictRetry();
+	}
+
+	/**
+	 * Activates the test catalog, retrying while the engine reports that another lifecycle operation for it is
+	 * still in flight.
+	 */
+	private void activateWithConflictRetry() {
+		final long deadline = System.currentTimeMillis() + AWAIT_BUDGET_MILLIS;
+		RuntimeException lastConflict;
+		do {
+			try {
+				this.evita.activateCatalog(TEST_CATALOG);
+				return;
+			} catch (RuntimeException ex) {
+				if (!(ex instanceof ConflictingEngineMutationException)
+					&& !(ex.getCause() instanceof ConflictingEngineMutationException)) {
+					throw ex;
+				}
+				lastConflict = ex;
+				pauseBriefly();
+			}
+		} while (System.currentTimeMillis() < deadline);
+		fail("Catalog `" + TEST_CATALOG + "` could not be activated: " + lastConflict.getMessage());
+	}
+
+	/**
+	 * Waits until the test catalog is out of every transitional state and returns the state it settled in.
+	 *
+	 * @return the settled state; never null
+	 */
+	@Nonnull
+	private CatalogState awaitSettledCatalogState() {
+		final long deadline = System.currentTimeMillis() + AWAIT_BUDGET_MILLIS;
+		CatalogState observedState = null;
+		while (System.currentTimeMillis() < deadline) {
+			observedState = this.evita.getCatalogState(TEST_CATALOG).orElse(null);
+			if (observedState != null && !observedState.isTransitional()) {
+				return observedState;
+			}
+			pauseBriefly();
+		}
+		fail("Catalog `" + TEST_CATALOG + "` stayed transitional at `" + observedState + "`.");
+		throw new IllegalStateException("unreachable");
+	}
+
+	/**
+	 * Sleeps for one polling interval, turning an interrupt into a test failure rather than a silent early return.
+	 */
+	private void pauseBriefly() {
+		try {
+			Thread.sleep(POLL_INTERVAL_MILLIS);
+		} catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			fail("Interrupted while waiting for an asynchronous catalog lifecycle step to settle.");
+		}
+	}
+
+	/**
+	 * Defines the product schema with a single `String` attribute that is neither filterable nor unique in any scope,
+	 * so that an accelerator declared on it has no filter index to sit on.
+	 */
+	private void defineProductWithPlainAttribute() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withAttribute(ATTRIBUTE_CODE, String.class, AttributeSchemaEditor::nullable)
+					.updateVia(session);
+			}
+		);
+	}
+
+	/**
+	 * Closes the running instance and opens a fresh one over the same storage directory, returning the product schema
+	 * as it was actually read back from disk.
+	 *
+	 * Reopening is the only honest way to ask what a refused session left behind - the in-memory catalog would answer
+	 * for a schema that was never written, and the close is itself the write under test.
+	 *
+	 * @return the product entity schema of the reopened catalog; never null
+	 */
+	@Nonnull
+	private EntitySchemaContract reopenAndReadSchema() {
+		this.evita.close();
+		this.evita = new Evita(configuration());
+		// a refusal schedules a deactivation, and whether that lands before the close is a race this test must not
+		// depend on. When it does land, the INACTIVE state is persisted and the reopened engine leaves the catalog
+		// unloaded; when the close wins, the catalog comes back loaded. Both sides read the same bootstrap record -
+		// the one published by the last session that closed successfully - which is the state under assertion
+		if (awaitSettledCatalogState() == CatalogState.INACTIVE) {
+			activateWithConflictRetry();
+		}
+		return this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				return session.getEntitySchemaOrThrow(Entities.PRODUCT);
+			}
+		);
+	}
+
+	/**
+	 * Builds the throw-away embedded configuration this test runs against.
+	 *
+	 * @return the configuration; never null
+	 */
+	@Nonnull
+	private EvitaConfiguration configuration() {
+		return newTestEvitaConfigurationBuilder(this.paths).build();
+	}
+
+}


### PR DESCRIPTION
Closes #1466

A schema change refused by `CatalogSchema#validate()` in a `WARMING_UP` catalog still reached the disk and loaded silently on the next open, leaving the operator with a schema the engine itself would have rejected.

## Why the refusal was not enough

`EvitaSession#closeInternal` already validates before it flushes, so the refused session performs no write of its own — but it cannot un-apply the change. `EntityCollection#updateSchema` has already exchanged the schema into every collection the change reached, run the structural work that goes with it, and trapped an `EntitySchemaStoragePart` in the data-store buffer. The poisoned state survived on the running catalog and the *next* publisher wrote it out: the shutdown flush, and — measured, not assumed — any later session close, including a read-only one.

Validation cannot simply move earlier: a schema is routinely built across several steps whose intermediate states are legitimately invalid (a reflected reference declared before its target), which is why it runs on the whole graph once, at session close.

## The fix

The change is not undone. The refusal raises the **pre-existing unpublishable barrier** instead, through a new `Catalog#markUnpublishableDueToInvalidSchema` whose message is written for a rejected user change rather than the flush failure `markUnpublishable` describes. Every publication route consults that barrier, and the deactivation it schedules returns the catalog to the newest state that reached the disk once the client activates it again.

Because `validate()` has exactly one engine call site, the hard stop is limited to post-exchange failures by construction — pre-flight refusals are untouched and keep refusing cleanly, so an ordinary schema typo never costs a reload.

## Three defects review found that tests did not

1. **The barrier is raised at session *close***, so anything publishing earlier in the same session beat it. Two routes did: the warm-up flush that collection-level DDL runs inline (now gated by `Catalog#flushMidSessionIfSchemaValid`, which skips rather than refuses, because a half-built schema is legitimate) and go-live (now validated by `MakeCatalogAliveMutationOperator` ahead of its own flush). Five green tests and a 23,717-green suite missed this because every test made the invalid change the session's last operation.

2. **A lifecycle mutation racing shutdown stranded the real catalog.** `Evita#closeCatalogs` clears the engine state before draining in-flight mutations, so every completion updater throws and its teardown is skipped — and what the shutdown pass terminated on its way through was the `UnusableCatalog` placeholder, whose `terminate()` only flips a flag. `SetCatalogStateMutationOperator` (both branches), `CreateCatalogMutationOperator` and `RemoveCatalogSchemaMutationOperator` now release the catalog whether or not the state update lands. The removal path deliberately releases the handles **without** wiping the folder: the removal never committed, the engine state still names that folder, and deleting a file the published record reaches is the one act that damages a catalog for real.

3. **`validate()` refuses in two exception vocabularies.** A rule it evaluates throws `SchemaAlteringException`; a getter it reaches on a schema it cannot resolve refuses to answer with a plain `EvitaInvalidUsageException` (`ReflectedReferenceSchema#isIndexedInScope`). Catching only the narrow type in `isSchemaValid` turned a legitimate intermediate state into a failed DDL operation and cost 17 tests in the first full run.

Deactivation also now waits out a lifecycle conflict: the go-live operator raises the barrier while its own mutation is still finalizing, so the deactivation it schedules was refused by that mutation's conflict key, logged and dropped — leaving a catalog only a restart could clear. Five attempts, 200 ms apart, and the returned `Progress` is observed.

## One judgement call, flagged for review

The wide `EvitaInvalidUsageException` catch at the two **barrier** sites (`EvitaSession#closeInternal`, `MakeCatalogAliveMutationOperator`) is *not* demonstrated — narrowing it back leaves the whole test class green, on two separately constructed shapes. It is kept on an asymmetry argument, and the comment at `EvitaSession#closeInternal`, the ADR and the test all say so. Only the mid-session `isSchemaValid` site is proven to need it.

## Verification

- `WarmUpRefusedSchemaPersistenceTest` — 7 tests: two independent validation rules each paired with a control, a reflected-reference case, the two mid-session publication routes, and full recovery (an entity written by a session that closed successfully survives; one written by the refused session does not). Every refusal site asserts the barrier by awaiting the deactivation over the system CDC stream.
- Two counterfactuals recorded in the ADR: removing `scheduleDeactivation()` fails exactly the 5 barrier-asserting tests with both controls passing; narrowing the close-time catch fails nothing — which is what stopped an overstated claim from shipping.
- Full functional suite: **23,723 tests, 0 failures**, 1 error (`ExportS3ServiceTest`, requires Docker) — the documented baseline.

## Documentation

`CatalogState.WARMING_UP` and the user documentation claimed the catalog should be discarded and rebuilt from scratch after any failed write. They now describe what the phase actually does, when the catalog is made INACTIVE and needs reactivating, and why the recovery is this coarse. `.claude/rules/durability-model.md` gained the qualifier that a warm-up flush *that runs* publishes — a DDL flush is now skipped while the schema does not validate.

ADR: `documentation/adr/2026-09-08-warm-up-invalid-schema-refuses-to-publish.md`
