### PR TITLE
docs: move the Java-only rules into the Java code-style rule

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -14,7 +14,15 @@ paths:
 - **Data structures**: Prefer immutable classes / records for data structures
 - **Maps and sets**: create them through `io.evitadb.utils.CollectionUtils` — `createHashMap(n)`, `createLinkedHashMap(n)`, `createHashSet(n)`, `createLinkedHashSet(n)`, `createConcurrentHashMap(n)` — never `new HashMap<>(n)`. The JDK constructor takes a **bucket capacity**, not an expected element count, so `new HashMap<>(64)` rehashes once it passes 48 entries; the factories convert the count you actually know (`n / 0.75 + 1`) into the capacity the JDK wants. Two things are *not* covered and stay as they are: copy constructors (`new HashMap<>(otherMap)`), which the JDK already sizes from the source, and a genuinely unknown size, which stays `new HashMap<>()`.
 - **Annotations**: Automatically add `javax.annotation.Nullable` and `javax.annotation.Nonnull` annotations to method parameters and return types
-- **Optional as parameter**: `java.util.Optional` is permitted **only as a method return type**. Never declare it as a method parameter, constructor parameter, or field. For an optional input use a `@Nullable` reference instead; for optional state store the bare value and wrap it with `Optional.ofNullable(...)` at the read boundary. (`Optional` was designed to signal "no result" from a return, not to be passed around — boxing it into arguments adds allocation and an extra null-vs-empty axis.)
+- **Optional as parameter**: `java.util.Optional` is permitted **only as a method return type**, and as a local
+  variable holding one. Never declare it as a method parameter, constructor parameter, or field. A field pays a
+  wrapper object per instance for something `null` already expresses, and then drags it through every copy,
+  serializer and equality check on the class. An argument forces every caller to wrap while the parameter still
+  accepts `null` — a signature promising a guarantee it does not give. For an optional input use a `@Nullable`
+  reference instead; for optional state store the bare value and wrap it with `Optional.ofNullable(...)` at the
+  read boundary. The case that tempts a field is memoizing a nullable lookup, where `null` means *not computed*
+  and *absent* at once: do not separate them with an `Optional` field — recompute instead, and keep the scan
+  allocation-free. `ReferenceContent#getFilterBy` is the worked example.
 - **Local variables**: Use `final` for local variables
 - **Instance variables**: Use `this` for instance variables
 - **Type declarations**: Never use `var` - always use explicit types
@@ -22,6 +30,14 @@ paths:
 - **Resource management**: Use try-with-resources for all `AutoCloseable` resources wherever applicable
 - **Documentation**: Automatically add JavaDoc to all generated classes and methods
 - **Comments**: Add line comments to complex logic
+
+## Defensive Design
+
+- **Never silently skip unexpected states.** If a code path should be unreachable (e.g., an `else` after
+  exhaustive enum checks, a `default` in a switch over a closed enum), it must throw an exception
+  (`GenericEvitaInternalError` or equivalent) — never `continue`, `return`, `break`, or no-op.
+- Treat every unhandled enum value, unexpected type, or impossible branch as a programming error that must
+  surface immediately at runtime.
 
 ## Performance-Critical Code
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,6 @@ evitaDB is an in-memory NoSQL database that acts as a fast secondary search/look
 
 ## Building
 
-- **Primary**: try to use IntelliJ MCP for building and running the project, when not possible use Maven
 - **CLI Build Tool**: Maven
 - **Java Version**: OpenJDK 17 (requires Maven toolchains configuration)
 
@@ -155,21 +154,7 @@ these be one enum?") must be answered *before* the second one ships, not after.
 User-facing docs live under `documentation/user/`. English is the only hand-written source; the
 Czech mirror is machine-translated, never hand-edited — see `.claude/rules/documentation.md`.
 
-## Defensive Design
+## Java Code Style
 
-- **Never silently skip unexpected states.** If a code path should be unreachable (e.g., an `else` after exhaustive enum checks, a `default` in a switch over a closed enum), it must throw an exception (`GenericEvitaInternalError` or equivalent) — never `continue`, `return`, `break`, or no-op.
-- Treat every unhandled enum value, unexpected type, or impossible branch as a programming error that must surface immediately at runtime.
-
-## Optionals
-
-**`Optional` is a return type, and nothing else.** It is legal as a method return value and as a local variable
-holding one. Never as a **class field**, never as a **method argument**.
-
-A field pays a wrapper object per instance for something `null` already expresses, and then drags it through
-every copy, serializer and equality check on the class. An argument forces every caller to wrap, while the
-parameter still accepts `null` - a signature promising a guarantee it does not give. Take the value and mark it
-`@Nullable`.
-
-The case that tempts a field is memoizing a nullable lookup, where `null` means *not computed* and *absent* at
-once. Do not separate them with an `Optional` field - recompute instead, and keep the scan allocation-free.
-`ReferenceContent#getFilterBy` is the worked example.
+Indentation, annotations, `Optional` placement, defensive design, collection factories and the rules for
+performance-critical code live in `.claude/rules/code-style.md`, which loads whenever a `.java` file is in play.


### PR DESCRIPTION
Two Claude-guidance changes, no code touched.

**Java rules move to the Java rule file.** `Defensive Design` and `Optionals` only apply when Java is being written, but lived in the root `CLAUDE.md`, which loads in full at the start of every session regardless of what the session is doing. Both now sit in `.claude/rules/code-style.md`, which is already scoped `paths: ["**/*.java"]` and therefore loads on demand.

The `Optionals` rationale is merged into the existing **Optional as parameter** bullet rather than repeated next to it — that bullet already stated the rule, so the two would otherwise have drifted. The root file keeps a two-line pointer so the trigger remains visible to a session that has not opened a `.java` file yet.

**The IntelliJ-MCP-first build instruction is removed.** `- **Primary**: try to use IntelliJ MCP for building and running the project, when not possible use Maven` has not been followed once: the `mcp__jetbrains__*` tools show zero invocations across every recorded session. The line only sent each session down a dead path before falling back to Maven, which the following line already prescribes.

Net effect on always-loaded context: `CLAUDE.md` drops from 10,217 to 9,078 characters.