### PR TITLE
fix: resolve named schema arguments inside descriptor description() itself

### DIFF
--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/model/DescriptionFormatter.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/model/DescriptionFormatter.java
@@ -1,0 +1,66 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.api.model;
+
+import io.evitadb.api.requestResponse.schema.NamedContract;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Shared formatter of parametrized descriptions of all descriptors in this package
+ * ({@link PropertyDescriptor}, {@link ObjectDescriptor}, {@link UnionDescriptor} and {@link EndpointDescriptor}).
+ *
+ * <p>Description templates are plain {@link String#format(String, Object...)} patterns that usually want the
+ * <em>name</em> of a schema, not the schema object itself. Relying on {@link Object#toString()} of a schema would
+ * leak an internal class name — and, for schema decorators that don't override {@code toString()}, a JVM identity
+ * hash that differs on every boot, making the published GraphQL/OpenAPI schema irreproducible. Therefore any
+ * argument implementing {@link NamedContract} is resolved to its {@link NamedContract#getName()} before formatting,
+ * so that callers may pass schemas directly and don't have to remember to unwrap them.</p>
+ *
+ * @author Lukáš Hornych, FG Forrest a.s. (c) 2026
+ */
+class DescriptionFormatter {
+
+	private DescriptionFormatter() {
+	}
+
+	/**
+	 * Formats the passed description template with the passed arguments, resolving every {@link NamedContract}
+	 * argument to its {@link NamedContract#getName()}.
+	 *
+	 * @param description description template with {@link String#format(String, Object...)} placeholders
+	 * @param args        arguments to fill the placeholders with
+	 * @return formatted description
+	 */
+	@Nonnull
+	static String format(@Nonnull String description, @Nonnull Object... args) {
+		final Object[] resolvedArgs = new Object[args.length];
+		for (int i = 0; i < args.length; i++) {
+			final Object arg = args[i];
+			resolvedArgs[i] = arg instanceof NamedContract namedContract ? namedContract.getName() : arg;
+		}
+		return String.format(description, resolvedArgs);
+	}
+
+}

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/model/EndpointDescriptor.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/model/EndpointDescriptor.java
@@ -192,7 +192,7 @@ public record EndpointDescriptor(@Nonnull String operation,
 
 	@Nonnull
 	public String description(@Nonnull Object... args) {
-		return String.format(this.description, args);
+		return DescriptionFormatter.format(this.description, args);
 	}
 
 	@Nullable

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/model/ObjectDescriptor.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/model/ObjectDescriptor.java
@@ -210,7 +210,7 @@ public record ObjectDescriptor(@Nonnull String name,
 		if (this.description == null) {
 			return null;
 		}
-		return String.format(this.description, args);
+		return DescriptionFormatter.format(this.description, args);
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/model/PropertyDescriptor.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/model/PropertyDescriptor.java
@@ -144,7 +144,7 @@ public record PropertyDescriptor(@Nonnull String name,
 
 	@Nonnull
 	public String description(@Nonnull Object... args) {
-		return String.format(this.description, args);
+		return DescriptionFormatter.format(this.description, args);
 	}
 
 	@Nullable

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/model/UnionDescriptor.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/model/UnionDescriptor.java
@@ -138,7 +138,7 @@ public record UnionDescriptor(
 		if (this.description == null) {
 			return null;
 		}
-		return String.format(this.description, args);
+		return DescriptionFormatter.format(this.description, args);
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogDataApiGraphQLSchemaBuilder.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogDataApiGraphQLSchemaBuilder.java
@@ -478,7 +478,7 @@ public class CatalogDataApiGraphQLSchemaBuilder extends FinalGraphQLSchemaBuilde
 
 		final GraphQLFieldDefinition.Builder singleEntityFieldBuilder = CatalogDataApiRootDescriptor.GET_ENTITY
 			.to(new EndpointDescriptorToGraphQLFieldTransformer(this.propertyDataTypeBuilderTransformer, entitySchema))
-			.description(CatalogDataApiRootDescriptor.GET_ENTITY.description(entitySchema.getName()))
+			.description(CatalogDataApiRootDescriptor.GET_ENTITY.description(entitySchema))
 			.type(typeRef(EntityDescriptor.THIS.name(entitySchema)))
 			.argument(GetEntityHeaderDescriptor.PRIMARY_KEY.to(this.argumentBuilderTransformer));
 
@@ -544,7 +544,7 @@ public class CatalogDataApiGraphQLSchemaBuilder extends FinalGraphQLSchemaBuilde
 
 		final GraphQLFieldDefinition.Builder entityListFieldBuilder = CatalogDataApiRootDescriptor.LIST_ENTITY
 			.to(new EndpointDescriptorToGraphQLFieldTransformer(this.propertyDataTypeBuilderTransformer, entitySchema))
-			.description(CatalogDataApiRootDescriptor.LIST_ENTITY.description(entitySchema.getName()))
+			.description(CatalogDataApiRootDescriptor.LIST_ENTITY.description(entitySchema))
 			.type(nonNull(list(nonNull(typeRef(EntityDescriptor.THIS.name(entitySchema))))))
 			.argument(HeadAwareFieldHeaderDescriptor.HEAD
 				          .to(this.argumentBuilderTransformer)
@@ -596,7 +596,7 @@ public class CatalogDataApiGraphQLSchemaBuilder extends FinalGraphQLSchemaBuilde
 
 		final GraphQLFieldDefinition.Builder entityQueryFieldBuilder = CatalogDataApiRootDescriptor.QUERY_ENTITY
 			.to(new EndpointDescriptorToGraphQLFieldTransformer(this.propertyDataTypeBuilderTransformer, entitySchema))
-			.description(CatalogDataApiRootDescriptor.QUERY_ENTITY.description(entitySchema.getName()))
+			.description(CatalogDataApiRootDescriptor.QUERY_ENTITY.description(entitySchema))
 			.type(nonNull(entityFullResponseObject))
 			.argument(HeadAwareFieldHeaderDescriptor.HEAD
 				          .to(this.argumentBuilderTransformer)

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/builder/FullResponseObjectBuilder.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/builder/FullResponseObjectBuilder.java
@@ -265,7 +265,7 @@ public class FullResponseObjectBuilder {
 		return EntityRecordPageDescriptor.THIS
 			.to(this.objectBuilderTransformer)
 			.name(objectName)
-			.description(EntityRecordPageDescriptor.THIS.description(entitySchema.getName()))
+			.description(EntityRecordPageDescriptor.THIS.description(entitySchema))
 			.field(DataChunkDescriptor.DATA
 				.to(this.fieldBuilderTransformer)
 				.type(nonNull(list(nonNull(typeRef(EntityDescriptor.THIS.name(entitySchema)))))))
@@ -296,7 +296,7 @@ public class FullResponseObjectBuilder {
 		return EntityRecordStripDescriptor.THIS
 			.to(this.objectBuilderTransformer)
 			.name(objectName)
-			.description(EntityRecordStripDescriptor.THIS.description(entitySchema.getName()))
+			.description(EntityRecordStripDescriptor.THIS.description(entitySchema))
 			.field(DataChunkDescriptor.DATA
 				.to(this.fieldBuilderTransformer)
 				.type(nonNull(list(nonNull(typeRef(EntityDescriptor.THIS.name(entitySchema)))))))

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/builder/FullResponseObjectBuilder.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/builder/FullResponseObjectBuilder.java
@@ -180,7 +180,7 @@ public class FullResponseObjectBuilder {
 		final OpenApiObject recordPageObject = EntityRecordPageDescriptor.THIS
 			.to(this.objectBuilderTransformer)
 			.name(constructRecordPageObjectName(entitySchema, localized))
-			.description(EntityRecordPageDescriptor.THIS.description(entitySchema.getName()))
+			.description(EntityRecordPageDescriptor.THIS.description(entitySchema))
 			.property(buildDataChunkDataProperty(entityObject))
 			.property(createDataChunkDiscriminatorProperty())
 			.build();
@@ -196,7 +196,7 @@ public class FullResponseObjectBuilder {
 		final OpenApiObject recordStripObject = EntityRecordStripDescriptor.THIS
 			.to(this.objectBuilderTransformer)
 			.name(constructRecordStripObjectName(entitySchema, localized))
-			.description(EntityRecordStripDescriptor.THIS.description(entitySchema.getName()))
+			.description(EntityRecordStripDescriptor.THIS.description(entitySchema))
 			.property(buildDataChunkDataProperty(entityObject))
 			.property(createDataChunkDiscriminatorProperty())
 			.build();

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/api/model/DescriptionFormatterTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/api/model/DescriptionFormatterTest.java
@@ -1,0 +1,135 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.api.model;
+
+import io.evitadb.api.APITestConstants;
+import io.evitadb.api.proxy.mock.EmptyEntitySchemaAccessor;
+import io.evitadb.api.requestResponse.schema.CatalogEvolutionMode;
+import io.evitadb.api.requestResponse.schema.EntitySchemaDecorator;
+import io.evitadb.api.requestResponse.schema.dto.CatalogSchema;
+import io.evitadb.api.requestResponse.schema.dto.EntitySchema;
+import io.evitadb.test.Entities;
+import io.evitadb.utils.NamingConvention;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+
+import static io.evitadb.externalApi.api.model.PrimitivePropertyDataTypeDescriptor.nonNull;
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.QUERY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests that parametrized descriptions of all descriptor flavours resolve schema arguments to their names instead of
+ * printing the schema object itself. Regression test for #1528, where a schema passed to a description template
+ * rendered as `io.evitadb.…EntitySchemaDecorator@781bef51` and made the published GraphQL/OpenAPI schema differ
+ * between two boots of the same build.
+ *
+ * @author Lukáš Hornych, FG Forrest a.s. (c) 2026
+ */
+@Tag(EXTERNAL_API)
+@Tag(QUERY)
+class DescriptionFormatterTest {
+
+	private static final CatalogSchema CATALOG_SCHEMA = CatalogSchema._internalBuild(
+		APITestConstants.TEST_CATALOG,
+		NamingConvention.generate(APITestConstants.TEST_CATALOG),
+		null,
+		EnumSet.allOf(CatalogEvolutionMode.class),
+		EmptyEntitySchemaAccessor.INSTANCE
+	);
+	private static final EntitySchemaDecorator ENTITY_SCHEMA = new EntitySchemaDecorator(
+		() -> CATALOG_SCHEMA,
+		EntitySchema._internalBuild(Entities.PRODUCT)
+	);
+
+	@Test
+	@DisplayName("property description resolves a schema argument to its name")
+	void shouldResolveSchemaInPropertyDescription() {
+		assertEquals(
+			"Page of PRODUCT records.",
+			PropertyDescriptor.builder()
+				.name("data")
+				.description("Page of %s records.")
+				.type(nonNull(String.class))
+				.build()
+				.description(ENTITY_SCHEMA)
+		);
+	}
+
+	@Test
+	@DisplayName("object description resolves a schema argument to its name")
+	void shouldResolveSchemaInObjectDescription() {
+		assertEquals(
+			"Page of PRODUCT records.",
+			ObjectDescriptor.builder()
+				.name("EntityRecordPage")
+				.description("Page of %s records.")
+				.build()
+				.description(ENTITY_SCHEMA)
+		);
+	}
+
+	@Test
+	@DisplayName("union description resolves a schema argument to its name")
+	void shouldResolveSchemaInUnionDescription() {
+		assertEquals(
+			"Page of PRODUCT records.",
+			UnionDescriptor.builder()
+				.name("EntityRecordPage")
+				.description("Page of %s records.")
+				.build()
+				.description(ENTITY_SCHEMA)
+		);
+	}
+
+	@Test
+	@DisplayName("endpoint description resolves a schema argument to its name")
+	void shouldResolveSchemaInEndpointDescription() {
+		assertEquals(
+			"Returns single PRODUCT entity.",
+			EndpointDescriptor.builder()
+				.operation("getEntity")
+				.description("Returns single %s entity.")
+				.build()
+				.description(ENTITY_SCHEMA)
+		);
+	}
+
+	@Test
+	@DisplayName("description leaves non-schema arguments untouched")
+	void shouldLeaveNonSchemaArgumentsUntouched() {
+		assertEquals(
+			"Page of 10 PRODUCT records.",
+			PropertyDescriptor.builder()
+				.name("data")
+				.description("Page of %d %s records.")
+				.type(nonNull(String.class))
+				.build()
+				.description(10, ENTITY_SCHEMA)
+		);
+	}
+}


### PR DESCRIPTION
The #1528 fix made three GraphQL and two REST builders pass `entitySchema.getName()` into a description template. That works, but it puts the obligation on every call site: the next builder to parametrize a description with a schema reintroduces the identity hash, and nothing in the descriptor API says otherwise.

Move the resolution into `description(Object...)`. A new package-private `DescriptionFormatter` walks the arguments and replaces every `NamedContract` with its `getName()` before handing them to `String.format`, and all four descriptor flavours — property, object, union and endpoint — now format through it. `NamedContract` rather than `NamedSchemaContract`, because it is the narrower super-interface that carries `getName()` and it subsumes every schema type anyway.

The five builder call sites go back to passing the schema itself. Non-schema arguments pass through untouched, so no other description changes.

Ref: #1528