### PR TITLE
docs: correct the checkpoint cadence and fence depth descriptions

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/statistics/DurabilityStatistics.java
+++ b/evita_api/src/main/java/io/evitadb/api/statistics/DurabilityStatistics.java
@@ -44,6 +44,13 @@ import java.util.Optional;
  * from the other - a handful of large transactions and a flood of small ones give the same version lag and very
  * different fence depths - so a management screen wanting the operator-legible number wants this one.
  *
+ * **Read the two intervals together, and read the fence one first.** `lastFenceDepthMillis` never exceeds
+ * `lastCadenceMillis`, and the difference between them is time in which nothing was owed to the device. A fence
+ * depth close to the cadence means the catalog was writing throughout the window; a fence depth far below it means
+ * the catalog was mostly quiet. This is why a large cadence on its own says nothing: it is produced both by a
+ * catalog too busy to checkpoint on time and by one with nothing to checkpoint at all, and only the fence depth
+ * separates the two.
+ *
  * **The counters are process-scoped** and `countingSince` is what makes them readable: `checkpointsCompleted` starts
  * at zero when the catalog is opened and is not persisted, so reading it as "checkpoints this catalog has ever taken"
  * is wrong by everything before that open. Same treatment as {@link ActivityStatistics}.
@@ -60,10 +67,15 @@ import java.util.Optional;
  *                                 on how long a change may wait to become durable, and therefore the knob that trades
  *                                 write throughput against crash-replay cost
  * @param lastCadenceMillis        time between the last two completed checkpoints (milliseconds); `0` before the first
