### PR TITLE
Fix GraphQL/OpenAPI schemas embedding a JVM identity hash on every restart

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/CatalogSchemaDecorator.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/CatalogSchemaDecorator.java
@@ -27,6 +27,7 @@ import io.evitadb.api.requestResponse.schema.CatalogSchemaEditor.CatalogSchemaBu
 import io.evitadb.api.requestResponse.schema.builder.InternalCatalogSchemaBuilder;
 import io.evitadb.api.requestResponse.schema.dto.CatalogSchema;
 import io.evitadb.api.requestResponse.schema.mutation.LocalCatalogSchemaMutation;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Delegate;
 
@@ -41,6 +42,7 @@ import java.util.Collection;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
+@EqualsAndHashCode(of = "delegate")
 public class CatalogSchemaDecorator implements SealedCatalogSchema {
 	@Serial private static final long serialVersionUID = 8854250508519097535L;
 	@Delegate(types = CatalogSchemaContract.class)
@@ -73,6 +75,11 @@ public class CatalogSchemaDecorator implements SealedCatalogSchema {
 		return new InternalCatalogSchemaBuilder(
 			this.delegate, schemaMutations
 		);
+	}
+
+	@Override
+	public String toString() {
+		return this.delegate.toString();
 	}
 
 }

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/EntitySchemaDecorator.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/EntitySchemaDecorator.java
@@ -27,6 +27,7 @@ import io.evitadb.api.requestResponse.schema.EntitySchemaEditor.EntitySchemaBuil
 import io.evitadb.api.requestResponse.schema.builder.InternalEntitySchemaBuilder;
 import io.evitadb.api.requestResponse.schema.dto.EntitySchema;
 import io.evitadb.api.requestResponse.schema.mutation.LocalEntitySchemaMutation;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Delegate;
 
@@ -42,6 +43,7 @@ import java.util.function.Supplier;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
+@EqualsAndHashCode(of = "delegate")
 public class EntitySchemaDecorator implements SealedEntitySchema {
 	@Serial private static final long serialVersionUID = -5581711006960936882L;
 
@@ -87,6 +89,11 @@ public class EntitySchemaDecorator implements SealedEntitySchema {
 			this.delegate,
 			schemaMutations
 		);
+	}
+
+	@Override
+	public String toString() {
+		return this.delegate.toString();
 	}
 
 }

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogDataApiGraphQLSchemaBuilder.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogDataApiGraphQLSchemaBuilder.java
@@ -478,7 +478,7 @@ public class CatalogDataApiGraphQLSchemaBuilder extends FinalGraphQLSchemaBuilde
 
 		final GraphQLFieldDefinition.Builder singleEntityFieldBuilder = CatalogDataApiRootDescriptor.GET_ENTITY
 			.to(new EndpointDescriptorToGraphQLFieldTransformer(this.propertyDataTypeBuilderTransformer, entitySchema))
-			.description(CatalogDataApiRootDescriptor.GET_ENTITY.description(entitySchema))
+			.description(CatalogDataApiRootDescriptor.GET_ENTITY.description(entitySchema.getName()))
 			.type(typeRef(EntityDescriptor.THIS.name(entitySchema)))
 			.argument(GetEntityHeaderDescriptor.PRIMARY_KEY.to(this.argumentBuilderTransformer));
 
@@ -544,7 +544,7 @@ public class CatalogDataApiGraphQLSchemaBuilder extends FinalGraphQLSchemaBuilde
 
 		final GraphQLFieldDefinition.Builder entityListFieldBuilder = CatalogDataApiRootDescriptor.LIST_ENTITY
 			.to(new EndpointDescriptorToGraphQLFieldTransformer(this.propertyDataTypeBuilderTransformer, entitySchema))