- *                                 one completes. Sustained values above `checkpointIntervalMillis` mean checkpointing
- *                                 is not keeping up with the write rate
+ *                                 one completes, and measured from the catalog's open for the first one. A value above
+ *                                 `checkpointIntervalMillis` is **not** a problem signal on its own - it is the normal
+ *                                 reading for a catalog that is written to rarely, where every round checkpoints inline
+ *                                 and the fence depth stays `0`. Alone this figure cannot tell an idle catalog from an
+ *                                 overloaded one; {@link #fenceOverdue()} is the signal to act on
  * @param lastFenceDepthMillis     how long the oldest change covered by the last checkpoint waited to become durable
- *                                 (milliseconds); `0` when that round checkpointed without deferring anything
+ *                                 (milliseconds); `0` when that round checkpointed without deferring anything. Measured
+ *                                 from the end of the first round that deferred, so it is a lower bound on the age of
+ *                                 the oldest change a crash at that moment would have replayed
  * @param lastFilesForced          number of files the last checkpoint forced to the device
  * @param lastForceDurationMillis  wall-clock time those forces took (milliseconds) - the cost the interval exists to
  *                                 amortise, paid once per checkpoint instead of once per round

--- a/evita_engine/src/main/java/io/evitadb/core/metric/event/storage/CatalogCheckpointEvent.java
+++ b/evita_engine/src/main/java/io/evitadb/core/metric/event/storage/CatalogCheckpointEvent.java
@@ -42,11 +42,15 @@ import javax.annotation.Nonnull;
  *
  * Read the two gauges together - they answer different questions:
  *
- * - **Cadence** says whether checkpoints are happening as often as configured. Sustained values far above
- *   the configured interval mean checkpointing cannot keep up with the write rate.
+ * - **Cadence** says how often checkpoints are actually happening. It is *not* a health signal on its own: a value
+ *   far above the configured interval is equally the reading of a catalog too busy to checkpoint on time and of one
+ *   with nothing to checkpoint at all, and nothing in this gauge separates the two.
  * - **Fence depth** says how far behind durability is running, and therefore bounds both how much write-ahead log
- *   must be retained and how much of it a restart has to replay. On a quiet catalog it should show roughly one
- *   interval and then stay flat.
+ *   must be retained and how much of it a restart has to replay. This is the gauge to alert on: it exceeds the
+ *   configured interval only when durability really is falling behind the configured policy. On a quiet catalog it
+ *   sits at zero, because every round checkpoints inline and nothing is ever deferred.
+ *
+ * Fence depth never exceeds cadence; the difference between them is time in which nothing was owed to the device.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
@@ -63,12 +67,12 @@ public class CatalogCheckpointEvent extends AbstractStorageEvent {
 	private long forceDurationMilliseconds;
 
 	@Label("Checkpoint cadence in milliseconds")
-	@Description("The time elapsed since the previous completed checkpoint. Compare against the configured checkpoint interval - sustained higher values mean checkpointing is not keeping up with the write rate.")
+	@Description("The time elapsed since the previous completed checkpoint. On its own this says only how often checkpoints happen, not whether that is healthy - a value above the configured checkpoint interval is the normal reading for a rarely written catalog. Alert on fence depth instead, and read this alongside it.")
 	@ExportMetric(metricType = MetricType.GAUGE)
 	private long cadenceMilliseconds;
 
 	@Label("Fence depth in milliseconds")
-	@Description("How long the oldest change covered by this checkpoint waited to become durable. Bounds both the write-ahead log retention and the amount of replay a restart has to perform. Zero when the round checkpointed without deferring.")
+	@Description("How long the oldest change covered by this checkpoint waited to become durable - measured from the end of the first round that deferred, not from the start of the force. Bounds both the write-ahead log retention and the amount of replay a restart has to perform. Zero when the round checkpointed without deferring.")
 	@ExportMetric(metricType = MetricType.GAUGE)
 	private long fenceDepthMilliseconds;
 

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/DurabilitySnapshot.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/DurabilitySnapshot.java
@@ -42,13 +42,19 @@ import java.time.OffsetDateTime;
  *
  * @param checkpointIntervalMillis  the configured interval a checkpoint is deferred by, in milliseconds
  * @param lastCadenceMillis         time between the last two completed checkpoints, in milliseconds; `0` before the
- *                                  first one completes. Sustained values above the configured interval mean
- *                                  checkpointing is not keeping up with the write rate
+ *                                  first one completes, and measured from this coordinator's construction for the
+ *                                  first one. A value above the configured interval is **not** a problem signal on its
+ *                                  own - it is the normal reading for a catalog that is written to rarely, where every
+ *                                  round checkpoints inline and the fence depth stays `0`. Only alongside a fence
+ *                                  depth that also exceeds the interval does it mean checkpointing is not keeping up
+ *                                  with the write rate
  * @param lastFenceDepthMillis      how long the oldest change covered by the last checkpoint waited to become durable,
  *                                  in milliseconds; `0` when that round checkpointed without deferring anything. This
  *                                  is the time-domain answer to "how much replay would a crash cost me right now" -
  *                                  distinct from `CommitPipelineStatistics#durabilityLag()`, which answers the same
- *                                  question in catalog versions
+ *                                  question in catalog versions. Measured from the end of the first round that
+ *                                  deferred, so it is a lower bound on the age of the oldest change a crash at that
+ *                                  moment would have replayed. Never greater than `lastCadenceMillis`
  * @param lastFilesForced           number of files the last checkpoint forced to the device
  * @param lastForceDurationMillis   wall-clock time those forces took, in milliseconds - the cost the interval exists
  *                                  to amortise, paid once per checkpoint rather than once per round

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDurabilityStatistics.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDurabilityStatistics.java
@@ -99,8 +99,11 @@ private static final long serialVersionUID = 0L;
   private long lastCadenceMillis_ = 0L;
   /**
    * <pre>
-   * Time between the last two completed checkpoints (milliseconds); `0` before the first one completes. Sustained
-   * values above `checkpointIntervalMillis` mean checkpointing is not keeping up with the write rate.
+   * Time between the last two completed checkpoints (milliseconds); `0` before the first one completes, and measured
+   * from the catalog's open for the first one. A value above `checkpointIntervalMillis` is NOT a problem signal on its
+   * own - it is the normal reading for a catalog that is written to rarely, where every round checkpoints inline and
+   * the fence depth stays `0`. Alone this figure cannot tell an idle catalog from an overloaded one; alert on
+   * `lastFenceDepthMillis` exceeding `checkpointIntervalMillis` instead, and read this one alongside it.
    * </pre>
    *
    * <code>int64 lastCadenceMillis = 2;</code>
@@ -116,7 +119,10 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    * How long the oldest change covered by the last checkpoint waited to become durable (milliseconds); `0` when that
-   * round checkpointed without deferring anything.
+   * round checkpointed without deferring anything. Measured from the end of the first round that deferred, so it is a
+   * lower bound on the age of the oldest change a crash at that moment would have replayed - NOT the duration of the
+   * device force, which is `lastForceDurationMillis`. Never greater than `lastCadenceMillis`; the difference between
+   * the two is time in which nothing was owed to the device.
    * </pre>
    *
    * <code>int64 lastFenceDepthMillis = 3;</code>
@@ -858,8 +864,11 @@ private static final long serialVersionUID = 0L;
     private long lastCadenceMillis_ ;
     /**
      * <pre>
-     * Time between the last two completed checkpoints (milliseconds); `0` before the first one completes. Sustained
-     * values above `checkpointIntervalMillis` mean checkpointing is not keeping up with the write rate.
+     * Time between the last two completed checkpoints (milliseconds); `0` before the first one completes, and measured
+     * from the catalog's open for the first one. A value above `checkpointIntervalMillis` is NOT a problem signal on its
+     * own - it is the normal reading for a catalog that is written to rarely, where every round checkpoints inline and
+     * the fence depth stays `0`. Alone this figure cannot tell an idle catalog from an overloaded one; alert on
+     * `lastFenceDepthMillis` exceeding `checkpointIntervalMillis` instead, and read this one alongside it.
      * </pre>
      *
      * <code>int64 lastCadenceMillis = 2;</code>
@@ -871,8 +880,11 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Time between the last two completed checkpoints (milliseconds); `0` before the first one completes. Sustained
-     * values above `checkpointIntervalMillis` mean checkpointing is not keeping up with the write rate.
+     * Time between the last two completed checkpoints (milliseconds); `0` before the first one completes, and measured
+     * from the catalog's open for the first one. A value above `checkpointIntervalMillis` is NOT a problem signal on its
+     * own - it is the normal reading for a catalog that is written to rarely, where every round checkpoints inline and
+     * the fence depth stays `0`. Alone this figure cannot tell an idle catalog from an overloaded one; alert on
+     * `lastFenceDepthMillis` exceeding `checkpointIntervalMillis` instead, and read this one alongside it.
      * </pre>
      *
      * <code>int64 lastCadenceMillis = 2;</code>
@@ -888,8 +900,11 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Time between the last two completed checkpoints (milliseconds); `0` before the first one completes. Sustained
-     * values above `checkpointIntervalMillis` mean checkpointing is not keeping up with the write rate.
+     * Time between the last two completed checkpoints (milliseconds); `0` before the first one completes, and measured
+     * from the catalog's open for the first one. A value above `checkpointIntervalMillis` is NOT a problem signal on its
+     * own - it is the normal reading for a catalog that is written to rarely, where every round checkpoints inline and
+     * the fence depth stays `0`. Alone this figure cannot tell an idle catalog from an overloaded one; alert on
+     * `lastFenceDepthMillis` exceeding `checkpointIntervalMillis` instead, and read this one alongside it.
      * </pre>
      *
      * <code>int64 lastCadenceMillis = 2;</code>
@@ -906,7 +921,10 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * How long the oldest change covered by the last checkpoint waited to become durable (milliseconds); `0` when that
-     * round checkpointed without deferring anything.
+     * round checkpointed without deferring anything. Measured from the end of the first round that deferred, so it is a
+     * lower bound on the age of the oldest change a crash at that moment would have replayed - NOT the duration of the
+     * device force, which is `lastForceDurationMillis`. Never greater than `lastCadenceMillis`; the difference between
+     * the two is time in which nothing was owed to the device.
      * </pre>
      *
      * <code>int64 lastFenceDepthMillis = 3;</code>
@@ -919,7 +937,10 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * How long the oldest change covered by the last checkpoint waited to become durable (milliseconds); `0` when that
-     * round checkpointed without deferring anything.
+     * round checkpointed without deferring anything. Measured from the end of the first round that deferred, so it is a
+     * lower bound on the age of the oldest change a crash at that moment would have replayed - NOT the duration of the
+     * device force, which is `lastForceDurationMillis`. Never greater than `lastCadenceMillis`; the difference between
+     * the two is time in which nothing was owed to the device.
      * </pre>
      *
      * <code>int64 lastFenceDepthMillis = 3;</code>
@@ -936,7 +957,10 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      * How long the oldest change covered by the last checkpoint waited to become durable (milliseconds); `0` when that
-     * round checkpointed without deferring anything.
+     * round checkpointed without deferring anything. Measured from the end of the first round that deferred, so it is a
+     * lower bound on the age of the oldest change a crash at that moment would have replayed - NOT the duration of the
+     * device force, which is `lastForceDurationMillis`. Never greater than `lastCadenceMillis`; the difference between
+     * the two is time in which nothing was owed to the device.
      * </pre>
      *
      * <code>int64 lastFenceDepthMillis = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDurabilityStatisticsOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcDurabilityStatisticsOrBuilder.java
@@ -44,8 +44,11 @@ public interface GrpcDurabilityStatisticsOrBuilder extends
 
   /**
    * <pre>
-   * Time between the last two completed checkpoints (milliseconds); `0` before the first one completes. Sustained
-   * values above `checkpointIntervalMillis` mean checkpointing is not keeping up with the write rate.
+   * Time between the last two completed checkpoints (milliseconds); `0` before the first one completes, and measured
+   * from the catalog's open for the first one. A value above `checkpointIntervalMillis` is NOT a problem signal on its
+   * own - it is the normal reading for a catalog that is written to rarely, where every round checkpoints inline and
+   * the fence depth stays `0`. Alone this figure cannot tell an idle catalog from an overloaded one; alert on
+   * `lastFenceDepthMillis` exceeding `checkpointIntervalMillis` instead, and read this one alongside it.
    * </pre>
    *
    * <code>int64 lastCadenceMillis = 2;</code>
@@ -56,7 +59,10 @@ public interface GrpcDurabilityStatisticsOrBuilder extends
   /**
    * <pre>
    * How long the oldest change covered by the last checkpoint waited to become durable (milliseconds); `0` when that
-   * round checkpointed without deferring anything.
+   * round checkpointed without deferring anything. Measured from the end of the first round that deferred, so it is a
+   * lower bound on the age of the oldest change a crash at that moment would have replayed - NOT the duration of the
+   * device force, which is `lastForceDurationMillis`. Never greater than `lastCadenceMillis`; the difference between
+   * the two is time in which nothing was owed to the device.
    * </pre>
    *
    * <code>int64 lastFenceDepthMillis = 3;</code>

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcStatistics.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcStatistics.proto
@@ -491,11 +491,17 @@ message GrpcDurabilityStatistics {
   // The configured interval a checkpoint is deferred by (milliseconds). The upper bound on how long a change may wait
   // to become durable, and therefore the knob trading write throughput against crash-replay cost.
   int64 checkpointIntervalMillis = 1;
-  // Time between the last two completed checkpoints (milliseconds); `0` before the first one completes. Sustained
-  // values above `checkpointIntervalMillis` mean checkpointing is not keeping up with the write rate.
+  // Time between the last two completed checkpoints (milliseconds); `0` before the first one completes, and measured
+  // from the catalog's open for the first one. A value above `checkpointIntervalMillis` is NOT a problem signal on its
+  // own - it is the normal reading for a catalog that is written to rarely, where every round checkpoints inline and
+  // the fence depth stays `0`. Alone this figure cannot tell an idle catalog from an overloaded one; alert on
+  // `lastFenceDepthMillis` exceeding `checkpointIntervalMillis` instead, and read this one alongside it.
   int64 lastCadenceMillis = 2;
   // How long the oldest change covered by the last checkpoint waited to become durable (milliseconds); `0` when that
-  // round checkpointed without deferring anything.
+  // round checkpointed without deferring anything. Measured from the end of the first round that deferred, so it is a
+  // lower bound on the age of the oldest change a crash at that moment would have replayed - NOT the duration of the
+  // device force, which is `lastForceDurationMillis`. Never greater than `lastCadenceMillis`; the difference between
+  // the two is time in which nothing was owed to the device.
   int64 lastFenceDepthMillis = 3;
   // Number of files the last checkpoint forced to the device.
   int32 lastFilesForced = 4;


### PR DESCRIPTION
`DurabilityStatistics` and `DurabilitySnapshot` both claimed that sustained cadence values above the configured checkpoint interval mean checkpointing is not keeping up with the write rate. Only half true, and the misleading half is the common one: a rarely written catalog reports a large cadence with every round checkpointing inline and a fence depth of zero. Cadence alone cannot tell an idle catalog from an overloaded one — only the fence depth separates them, which is what `fenceOverdue()` already tests.

The claim had propagated into `CatalogCheckpointEvent`'s JFR gauge descriptions and from there into client tooling label copy, so all three are corrected together and the event's class doc now names fence depth as the gauge to alert on.

Also documents two properties that were previously only visible from the implementation:

- fence depth is measured from the end of the first round that deferred, so it is a lower bound on the age of the oldest change a crash would replay — **not** the duration of the force, which is `lastForceDurationMillis`;
- fence depth never exceeds cadence, the difference between them being time in which nothing was owed to the device.

Javadoc and JFR `@Description` text only — no behavioural change.

Ref: #1339