-			.description(CatalogDataApiRootDescriptor.LIST_ENTITY.description(entitySchema))
+			.description(CatalogDataApiRootDescriptor.LIST_ENTITY.description(entitySchema.getName()))
 			.type(nonNull(list(nonNull(typeRef(EntityDescriptor.THIS.name(entitySchema))))))
 			.argument(HeadAwareFieldHeaderDescriptor.HEAD
 				          .to(this.argumentBuilderTransformer)
@@ -596,7 +596,7 @@ public class CatalogDataApiGraphQLSchemaBuilder extends FinalGraphQLSchemaBuilde
 
 		final GraphQLFieldDefinition.Builder entityQueryFieldBuilder = CatalogDataApiRootDescriptor.QUERY_ENTITY
 			.to(new EndpointDescriptorToGraphQLFieldTransformer(this.propertyDataTypeBuilderTransformer, entitySchema))
-			.description(CatalogDataApiRootDescriptor.QUERY_ENTITY.description(entitySchema))
+			.description(CatalogDataApiRootDescriptor.QUERY_ENTITY.description(entitySchema.getName()))
 			.type(nonNull(entityFullResponseObject))
 			.argument(HeadAwareFieldHeaderDescriptor.HEAD
 				          .to(this.argumentBuilderTransformer)

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/builder/FullResponseObjectBuilder.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/builder/FullResponseObjectBuilder.java
@@ -265,7 +265,7 @@ public class FullResponseObjectBuilder {
 		return EntityRecordPageDescriptor.THIS
 			.to(this.objectBuilderTransformer)
 			.name(objectName)
-			.description(EntityRecordPageDescriptor.THIS.description(entitySchema))
+			.description(EntityRecordPageDescriptor.THIS.description(entitySchema.getName()))
 			.field(DataChunkDescriptor.DATA
 				.to(this.fieldBuilderTransformer)
 				.type(nonNull(list(nonNull(typeRef(EntityDescriptor.THIS.name(entitySchema)))))))
@@ -296,7 +296,7 @@ public class FullResponseObjectBuilder {
 		return EntityRecordStripDescriptor.THIS
 			.to(this.objectBuilderTransformer)
 			.name(objectName)
-			.description(EntityRecordStripDescriptor.THIS.description(entitySchema))
+			.description(EntityRecordStripDescriptor.THIS.description(entitySchema.getName()))
 			.field(DataChunkDescriptor.DATA
 				.to(this.fieldBuilderTransformer)
 				.type(nonNull(list(nonNull(typeRef(EntityDescriptor.THIS.name(entitySchema)))))))

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/builder/FullResponseObjectBuilder.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/builder/FullResponseObjectBuilder.java
@@ -180,7 +180,7 @@ public class FullResponseObjectBuilder {
 		final OpenApiObject recordPageObject = EntityRecordPageDescriptor.THIS
 			.to(this.objectBuilderTransformer)
 			.name(constructRecordPageObjectName(entitySchema, localized))
-			.description(EntityRecordPageDescriptor.THIS.description(entitySchema))
+			.description(EntityRecordPageDescriptor.THIS.description(entitySchema.getName()))
 			.property(buildDataChunkDataProperty(entityObject))
 			.property(createDataChunkDiscriminatorProperty())
 			.build();
@@ -196,7 +196,7 @@ public class FullResponseObjectBuilder {
 		final OpenApiObject recordStripObject = EntityRecordStripDescriptor.THIS
 			.to(this.objectBuilderTransformer)
 			.name(constructRecordStripObjectName(entitySchema, localized))
-			.description(EntityRecordStripDescriptor.THIS.description(entitySchema))
+			.description(EntityRecordStripDescriptor.THIS.description(entitySchema.getName()))
 			.property(buildDataChunkDataProperty(entityObject))
 			.property(createDataChunkDiscriminatorProperty())
 			.build();

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/AbstractEntityByAttributeFilteringFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/AbstractEntityByAttributeFilteringFunctionalTest.java
@@ -4658,7 +4658,7 @@ public abstract class AbstractEntityByAttributeFilteringFunctionalTest {
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
-				final Random random = new Random();
+				final Random random = new Random(SEED);
 				final String[] randomCodes = originalProductEntities
 					.stream()
 					.filter(it -> random.nextInt(10) == 1)
@@ -4704,7 +4704,7 @@ public abstract class AbstractEntityByAttributeFilteringFunctionalTest {
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
-				final Random random = new Random();
+				final Random random = new Random(SEED);
 				final String[] randomCodes = originalProductEntities
 					.stream()
 					.filter(it -> random.nextInt(10) == 1)
@@ -4758,7 +4758,7 @@ public abstract class AbstractEntityByAttributeFilteringFunctionalTest {
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
-				final Random random = new Random();
+				final Random random = new Random(SEED);
 				final AttributeTuple[] randomData = originalProductEntities
 					.stream()
 					.filter(it -> random.nextInt(10) == 1)
@@ -4814,7 +4814,7 @@ public abstract class AbstractEntityByAttributeFilteringFunctionalTest {
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
-				final Random random = new Random();
+				final Random random = new Random(SEED);
 				final AttributeTuple[] randomData = originalProductEntities
 					.stream()
 					.filter(it -> random.nextInt(10) == 1)
@@ -4853,7 +4853,8 @@ public abstract class AbstractEntityByAttributeFilteringFunctionalTest {
 						require(
 							entityFetch(
 								attributeContent(ATTRIBUTE_CODE)
-							)
+							),
+							page(1, randomCodes.length)
 						)
 					)
 				);
@@ -4948,7 +4949,7 @@ public abstract class AbstractEntityByAttributeFilteringFunctionalTest {
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
-				final Random random = new Random();
+				final Random random = new Random(SEED);
 				final AttributeTuple[] randomData = originalProductEntities
 					.stream()
 					.filter(it -> random.nextInt(10) == 1)
@@ -4994,7 +4995,8 @@ public abstract class AbstractEntityByAttributeFilteringFunctionalTest {
 						require(
 							entityFetch(
 								attributeContent(ATTRIBUTE_CODE)
-							)
+							),
+							page(1, randomCodes.length)
 						)
 					)
 				);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/CatalogSchemaDecoratorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/CatalogSchemaDecoratorTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -220,6 +221,62 @@ class CatalogSchemaDecoratorTest {
 
 			assertNotNull(builder);
 			assertEquals(APITestConstants.TEST_CATALOG, builder.getName());
+		}
+	}
+
+	@Nested
+	@DisplayName("Equality and string representation")
+	class EqualityAndToStringTest {
+
+		@Test
+		@DisplayName("two decorators wrapping value-equal but distinct delegate instances are equal")
+		void shouldConsiderDecoratorsWrappingEqualDelegatesEqual() {
+			final CatalogSchemaDecorator decorator1 = new CatalogSchemaDecorator(
+				CatalogSchema._internalBuild(
+					APITestConstants.TEST_CATALOG,
+					NamingConvention.generate(APITestConstants.TEST_CATALOG),
+					null,
+					EnumSet.allOf(CatalogEvolutionMode.class),
+					EmptyEntitySchemaAccessor.INSTANCE
+				)
+			);
+			final CatalogSchemaDecorator decorator2 = new CatalogSchemaDecorator(
+				CatalogSchema._internalBuild(
+					APITestConstants.TEST_CATALOG,
+					NamingConvention.generate(APITestConstants.TEST_CATALOG),
+					null,
+					EnumSet.allOf(CatalogEvolutionMode.class),
+					EmptyEntitySchemaAccessor.INSTANCE
+				)
+			);
+
+			assertEquals(decorator1, decorator2);
+			assertEquals(decorator1.hashCode(), decorator2.hashCode());
+		}
+
+		@Test
+		@DisplayName("decorators wrapping delegates with different names are not equal")
+		void shouldConsiderDecoratorsWrappingDifferentDelegatesNotEqual() {
+			final CatalogSchemaDecorator decorator1 = new CatalogSchemaDecorator(CATALOG_SCHEMA);
+			final CatalogSchemaDecorator decorator2 = new CatalogSchemaDecorator(
+				CatalogSchema._internalBuild(
+					"differentCatalog",
+					NamingConvention.generate("differentCatalog"),
+					null,
+					EnumSet.allOf(CatalogEvolutionMode.class),
+					EmptyEntitySchemaAccessor.INSTANCE
+				)
+			);
+
+			assertFalse(decorator1.equals(decorator2));
+		}
+
+		@Test
+		@DisplayName("toString() matches the delegate's toString() rather than the decorator's own identity")
+		void shouldDelegateToString() {
+			final CatalogSchemaDecorator decorator = new CatalogSchemaDecorator(CATALOG_SCHEMA);
+
+			assertEquals(CATALOG_SCHEMA.toString(), decorator.toString());
 		}
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/EntitySchemaDecoratorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/EntitySchemaDecoratorTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -236,6 +237,43 @@ class EntitySchemaDecoratorTest {
 			decorator.openForWrite();
 
 			assertEquals(2, callCount[0]);
+		}
+	}
+
+	@Nested
+	@DisplayName("Equality and string representation")
+	class EqualityAndToStringTest {
+
+		@Test
+		@DisplayName("two decorators wrapping value-equal but distinct delegate instances are equal")
+		void shouldConsiderDecoratorsWrappingEqualDelegatesEqual() {
+			final EntitySchemaDecorator decorator1 =
+				new EntitySchemaDecorator(() -> CATALOG_SCHEMA, EntitySchema._internalBuild(Entities.PRODUCT));
+			final EntitySchemaDecorator decorator2 =
+				new EntitySchemaDecorator(() -> CATALOG_SCHEMA, EntitySchema._internalBuild(Entities.PRODUCT));
+
+			assertEquals(decorator1, decorator2);
+			assertEquals(decorator1.hashCode(), decorator2.hashCode());
+		}
+
+		@Test
+		@DisplayName("decorators wrapping delegates with different names are not equal")
+		void shouldConsiderDecoratorsWrappingDifferentDelegatesNotEqual() {
+			final EntitySchemaDecorator decorator1 =
+				new EntitySchemaDecorator(() -> CATALOG_SCHEMA, EntitySchema._internalBuild(Entities.PRODUCT));
+			final EntitySchemaDecorator decorator2 =
+				new EntitySchemaDecorator(() -> CATALOG_SCHEMA, EntitySchema._internalBuild(Entities.BRAND));
+
+			assertFalse(decorator1.equals(decorator2));
+		}
+
+		@Test
+		@DisplayName("toString() matches the delegate's toString() rather than the decorator's own identity")
+		void shouldDelegateToString() {
+			final EntitySchemaDecorator decorator =
+				new EntitySchemaDecorator(() -> CATALOG_SCHEMA, ENTITY_SCHEMA);
+
+			assertEquals(ENTITY_SCHEMA.toString(), decorator.toString());
 		}
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/GraphQLSchemaDescriptionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/GraphQLSchemaDescriptionTest.java
@@ -66,7 +66,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 class GraphQLSchemaDescriptionTest {
 	private static final String GRAPHQL_SCHEMA_DESCRIPTION_TEST_DATA_SET = "GraphQLSchemaDescriptionTestDataSet";
 	private static final Pattern JVM_IDENTITY_STRING_PATTERN =
-		Pattern.compile("io\\.evitadb(?:\\.[\\w$]+)*@[0-9a-f]{6,10}\\b");
+		Pattern.compile("io\\.evitadb(?:\\.[\\w$]+)*@[0-9a-f]{1,8}\\b");
 
 	@DataSet(value = GRAPHQL_SCHEMA_DESCRIPTION_TEST_DATA_SET, destroyAfterClass = true)
 	DataCarrier setUp(Evita evita) {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/GraphQLSchemaDescriptionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/GraphQLSchemaDescriptionTest.java
@@ -1,0 +1,97 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.graphql.api.catalog.dataApi;
+
+import graphql.schema.GraphQLSchema;
+import io.evitadb.api.CatalogContract;
+import io.evitadb.core.Evita;
+import io.evitadb.externalApi.graphql.api.testSuite.TestDataGenerator;
+import io.evitadb.externalApi.graphql.configuration.GraphQLOptions;
+import io.evitadb.externalApi.graphql.utils.GraphQLSchemaPrinter;
+import io.evitadb.test.annotation.DataSet;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.DataCarrier;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static io.evitadb.test.TestConstants.TEST_CATALOG;
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.GRAPHQL;
+import static io.evitadb.test.TestTags.SCHEMA;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Verifies that the built {@link GraphQLSchema} SDL never embeds a JVM identity string (an internal class name
+ * followed by `Object#toString()`'s `@<hex>` identity hash) into a field or type description. Such a leak makes
+ * the published document non-reproducible across restarts, because the hash changes on every JVM start.
+ *
+ * @see io.evitadb.api.requestResponse.schema.EntitySchemaDecoratorTest
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@ExtendWith(EvitaParameterResolver.class)
+@Tag(GRAPHQL)
+@Tag(EXTERNAL_API)
+@Tag(SCHEMA)
+class GraphQLSchemaDescriptionTest {
+	private static final String GRAPHQL_SCHEMA_DESCRIPTION_TEST_DATA_SET = "GraphQLSchemaDescriptionTestDataSet";
+	private static final Pattern JVM_IDENTITY_STRING_PATTERN =
+		Pattern.compile("io\\.evitadb(?:\\.[\\w$]+)*@[0-9a-f]{6,10}\\b");
+
+	@DataSet(value = GRAPHQL_SCHEMA_DESCRIPTION_TEST_DATA_SET, destroyAfterClass = true)
+	DataCarrier setUp(Evita evita) {
+		TestDataGenerator.generateMockCatalogs(evita);
+		final Set<Entry<String, Object>> dataCarrier =
+			new HashSet<>(TestDataGenerator.generateMainCatalogEntities(evita, 20, false).entrySet());
+
+		final CatalogContract catalog = evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final GraphQLSchema graphQLSchema = new CatalogDataApiGraphQLSchemaBuilder(
+			new GraphQLOptions("localhost:5555"),
+			evita,
+			catalog
+		).build();
+		dataCarrier.add(new SimpleEntry<>("graphQLSchema", graphQLSchema));
+
+		return new DataCarrier(dataCarrier);
+	}
+
+	@Test
+	@UseDataSet(GRAPHQL_SCHEMA_DESCRIPTION_TEST_DATA_SET)
+	@DisplayName("Should not leak a JVM identity hash or internal class name into any description")
+	void shouldNotLeakJvmIdentityHashIntoDescriptions(Evita evita, GraphQLSchema graphQLSchema) {
+		final String sdl = GraphQLSchemaPrinter.print(graphQLSchema);
+
+		final Matcher matcher = JVM_IDENTITY_STRING_PATTERN.matcher(sdl);
+		assertFalse(matcher.find(), () -> "GraphQL SDL leaks a JVM identity string: `" + matcher.group() + "`");
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/openApi/SchemaUtilsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/openApi/SchemaUtilsTest.java
@@ -44,16 +44,22 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static io.evitadb.externalApi.rest.api.openApi.OpenApiScalar.scalarFrom;
 import static io.evitadb.externalApi.rest.api.openApi.OpenApiTypeReference.typeRefTo;
 import static io.evitadb.externalApi.rest.api.testSuite.TestDataGenerator.REST_THOUSAND_PRODUCTS;
 import static io.evitadb.test.TestConstants.TEST_CATALOG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static io.evitadb.test.TestTags.REST;
 import static io.evitadb.test.TestTags.EXTERNAL_API;
@@ -74,6 +80,8 @@ import static io.evitadb.test.TestTags.SCHEMA;
 class SchemaUtilsTest {
 	private static final String urlPathToProductList = "/PRODUCT/list";
 	public static final String REST_THOUSAND_PRODUCTS_OPEN_API = REST_THOUSAND_PRODUCTS + "openApi";
+	private static final Pattern JVM_IDENTITY_STRING_PATTERN =
+		Pattern.compile("io\\.evitadb(?:\\.[\\w$]+)*@[0-9a-f]{6,10}\\b");
 
 	@DataSet(value = REST_THOUSAND_PRODUCTS_OPEN_API, destroyAfterClass = true)
 	DataCarrier setUp(Evita evita) {
@@ -164,6 +172,18 @@ class SchemaUtilsTest {
 
 		assertEquals(integerSchema, SchemaUtils.getTargetSchema(referenceToInt, openApi));
 		assertEquals(integerSchema, SchemaUtils.getTargetSchema(topObject, openApi));
+	}
+
+	@Test
+	@UseDataSet(REST_THOUSAND_PRODUCTS_OPEN_API)
+	@DisplayName("Should not leak a JVM identity hash or internal class name into any description")
+	void shouldNotLeakJvmIdentityHashIntoDescriptions(Evita evita, OpenAPI openApi) throws IOException {
+		final ByteArrayOutputStream out = new ByteArrayOutputStream();
+		OpenApiWriter.toJson(openApi, out);
+		final String document = out.toString(StandardCharsets.UTF_8);
+
+		final Matcher matcher = JVM_IDENTITY_STRING_PATTERN.matcher(document);
+		assertFalse(matcher.find(), () -> "OpenAPI document leaks a JVM identity string: `" + matcher.group() + "`");
 	}
 
 	@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/openApi/SchemaUtilsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/openApi/SchemaUtilsTest.java
@@ -81,7 +81,7 @@ class SchemaUtilsTest {
 	private static final String urlPathToProductList = "/PRODUCT/list";
 	public static final String REST_THOUSAND_PRODUCTS_OPEN_API = REST_THOUSAND_PRODUCTS + "openApi";
 	private static final Pattern JVM_IDENTITY_STRING_PATTERN =
-		Pattern.compile("io\\.evitadb(?:\\.[\\w$]+)*@[0-9a-f]{6,10}\\b");
+		Pattern.compile("io\\.evitadb(?:\\.[\\w$]+)*@[0-9a-f]{1,8}\\b");
 
 	@DataSet(value = REST_THOUSAND_PRODUCTS_OPEN_API, destroyAfterClass = true)
 	DataCarrier setUp(Evita evita) {


### PR DESCRIPTION
## Summary
- Seven builder call sites in the GraphQL and REST schema builders passed an `EntitySchemaContract` where the description template expected its name, so `String.format` fell back to `Object#toString()` and embedded a JVM identity hash (e.g. `EntitySchemaDecorator@781bef51`) that changes on every restart. Fixed all seven to pass `entitySchema.getName()`.
- `EntitySchemaDecorator`/`CatalogSchemaDecorator` compounded this: their `@Delegate(types = ...Contract.class)` never covers `Object` methods, so `equals()`/`hashCode()`/`toString()` silently fell back to JVM identity even though the wrapped `EntitySchema`/`CatalogSchema` have value equality. Added `@EqualsAndHashCode(of = "delegate")` and a delegating `toString()`, matching the existing `PriceHistogram`/`CacheablePriceHistogram` idiom elsewhere in the codebase.

Closes #1528

## Test plan
- New `SchemaUtilsTest#shouldNotLeakJvmIdentityHashIntoDescriptions` builds the real in-process OpenAPI document and asserts no `io.evitadb...@<hex>` pattern appears anywhere.
- New `GraphQLSchemaDescriptionTest` does the same for the printed GraphQL SDL.
- Both regression tests were proven by counterfactual — reverting a fix reproduces the exact reported symptom (`EntitySchema@3c8634e`) and fails the test.
- New equality/toString tests in `EntitySchemaDecoratorTest`/`CatalogSchemaDecoratorTest` confirm decorator equality is now value-based rather than identity-based.
- Full schema/GraphQL/REST-tagged functional suite (1989 tests) passes.