### PR TITLE
Bound the cross-entity facet trigger with an owner-to-partition reverse index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,9 @@ mcp-jdwp-inspector.log
 /data/*
 /**/evita-server-certificates/*
 /evita_server/logs
+# The server writes `logs/` relative to its working directory, so launching it from the reactor
+# root (as the benchmark scripts do) drops one here rather than under /evita_server.
+/logs/
 /evita_test/evita_functional_tests/export/*
 /evita_test/evita_functional_tests/data/*
 

--- a/documentation/adr/2026-04-23-conditional-facet-indexing.md
+++ b/documentation/adr/2026-04-23-conditional-facet-indexing.md
@@ -1,7 +1,7 @@
 ---
 title: Conditional (partial) facet indexing via schema-compiled expression triggers, not per-mutation full-entity evaluation
 date: 2026-04-23
-updated: 2026-09-09 12:41
+updated: 2026-09-09 19:12
 status: accepted
 kind: feature
 issues: [8]
@@ -9,7 +9,11 @@ prs: [1136]
 areas: [evita_api/src/main/java/io/evitadb/api/requestResponse/mutation, evita_engine/src/main/java/io/evitadb/core/expression, evita_engine/src/main/java/io/evitadb/core/catalog, evita_engine/src/main/java/io/evitadb/index/mutation]
 supersedes: []
 superseded-by: []
-relates: [2026-04-23-bucketed-histogram-indexing, 2026-05-06-reference-histogram-statistics, 2026-05-27-range-and-multi-histogram-schema]
+relates:
+  - 2026-04-23-bucketed-histogram-indexing
+  - 2026-05-06-reference-histogram-statistics
+  - 2026-05-27-range-and-multi-histogram-schema
+  - 2026-09-09-sibling-resolver-partition-cardinality
 ---
 
 # Conditional (partial) facet indexing
@@ -295,6 +299,12 @@ not a parallel mechanism.
     trade reverses - and note the map need not be persisted, since every entity index is loaded eagerly at
     catalog open and it is therefore derivable, which removes the storage-format and BWC burden the
     original assessment assumed.
+  - **Answered on 2026-09-09 by `2026-09-09-sibling-resolver-partition-cardinality`.** Measured against a
+    production catalog: the walk is 0.78 ms at that catalog's 4,633 partitions, and 81-113 ms after one
+    schema edit that switches high-cardinality references to `FOR_FILTERING_AND_PARTITIONING`. Scaling is
+    **super-linear** - 40.7x the partitions costs 104.8x the time. The constant-factor change measured here
+    at 20-35 % by cost model is worth **4.7 %**. The reverse index is worth building only in a
+    size-thresholded form; the blanket structure costs 274.7 MiB against 24.6 MiB for 96 % of the benefit.
 
 - **Second post-ship bug, fixed 2026-09-08: a conditional facet never reached the owner's *sibling*
   partitions.** Reported as edee/eshop#2933 against `2026.2.6`, seen in production on two unrelated

--- a/documentation/adr/2026-08-31-cross-entity-histogram-removal-pre-pass.md
+++ b/documentation/adr/2026-08-31-cross-entity-histogram-removal-pre-pass.md
@@ -1,7 +1,7 @@
 ---
 title: Gate cross-entity histogram removal on a pre-mutation condition pre-pass, not bucket membership
 date: 2026-08-31
-updated: 2026-09-09 19:12
+updated: 2026-09-10 14:45
 status: accepted
 kind: fix
 issues: [1467]
@@ -265,12 +265,19 @@ The investigation spent most of its time on two wrong theories. Both are the nat
 
 - **It is not a `TransactionalMap` / `MapChanges` bug.** Remove-then-re-add of the same key was walked
   down both branches: created-then-removed (`existing == false`, so `removedKeys` is never touched and
-  the instance is stashed in `createdThenRemovedProducers`, released at commit) and
+  the instance is stashed in `discardedProducers`, released at commit) and
   base-map-remove-then-re-add (`registerModifiedKey` plus `removedKeys.remove(key)`). Neither loses the
   new instance. The eager `removed.removeLayer(transactionalLayer)` in `HistogramIndexOperations` is
   redundant with what `MapChanges.put` already does, but release is documented idempotent. The
   decisive evidence is simpler than any of that: the defect reproduces identically in `WARMING_UP`,
   where there is no transaction at all.
+
+  **Read this bullet narrowly.** It answers one question — *does the new instance get lost?* — and the
+  answer is still no. It is **not** a clearance of `MapChanges`, and it must not be cited as one: two
+  orphaned-**layer** defects were later found in these very branches, where the *displaced* instance,
+  not the new one, is the casualty. See *2026-09-09-sibling-resolver-partition-cardinality*. The
+  `WARMING_UP` reproduction is what actually rules transactional memory out here, and it is the only
+  part of this bullet that generalises.
 - **`HistogramIndexOperations` lines 152-158 are not the bug**, and the evidence that pointed there
   could not have shown it. `SimpleHistogramIndex.getFilterIndex` returns
   `this.filterIndex.isEmpty() ? null : this.filterIndex`, so a `getHistogramFilterIndex(...) == null`

--- a/documentation/adr/2026-08-31-cross-entity-histogram-removal-pre-pass.md
+++ b/documentation/adr/2026-08-31-cross-entity-histogram-removal-pre-pass.md
@@ -1,7 +1,7 @@
 ---
 title: Gate cross-entity histogram removal on a pre-mutation condition pre-pass, not bucket membership
 date: 2026-08-31
-updated: 2026-08-31 11:48
+updated: 2026-09-09 19:12
 status: accepted
 kind: fix
 issues: [1467]
@@ -9,7 +9,7 @@ prs: [1468, 1469]
 areas: [evita_engine/src/main/java/io/evitadb/index/mutation, evita_engine/src/main/java/io/evitadb/core/collection]
 supersedes: []
 superseded-by: []
-relates: [2026-04-23-bucketed-histogram-indexing]
+relates: [2026-04-23-bucketed-histogram-indexing, 2026-09-09-sibling-resolver-partition-cardinality]
 ---
 
 # Cross-entity histogram removal is gated on the pre-mutation condition, captured before the batch is applied

--- a/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
+++ b/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
@@ -24,6 +24,19 @@ touches. Measured against a production catalog it is **0.78 ms** as that catalog
 **81–113 ms** after a single schema edit any client can make. This record fixes what was measured, what the
 numbers mean, and which of the candidate fixes is worth building.
 
+**Vocabulary, because both words are used throughout and neither is obvious.** A **partition** is one
+reduced entity index — a `ReducedEntityIndex` or `ReducedGroupEntityIndex` of
+`EntityIndexType.REFERENCED_ENTITY` / `REFERENCED_GROUP_ENTITY`, one per distinct referenced entity. The
+word is the schema flag's own: `FOR_FILTERING_AND_PARTITIONING` is documented as creating "partitioning
+indexes for the main entity type". A partition's **members** are the owner-entity primary keys it holds
+(`getAllPrimaryKeys()`) — what `EntityIndexType.REFERENCED_ENTITY`'s javadoc calls the record ids connected
+to that referenced entity. For `Product.parameterValues`: one partition per parameter value, whose members
+are the products carrying it.
+
+The distinction carries the entire decision below, because **cost is per member while benefit is per
+partition** — covering a partition costs one map entry per member and saves exactly one bitmap
+intersection, however many members it has.
+
 Option A is **implemented and measured**; the figures below distinguish throughout between what the
 harness *modelled* and what the shipped code *does*. The prior constant-factor change (PRs #1524 / #1525)
 shipped unmeasured and is now quantified — at far less than its cost model claimed.

--- a/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
+++ b/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
@@ -1,7 +1,7 @@
 ---
 title: Bound the cross-entity facet walk with a size-thresholded owner→partition index, not a blanket one
 date: 2026-09-09
-updated: 2026-09-11 17:45
+updated: 2026-09-11 19:20
 status: accepted
 kind: optimization
 issues: [1529]
@@ -474,7 +474,8 @@ without a performance claim was the right call — the claim it was never given 
   the dense shape has 57,962. **A primitive int-keyed map is a separate, unmeasured lever.**
 - **The dense shape is bound by the accumulator, not by the walk, and `T` cannot move it.** Once the harness
   was corrected (2026-09-11) the dense rows fell to 1.07–1.09× and 1.34–1.50×. The reason is
-  `ReevaluateExpressionExecutor#addSibling`: it runs once per `(owner, partition)` pair of the *answer*, and
+  `ReevaluateExpressionExecutor#probeReducedIndexForAffectedOwners`: its accumulation runs once per
+  `(owner, partition)` pair of the *answer*, and
   both the lookup and the walk must produce that answer in full. Raising the coverage threshold changes which
   partitions are probed; it cannot change how many pairs exist.
 - **The accumulator was profiled, and its cost was a de-duplication scan that never de-duplicated anything —
@@ -486,10 +487,22 @@ without a performance claim was the right call — the claim it was never given 
   The scan was then shown to be dead rather than merely expensive. A `COUNT_DEDUP` variant tallying its
   rejections reported **0 out of 1,568,849,000 offered pairs** across both arms and both shapes on the
   production catalog; replacing it with a throwing premise left the conditional-facet suite green at 287 tests,
-  after a counterfactual run proved that same suite reaches the code 48 times. The reason is structural: one
-  reduced index primary key reaches the probe **at most once per sibling reference** — the covered half
-  collects into a bitmap before probing, the residual set is a bitmap disjoint from the covered one, and the
-  walk's two families advertise primary keys drawn from one collection-wide sequence and never collide.
+  after a counterfactual run proved that same suite reaches the code 48 times, and a wider run of the same
+  premise over 350 tests offered no duplicate pair either. The reason is structural: one reduced index primary
+  key reaches the probe **at most once per sibling reference** — the covered half collects its selected keys
+  into a bitmap before probing, the residual set is itself a bitmap, and the walk's two families advertise
+  primary keys drawn from one collection-wide sequence and never collide.
+  **That argument has one seam, and stating it as unconditional disjointness — as this record and the code
+  comment both first did — is wrong.** The covered half selects out of `ReducedIndexMembership`'s owner→index
+  map, *never* out of `getCoveredIndexPrimaryKeys()`, and the two are never intersected; so the disjointness of
+  the covered and residual *sets* does not by itself bound what the two halves probe. `dropCoverage` forgets
+  one entry per member of the membership handed to it, so an entry built from a membership the index did not
+  actually have would outlive the promotion that made the index residual, and both halves would then probe it.
+  No engine path is known to reach that state — every caller passes `referenceIndex.getAllPrimaryKeys()`, the
+  live membership, so entries and members move in lockstep — and it is harmless if it ever does, for the reason
+  given below. It is constructible through the map's own API, and
+  `ReducedIndexMembershipTest#promotionKeepsAnEntryBuiltFromDriftedMembership` pins it so that a future change
+  which starts *relying* on pair uniqueness has something to fail against.
   The scan's own comment (`references sharing a reduced group index resolve to the same instance more than
   once`) described a real phenomenon attached to the wrong traversal: several of **one owner's references** do
   resolve to a single `ReducedGroupEntityIndex`, which is why `ReferenceIndexMutator#forEachUniqueReferenceIndex`

--- a/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
+++ b/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
@@ -1,0 +1,374 @@
+---
+title: Bound the cross-entity facet walk with a size-thresholded owner→partition index, not a blanket one
+date: 2026-09-09
+updated: 2026-09-09 20:15
+status: proposed
+kind: optimization
+issues: [1529]
+prs: []
+areas:
+  - evita_engine/src/main/java/io/evitadb/index/mutation
+  - evita_engine/src/main/java/io/evitadb/index
+  - evita_test/evita_performance_tests/src/main/java/io/evitadb/spike
+supersedes: []
+superseded-by: []
+relates: [2026-04-23-conditional-facet-indexing, 2026-08-31-cross-entity-histogram-removal-pre-pass]
+---
+
+# Bound the sibling-resolver walk with a size-thresholded owner→partition index
+
+`ReevaluateExpressionExecutor#collectOwnersOfReducedIndexes` walks **every** reduced partition of a
+collection on **every** cross-entity conditional-facet trigger, intersecting each partition's member bitmap
+against the affected owners. The cost is `O(total partitions)`, independent of how many owners the trigger
+touches. Measured against a production catalog it is **0.78 ms** as that catalog is configured today — and
+**81–113 ms** after a single schema edit any client can make. This record fixes what was measured, what the
+numbers mean, and which of the candidate fixes is worth building.
+
+Nothing here is implemented yet beyond the measurement harness. The prior constant-factor change (PRs
+#1524 / #1525) shipped unmeasured and is now quantified — at far less than its cost model claimed.
+
+**Three local optimizations of this loop were measured and all three failed**, two of them after being
+argued for on a cost model that looked sound. That is the record's second finding, and it is worth as much
+as the first: on this walk, do not ship a local fix on an allocation or instruction-count argument.
+
+## Why
+
+`2026-04-23-conditional-facet-indexing` measured this walk at 3,000 partitions, found it to be 1.4 % of a
+trigger, and said plainly that the figure "does not generalise, and must not be quoted without its
+cardinality". Issue #1529 exists to establish what happens at real cardinality. It projected the walk
+reaching 32 % of a trigger at 100k partitions **by linear extrapolation** from ~157 ns/partition, and named
+migrated catalogs as the population at risk, because `ReferenceSchemaSerializer_2025_5:118-125` promotes
+every indexed reference of a pre-2025.7 schema to `FOR_FILTERING_AND_PARTITIONING`.
+
+Both the mechanism and the magnitude turned out to be wrong, in opposite directions.
+
+### Previous state
+
+The walk iterates each partitioned sibling reference's `REFERENCED_*_TYPE` index, excluding the reference
+the trigger fired for (`ReevaluateExpressionExecutor.java:449`), probes every advertised partition, and
+intersects. Partitions that actually hold an affected owner are then re-fetched through
+`getOrCreateIndexByPrimaryKey` (`:517`) to enrol them in the dirty set — required for correctness and
+proportional to *intersecting* partitions only.
+
+## The measurement
+
+Production e-commerce catalog: 18 collections, 3.44 GB, `ALIVE`. `Product` holds 160,216 entities and
+**281,784 entity indexes**, of which 281,497 are `REFERENCED_ENTITY`.
+
+Regenerate with the committed spikes in `evita_test/evita_performance_tests/.../spike/`:
+`ConditionalFacetPartitionCensus` (counts), `ConditionalFacetReverseIndexFootprint` (memory, threshold
+sweep), `ConditionalFacetPartitionExistenceProbe` (which partitions exist at which index type),
+`ConditionalFacetSiblingResolverReport` (timings). Only the last needs a quiet machine; the other three emit
+counts and sizes.
+
+### The exposure is a schema flag, not migration drift
+
+Only **3 of 15** `Product` references are `FOR_FILTERING_AND_PARTITIONING` (`brand` 148 partitions,
+`categories` 516, `groups` 3,969), so the walk probes **4,633**. The remaining eleven sit at
+`FOR_FILTERING` — including `parameterValues`, the reference this issue named as the danger and the one
+that actually carries the `facetedPartially` expression.
+
+But their reduced indexes **already exist and are already populated** — verified partition by partition,
+not inferred: `ConditionalFacetPartitionExistenceProbe` resolved every primary key advertised by every
+`REFERENCED_*_TYPE` index of `Product`, and **all 205,315 belonging to `FOR_FILTERING` references resolved
+to a live `ReducedEntityIndex`**, against 4,633 for the three partitioned ones. `media` alone holds 168,039.
+
+This matters more than it looks, because two committed comments asserted the opposite —
+`ReevaluateExpressionExecutor:346` ("Reduced indexes only exist when the reference uses
+FOR_FILTERING_AND_PARTITIONING indexing") and `ReferenceIndexMutator:1247` ("the only ones for which reduced
+indexes exist at all"). Both were wrong and both were load-bearing: they make the walk's cost look bounded
+by the current schema, and they are why this record's own author briefly doubted a correct measurement.
+Reduced indexes are created behind `isIndexedReferenceForFiltering` — anything but `NONE`
+(`EntityIndexLocalMutationExecutor:2652` and peers). What `FOR_FILTERING_AND_PARTITIONING` governs is
+**facet maintenance inside** them. Both comments are corrected in this change.
+
+So what keeps 205,315 partitions out of the walk is one enum per reference, and nothing else — no absent
+structure, no data to build. Counted from the live indexes without touching the schema:
+
+| reference | advertises | state |
+|---|---|---|
+| `media` | 168,039 | `FOR_FILTERING` |
+| `parameterValues` | 21,561 | `FOR_FILTERING`, carries the trigger |
+| `relatedProducts` | 13,131 | `FOR_FILTERING` |
+| `groups` / `categories` / `brand` | 3,969 / 516 / 148 | partitioned |
+| **walk today** | **4,633** | |
+| **every reference switched** | **209,948** | **45×** |
+
+`ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING`'s own javadoc recommends itself "when reference
+filtering is frequently used in queries and query performance is critical" — advice a client would
+reasonably follow on `media` or `parameterValues`. **The walk's cost is unbounded in a dimension the client
+controls, through a knob documented as an optimization.** That, not migration drift, is the exposure.
+
+And because the partitions already exist, the flip needs **no reindexing, no republish and no entity
+write**: `SetReferenceSchemaIndexedMutation` changes the schema, no engine handler rebuilds anything, and
+`resolveSiblingReducedIndexes`'s filter simply admits 40× more partitions on the next trigger. The walk
+goes from 4,633 to 188,387 partitions the moment the schema mutation commits.
+
+A second, compounding case: the `:449` exclusion protects the trigger's own reference from its *own* walk,
+never from anybody else's. A `facetedPartially` expression on a second reference makes today's protected
+`parameterValues` that trigger's sibling.
+
+### Timings
+
+Quiet box, AMD Ryzen AI 9 HX 370, 16 MiB L3, `-Xmx48g`, JDK 21. All arms probe-only and checksum-gated on
+the `(owner, partition)` pairs emitted; every run agreed. `WARM` = arms back-to-back, order rotated;
+`COLD` = one arm per round with 128 MiB streamed outside the timed region. The two series are never mixed.
+
+| P | shape | series | pre-#1524 walk | `HEAD` walk | hybrid `T`=16 |
+|---|---|---|---|---|---|
+| 4,633 | sparse (20 owners) | WARM | 814.7 µs | 776.1 µs | **289.1 µs** |
+| 4,633 | sparse | COLD | 3.69 ms | 3.56 ms | **1.59 ms** |
+| 4,633 | dense (57,962) | WARM | 2.88 ms | 2.89 ms | 2.45 ms |
+| 188,387 | sparse | WARM | 83.9 ms | **81.4 ms** | **1.72 ms** |
+| 188,387 | dense | WARM | 112.7 ms | **112.8 ms** | **10.6 ms** |
+
+**Scaling is super-linear, as suspected but never previously shown.** Partition count grows 40.7 ×
+(4,633 → 188,387) while walk time grows **104.8 ×**; the per-probe constant degrades from 167.5 ns to
+431.8 ns. The issue's linear model predicted 39 ms at 250k partitions; the truth is 81 ms at 188k.
+
+**Cache state matters more than any arm, and only at low `P`.** At 4,633 partitions COLD is **4.6 ×** WARM
+(768 vs 167 ns/probe); at 188,387 they agree within 3 %, because nothing fits cache either way. A
+warm-only protocol — which is what was originally planned — would have understated the low-`P` case
+fourfold and hidden the knee completely.
+
+### What the per-partition cost is actually made of
+
+Two further arms bound what any local fix could recover. **D** replaces the engine's
+`getIndexByPrimaryKeyIfExists` with a bare int-keyed hash get; **E** additionally pre-resolves the partition's
+membership bitmap, leaving only the traversal and the `and()`. Neither is implementable — a real walk cannot
+pre-resolve a transactional bitmap and still see the transaction's own writes — and that is the point: no
+engine change can beat a bare hash lookup, so no engine change can recover more than these deltas.
+
+| `P` | shape | `HEAD` (B) | index preresolved (D) | bitmap preresolved (E) | no transaction |
+|---|---|---|---|---|---|
+| 4,633 | sparse | 836.5 µs | 622.7 µs (−25.6 %) | 493.2 µs (−41.0 %) | 486.2 µs (−41.9 %) |
+| 4,633 | dense | 2.77 ms | 2.59 ms (−6.6 %) | 2.38 ms (−14.0 %) | 2.55 ms (−8.2 %) |
+| 188,387 | sparse | 80.69 ms | 73.30 ms (−9.2 %) | 46.36 ms (−42.6 %) | 77.05 ms (−4.5 %) |
+| 188,387 | dense | 100.16 ms | 93.33 ms (−6.8 %) | 66.74 ms (−33.4 %) | 93.47 ms (−6.7 %) |
+
+**The overhead is a constant per partition, not a share, and reporting it as a share is how this record's
+first draft reached a wrong conclusion.** `B − E` is 74.1 ns/partition sparse and 84.0 ns/partition dense at
+`P`=4,633 — the same number across a 2,900× change in affected-owner count. It reads as 41 % against one
+denominator and 14 % against another. Quote nanoseconds per partition.
+
+**At low `P` the whole gap is the transaction; at high `P` almost none of it is.** At `P`=4,633, arm E
+(493.2 µs) lands on top of the no-transaction walk (486.2 µs): once the transactional layer resolutions are
+gone, nothing else in the lookup costs anything measurable. At `P`=188,387 the no-transaction walk saves only
+4.5 %, while E saves 42.6 % — so what B − E is buying there is **cache, not transaction machinery**. Reaching
+a partition's bitmap through its `EntityIndex` costs 28.0 ns/partition at `P`=4,633 and **143.0 ns/partition
+at `P`=188,387**, 5.1× worse on identical code: two pointer hops into objects that no longer fit in cache.
+
+A probe inside a transaction resolves a transactional layer three separate times — the collection's
+`DataStoreChanges`, the `indexesByPrimaryKey` ChampMap's `MapChanges`, and the partition's own bitmap — and
+`getIndexByPrimaryKeyIfExists` additionally allocates an `IntFunction`, an `Optional`, a capturing lambda and
+an `Integer` box per call. All of that together is the 39 ns/partition of `B − D`. It is real, and at high
+`P` it is not the problem.
+
+## Options considered
+
+### Option A — hybrid owner→partition index with a per-partition size threshold (chosen for the structural fix)
+
+Cover partitions of at most `T` owners in an `ownerPK → partitionPK` map; leave larger partitions on the
+walk. Derived at catalog open, maintained at the existing owner-membership boundaries.
+
+- **Pros:** `T`=16 removes 96 % of the walk for **13 %** of the blanket structure's memory. At P=188,387 it
+  takes the sparse walk from 81.4 ms to 1.72 ms and the dense one from 112.8 ms to 10.6 ms. References whose
+  partitions are all large disqualify themselves automatically — `stocks`, `stockVisibilities` and
+  `bonusVisibilities` each produce a **112-byte map covering zero owners** — so no per-reference heuristic is
+  needed.
+- **Cost: 36.3 MiB, not the 24.6 MiB an earlier draft of this record quoted.** The two figures scope the map
+  differently and only one of them is a structure that can be maintained. 24.6 MiB covers one trigger's
+  sibling set, with the mutated reference excluded at *build* time — but which reference is mutated changes
+  per trigger, so no such map exists. The maintainable structure covers every reference whose partitions the
+  walk could ever visit (`P`=209,948) and filters the mutated one **at use**: 36.3 MiB, 8,308 residual
+  partitions. Against 274.7 MiB for the blanket structure the decision is unchanged; the number is not.
+- **Cons:** a permanent resident structure; threshold crossings are bulk operations; the map must join
+  transactional memory *and* the warm-up savepoint; and it needs a schema hook (see *Key technical details*).
+
+### Option B — blanket owner→partition index on every `ReferencedTypeEntityIndex` (declined)
+
+The structure #1529 proposes: cover every partition.
+
+- **Pros:** removes the walk entirely; simplest to reason about.
+- **Rejected because:** **cost is per membership while benefit is per partition**, and the two are
+  decoupled by 40,000 × across references of one collection. A partition with 21,467 owners costs 21,467
+  map entries and saves exactly **one** probe. Measured: 78.2 MiB today (17.7 KB per probe removed) and
+  274.7 MiB if every reference were switched — against 36.3 MiB for Option A at 96 % of the benefit.
+  `stocks` alone would cost 33.4 MiB to remove 9 probes. **Revisit if** a catalog is ever found whose
+  partitions are uniformly small, where the threshold would cover everything anyway.
+
+### Option C — hoist the loop-invariant transaction resolution out of the walk (declined)
+
+`TransactionalDataStoreMemoryBuffer#getIndexIfExists:112` resolves a transactional layer for the *same*
+data source on every iteration, and `TransactionalBitmap#getRoaringBitmap:198` reads the `CURRENT_TRANSACTION`
+ThreadLocal again per partition. `Transaction.java:331-338` already tells callers touching several
+transactional members to resolve once and pass down, pricing the machinery at 5.25 % of busy-thread wall
+time elsewhere. An earlier draft of this record chose it, and chose it *first*.
+
+- **Pros:** zero memory, local, no new resident structure.
+- **Rejected because it is worth 4.5–6.7 % where it matters, and nothing at all once Option A ships.**
+  Measured as a ceiling by running the identical walk with no transaction bound:
+
+  | configuration | with tx | without | share | absolute |
+  |---|---|---|---|---|
+  | P=4,633 sparse | 836.5 µs | 486.2 µs | 41.9 % | 0.35 ms |
+  | P=188,387 sparse | 80.69 ms | 77.05 ms | **4.5 %** | **3.64 ms** |
+  | P=188,387 dense | 100.16 ms | 93.47 ms | **6.7 %** | **6.69 ms** |
+
+  That is the *ceiling*; a real hoist recovers only part of it, because one of the three layer resolutions
+  per partition is the partition's own bitmap and cannot be hoisted at all. **And the two options are not
+  additive**: after A the walk covers 2,912 partitions instead of 188,387, leaving roughly 0.1 ms of
+  transaction overhead on it. A hoist landing before A is thrown away by it; landing after A it is worth
+  nothing. **Revisit if** Option A is abandoned, or independently for a workload where this machinery is
+  the dominant cost — `Transaction.java:331-338` already documents one, and it is not this walk.
+
+### Option F — gate the intersection behind an allocation-free `intersects` test (declined)
+
+The walk materialises an intersection bitmap *and* an `int[]` for every probed partition, including the
+overwhelming majority that share no owner with the affected set. `PersistentRoaringBitmap#intersects`
+allocates nothing and short-circuits on the first common bit.
+
+- **Pros:** implementable as a two-line reordering of operations that already exist; zero memory.
+- **Rejected because it is a regression in the shape that matters most.** Measured at P=188,387: **−5.8 %**
+  sparse (80.63 → 75.96 ms) but **+8.2 %** dense (101.24 → 109.55 ms). At DENSE nearly every partition *does*
+  intersect, so `intersects` finds a hit and `and()` then re-walks the same containers — a second pass for
+  nothing. The sparse gain is also smaller than the allocation argument predicts, because `and()` over two
+  bitmaps with no common container keys is already cheap and the discarded result is empty. **Revisit if**
+  a workload is found whose triggers are reliably sparse; the sign of this change depends on the shape.
+
+### Option D — do nothing (declined)
+
+- **Pros:** the walk is 0.78 ms on the measured catalog as configured; the 2026-04-23 assessment stands.
+- **Rejected because:** it stands only for that configuration. One enum edit takes it to 81–113 ms, with no
+  data growth, no migration, and no warning — and the enum is documented as a performance feature.
+
+### Option E — serve partition facets as `globalIndex facets AND partition members` at query time (not evaluated)
+
+Recorded in #1529 as the way to delete the walk, the registration and the per-owner writes together.
+**Rejected because** it was out of scope for a measurement issue and its price — a query-time intersection
+per facet lookup plus recomputing per-partition facet counts — was never measured. **Revisit if** the
+write-path fixes prove insufficient.
+
+## Decision
+
+**Option A, alone.** It is the only candidate that changes the asymptotics, and the threshold is what makes
+it affordable: 36.3 MiB rather than 274.7 MiB, for 96 % of the benefit.
+
+**Every local alternative was measured and every one failed.** C is worth 4.5–6.7 % and nothing at all once
+A ships; F is a regression in the dense shape; the D and E bounds show that even a *perfect* index lookup
+recovers 9.2 % and a perfect bitmap resolution 42.6 % — and the latter is unreachable except by holding a
+flat partition→bitmap map, which is itself a reverse index. Nothing local saves the high-`P` walk. Only not
+walking does.
+
+**Do not re-propose a local fix here on a cost model.** Three have now been argued convincingly and
+measured as regressions or near-nothing: the two named in `2026-04-23-conditional-facet-indexing`, and
+Option F above. The two shapes disagree in sign, so a single-shape measurement is not evidence either.
+
+**Option A must not ship as the blanket structure #1529 describes.** If a future reader finds this record
+while proposing that structure, the number to look at is the 40,000 × spread in benefit-per-byte across
+references of a single collection.
+
+## Key technical details
+
+- The walk: `ReevaluateExpressionExecutor.java:480-527`; sibling selection and the mutated-reference
+  exclusion at `:441-466`, notably `:449`. Registration at `:517`, proportional to intersecting partitions
+  and **unchanged by any option here** — a reverse index changes how intersecting partitions are *found*,
+  never which ones they are.
+- Maintenance boundaries for Option A already exist and already return the owner 0→1 / 1→0 signal:
+  `ReferenceIndexMutator.java:808`, `:820` (insert) and `:972`, `:984` (remove). `:770` / `:936` maintain
+  the *referenced-entity → partition* direction and are a separate concern.
+- **Threshold crossing is O(1) amortised**: a partition can only cross upward once per `T` insertions into
+  it. Use hysteresis (promote at `T`, demote at `T/2`). In `WARM_UP` partitions grow monotonically, so each
+  crosses at most once.
+- **The map must be `TransactionalMap<Integer, TransactionalBitmap>`, or an equally rollback-capable
+  structure.** A plain `Map<Integer,int[]>` is *not* a `TransactionalLayerCreator`, so it never reaches
+  `WarmUpSavepoint#verifyRollbackSupported` and would diverge **silently** on a rolled-back transaction or
+  a failed warm-up mutation. This is a correctness disqualification, not a footprint trade-off — and it
+  costs 6-8 ×, not the "roughly half" #1529 assumes.
+- A new field on `ReferencedTypeEntityIndex` must be threaded through
+  `createCopyWithMergedTransactionalMemory` (`:804-823`) and is picked up by `removeLayer` (`:826-831`) via
+  component registration.
+- **The map deliberately has NO schema hook, and must be an accelerator rather than an authority.** The
+  map's domain — which references contribute entries — is decided by `getReferenceIndexType`, and that flag
+  can flip with no entity write to hang maintenance off, over partitions that already exist. The tempting
+  conclusion is that a raise must rebuild the map. It must not: **the engine does not rebuild indexes on a
+  schema change at all** (issue #409 owns that work and has not landed), and the supported way to change a
+  reference's index type is a **full reindex**, which builds the map from the final schema with nothing to
+  react to. A hook here would be schema-change index maintenance implemented in one corner of the engine,
+  and would rot the moment #409 lands.
+  What makes that safe is a property the design needs anyway: **anything the map does not cover stays on
+  the walk.** Partitions above the threshold already work that way; extending "not covered" to include
+  "reference not in the map" costs nothing. A flag raised on a live catalog without a reindex therefore
+  yields the ordinary unaccelerated walk over the newly-visited partitions — correct, merely slow, which is
+  exactly today's behaviour and the right failure mode for a state the engine does not support.
+  **When #409 lands, this map is one of the structures it must rebuild.**
+- **Resident cost tracks what the client turned on:** 4.0 MiB on today's schema (three partitioned
+  references), 36.3 MiB only if every reference is raised and the catalog reindexed.
+- **Derived at load, not persisted.** Deriving costs one pass over the partitions — the same traversal the
+  walk does, paid once per collection load — which avoids a storage format change for a structure that is
+  pure acceleration.
+- **Option A must not tolerate a stale partition PK with a null check.** Today's walk cannot meet one — it
+  only visits currently-advertised partitions. A reverse map reads its own state and would go straight to
+  `getOrCreateIndexByPrimaryKey`, whose accessor returns `null` for a removed index. Index PKs come from a
+  monotonic sequence and are never reused, so a stale entry is a hard failure rather than silent
+  corruption; that is the desired behaviour and must not be papered over.
+
+## Verification
+
+Measurement only; no production code changed. Every arm is checksum-gated on the `(owner, partition)` pairs
+it emits and all runs agreed, so no arm was compared while computing a different answer.
+
+Six arms, all checksum-gated against each other: the pre-#1524 walk, current `HEAD`, the hybrid, the two
+unimplementable bounds (D, E) and the `intersects` gate (F). Run-to-run reproducibility across independent
+JVMs: `HEAD` at P=188,387 sparse measured 80,687,553 ns and 80,626,005 ns — **0.08 % apart**; the dense pair
+1.1 % apart. The deltas quoted here are resolved comfortably by the paired warm-rotation series.
+
+`ConditionalFacetPartitionExistenceProbe` (counts only, no quiet machine needed) is what establishes that
+205,315 partitions of `FOR_FILTERING` references already exist and resolve to live indexes; it prints its
+own verdict line so the claim can be re-checked in one run rather than re-derived.
+
+**The constant-factor change that shipped unmeasured (PRs #1524 / #1525, `5db4385e1`) is now quantified:**
+its cost model claimed 20-35 % of the walk; measured **4.7 %** (P=4,633 sparse warm), **3.6 %** cold,
+**0.0 %** in the dense shape, **3.1 %** at P=188,387. A real, consistent, small improvement. Shipping it
+without a performance claim was the right call — the claim it was never given would have been wrong.
+
+## Consequences & open follow-ups
+
+- **#1529's decision rule cannot be applied as written.** Its second clause requires "the sparse shape
+  shows a registration saving too", and no reverse index can deliver one: registration fires for exactly
+  the partitions holding an affected owner, and the union of the affected owners' partition sets *is* that
+  set. Its first clause ("walk exceeds ~10 % of the trigger") is also corpus-dependent, since
+  `trigger total ≈ affectedOwners × refsPerOwner × groups` — all three chosen by whoever builds the
+  fixture. Report the walk in **absolute milliseconds**; that is what this record does.
+- **The hybrid's own cost scales with affected owners.** Arm C is 47 × faster than `HEAD` in the sparse
+  shape but 10.6 × in the dense one, because it performs one boxed `HashMap` lookup per affected owner and
+  the dense shape has 57,962. **A primitive int-keyed map is a separate, unmeasured lever.**
+- **Schema evolution changing `ReferenceIndexType` is now traced.** It does move the map's domain, and the
+  resolution is deliberately *not* to react to it — see *Key technical details*. **The completeness test
+  must pin the degradation property instead**: with a reference raised on a populated collection and no
+  reindex, a trigger must still register every owner it owes, via the walk, unaccelerated. That is the
+  assertion that keeps the map an accelerator; without it, a later change could quietly make the map
+  authoritative and turn an unsupported-but-correct state into a wrong one.
+- **Still unmeasured: the `WARM_UP` build cost of the map.** Every figure here is steady-state. Deriving the
+  map at catalog open walks every partition once — the same traversal the walk does, paid once — but the
+  bulk-load path builds partitions incrementally and its cost was never measured.
+- **The trigger total was never measured**, so "walk as a share of the trigger" is not reported. At 81 ms
+  of walk it can no longer change a conclusion.
+- **One catalog is not a population.** Every count here is exact for one snapshot of one schema.
+
+## Related work
+
+- `2026-04-23-conditional-facet-indexing` — introduced this walk and measured it at 3,000 partitions;
+  this record supplies the cardinality that assessment explicitly deferred, and confirms its caution
+  (two "obvious" optimizations of the same loop had measured as regressions).
+- `2026-08-31-cross-entity-histogram-removal-pre-pass` — rejected its Option D for want of an
+  owner→references mapping. Option A here would supply one, but only for partitions below the threshold,
+  which may not satisfy that use case.
+
+## Timeline
+
+- **2026-09-09** — arm (b) shipped unmeasured in PRs #1524 / #1525; #1529 opened to fix the protocol
+- **2026-09-09** — census, footprint, threshold sweep and timings taken against a production catalog
+- **2026-09-09** — cost decomposed into its parts (arms D/E); Options C and F measured and both declined;
+  partition existence at `FOR_FILTERING` verified, two committed comments corrected; decision narrowed to
+  Option A alone

--- a/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
+++ b/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
@@ -1,7 +1,7 @@
 ---
 title: Bound the cross-entity facet walk with a size-thresholded owner→partition index, not a blanket one
 date: 2026-09-09
-updated: 2026-09-11 15:10
+updated: 2026-09-11 15:30
 status: accepted
 kind: optimization
 issues: [1529]
@@ -220,9 +220,11 @@ proportional to the number of `(owner, partition)` pairs in the *answer*, which 
 full. `T` decides which partitions are probed; it cannot decide how large the answer is. In the dense shape
 the affected set is 57,962 owners out of 160,216 entities — roughly 36 % of the collection — so most sibling
 partitions genuinely hold an affected owner and there is nothing to skip. Subtracting the accumulator (about
-136 ms, derived as the walk's before/after difference rather than measured directly) leaves the probe work
-alone at roughly 3.3×, which is the optimization's actual contribution; the accumulator dilutes it to the
-measured 1.34–1.50×.
+129 ms on the walk and 116 ms on the lookup, measured directly by running the harness with the accumulator
+disabled) leaves the probe work alone at **1.84×**, which is the optimization's actual contribution; the
+accumulator dilutes it to the measured 1.34–1.50×. Note the two arms are **not** charged equally despite
+emitting the same pair set — 129 ms against 116 ms — so a ratio cannot be reconstructed by subtracting one
+figure from both.
 
 **Absolute figures are not comparable across the harness correction.** Any number quoted from this record
 before 2026-09-11 is a lower bound on the lookup and an upper bound on the speedup.
@@ -441,13 +443,20 @@ without a performance claim was the right call — the claim it was never given 
 - **The dense shape is bound by the accumulator, not by the walk, and `T` cannot move it.** Once the harness
   was corrected (2026-09-11) the dense rows fell to 1.07–1.09× and 1.34–1.50×. The reason is
   `ReevaluateExpressionExecutor#addSibling`: it runs once per `(owner, partition)` pair of the *answer*, and
-  both the lookup and the walk must produce that answer in full, so it is a constant common to both and
-  dilutes any ratio built on top of it. Raising the coverage threshold changes which partitions are probed;
-  it cannot change how many pairs exist. **Roughly 136 ms of the 188,387-dense figure is this, derived as the
-  walk's before/after difference across the harness correction and never profiled directly.** The candidate
-  on inspection is the boxed `Map<Integer, List<SiblingReducedIndex>>` and its per-pair `computeIfAbsent` —
-  not the `contains` de-duplication beside it, which scans a four-element list of identity-compared records.
-  **Measure before changing either.**
+  both the lookup and the walk must produce that answer in full. Raising the coverage threshold changes which
+  partitions are probed; it cannot change how many pairs exist.
+- **The accumulator is profiled, and its cost is the linear de-duplication scan.** Measured by running
+  `ConditionalFacetMembershipReport` with `-Dspike.accumulator=FULL|OFF|NO_DEDUP|INT_KEYED`, which swaps the
+  per-pair bookkeeping behind a seam while leaving the checksum outside it. At `P`=188,387 dense, on the
+  lookup arm: whole accumulator **116 ms**, of which the `indexes.contains(sibling)` scan is **65 ms (56 %)**,
+  map insertion plus `ArrayList` allocation and growth **51 ms**, and the boxed `Integer` key only **4 ms
+  (3 %)**. In the sparse shape every variant is identical within noise.
+  **So de-boxing the map is not worth doing, and the scan is.** It is `O(k)` per pair for an owner in `k`
+  partitions, i.e. `O(k²)` per owner, and `new ArrayList<>(4)` is an initial capacity rather than a bound.
+  The duplicate it exists to catch arises only when two references share a reduced group index, so the
+  promising direction is to establish that once per probed partition instead of once per emitted pair —
+  **not** a `LinkedHashSet`, whose hashing would be paid on every pair to avoid a scan that is only sometimes
+  long.
 - **`DEFAULT_COVERAGE_THRESHOLD` = 16 has never been swept against the shipped implementation.** Every
   threshold figure in this record comes from `ConditionalFacetReverseIndexFootprint`, which models memory
   only. `ReducedIndexMembership(int)` exists, but both real construction sites — `GlobalEntityIndex:476` and

--- a/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
+++ b/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
@@ -1,7 +1,7 @@
 ---
 title: Bound the cross-entity facet walk with a size-thresholded owner→partition index, not a blanket one
 date: 2026-09-09
-updated: 2026-09-11 15:30
+updated: 2026-09-11 17:45
 status: accepted
 kind: optimization
 issues: [1529]
@@ -188,14 +188,34 @@ resolve the dense high-cardinality walk better than ~11 %.
 
 | `P` | shape | walk | lookup | |
 |---|---|---|---|---|
-| 4,633 | sparse | 653 / 681 µs | **232 / 232 µs** | 2.8–2.9× |
-| 4,633 | dense | 12.02 / 12.06 ms | **11.22 / 11.02 ms** | 1.07–1.09× |
-| 188,387 | sparse | 82.4 / 85.4 ms | **1.50 / 1.60 ms** | **54–55×** |
-| 188,387 | dense | 259.6 / 230.2 ms | **173.0 / 172.2 ms** | **1.34–1.50×** |
+| 4,633 | sparse | 807 / 798 µs | **268 / 283 µs** | 2.8–3.0× |
+| 4,633 | dense | 10.32 / 10.33 ms | **9.71 / 9.62 ms** | 1.06–1.07× |
+| 188,387 | sparse | 84.0 / 87.3 ms | **1.55 / 1.53 ms** | **54–57×** |
+| 188,387 | dense | 159.6 / 158.8 ms | **105.5 / 101.2 ms** | **1.51–1.57×** |
 
 Memory: **4.2 MiB** on the shipping schema, **24.9 MiB** with every reference partitioned. Rebuilding the
 lookup over 188,387 reduced indexes costs **156.0 ms**, against a 26 s catalog load. Coverage reproduced
 exactly across both runs and both configurations — 2,697 covered / 1,936 residual, and 185,475 / **2,912**.
+
+These are the timings **after** the per-pair de-duplication scan was removed from the accumulator (see below).
+The same harness, same box and same session, with the scan restored via `-Dspike.accumulator=DEDUP_SCAN`:
+
+| `P` | shape | walk | lookup |
+|---|---|---|---|
+| 4,633 | sparse | 793 / 655 µs | 274 / 226 µs |
+| 4,633 | dense | 11.83 / 12.02 ms | 10.95 / 11.27 ms |
+| 188,387 | sparse | 82.8 ms | 1.59 ms |
+| 188,387 | dense | 228.5 ms | 168.1 ms |
+
+So the removal is worth **−13 %** on both arms at `P`=4,633 dense and **−38 % / −30 %** (lookup / walk) at
+`P`=188,387 dense, and nothing at all in the sparse shapes. **The ratio barely moves** — 1.34× to 1.51–1.57×
+at high `P` — because both arms were paying the scan; the gain is absolute milliseconds off every dense
+trigger, on the unaccelerated walk as much as on the lookup. An estimate that subtracted the scan from the
+lookup arm alone predicted 1.9–2.1× and was wrong for exactly that reason.
+
+**Cross-session comparison at `P`=4,633 sparse is not meaningful and must not be quoted.** That shape swings
+~20 % run to run *within* one session (control runs 655 µs and 793 µs on the same build), which is larger than
+any effect being looked for. Only the same-session control pairs above support a claim.
 
 **These figures supersede the ones this record carried until 2026-09-11, which were too high.** The harness
 had diverged from `ReevaluateExpressionExecutor` in two ways its checksum gate could not see, because that
@@ -205,8 +225,9 @@ gate compares the emitted `(owner, index)` pairs and the pairs were identical ei
   *selector* and probing what it named — so only one arm was short-changed, and the ratio was inflated
   directly;
 - **neither** arm ran the executor's accumulator, the owner-keyed `Map<Integer, List<SiblingReducedIndex>>`
-  built by `addSibling`. That one is symmetric — both arms emit the same pair set — but omitting a cost
-  common to both inflates a ratio just the same.
+  built per emitted pair in `ReevaluateExpressionExecutor#probeReducedIndexForAffectedOwners`. That one is
+  symmetric — both arms emit the same pair set — but omitting a cost common to both inflates a ratio just the
+  same.
 
 The superseded row that mattered most was `188,387 dense`, published as **8.3×** and actually **1.34–1.50×**.
 The `4,633 dense` row went from 1.41× to 1.07–1.09×. The two sparse rows barely moved.
@@ -424,6 +445,17 @@ index or the global index.
 205,315 partitions of `FOR_FILTERING` references already exist and resolve to live indexes; it prints its
 own verdict line so the claim can be re-checked in one run rather than re-derived.
 
+**The de-duplication removal is proved dead before being deleted, not after.** Three independent legs, because
+this method had already produced two wrong conclusions from inspection alone: a `COUNT_DEDUP` tally on the
+production catalog (**0 rejections / 1,568,849,000 offered pairs**, both arms, both shapes); a counterfactual
+pair on the conditional-facet suite — an unconditional throw errors 12 tests across 4 classes including
+`ConditionalFacetGroupPartitionGapTest`, proving the path is reached, after which a throw-on-duplicate leaves
+all 287 green; and two independent static traces of every writer of
+`ReferenceTypeCardinalityIndex.referencedPrimaryKeysIndex`, both finding a single writer
+(`ReferenceIndexMutator#referenceInsertPerComponent`) that files each reduced index under exactly the key it
+was resolved by. Full suite after the change: **23,782 tests, 0 failures**, one environmental error
+(`ExportS3ServiceTest`, needs Docker) — the same count and the same single error as before it.
+
 **The constant-factor change that shipped unmeasured (PRs #1524 / #1525, `5db4385e1`) is now quantified:**
 its cost model claimed 20-35 % of the walk; measured **4.7 %** (P=4,633 sparse warm), **3.6 %** cold,
 **0.0 %** in the dense shape, **3.1 %** at P=188,387. A real, consistent, small improvement. Shipping it
@@ -445,18 +477,27 @@ without a performance claim was the right call — the claim it was never given 
   `ReevaluateExpressionExecutor#addSibling`: it runs once per `(owner, partition)` pair of the *answer*, and
   both the lookup and the walk must produce that answer in full. Raising the coverage threshold changes which
   partitions are probed; it cannot change how many pairs exist.
-- **The accumulator is profiled, and its cost is the linear de-duplication scan.** Measured by running
-  `ConditionalFacetMembershipReport` with `-Dspike.accumulator=FULL|OFF|NO_DEDUP|INT_KEYED`, which swaps the
-  per-pair bookkeeping behind a seam while leaving the checksum outside it. At `P`=188,387 dense, on the
-  lookup arm: whole accumulator **116 ms**, of which the `indexes.contains(sibling)` scan is **65 ms (56 %)**,
-  map insertion plus `ArrayList` allocation and growth **51 ms**, and the boxed `Integer` key only **4 ms
-  (3 %)**. In the sparse shape every variant is identical within noise.
-  **So de-boxing the map is not worth doing, and the scan is.** It is `O(k)` per pair for an owner in `k`
-  partitions, i.e. `O(k²)` per owner, and `new ArrayList<>(4)` is an initial capacity rather than a bound.
-  The duplicate it exists to catch arises only when two references share a reduced group index, so the
-  promising direction is to establish that once per probed partition instead of once per emitted pair —
-  **not** a `LinkedHashSet`, whose hashing would be paid on every pair to avoid a scan that is only sometimes
-  long.
+- **The accumulator was profiled, and its cost was a de-duplication scan that never de-duplicated anything —
+  now removed.** Profiling with `-Dspike.accumulator=FULL|OFF|DEDUP_SCAN|INT_KEYED`, a seam that swaps the
+  per-pair bookkeeping while leaving the checksum outside it, put the whole accumulator at **116 ms** of a
+  171 ms dense lookup, of which the `indexes.contains(sibling)` scan was **65 ms (56 %)**, map insertion plus
+  `ArrayList` growth **51 ms**, and the boxed `Integer` key only **4 ms (3 %)** — so de-boxing the map is not
+  worth doing.
+  The scan was then shown to be dead rather than merely expensive. A `COUNT_DEDUP` variant tallying its
+  rejections reported **0 out of 1,568,849,000 offered pairs** across both arms and both shapes on the
+  production catalog; replacing it with a throwing premise left the conditional-facet suite green at 287 tests,
+  after a counterfactual run proved that same suite reaches the code 48 times. The reason is structural: one
+  reduced index primary key reaches the probe **at most once per sibling reference** — the covered half
+  collects into a bitmap before probing, the residual set is a bitmap disjoint from the covered one, and the
+  walk's two families advertise primary keys drawn from one collection-wide sequence and never collide.
+  The scan's own comment (`references sharing a reduced group index resolve to the same instance more than
+  once`) described a real phenomenon attached to the wrong traversal: several of **one owner's references** do
+  resolve to a single `ReducedGroupEntityIndex`, which is why `ReferenceIndexMutator#forEachUniqueReferenceIndex`
+  de-duplicates by identity — but this walk iterates *advertised indexes*, not an owner's references. The same
+  misconception was restated in `EntityCollection#registerReducedIndex`'s javadoc and has been corrected there.
+  Had a duplicate ever arisen it would have cost nothing anyway: `ReferenceIndexMutator#applyFacetDecisionMatrix`
+  short-circuits through pure reads when the facet is already in its target bucket, so a repeat never reaches
+  `addFacet` or `removeFromCurrentGroup`.
 - **`DEFAULT_COVERAGE_THRESHOLD` = 16 has never been swept against the shipped implementation.** Every
   threshold figure in this record comes from `ConditionalFacetReverseIndexFootprint`, which models memory
   only. `ReducedIndexMembership(int)` exists, but both real construction sites — `GlobalEntityIndex:476` and
@@ -502,3 +543,7 @@ without a performance claim was the right call — the claim it was never given 
 - **2026-09-09** — cost decomposed into its parts (arms D/E); Options C and F measured and both declined;
   partition existence at `FOR_FILTERING` verified, two committed comments corrected; decision narrowed to
   Option A alone
+- **2026-09-11** — harness found to diverge from the shipped resolver in two ways its checksum gate could not
+  see; corrected and every ratio re-measured downward, the dense high-cardinality row from 8.3× to 1.34–1.50×
+- **2026-09-11** — accumulator profiled behind a variant seam; the per-pair de-duplication scan measured at
+  56 % of it, then shown to reject nothing and removed, worth −13 % to −38 % on the dense shapes

--- a/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
+++ b/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
@@ -1,7 +1,7 @@
 ---
 title: Bound the cross-entity facet walk with a size-thresholded owner→partition index, not a blanket one
 date: 2026-09-09
-updated: 2026-09-10 20:10
+updated: 2026-09-11 15:10
 status: accepted
 kind: optimization
 issues: [1529]
@@ -181,42 +181,51 @@ an `Integer` box per call. All of that together is the 39 ns/partition of `B −
 
 ### The implementation, measured against the model that justified it
 
-`ConditionalFacetMembershipReport` runs a *probe-only approximation* of the shipped resolver against the walk
-it replaces, in one process, with a bound transaction and rotated arm order, checksum-compared.
-
-> **The lookup figures below are a lower bound, and every speedup ratio is an upper bound.** The harness's
-> covered half emits the map's `(owner, index)` pairs directly, where the shipped
-> `ReevaluateExpressionExecutor#collectOwnersFromMembership` collects the selected keys and hands them to
-> `collectOwnersOfProbedIndexes`, which *resolves each index and intersects its members against the affected
-> set*. Neither arm pays the registering re-fetch or the per-owner de-duplication either. The checksum gate
-> cannot catch this: on freshly loaded, unmutated data both arms compute the same answer while doing different
-> amounts of work to reach it. The harness must be corrected to match the shipped resolver and re-run before
-> any figure here is quoted as the implementation's cost.
+`ConditionalFacetMembershipReport` runs the shipped resolver's own shape against the walk it replaces, in one
+process, with a bound transaction and rotated arm order, checksum-compared. Figures below are **two
+independent runs**, 2026-09-11, same box, reported as `run A / run B` — a single run of this harness does not
+resolve the dense high-cardinality walk better than ~11 %.
 
 | `P` | shape | walk | lookup | |
 |---|---|---|---|---|
-| 4,633 | sparse | 1.76 ms | **391 µs** | 4.5× |
-| 4,633 | dense | 7.45 ms | **5.28 ms** | 1.41× |
-| 188,387 | sparse | 103.18 ms | **1.78 ms** | **58×** |
-| 188,387 | dense | 123.73 ms | **14.89 ms** | **8.3×** |
+| 4,633 | sparse | 653 / 681 µs | **232 / 232 µs** | 2.8–2.9× |
+| 4,633 | dense | 12.02 / 12.06 ms | **11.22 / 11.02 ms** | 1.07–1.09× |
+| 188,387 | sparse | 82.4 / 85.4 ms | **1.50 / 1.60 ms** | **54–55×** |
+| 188,387 | dense | 259.6 / 230.2 ms | **173.0 / 172.2 ms** | **1.34–1.50×** |
 
-Memory: **4.3 MiB** on the shipping schema, **25.0 MiB** with every reference partitioned. Rebuilding the
-lookup over 188,387 reduced indexes costs **173.5 ms**, against a 26 s catalog load.
+Memory: **4.2 MiB** on the shipping schema, **24.9 MiB** with every reference partitioned. Rebuilding the
+lookup over 188,387 reduced indexes costs **156.0 ms**, against a 26 s catalog load. Coverage reproduced
+exactly across both runs and both configurations — 2,697 covered / 1,936 residual, and 185,475 / **2,912**.
 
-**Holding the model to account.** Arm C predicted the sparse case to 3.5 % (1.72 vs 1.78 ms), the memory to
-1.6 % (24.6 vs 25.0 MiB) and the residual walk exactly (2,912). It was **40 % optimistic in the dense shape**
-— 10.65 ms modelled against 14.89 ms measured.
+**These figures supersede the ones this record carried until 2026-09-11, which were too high.** The harness
+had diverged from `ReevaluateExpressionExecutor` in two ways its checksum gate could not see, because that
+gate compares the emitted `(owner, index)` pairs and the pairs were identical either way:
 
-**The reason originally given for that 40 % was wrong, and is retracted.** It attributed the gap to the
-implementation resolving each emitted index through `getOrCreateIndexByPrimaryKey` and de-duplicating siblings
-per owner. `ConditionalFacetMembershipReport` does neither — `getOrCreateIndexByPrimaryKey` does not appear in
-it, and its own `reportTimings` javadoc states both arms are probe-only. So the 14.89 ms it measured is not
-the implementation's cost either; it is a lower bound on it, and whatever produced the 40 % gap has not been
-identified. What survives unchanged is the conclusion: **arm C's dense figure must not be quoted for the
-implementation** — and neither, now, may this row's. The 8.3× and 58× cases carry the decision comfortably at
-any plausible correction; the **1.41x** dense case at `P` = 4,633 is the one to re-take first, being the
-smallest reported gain and therefore the one a missing per-index resolve-and-intersect erodes proportionally
-most.
+- the lookup arm's covered half emitted the map's pairs directly rather than using the map as an index
+  *selector* and probing what it named — so only one arm was short-changed, and the ratio was inflated
+  directly;
+- **neither** arm ran the executor's accumulator, the owner-keyed `Map<Integer, List<SiblingReducedIndex>>`
+  built by `addSibling`. That one is symmetric — both arms emit the same pair set — but omitting a cost
+  common to both inflates a ratio just the same.
+
+The superseded row that mattered most was `188,387 dense`, published as **8.3×** and actually **1.34–1.50×**.
+The `4,633 dense` row went from 1.41× to 1.07–1.09×. The two sparse rows barely moved.
+
+**What the correction did not change: the decision.** The lookup is faster in all four shapes, nothing is a
+regression, and the sparse cases — the ones a real conditional-facet trigger produces most often, since a
+trigger names the owners of one changed attribute value — remain 2.8× and 54×.
+
+**Why the dense rows are bounded, and why no threshold setting rescues them.** The accumulator's cost is
+proportional to the number of `(owner, partition)` pairs in the *answer*, which both arms must produce in
+full. `T` decides which partitions are probed; it cannot decide how large the answer is. In the dense shape
+the affected set is 57,962 owners out of 160,216 entities — roughly 36 % of the collection — so most sibling
+partitions genuinely hold an affected owner and there is nothing to skip. Subtracting the accumulator (about
+136 ms, derived as the walk's before/after difference rather than measured directly) leaves the probe work
+alone at roughly 3.3×, which is the optimization's actual contribution; the accumulator dilutes it to the
+measured 1.34–1.50×.
+
+**Absolute figures are not comparable across the harness correction.** Any number quoted from this record
+before 2026-09-11 is a lower bound on the lookup and an upper bound on the speedup.
 
 **Absolute figures do not transfer between the two spikes.** The same walk measures 1.76 ms here and 836 µs
 in `ConditionalFacetSiblingResolverReport`, 103 ms here and 80.7 ms there. Only ratios within one run mean
@@ -429,6 +438,22 @@ without a performance claim was the right call — the claim it was never given 
 - **The hybrid's own cost scales with affected owners.** Arm C is 47 × faster than `HEAD` in the sparse
   shape but 10.6 × in the dense one, because it performs one boxed `HashMap` lookup per affected owner and
   the dense shape has 57,962. **A primitive int-keyed map is a separate, unmeasured lever.**
+- **The dense shape is bound by the accumulator, not by the walk, and `T` cannot move it.** Once the harness
+  was corrected (2026-09-11) the dense rows fell to 1.07–1.09× and 1.34–1.50×. The reason is
+  `ReevaluateExpressionExecutor#addSibling`: it runs once per `(owner, partition)` pair of the *answer*, and
+  both the lookup and the walk must produce that answer in full, so it is a constant common to both and
+  dilutes any ratio built on top of it. Raising the coverage threshold changes which partitions are probed;
+  it cannot change how many pairs exist. **Roughly 136 ms of the 188,387-dense figure is this, derived as the
+  walk's before/after difference across the harness correction and never profiled directly.** The candidate
+  on inspection is the boxed `Map<Integer, List<SiblingReducedIndex>>` and its per-pair `computeIfAbsent` —
+  not the `contains` de-duplication beside it, which scans a four-element list of identity-compared records.
+  **Measure before changing either.**
+- **`DEFAULT_COVERAGE_THRESHOLD` = 16 has never been swept against the shipped implementation.** Every
+  threshold figure in this record comes from `ConditionalFacetReverseIndexFootprint`, which models memory
+  only. `ReducedIndexMembership(int)` exists, but both real construction sites — `GlobalEntityIndex:476` and
+  the spike's `buildSlicesFor` — call the no-argument constructor, so the value is not reachable without
+  plumbing it through. A sweep would trade memory against the residual probe and is the one lever that
+  genuinely improves the **sparse** cases, which are the shape a real trigger produces most often.
 - **Schema evolution changing `ReferenceIndexType` is now traced.** It does move the map's domain, and the
   resolution is deliberately *not* to react to it — see *Key technical details*. **The completeness test
   must pin the degradation property instead**: with a reference raised on a populated collection and no

--- a/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
+++ b/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
@@ -1,7 +1,7 @@
 ---
 title: Bound the cross-entity facet walk with a size-thresholded owner→partition index, not a blanket one
 date: 2026-09-09
-updated: 2026-09-09 21:45
+updated: 2026-09-10 13:40
 status: accepted
 kind: optimization
 issues: [1529]
@@ -9,6 +9,7 @@ prs: []
 areas:
   - evita_engine/src/main/java/io/evitadb/index/mutation
   - evita_engine/src/main/java/io/evitadb/index
+  - evita_engine/src/main/java/io/evitadb/index/map
   - evita_test/evita_performance_tests/src/main/java/io/evitadb/spike
 supersedes: []
 superseded-by: []
@@ -348,11 +349,26 @@ references of a single collection.
 - **Derived at load, not persisted.** Deriving costs one pass over the partitions — the same traversal the
   walk does, paid once per collection load — which avoids a storage format change for a structure that is
   pure acceleration.
-- **Option A must not tolerate a stale partition PK with a null check.** Today's walk cannot meet one — it
-  only visits currently-advertised partitions. A reverse map reads its own state and would go straight to
-  `getOrCreateIndexByPrimaryKey`, whose accessor returns `null` for a removed index. Index PKs come from a
-  monotonic sequence and are never reused, so a stale entry is a hard failure rather than silent
-  corruption; that is the desired behaviour and must not be papered over.
+- **Option A tolerates a null partition PK, and the design review that forbade it was incomplete.** The
+  original reasoning was: today's walk cannot meet a stale PK, because it only visits currently-advertised
+  partitions; a reverse map reads its own state and would go straight to `getOrCreateIndexByPrimaryKey`,
+  whose accessor returns `null` for a removed index. Index PKs come from a monotonic sequence and are never
+  reused, so a stale entry naming a *dropped* index is a hard failure rather than silent corruption. On that
+  shape alone, throwing is the right call.
+
+  It misses the other shape. A stale entry can equally name an index that still **exists** while the owner
+  has already left it. There is no null to throw on: the probe finds a live index and hands back owners that
+  do not belong in the trigger's set — silent wrong data, which is the very failure the throw was meant to
+  prevent and the one it cannot see. The shipped resolver therefore intersects the probed index's members
+  with the affected owners (`ReevaluateExpressionExecutor#collectOwnersOfProbedIndexes`), rejecting both
+  shapes with one test; the `null` branch is then the same rejection reached a step earlier, not a papering
+  over.
+
+  The invariant is not abandoned — it is enforced where it can be enforced completely.
+  `ReducedIndexMembershipCompletenessTest#assertMembershipMatchesIndexes` compares the map against the live
+  indexes in both directions, in every scope, and refuses to pass vacuously. That is strictly stronger than
+  a runtime throw, because it also catches the stale-positive the throw is blind to, and it costs operators
+  nothing at runtime.
 
 ## Verification
 
@@ -408,6 +424,16 @@ without a performance claim was the right call — the claim it was never given 
   bulk-load path builds partitions incrementally and its cost was never measured.
 - **The trigger total was never measured**, so "walk as a share of the trigger" is not reported. At 81 ms
   of walk it can no longer change a conclusion.
+- **This map exposed a pre-existing hole in `MapChanges`, and any future producer-valued
+  `TransactionalMap` can reach it.** When a key holding a `TransactionalStateProducer` is overwritten (or
+  removed and re-inserted) and then removed again inside one transaction, the commit-time sweep visits the
+  key but finds the *delegate's original* under it — the replacement instance is visited by nothing, its
+  nested diff layer orphans, and the commit fails with `StaleTransactionMemoryException` **after** the
+  version reached disk. `ProducerMapChanges#createMergedChampMap` shared the blind spot for the same
+  reason: it also releases `getMapDelegate().get(key)`. The membership map is simply the first structure
+  that churns one key's value repeatedly within a single entity mutation, which is why the hole went
+  unseen. Fixed by stashing the discarded replacement under the existing survivor-guarded, commit-time
+  release; both commit paths are covered because neither overrides `remove`.
 - **One catalog is not a population.** Every count here is exact for one snapshot of one schema.
 
 ## Related work

--- a/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
+++ b/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
@@ -1,8 +1,8 @@
 ---
 title: Bound the cross-entity facet walk with a size-thresholded owner→partition index, not a blanket one
 date: 2026-09-09
-updated: 2026-09-09 20:15
-status: proposed
+updated: 2026-09-09 21:45
+status: accepted
 kind: optimization
 issues: [1529]
 prs: []
@@ -24,8 +24,9 @@ touches. Measured against a production catalog it is **0.78 ms** as that catalog
 **81–113 ms** after a single schema edit any client can make. This record fixes what was measured, what the
 numbers mean, and which of the candidate fixes is worth building.
 
-Nothing here is implemented yet beyond the measurement harness. The prior constant-factor change (PRs
-#1524 / #1525) shipped unmeasured and is now quantified — at far less than its cost model claimed.
+Option A is **implemented and measured**; the figures below distinguish throughout between what the
+harness *modelled* and what the shipped code *does*. The prior constant-factor change (PRs #1524 / #1525)
+shipped unmeasured and is now quantified — at far less than its cost model claimed.
 
 **Three local optimizations of this loop were measured and all three failed**, two of them after being
 argued for on a cost model that looked sound. That is the record's second finding, and it is worth as much
@@ -163,6 +164,33 @@ A probe inside a transaction resolves a transactional layer three separate times
 `getIndexByPrimaryKeyIfExists` additionally allocates an `IntFunction`, an `Optional`, a capturing lambda and
 an `Integer` box per call. All of that together is the 39 ns/partition of `B − D`. It is real, and at high
 `P` it is not the problem.
+
+### The implementation, measured against the model that justified it
+
+`ConditionalFacetMembershipReport` runs the shipped resolver and the walk it replaces in one process, with a
+bound transaction and rotated arm order, checksum-compared.
+
+| `P` | shape | walk | lookup | |
+|---|---|---|---|---|
+| 4,633 | sparse | 1.76 ms | **391 µs** | 4.5× |
+| 4,633 | dense | 7.45 ms | **5.28 ms** | 1.41× |
+| 188,387 | sparse | 103.18 ms | **1.78 ms** | **58×** |
+| 188,387 | dense | 123.73 ms | **14.89 ms** | **8.3×** |
+
+Memory: **4.3 MiB** on the shipping schema, **25.0 MiB** with every reference partitioned. Rebuilding the
+lookup over 188,387 reduced indexes costs **173.5 ms**, against a 26 s catalog load.
+
+**Holding the model to account.** Arm C predicted the sparse case to 3.5 % (1.72 vs 1.78 ms), the memory to
+1.6 % (24.6 vs 25.0 MiB) and the residual walk exactly (2,912). It was **40 % optimistic in the dense
+shape** — 10.65 ms modelled against 14.89 ms measured — because the model emitted a pair and moved on where
+the implementation must resolve each emitted index through `getOrCreateIndexByPrimaryKey` (the registering
+accessor that enrols it in the dirty set, not optional) and de-duplicate siblings per owner. At 57,962
+affected owners that is paid tens of thousands of times. The decision stands; **arm C's dense figure must
+not be quoted for the implementation.**
+
+**Absolute figures do not transfer between the two spikes.** The same walk measures 1.76 ms here and 836 µs
+in `ConditionalFacetSiblingResolverReport`, 103 ms here and 80.7 ms there. Only ratios within one run mean
+anything — the cross-run comparison is what produced a spurious +11.6 % on this loop once before.
 
 ## Options considered
 
@@ -322,6 +350,19 @@ Six arms, all checksum-gated against each other: the pre-#1524 walk, current `HE
 unimplementable bounds (D, E) and the `intersects` gate (F). Run-to-run reproducibility across independent
 JVMs: `HEAD` at P=188,387 sparse measured 80,687,553 ns and 80,626,005 ns — **0.08 % apart**; the dense pair
 1.1 % apart. The deltas quoted here are resolved comfortably by the paired warm-rotation series.
+
+**The implementation's own tests are proved by counterfactual, not by being green.**
+`ReducedIndexMembershipCompletenessTest` asserts the lookup against the reduced indexes themselves — never
+against its own bookkeeping — and each mechanism was disabled in turn to confirm the assertions are
+load-bearing. Disabling the remove boundary fails exactly four tests with
+`coveredOwners must be exactly the owners of covered indexes ==> expected: <[2, 3, 4, 5]> but was: <[1, 2, 3, 4, 5]>`.
+This matters more than usual here: the failure mode is silent, because a lookup that omits an entry makes the
+trigger skip a facet registration, and a missing facet is invisible to anyone not looking for it.
+
+The completeness quantifier is also checked statically, since a green test says nothing about an unhooked
+path: `rg -n "insertPrimaryKeyIfMissing|removePrimaryKey" evita_engine/src/main/java` returns exactly four
+sites that mutate a **reduced** index's membership, and both hooks cover all four; every other hit is the type
+index or the global index.
 
 `ConditionalFacetPartitionExistenceProbe` (counts only, no quiet machine needed) is what establishes that
 205,315 partitions of `FOR_FILTERING` references already exist and resolve to live indexes; it prints its

--- a/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
+++ b/documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md
@@ -1,7 +1,7 @@
 ---
 title: Bound the cross-entity facet walk with a size-thresholded owner→partition index, not a blanket one
 date: 2026-09-09
-updated: 2026-09-10 13:40
+updated: 2026-09-10 20:10
 status: accepted
 kind: optimization
 issues: [1529]
@@ -181,8 +181,17 @@ an `Integer` box per call. All of that together is the 39 ns/partition of `B −
 
 ### The implementation, measured against the model that justified it
 
-`ConditionalFacetMembershipReport` runs the shipped resolver and the walk it replaces in one process, with a
-bound transaction and rotated arm order, checksum-compared.
+`ConditionalFacetMembershipReport` runs a *probe-only approximation* of the shipped resolver against the walk
+it replaces, in one process, with a bound transaction and rotated arm order, checksum-compared.
+
+> **The lookup figures below are a lower bound, and every speedup ratio is an upper bound.** The harness's
+> covered half emits the map's `(owner, index)` pairs directly, where the shipped
+> `ReevaluateExpressionExecutor#collectOwnersFromMembership` collects the selected keys and hands them to
+> `collectOwnersOfProbedIndexes`, which *resolves each index and intersects its members against the affected
+> set*. Neither arm pays the registering re-fetch or the per-owner de-duplication either. The checksum gate
+> cannot catch this: on freshly loaded, unmutated data both arms compute the same answer while doing different
+> amounts of work to reach it. The harness must be corrected to match the shipped resolver and re-run before
+> any figure here is quoted as the implementation's cost.
 
 | `P` | shape | walk | lookup | |
 |---|---|---|---|---|
@@ -195,12 +204,19 @@ Memory: **4.3 MiB** on the shipping schema, **25.0 MiB** with every reference pa
 lookup over 188,387 reduced indexes costs **173.5 ms**, against a 26 s catalog load.
 
 **Holding the model to account.** Arm C predicted the sparse case to 3.5 % (1.72 vs 1.78 ms), the memory to
-1.6 % (24.6 vs 25.0 MiB) and the residual walk exactly (2,912). It was **40 % optimistic in the dense
-shape** — 10.65 ms modelled against 14.89 ms measured — because the model emitted a pair and moved on where
-the implementation must resolve each emitted index through `getOrCreateIndexByPrimaryKey` (the registering
-accessor that enrols it in the dirty set, not optional) and de-duplicate siblings per owner. At 57,962
-affected owners that is paid tens of thousands of times. The decision stands; **arm C's dense figure must
-not be quoted for the implementation.**
+1.6 % (24.6 vs 25.0 MiB) and the residual walk exactly (2,912). It was **40 % optimistic in the dense shape**
+— 10.65 ms modelled against 14.89 ms measured.
+
+**The reason originally given for that 40 % was wrong, and is retracted.** It attributed the gap to the
+implementation resolving each emitted index through `getOrCreateIndexByPrimaryKey` and de-duplicating siblings
+per owner. `ConditionalFacetMembershipReport` does neither — `getOrCreateIndexByPrimaryKey` does not appear in
+it, and its own `reportTimings` javadoc states both arms are probe-only. So the 14.89 ms it measured is not
+the implementation's cost either; it is a lower bound on it, and whatever produced the 40 % gap has not been
+identified. What survives unchanged is the conclusion: **arm C's dense figure must not be quoted for the
+implementation** — and neither, now, may this row's. The 8.3× and 58× cases carry the decision comfortably at
+any plausible correction; the **1.41x** dense case at `P` = 4,633 is the one to re-take first, being the
+smallest reported gain and therefore the one a missing per-index resolve-and-intersect erodes proportionally
+most.
 
 **Absolute figures do not transfer between the two spikes.** The same walk measures 1.76 ms here and 836 µs
 in `ConditionalFacetSiblingResolverReport`, 103 ms here and 80.7 ms there. Only ratios within one run mean

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,6 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
+| 2026-09-09 | [Bound the cross-entity facet walk with a size-thresholded owner→partition index, not a blanket one](2026-09-09-sibling-resolver-partition-cardinality.md) | optimization | proposed | #1529 |
 | 2026-09-07 | [Equalized histograms bucket on the quantile function and report a kernel density, not a per-bucket ratio](2026-09-07-equalized-histogram-density-and-quantile-bucketing.md) | fix | accepted | #1501 |
 | 2026-09-07 | [A storage part declares which kind of data it holds, at registration, in a closed enum](2026-09-07-storage-part-classification.md) | feature | accepted | #1500 |
 | 2026-09-06 | [The engine-level go-live drains its catalog's sessions itself, and publishes the ALIVE bootstrap only behind that drain](2026-09-06-go-live-session-drain.md) | fix | accepted | #1495 |

--- a/documentation/adr/README.md
+++ b/documentation/adr/README.md
@@ -33,7 +33,7 @@ filename date that disagrees with `date:`.
 
 | Date | Record | Kind | Status | Refs |
 |------|--------|------|--------|------|
-| 2026-09-09 | [Bound the cross-entity facet walk with a size-thresholded owner→partition index, not a blanket one](2026-09-09-sibling-resolver-partition-cardinality.md) | optimization | proposed | #1529 |
+| 2026-09-09 | [Bound the cross-entity facet walk with a size-thresholded owner→partition index, not a blanket one](2026-09-09-sibling-resolver-partition-cardinality.md) | optimization | accepted | #1529 |
 | 2026-09-07 | [Equalized histograms bucket on the quantile function and report a kernel density, not a per-bucket ratio](2026-09-07-equalized-histogram-density-and-quantile-bucketing.md) | fix | accepted | #1501 |
 | 2026-09-07 | [A storage part declares which kind of data it holds, at registration, in a closed enum](2026-09-07-storage-part-classification.md) | feature | accepted | #1500 |
 | 2026-09-06 | [The engine-level go-live drains its catalog's sessions itself, and publishes the ALIVE bootstrap only behind that drain](2026-09-06-go-live-session-drain.md) | fix | accepted | #1495 |

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/dto/EntitySchema.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/dto/EntitySchema.java
@@ -214,6 +214,12 @@ public final class EntitySchema implements EntitySchemaContract {
 	 * the calculation is expensive, it is memoized.
 	 */
 	private volatile Boolean memoizedLocalized;
+	/**
+	 * Memoized set of scopes in which at least one reference declares a conditional facet. Computed for every scope
+	 * at once, because the calculation walks every reference definition and the answer is asked for on the write
+	 * path — once per reference-index boundary — where an `O(reference definitions)` scan would be the whole cost.
+	 */
+	private volatile Set<Scope> memoizedConditionalFacetScopes;
 
 	/**
 	 * Method generates name variant index used for quickly looking up for schemas by name in specific name convention.
@@ -795,6 +801,34 @@ public final class EntitySchema implements EntitySchemaContract {
 					.anyMatch(AttributeSchemaContract::isLocalized);
 		}
 		return this.memoizedLocalized;
+	}
+
+	/**
+	 * Returns `true` when at least one reference of this entity declares a **conditional** facet — a
+	 * {@link ReferenceSchemaContract#getFacetedPartiallyInScope(Scope) facetedPartially} expression — in the given
+	 * scope.
+	 *
+	 * This is what decides whether the cross-entity facet trigger can ever fire for the collection, and hence
+	 * whether the reduced-index membership lookup the trigger consults is worth building and maintaining at all.
+	 * Both the load-time build and the per-write maintenance ask it, so it is memoized: it is derived purely from
+	 * the immutable reference definitions, and is therefore neither persisted nor part of the schema's version.
+	 *
+	 * @param scope the scope to examine
+	 * @return `true` when a conditional facet is declared in that scope
+	 */
+	public boolean declaresConditionalFacetInScope(@Nonnull Scope scope) {
+		if (this.memoizedConditionalFacetScopes == null) {
+			final Set<Scope> scopes = EnumSet.noneOf(Scope.class);
+			for (final ReferenceSchemaContract referenceSchema : this.references.values()) {
+				for (final Scope examinedScope : Scope.values()) {
+					if (referenceSchema.getFacetedPartiallyInScope(examinedScope) != null) {
+						scopes.add(examinedScope);
+					}
+				}
+			}
+			this.memoizedConditionalFacetScopes = scopes;
+		}
+		return this.memoizedConditionalFacetScopes.contains(scope);
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
@@ -663,6 +663,13 @@ public final class Catalog
 				}
 				// after all schemas are resolved, build the expression trigger registry
 				catalog.buildInitialExpressionTriggerRegistry();
+				// derived state that is not persisted and has to come back with the collection: the reverse
+				// lookup the cross-entity facet trigger uses instead of walking every reduced index. Built
+				// here because it is the one moment that has every index in place, every schema resolved, and
+				// no transaction open - and it must not be built inside one, see the method's javadoc.
+				for (EntityCollection collection : initBulk.collections().values()) {
+					collection.rebuildReducedIndexMembership();
+				}
 				onSuccess.accept(catalogName, catalog);
 				theFuture.updateProgress(1);
 				return catalog;

--- a/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
@@ -94,6 +94,7 @@ import io.evitadb.api.requestResponse.schema.NamedSchemaContract;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.EntityAttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.AttributeFilterAccelerator;
+import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
 import io.evitadb.api.requestResponse.schema.ReflectedReferenceSchemaContract;
 import io.evitadb.api.requestResponse.schema.SealedCatalogSchema;
@@ -149,11 +150,10 @@ import io.evitadb.dataType.EvitaDataTypes;
 import io.evitadb.index.*;
 import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.bitmap.Bitmap;
-import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
-import io.evitadb.index.membership.ReducedIndexMembership;
 import io.evitadb.index.map.MapChanges;
 import io.evitadb.index.map.MapChanges.ValueMerger;
 import io.evitadb.index.map.PersistentTransactionalProducerMap;
+import io.evitadb.index.membership.ReducedIndexMembership;
 import io.evitadb.index.mutation.ConsistencyCheckingLocalMutationExecutor.ImplicitMutationBehavior;
 import io.evitadb.index.mutation.EntityIndexMutation;
 import io.evitadb.index.mutation.IndexMutation;
@@ -1931,7 +1931,7 @@ public final class EntityCollection implements
 		final EntityIndex reducedIndex = getIndexByPrimaryKeyIfExists(reducedIndexPk);
 		if (reducedIndex == null) {
 			// Advertised but not resolvable, so its members cannot be read and coverage cannot be decided.
-			// Recording it as residual keeps `covered u residual == advertised` - the invariant that lets a
+			// Recording it as residual keeps `covered ∪ residual == advertised` - the invariant that lets a
 			// caller tell "this index is accounted for" from "this index is unknown to the map" - and leaves
 			// the index on the probe, which is exactly where it was before the map existed.
 			membership.registerIndexAsResidual(reducedIndexPk);

--- a/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
@@ -1928,10 +1928,11 @@ public final class EntityCollection implements
 	 * `ReferenceIndexMutator#forEachUniqueReferenceIndex` de-duplicates by identity. It cannot reach a walk over
 	 * *advertised indexes*, which is what this one is.
 	 *
-	 * The pre-check is kept regardless, because this is the load path:
-	 * {@link ReducedIndexMembership#registerIndex} refuses a repeat by design, and raising there would take the
-	 * whole catalog offline over a structure that is only an accelerator. Skipping a repeat would rebuild the
-	 * identical map.
+	 * A repeat is therefore a programming error, and it is left to surface as one:
+	 * {@link ReducedIndexMembership#registerIndex} and {@link ReducedIndexMembership#registerIndexAsResidual}
+	 * both refuse a primary key they already hold. This method used to swallow the repeat with an
+	 * {@link ReducedIndexMembership#isKnown} pre-check, which turned a corrupt advertisement into a silent
+	 * no-op at the one moment the whole structure is built from scratch.
 	 *
 	 * @param membership      the lookup being built
 	 * @param reducedIndexPk  primary key of the advertised reduced index
@@ -1940,9 +1941,6 @@ public final class EntityCollection implements
 		@Nonnull ReducedIndexMembership membership,
 		int reducedIndexPk
 	) {
-		if (membership.isKnown(reducedIndexPk)) {
-			return;
-		}
 		final EntityIndex reducedIndex = getIndexByPrimaryKeyIfExists(reducedIndexPk);
 		if (reducedIndex == null) {
 			// Advertised but not resolvable, so its members cannot be read and coverage cannot be decided.

--- a/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
@@ -1915,8 +1915,23 @@ public final class EntityCollection implements
 	}
 
 	/**
-	 * Registers one reduced index into the membership lookup, skipping primary keys the type index advertises
-	 * more than once — a group index is advertised once per referenced entity filed under it.
+	 * Registers one reduced index into the membership lookup.
+	 *
+	 * The traversal cannot in fact advertise a primary key twice. A reduced index is filed in its type index
+	 * under exactly one referenced (or group) primary key — `ReferenceIndexMutator#referenceInsertPerComponent`
+	 * is the only writer and always pairs the index with the key it was resolved by — so
+	 * {@link ReferencedTypeEntityIndex#forEachReferenceIndexPrimaryKey} emits each key once, and the entity and
+	 * group families draw from one primary-key sequence and never collide.
+	 *
+	 * The index sharing this check was once justified by is real, but it belongs to the OWNER side: several of
+	 * one owner's references resolve to a single {@link ReducedGroupEntityIndex}, which is why
+	 * `ReferenceIndexMutator#forEachUniqueReferenceIndex` de-duplicates by identity. It cannot reach a walk over
+	 * *advertised indexes*, which is what this one is.
+	 *
+	 * The pre-check is kept regardless, because this is the load path:
+	 * {@link ReducedIndexMembership#registerIndex} refuses a repeat by design, and raising there would take the
+	 * whole catalog offline over a structure that is only an accelerator. Skipping a repeat would rebuild the
+	 * identical map.
 	 *
 	 * @param membership      the lookup being built
 	 * @param reducedIndexPk  primary key of the advertised reduced index

--- a/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
@@ -1848,14 +1848,6 @@ public final class EntityCollection implements
 	}
 
 	/**
-	 * The two families of `REFERENCED_*_TYPE` index a reference may own; both advertise reduced indexes whose
-	 * membership the cross-entity facet trigger consults, and neither can stand in for the other.
-	 */
-	private static final EntityIndexType[] REFERENCED_TYPE_INDEX_FAMILIES = {
-		EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
-	};
-
-	/**
 	 * Rebuilds the reduced-index membership lookup the cross-entity conditional-facet trigger consults instead
 	 * of walking every reduced index of this collection. Called once, after a load has put every index in
 	 * place and every schema has been resolved.
@@ -1869,40 +1861,53 @@ public final class EntityCollection implements
 	 * entry-level ones. At load there is no transaction and no concurrency, which is what makes this the
 	 * single safe moment.
 	 *
-	 * # Why references that are not partitioned are registered too
+	 * # Why references that are not partitioned get no slice at all
 	 *
-	 * They are registered as residual, which costs one bit per reduced index and no entries at all. It buys
-	 * the invariant everything else depends on: **a slice is absent only when the reference has no reduced
-	 * indexes.** Maintenance may therefore create a slice on demand — during a bulk load, say — without ever
-	 * risking one that silently omits indexes which existed before it started watching.
+	 * The trigger's sibling walk visits only references indexed at
+	 * {@link ReferenceIndexType#FOR_FILTERING_AND_PARTITIONING}, and the maintenance hooks that keep a slice
+	 * current are gated on the same level. A slice built here for a merely filterable reference would
+	 * therefore freeze at its load-time contents while its reduced indexes kept changing — and the moment
+	 * such a reference is raised to partitioning without a reindex (issue #409), the trigger would consult
+	 * that frozen slice instead of walking, and silently skip every index created since the load. Leaving
+	 * the slice absent keeps the reference on the full walk until the first write raises it, at which point
+	 * `ReferenceIndexMutator#seedFromAdvertisedIndexes` records everything already advertised.
 	 *
-	 * Collections that declare no conditional facet at all never fire this trigger, so they are skipped
-	 * entirely and pay nothing.
+	 * The trigger cannot fire in a scope where no reference declares a conditional facet, so such a scope is
+	 * skipped before any index is even resolved — which means a collection that declares one nowhere pays a
+	 * single bit test per scope and nothing else. That gate is the same one
+	 * `ReferenceIndexMutator#recordOwnerEnteredReducedIndex` applies on the write path, and the two must agree:
+	 * a collection skipped here but maintained on write would carry a lookup whose contents begin at an
+	 * arbitrary moment in its life.
 	 */
 	public void rebuildReducedIndexMembership() {
 		final EntitySchema schema = getInternalSchema();
 		for (final Scope scope : Scope.values()) {
-			if (!declaresConditionalFacet(schema, scope)) {
+			if (!schema.declaresConditionalFacetInScope(scope)) {
 				continue;
 			}
-			final EntityIndex globalIndex = getIndexByKeyIfExists(new EntityIndexKey(EntityIndexType.GLOBAL, scope));
-			if (!(globalIndex instanceof final GlobalEntityIndex typedGlobalIndex)) {
+			final GlobalEntityIndex typedGlobalIndex = asGlobalEntityIndexIfExists(
+				getIndexByKeyIfExists(new EntityIndexKey(EntityIndexType.GLOBAL, scope)), scope
+			);
+			if (typedGlobalIndex == null) {
 				continue;
 			}
 			for (final ReferenceSchemaContract referenceSchema : schema.getReferences().values()) {
-				final boolean partitioned = referenceSchema.getReferenceIndexType(scope)
-					== ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING;
+				if (referenceSchema.getReferenceIndexType(scope)
+					!= ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING) {
+					continue;
+				}
 				final ReducedIndexMembership membership =
 					typedGlobalIndex.getOrCreateReducedIndexMembership(referenceSchema.getName());
-				for (final EntityIndexType family : REFERENCED_TYPE_INDEX_FAMILIES) {
-					final EntityIndex typeIndex = getIndexByKeyIfExists(
-						new EntityIndexKey(family, scope, referenceSchema.getName())
+				for (final EntityIndexType family : ReducedIndexMembership.REFERENCED_TYPE_INDEX_FAMILIES) {
+					final EntityIndexKey typeIndexKey = new EntityIndexKey(family, scope, referenceSchema.getName());
+					final ReferencedTypeEntityIndex typedTypeIndex = asReferencedTypeEntityIndexIfExists(
+						getIndexByKeyIfExists(typeIndexKey), typeIndexKey
 					);
-					if (!(typeIndex instanceof final ReferencedTypeEntityIndex typedTypeIndex)) {
+					if (typedTypeIndex == null) {
 						continue;
 					}
 					typedTypeIndex.forEachReferenceIndexPrimaryKey(
-						reducedIndexPk -> registerReducedIndex(membership, reducedIndexPk, partitioned)
+						reducedIndexPk -> registerReducedIndex(membership, reducedIndexPk)
 					);
 				}
 			}
@@ -1915,45 +1920,131 @@ public final class EntityCollection implements
 	 *
 	 * @param membership      the lookup being built
 	 * @param reducedIndexPk  primary key of the advertised reduced index
-	 * @param partitioned     `true` when the owning reference is indexed for partitioning, and its indexes are
-	 *                        therefore worth covering rather than merely recording
 	 */
 	private void registerReducedIndex(
 		@Nonnull ReducedIndexMembership membership,
-		int reducedIndexPk,
-		boolean partitioned
+		int reducedIndexPk
 	) {
 		if (membership.isKnown(reducedIndexPk)) {
 			return;
 		}
-		if (!partitioned) {
-			membership.registerIndexAsResidual(reducedIndexPk);
-			return;
-		}
 		final EntityIndex reducedIndex = getIndexByPrimaryKeyIfExists(reducedIndexPk);
 		if (reducedIndex == null) {
-			// advertised but not resolvable - leave it entirely unknown so the walk still visits it
+			// Advertised but not resolvable, so its members cannot be read and coverage cannot be decided.
+			// Recording it as residual keeps `covered u residual == advertised` - the invariant that lets a
+			// caller tell "this index is accounted for" from "this index is unknown to the map" - and leaves
+			// the index on the probe, which is exactly where it was before the map existed.
+			membership.registerIndexAsResidual(reducedIndexPk);
 			return;
 		}
 		membership.registerIndex(reducedIndexPk, reducedIndex.getAllPrimaryKeys());
 	}
 
 	/**
-	 * Returns `true` when the schema declares a conditional facet in the given scope, which is the only
-	 * situation in which the cross-entity facet trigger — and hence the reduced-index membership lookup — is
-	 * ever used.
+	 * Drops every reduced-index membership lookup this schema change stops maintaining.
 	 *
-	 * @param schema the entity schema to inspect
-	 * @param scope  the scope to inspect
-	 * @return `true` when a conditional facet is declared
+	 * The lookup is maintained only while the collection declares a conditional facet in the scope **and** the
+	 * reference is indexed at {@link ReferenceIndexType#FOR_FILTERING_AND_PARTITIONING}. Both are pure functions of
+	 * the schema, so a schema change is the only event that can end maintenance — and a lookup kept past it freezes
+	 * while its reduced indexes go on changing. Trusted again when the flag comes back, it makes the trigger skip
+	 * every partition created in between: a **wrong facet**, not a slow one.
+	 *
+	 * Doing it here rather than on the write path is what makes it free. The condition is rare and discrete, so it
+	 * is evaluated once per schema change instead of once per reference write, and the write path keeps the bit test
+	 * it already does. What replaces the dropped lookup is nothing at all: an absent lookup puts the reference back
+	 * on the full walk, and `ReferenceIndexMutator#seedFromAdvertisedIndexes` rebuilds it from the reference's own
+	 * advertisement on the first write after the flag returns.
+	 *
+	 * It hangs off {@link #exchangeSchema} rather than off {@link #updateSchema} because that is where every schema
+	 * change converges: a **reflected** reference inherits its index type from another collection's reference and is
+	 * resolved by `notifyAboutExternalReferenceUpdate` → `exchangeSchema`, a path that never passes through
+	 * `updateSchema` (see the note in `verifyNoAcceleratorAddedToNonEmptyCollection`). Hooked one level up, that
+	 * reference would keep a lookup nothing maintains.
+	 *
+	 * @param updatedSchema the schema this collection has just been exchanged to
 	 */
-	private static boolean declaresConditionalFacet(@Nonnull EntitySchema schema, @Nonnull Scope scope) {
-		for (final ReferenceSchemaContract referenceSchema : schema.getReferences().values()) {
-			if (referenceSchema.getFacetedPartiallyInScope(scope) != null) {
-				return true;
+	private void discardUnmaintainedReducedIndexMemberships(@Nonnull EntitySchema updatedSchema) {
+		for (final Scope scope : Scope.values()) {
+			final GlobalEntityIndex globalIndex = asGlobalEntityIndexIfExists(
+				getIndexByKeyIfExists(new EntityIndexKey(EntityIndexType.GLOBAL, scope)), scope
+			);
+			if (globalIndex == null) {
+				continue;
+			}
+			// a copy, so the removals below cannot disturb the iteration
+			final Set<String> maintainedReferences = globalIndex.getReducedIndexMembershipReferenceNames();
+			if (maintainedReferences.isEmpty()) {
+				continue;
+			}
+			final boolean conditionalFacetDeclared = updatedSchema.declaresConditionalFacetInScope(scope);
+			GlobalEntityIndex writableGlobalIndex = null;
+			for (final String referenceName : maintainedReferences) {
+				final ReferenceSchemaContract referenceSchema = updatedSchema.getReferences().get(referenceName);
+				if (conditionalFacetDeclared && referenceSchema != null &&
+					referenceSchema.getReferenceIndexType(scope) == ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING) {
+					continue;
+				}
+				if (writableGlobalIndex == null) {
+					// enrolled for modification only once there is something to drop - that registration is what gets
+					// the index's transactional layer swept at commit
+					writableGlobalIndex = (GlobalEntityIndex) this.dataStoreBuffer.getOrCreateIndexForModification(
+						new EntityIndexKey(EntityIndexType.GLOBAL, scope), this.indexes::get
+					);
+				}
+				writableGlobalIndex.removeReducedIndexMembership(referenceName);
 			}
 		}
-		return false;
+	}
+
+	/**
+	 * Casts an index registered under a `GLOBAL` key, or returns `null` when the scope holds none.
+	 *
+	 * Absence is a legitimate state — a scope no entity has entered yet — while an index registered under
+	 * that key and turning out to be something other than a {@link GlobalEntityIndex} is a programming error
+	 * that must surface rather than be skipped.
+	 *
+	 * @param index the index resolved from the `GLOBAL` key, may be `null`
+	 * @param scope the scope the key was read in, for the error message
+	 * @return the cast index, or `null` when there is none
+	 */
+	@Nullable
+	private GlobalEntityIndex asGlobalEntityIndexIfExists(@Nullable EntityIndex index, @Nonnull Scope scope) {
+		if (index == null) {
+			return null;
+		}
+		Assert.isPremiseValid(
+			index instanceof GlobalEntityIndex,
+			() -> "Invalid type of the global index (`" + index.getClass() + "`) in scope `" + scope +
+				"` of entity collection `" + getSchema().getName() + "`."
+		);
+		return (GlobalEntityIndex) index;
+	}
+
+	/**
+	 * Casts an index registered under a `REFERENCED_*_TYPE` key, or returns `null` when there is none.
+	 *
+	 * Absence is a legitimate state — the reference simply has no partitions of that family yet — while an
+	 * index registered under such a key and turning out to be something other than a
+	 * {@link ReferencedTypeEntityIndex} is a programming error that must surface rather than be skipped.
+	 *
+	 * @param index          the index resolved from the key, may be `null`
+	 * @param entityIndexKey the key the index was read under, for the error message
+	 * @return the cast index, or `null` when there is none
+	 */
+	@Nullable
+	private ReferencedTypeEntityIndex asReferencedTypeEntityIndexIfExists(
+		@Nullable EntityIndex index,
+		@Nonnull EntityIndexKey entityIndexKey
+	) {
+		if (index == null) {
+			return null;
+		}
+		Assert.isPremiseValid(
+			index instanceof ReferencedTypeEntityIndex,
+			() -> "Invalid type of the index (`" + index.getClass() + "`) registered under `" + entityIndexKey +
+				"` in entity collection `" + getSchema().getName() + "`."
+		);
+		return (ReferencedTypeEntityIndex) index;
 	}
 
 	/**
@@ -2909,6 +3000,10 @@ public final class EntityCollection implements
 	 * leave the registry holding counters for capabilities the schema no longer declares, and leave a newly declared
 	 * capability without the row whose observation window is supposed to open at this very mutation.
 	 *
+	 * {@link #discardUnmaintainedReducedIndexMemberships} rides on the same property, and specifically on the
+	 * reflected-reference half of it: that is the adoption path `updateSchema` never sees, and a reflected reference
+	 * lowered from the collection it reflects is exactly the case a hook one level up would miss.
+	 *
 	 * # What a rollback leaves behind, in both directions
 	 *
 	 * The alignment runs against the schema the exchange has just published, so it precedes the commit of a
@@ -2962,6 +3057,7 @@ public final class EntityCollection implements
 		);
 		// only after the exchange is known to have won the race - a losing exchange changed nothing to align against
 		this.usageRegistry.alignWith(updatedSchema);
+		discardUnmaintainedReducedIndexMemberships(updatedSchema);
 		this.catalog.entitySchemaUpdated(updatedSchema);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
@@ -149,6 +149,8 @@ import io.evitadb.dataType.EvitaDataTypes;
 import io.evitadb.index.*;
 import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
+import io.evitadb.index.membership.ReducedIndexMembership;
 import io.evitadb.index.map.MapChanges;
 import io.evitadb.index.map.MapChanges.ValueMerger;
 import io.evitadb.index.map.PersistentTransactionalProducerMap;
@@ -1843,6 +1845,115 @@ public final class EntityCollection implements
 	@Nullable
 	public EntityIndex getIndexByKeyIfExists(@Nonnull EntityIndexKey entityIndexKey) {
 		return this.dataStoreBuffer.getIndexIfExists(entityIndexKey, this.indexes::get);
+	}
+
+	/**
+	 * The two families of `REFERENCED_*_TYPE` index a reference may own; both advertise reduced indexes whose
+	 * membership the cross-entity facet trigger consults, and neither can stand in for the other.
+	 */
+	private static final EntityIndexType[] REFERENCED_TYPE_INDEX_FAMILIES = {
+		EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
+	};
+
+	/**
+	 * Rebuilds the reduced-index membership lookup the cross-entity conditional-facet trigger consults instead
+	 * of walking every reduced index of this collection. Called once, after a load has put every index in
+	 * place and every schema has been resolved.
+	 *
+	 * # Why this runs at load and never inside a transaction
+	 *
+	 * The lookup is derived state, so it is not persisted and has to be rebuilt when a collection comes back
+	 * from disk. It must be rebuilt **outside** a transaction: building it inside one would record every
+	 * entry into that transaction's diff layer, and merging such a diff would overwrite entries a
+	 * concurrently-committed transaction had already contributed — a whole-structure write racing with
+	 * entry-level ones. At load there is no transaction and no concurrency, which is what makes this the
+	 * single safe moment.
+	 *
+	 * # Why references that are not partitioned are registered too
+	 *
+	 * They are registered as residual, which costs one bit per reduced index and no entries at all. It buys
+	 * the invariant everything else depends on: **a slice is absent only when the reference has no reduced
+	 * indexes.** Maintenance may therefore create a slice on demand — during a bulk load, say — without ever
+	 * risking one that silently omits indexes which existed before it started watching.
+	 *
+	 * Collections that declare no conditional facet at all never fire this trigger, so they are skipped
+	 * entirely and pay nothing.
+	 */
+	public void rebuildReducedIndexMembership() {
+		final EntitySchema schema = getInternalSchema();
+		for (final Scope scope : Scope.values()) {
+			if (!declaresConditionalFacet(schema, scope)) {
+				continue;
+			}
+			final EntityIndex globalIndex = getIndexByKeyIfExists(new EntityIndexKey(EntityIndexType.GLOBAL, scope));
+			if (!(globalIndex instanceof final GlobalEntityIndex typedGlobalIndex)) {
+				continue;
+			}
+			for (final ReferenceSchemaContract referenceSchema : schema.getReferences().values()) {
+				final boolean partitioned = referenceSchema.getReferenceIndexType(scope)
+					== ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING;
+				final ReducedIndexMembership membership =
+					typedGlobalIndex.getOrCreateReducedIndexMembership(referenceSchema.getName());
+				for (final EntityIndexType family : REFERENCED_TYPE_INDEX_FAMILIES) {
+					final EntityIndex typeIndex = getIndexByKeyIfExists(
+						new EntityIndexKey(family, scope, referenceSchema.getName())
+					);
+					if (!(typeIndex instanceof final ReferencedTypeEntityIndex typedTypeIndex)) {
+						continue;
+					}
+					typedTypeIndex.forEachReferenceIndexPrimaryKey(
+						reducedIndexPk -> registerReducedIndex(membership, reducedIndexPk, partitioned)
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Registers one reduced index into the membership lookup, skipping primary keys the type index advertises
+	 * more than once — a group index is advertised once per referenced entity filed under it.
+	 *
+	 * @param membership      the lookup being built
+	 * @param reducedIndexPk  primary key of the advertised reduced index
+	 * @param partitioned     `true` when the owning reference is indexed for partitioning, and its indexes are
+	 *                        therefore worth covering rather than merely recording
+	 */
+	private void registerReducedIndex(
+		@Nonnull ReducedIndexMembership membership,
+		int reducedIndexPk,
+		boolean partitioned
+	) {
+		if (membership.isKnown(reducedIndexPk)) {
+			return;
+		}
+		if (!partitioned) {
+			membership.registerIndexAsResidual(reducedIndexPk);
+			return;
+		}
+		final EntityIndex reducedIndex = getIndexByPrimaryKeyIfExists(reducedIndexPk);
+		if (reducedIndex == null) {
+			// advertised but not resolvable - leave it entirely unknown so the walk still visits it
+			return;
+		}
+		membership.registerIndex(reducedIndexPk, reducedIndex.getAllPrimaryKeys());
+	}
+
+	/**
+	 * Returns `true` when the schema declares a conditional facet in the given scope, which is the only
+	 * situation in which the cross-entity facet trigger — and hence the reduced-index membership lookup — is
+	 * ever used.
+	 *
+	 * @param schema the entity schema to inspect
+	 * @param scope  the scope to inspect
+	 * @return `true` when a conditional facet is declared
+	 */
+	private static boolean declaresConditionalFacet(@Nonnull EntitySchema schema, @Nonnull Scope scope) {
+		for (final ReferenceSchemaContract referenceSchema : schema.getReferences().values()) {
+			if (referenceSchema.getFacetedPartiallyInScope(scope) != null) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/GlobalEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/GlobalEntityIndex.java
@@ -314,14 +314,14 @@ public class GlobalEntityIndex extends EntityIndex
 	}
 
 	/**
-	 * Reconstructs a global entity index from persisted or committed state, together with its substring-search
-	 * accelerators.
+	 * Reconstructs a global entity index from persisted or committed state, together with the two derived
+	 * structures it hosts — the substring-search accelerators and the reduced-index membership lookup.
 	 *
-	 * @param reducedIndexMembership the per-reference reverse lookup of owners to the reduced indexes holding
-	 *                               them — derived state, empty on a freshly loaded index until it is rebuilt
 	 * @param trigramIndexes the per-`(attribute, locale)` trigram indexes — the committed ones on the merge copy, the
 	 *                       ones {@link TrigramIndex#rebuildAll} derived from the reloaded shared value trees on a cold
 	 *                       load, and empty for a caller that maintains none
+	 * @param reducedIndexMembership the per-reference reverse lookup of owners to the reduced indexes holding
+	 *                               them — derived state, empty on a freshly loaded index until it is rebuilt
 	 * @param activity       the activity holder to keep counting into — the copied index's own instance on the
 	 *                       commit-time merge copy, a fresh one when loading from disk; see
 	 *                       {@link io.evitadb.index.IndexActivity}
@@ -430,9 +430,20 @@ public class GlobalEntityIndex extends EntityIndex
 	 * Returns the reverse lookup of "which reduced indexes of this reference hold this owner", or `null` when
 	 * nothing has been recorded for the reference yet.
 	 *
-	 * A `null` result — and an incomplete non-`null` one — is not an error: the map is an accelerator, and a
-	 * reduced index it does not cover is walked exactly as it was before this structure existed. Callers must
-	 * treat "advertised but not covered" as *walk it*, never as *not there*.
+	 * A `null` result is not an error and never becomes one: with no lookup the trigger walks every reduced
+	 * index the reference advertises, exactly as it did before this structure existed. Absence costs speed,
+	 * never correctness.
+	 *
+	 * A non-`null` result is a different matter, and the asymmetry is the whole contract. What comes back is
+	 * probed as it stands — the caller never re-derives the reference's advertisement to check it against, since
+	 * that is the `O(total reduced indexes)` traversal the structure exists to remove — so an index the slice
+	 * names in neither its covered nor its residual set is simply never visited. An index left *uncovered* is
+	 * safe because it is *residual*, and residual is probed whole; it is not safe merely by virtue of being
+	 * absent from the covered set. The extreme case is a slice present with both sets empty while its reference
+	 * still advertises indexes: that skips every one of them, which is a wrong facet rather than a slow one.
+	 * The invariant `covered ∪ residual == advertised` is what rules it out, and
+	 * `ReducedIndexMembershipCompletenessTest#assertMembershipMatchesIndexes` is what enforces it — see
+	 * {@link ReducedIndexMembership} for the reasoning in full.
 	 *
 	 * @param referenceName name of the reference whose membership is requested
 	 * @return the membership map, or `null` when the reference has none
@@ -460,8 +471,31 @@ public class GlobalEntityIndex extends EntityIndex
 	}
 
 	/**
-	 * Returns the names of the references this index holds a reverse lookup for. Used by the completeness
-	 * verification in tests, which compares the map against the reduced indexes themselves.
+	 * Drops the reverse lookup of the given reference, returning the trigger to walking every reduced index the
+	 * reference advertises.
+	 *
+	 * Called when a schema change stops maintenance following the reference — either the reference itself fell
+	 * below {@link io.evitadb.api.requestResponse.schema.ReferenceIndexType#FOR_FILTERING_AND_PARTITIONING}, or
+	 * the collection's last conditional facet in this scope went away. Both gates are read on every write, so a
+	 * lookup kept past either of them would freeze while the reduced indexes went on changing — and a frozen
+	 * lookup is consulted as an authority the moment the gate comes back. A dropped one is rebuilt from the
+	 * reference's own advertisement by `ReferenceIndexMutator#seedFromAdvertisedIndexes`, on the first write
+	 * after that happens.
+	 *
+	 * @param referenceName name of the reference whose lookup is dropped
+	 */
+	public void removeReducedIndexMembership(@Nonnull String referenceName) {
+		this.reducedIndexMembership.remove(referenceName);
+	}
+
+	/**
+	 * Returns the names of the references this index holds a reverse lookup for.
+	 *
+	 * A copy rather than a live view, because the caller that needs it iterates while dropping: a schema change
+	 * asks this index which lookups it is still holding and removes the ones the new schema stops maintaining
+	 * (`EntityCollection#discardUnmaintainedReducedIndexMemberships`). The completeness verification in tests
+	 * uses it for the other direction, comparing the map's reference names against the schema and against the
+	 * reduced indexes themselves.
 	 *
 	 * @return reference names with a membership map; never `null`
 	 */

--- a/evita_engine/src/main/java/io/evitadb/index/GlobalEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/GlobalEntityIndex.java
@@ -43,6 +43,7 @@ import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.EmptyBitmap;
 import io.evitadb.index.bitmap.TransactionalBitmap;
 import io.evitadb.index.component.PriceIndexComponent;
+import io.evitadb.index.component.ReducedIndexMembershipMapComponent;
 import io.evitadb.index.component.TrigramIndexMapComponent;
 import io.evitadb.index.component.loader.AttributeIndexLoader;
 import io.evitadb.index.component.loader.FacetIndexLoader;
@@ -53,12 +54,14 @@ import io.evitadb.index.component.loader.PriceSuperIndexLoader;
 import io.evitadb.index.facet.FacetIndex;
 import io.evitadb.index.hierarchy.HierarchyIndex;
 import io.evitadb.index.map.TransactionalMap;
+import io.evitadb.index.membership.ReducedIndexMembership;
 import io.evitadb.index.price.PriceIndexContract;
 import io.evitadb.index.price.PriceSuperIndex;
 import io.evitadb.index.trigram.TrigramIndex;
 import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.PriceListAndCurrencySuperIndexStoragePart;
+import io.evitadb.utils.MemoryMeasuringConstants;
 import io.evitadb.utils.VMLayout;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -185,6 +188,17 @@ public class GlobalEntityIndex extends EntityIndex
 	 * shared value tree it indexes is dropped, which is the moment its value ids stop meaning anything.
 	 */
 	@Nonnull private final TransactionalMap<AttributeIndexKey, TrigramIndex> trigramIndex;
+	/**
+	 * Per-reference reverse lookup of "which reduced indexes hold this owner", keyed by reference name, used
+	 * by the cross-entity conditional-facet trigger to avoid walking every reduced index of the collection.
+	 *
+	 * Derived state, never persisted, and an **accelerator rather than an authority** — a reduced index it
+	 * does not cover must still be walked, so an absent or incomplete entry costs speed and never
+	 * correctness. See {@link ReducedIndexMembership} for the whole contract.
+	 *
+	 * Empty for every collection that never fires such a trigger, which is why it is charged nothing there.
+	 */
+	@Nonnull private final TransactionalMap<String, ReducedIndexMembership> reducedIndexMembership;
 
 	@Nonnull
 	@Override
@@ -265,6 +279,11 @@ public class GlobalEntityIndex extends EntityIndex
 		// nowhere is charged the map object alone
 		this.trigramIndex = new TransactionalMap<>(new HashMap<>(), TrigramIndex.class, Function.identity());
 		addComponent(new TrigramIndexMapComponent(this.trigramIndex));
+		// likewise allocated empty: a collection with no cross-entity conditional facet never puts anything here
+		this.reducedIndexMembership = new TransactionalMap<>(
+			new HashMap<>(), ReducedIndexMembership.class, Function.identity()
+		);
+		addComponent(new ReducedIndexMembershipMapComponent(this.reducedIndexMembership));
 		// fresh empty index — every component contributes an empty manifest, so the baseline
 		// captured here is the immutable empty set, preventing spurious manifest emits
 		captureOriginalsFromComponents();
@@ -290,7 +309,7 @@ public class GlobalEntityIndex extends EntityIndex
 	) {
 		this(
 			primaryKey, entityIndexKey, version, entityIds, entityIdsByLanguage,
-			attributeIndex, priceIndex, hierarchyIndex, facetIndex, Map.of(), activity
+			attributeIndex, priceIndex, hierarchyIndex, facetIndex, Map.of(), Map.of(), activity
 		);
 	}
 
@@ -298,6 +317,8 @@ public class GlobalEntityIndex extends EntityIndex
 	 * Reconstructs a global entity index from persisted or committed state, together with its substring-search
 	 * accelerators.
 	 *
+	 * @param reducedIndexMembership the per-reference reverse lookup of owners to the reduced indexes holding
+	 *                               them — derived state, empty on a freshly loaded index until it is rebuilt
 	 * @param trigramIndexes the per-`(attribute, locale)` trigram indexes — the committed ones on the merge copy, the
 	 *                       ones {@link TrigramIndex#rebuildAll} derived from the reloaded shared value trees on a cold
 	 *                       load, and empty for a caller that maintains none
@@ -316,6 +337,7 @@ public class GlobalEntityIndex extends EntityIndex
 		@Nonnull HierarchyIndex hierarchyIndex,
 		@Nonnull FacetIndex facetIndex,
 		@Nonnull Map<AttributeIndexKey, TrigramIndex> trigramIndexes,
+		@Nonnull Map<String, ReducedIndexMembership> reducedIndexMembership,
 		@Nullable IndexActivity activity
 	) {
 		super(
@@ -329,6 +351,10 @@ public class GlobalEntityIndex extends EntityIndex
 			new HashMap<>(trigramIndexes), TrigramIndex.class, Function.identity()
 		);
 		addComponent(new TrigramIndexMapComponent(this.trigramIndex));
+		this.reducedIndexMembership = new TransactionalMap<>(
+			new HashMap<>(reducedIndexMembership), ReducedIndexMembership.class, Function.identity()
+		);
+		addComponent(new ReducedIndexMembershipMapComponent(this.reducedIndexMembership));
 		// re-capture the change-detection baseline from the components now that the price super
 		// index is registered, so the baseline includes every persisted sub-index
 		captureOriginalsFromComponents();
@@ -389,11 +415,60 @@ public class GlobalEntityIndex extends EntityIndex
 					manifest.getEntityIndexKey().scope(),
 					attributes.sharedValueIndexes()
 				),
+				// likewise derived state, but derived from the REDUCED indexes rather than from anything this
+				// index carries - and those are loaded independently of it, so there is nothing to rebuild from
+				// here. It starts empty, which costs correctness nothing (an uncovered reduced index is walked)
+				// and is filled by `EntityCollection` once the collection's indexes are all in place.
+				Map.of(),
 				// loaded from disk — the counters start over, which is what "since catalog load" means, and are
 				// not opened at all when the server does not track usage statistics
 				context.createActivity()
 			);
 		});
+
+	/**
+	 * Returns the reverse lookup of "which reduced indexes of this reference hold this owner", or `null` when
+	 * nothing has been recorded for the reference yet.
+	 *
+	 * A `null` result — and an incomplete non-`null` one — is not an error: the map is an accelerator, and a
+	 * reduced index it does not cover is walked exactly as it was before this structure existed. Callers must
+	 * treat "advertised but not covered" as *walk it*, never as *not there*.
+	 *
+	 * @param referenceName name of the reference whose membership is requested
+	 * @return the membership map, or `null` when the reference has none
+	 */
+	@Nullable
+	public ReducedIndexMembership getReducedIndexMembership(@Nonnull String referenceName) {
+		return this.reducedIndexMembership.get(referenceName);
+	}
+
+	/**
+	 * Returns the reverse lookup for the given reference, creating an empty one when it does not exist yet.
+	 *
+	 * @param referenceName name of the reference whose membership is maintained
+	 * @return the membership map, never `null`
+	 */
+	@Nonnull
+	public ReducedIndexMembership getOrCreateReducedIndexMembership(@Nonnull String referenceName) {
+		final ReducedIndexMembership existing = this.reducedIndexMembership.get(referenceName);
+		if (existing != null) {
+			return existing;
+		}
+		final ReducedIndexMembership created = new ReducedIndexMembership();
+		this.reducedIndexMembership.put(referenceName, created);
+		return created;
+	}
+
+	/**
+	 * Returns the names of the references this index holds a reverse lookup for. Used by the completeness
+	 * verification in tests, which compares the map against the reduced indexes themselves.
+	 *
+	 * @return reference names with a membership map; never `null`
+	 */
+	@Nonnull
+	public Set<String> getReducedIndexMembershipReferenceNames() {
+		return Set.copyOf(this.reducedIndexMembership.keySet());
+	}
 
 	/*
 		TRANSACTIONAL MEMORY IMPLEMENTATION
@@ -416,6 +491,7 @@ public class GlobalEntityIndex extends EntityIndex
 			transactionalLayer.getStateCopyWithCommittedChanges(this.hierarchyIndex),
 			transactionalLayer.getStateCopyWithCommittedChanges(this.facetIndex),
 			transactionalLayer.getStateCopyWithCommittedChanges(this.trigramIndex),
+			transactionalLayer.getStateCopyWithCommittedChanges(this.reducedIndexMembership),
 			// the very same holder, not a copy: this is one logical index carried into the next catalog version
 			getActivity()
 		);
@@ -770,8 +846,8 @@ public class GlobalEntityIndex extends EntityIndex
 	@Override
 	public long getHeapSizeInBytes() {
 		final VMLayout layout = VMLayout.current();
-		// the priceIndex and trigramIndex slots
-		return getBaseHeapSizeInBytes(2L * layout.referenceSize())
+		// the priceIndex, trigramIndex and reducedIndexMembership slots
+		return getBaseHeapSizeInBytes(3L * layout.referenceSize())
 			+ this.priceIndex.getHeapSizeInBytes()
 			// the price component this class registers, holding the price index alone
 			+ layout.sizeOfObject(layout.referenceSize())
@@ -781,6 +857,12 @@ public class GlobalEntityIndex extends EntityIndex
 			// AttributeIndex#getHeapSizeInBytes) - charging it here as well would report one object twice in one figure
 			+ this.trigramIndex.getHeapSizeInBytes(key -> 0L, TrigramIndex::getHeapSizeInBytes)
 			// the trigram component this class registers, holding the map alone
+			+ layout.sizeOfObject(layout.referenceSize())
+			// the membership map charges its own keys: a reference name is held here and nowhere else in this index
+			+ this.reducedIndexMembership.getHeapSizeInBytes(
+				MemoryMeasuringConstants::computeStringSize, ReducedIndexMembership::getHeapSizeInBytes
+			)
+			// the membership component this class registers, holding the map alone
 			+ layout.sizeOfObject(layout.referenceSize());
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/GlobalEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/GlobalEntityIndex.java
@@ -192,11 +192,19 @@ public class GlobalEntityIndex extends EntityIndex
 	 * Per-reference reverse lookup of "which reduced indexes hold this owner", keyed by reference name, used
 	 * by the cross-entity conditional-facet trigger to avoid walking every reduced index of the collection.
 	 *
-	 * Derived state, never persisted, and an **accelerator rather than an authority** — a reduced index it
-	 * does not cover must still be walked, so an absent or incomplete entry costs speed and never
-	 * correctness. See {@link ReducedIndexMembership} for the whole contract.
+	 * Derived state, never persisted, and an **accelerator rather than an authority** — nothing it records is
+	 * taken as an answer, and every index it names is asked itself who is in it, so a stale entry costs a probe
+	 * and never correctness.
 	 *
-	 * Empty for every collection that never fires such a trigger, which is why it is charged nothing there.
+	 * What that does **not** license is an incomplete entry. An absent entry is safe — with no lookup the
+	 * trigger walks every index the reference advertises, exactly as it did before this map existed — but an
+	 * entry that EXISTS is probed exactly as it stands, so a reduced index missing from it is never visited and
+	 * the trigger writes a wrong facet rather than a slow one. Absence of the whole entry is therefore the safe
+	 * state, and the one this map is left in when maintenance stops. See {@link ReducedIndexMembership} for the
+	 * whole contract.
+	 *
+	 * Empty for every collection that never fires such a trigger, where it is charged its own map object and
+	 * nothing per reference — a `HashMap` allocates its table on the first put.
 	 */
 	@Nonnull private final TransactionalMap<String, ReducedIndexMembership> reducedIndexMembership;
 

--- a/evita_engine/src/main/java/io/evitadb/index/component/ReducedIndexMembershipMapComponent.java
+++ b/evita_engine/src/main/java/io/evitadb/index/component/ReducedIndexMembershipMapComponent.java
@@ -1,0 +1,100 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.component;
+
+import io.evitadb.core.buffer.TrappedChanges;
+import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
+import io.evitadb.index.map.TransactionalMap;
+import io.evitadb.index.membership.ReducedIndexMembership;
+
+import javax.annotation.Nonnull;
+
+/**
+ * {@link IndexComponent} adapter for the per-reference {@link ReducedIndexMembership} map carried by
+ * {@link io.evitadb.index.GlobalEntityIndex}.
+ *
+ * # Why it emits nothing
+ *
+ * A {@link ReducedIndexMembership} is **derived state**: every entry it holds is a function of the membership
+ * bitmaps of the collection's reduced indexes, which are persisted in their own right. It has no on-disk
+ * footprint of its own and is rebuilt when the collection is loaded, so {@link #collectModifiedStorageParts}
+ * emits no storage part and announces no key into the {@link EntityIndexManifest} — which
+ * {@link IndexComponent} explicitly permits — and {@link #emitPersistedFootprintRemovals} keeps the default
+ * no-op, because there is nothing on disk to reclaim when the owning index is dropped.
+ *
+ * Keeping it out of storage is deliberate rather than incidental: the map is an accelerator whose absence
+ * costs only speed, so persisting it would buy a faster first trigger at the price of a storage format
+ * change and a reload path that could disagree with the indexes it summarises.
+ *
+ * # Why it exists at all
+ *
+ * For the other half of the {@link IndexComponent} contract: the transactional-layer lifecycle. A
+ * {@link ReducedIndexMembership} is a
+ * {@link io.evitadb.core.transaction.memory.VoidTransactionMemoryProducer} — it owns no diff piece of its
+ * own, but the map and the three bitmaps underneath it do register layers, and those have to be dropped on
+ * commit and rollback along with every other sub-index's. This is what puts it into the parent index's
+ * single uniform loop rather than into a hand-rolled extra hop.
+ *
+ * @author Claude (issue #1529 sibling-resolver optimization), FG Forrest a.s. (c) 2026
+ */
+public final class ReducedIndexMembershipMapComponent implements IndexComponent {
+
+	/**
+	 * Backing per-reference map owned by the parent index. Held by reference because the parent index never
+	 * swaps the map instance during its lifetime — only the contents change.
+	 */
+	@Nonnull private final TransactionalMap<String, ReducedIndexMembership> membershipByReference;
+
+	/**
+	 * @param membershipByReference the wrapped per-reference membership map
+	 */
+	public ReducedIndexMembershipMapComponent(
+		@Nonnull TransactionalMap<String, ReducedIndexMembership> membershipByReference
+	) {
+		this.membershipByReference = membershipByReference;
+	}
+
+	@Override
+	public void collectModifiedStorageParts(
+		int entityIndexPrimaryKey,
+		@Nonnull EntityIndexManifest manifest,
+		@Nonnull TrappedChanges trappedChanges
+	) {
+		// derived state - see the class javadoc. Nothing is written, and nothing is announced into the
+		// manifest, because announcing a key would promise a reload path that reads it back off disk.
+	}
+
+	@Override
+	public void resetDirty() {
+		// nothing to reset - this component contributes no flush state, because it contributes no storage part
+	}
+
+	@Override
+	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
+		// TransactionalMap#removeLayer drops its own diff layer AND propagates into every value that is a
+		// TransactionalStateProducer, so the layers each per-reference membership registered are covered
+		this.membershipByReference.removeLayer(transactionalLayer);
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/index/map/MapChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/map/MapChanges.java
@@ -90,9 +90,11 @@ public class MapChanges<K, V>
 	 * - a REPLACEMENT value (the key was overwritten, or removed and re-inserted) that is then REMOVED again — the
 	 *   base-map loop of {@link #createMergedMap(TransactionalLayerMaintainer)} visits the key, but the instance it
 	 *   finds under it is the delegate's ORIGINAL, so the replacement is never visited either;
-	 * - a value DISPLACED by a plain overwrite — the key survives, but the base-map loop skips it precisely because
-	 *   it is now in {@link #modifiedKeys}, and that loop merges the new value, so the displaced instance is
-	 *   visited by neither.
+	 * - a value DISPLACED by a write — whether the key was overwritten outright or removed earlier in this
+	 *   transaction and re-inserted, the key survives and the base-map loop skips it precisely because it is now in
+	 *   {@link #modifiedKeys}, while the {@link #modifiedKeys} loop merges the NEW value, so the displaced instance
+	 *   is visited by neither. The two are one shape and are stashed by one rule; see {@link #put(Object, Object)}
+	 *   for why the release cannot be taken at the moment of the write.
 	 *
 	 * In all three the discarded instance's nested diff layer would orphan and fail the commit with
 	 * `StaleTransactionMemoryException`. Such an instance is stashed here the moment the transaction discards it —
@@ -259,6 +261,11 @@ public class MapChanges<K, V>
 	/**
 	 * Method records insertion / update of the record with particular key. The update is trapped within this object
 	 * data. If the record was not in original map the {@link #createdKeyCount} is incremented.
+	 *
+	 * It also owns half of the transactional-layer lifecycle this class maintains: a {@link TransactionalStateProducer}
+	 * value that the write DISPLACES is stashed into {@link #discardedProducers} for the survivor-guarded release at
+	 * commit, because after the write no commit-time loop visits it. {@link #remove(Object)} owns the other two
+	 * shapes. The body says why the release cannot be taken here.
 	 */
 	@Nullable
 	V put(@Nonnull K key, @Nullable V value) {
@@ -275,24 +282,30 @@ public class MapChanges<K, V>
 		}
 		// record the pending removed-key mutation so a savepoint rollback can reinstate it
 		journalRemovedKeyMembership(key);
-		if (this.removedKeys.remove(key)) {
-			// the key was removed earlier in this transaction and is now being re-inserted with a (potentially)
-			// different value — the original instance is discarded, so release its layer. The release is
-			// identity-based: keep the layer if some surviving key still references the very same instance.
-			if (originalValue instanceof TransactionalStateProducer<?> transactionalLayerProducer
-				&& originalValue != value
-				&& isInstanceNotReferencedBySurvivingKey(key, originalValue)
-			) {
-				transactionalLayerProducer.removeLayer();
-			}
-		} else if (originalValue instanceof TransactionalStateProducer && originalValue != value) {
-			// A PLAIN overwrite, with no removal anywhere: the key now resolves to the new value, so the
-			// commit-time base-map loop skips it (it is in `modifiedKeys`) while the `modifiedKeys` loop merges
-			// the NEW value — the displaced instance is visited by neither, and its nested diff layer orphans.
-			// `ProducerMapChanges#createMergedChampMap` skips it in the same way. Stashed rather than released
-			// here for the same reason removals are: callers may still read the displaced value's live
-			// in-transaction state, and the commit-time release is survivor-guarded, so an instance a surviving
-			// key still references keeps its layer.
+		// a key removed earlier in this transaction is being re-inserted, so it is no longer removed
+		this.removedKeys.remove(key);
+		if (originalValue instanceof TransactionalStateProducer && originalValue != value) {
+			// Whether the key was removed earlier in this transaction and is now re-inserted, or simply
+			// overwritten, the outcome is identical: the key resolves to the NEW value, so the commit-time
+			// base-map loop skips it (it is in `modifiedKeys`) while the `modifiedKeys` loop merges the new
+			// value — the displaced instance is visited by neither, and its nested diff layer orphans.
+			// `ProducerMapChanges#createMergedChampMap` skips it in the same way. Both shapes are therefore
+			// handled by ONE rule: stash the displaced instance and let `releaseOrphanedDiscardedLayers` release
+			// it at commit, under the identity-based survivor guard.
+			//
+			// Deferring is not a stylistic preference. Evaluated here, that guard answers from a key → value
+			// mapping that is not yet final, so an alias created LATER in the same transaction is invisible to it
+			// and the layer is released out from under a key that survives — after which `copyWithOwnLayer` finds
+			// no entry, `TransactionalLayerProducer#createCopyWithMergedTransactionalMemory` is handed a `null`
+			// layer, and the transaction commits having silently dropped the change. Nothing raises, because a
+			// released layer is exactly what `verifyLayerWasFullySwept` is looking for. At commit the mapping is
+			// final and the same guard sees every alias. It also keeps the value readable: callers legitimately
+			// read a discarded value's live in-transaction state afterwards (`HierarchyIndex
+			// #makeOrphansRecursively` iterates the removed `TransactionalIntArray`, then releases its layer
+			// itself — `removeLayer` is idempotent, so that explicit release simply makes this one a no-op).
+			//
+			// The cost is retention: the stash holds a strong reference to every displaced producer until commit,
+			// so a transaction churning many keys under one map holds more than an eager release would.
 			stashDiscardedProducer(originalValue);
 		}
 		return originalValue;
@@ -358,6 +371,19 @@ public class MapChanges<K, V>
 	 * just that set is both correct and `O(modifiedKeys)` rather than `O(mapDelegate)`; the latter would silently
 	 * degrade producer-map removals to `O(removed · N)` and defeat {@link ProducerMapChanges#createMergedChampMap}'s
 	 * intended `O(Δ·log₃₂N)` commit.
+	 *
+	 * **{@link ProducerMapChanges#markValueMutated} keys are deliberately not scanned either, and adding them would
+	 * not help.** A dirty key's value still lives in {@link #mapDelegate} — the very map excluded above — so a scan
+	 * of the dirty set would reach the same instances by a different route while missing the case that matters: a
+	 * mark records the key the *caller* used, so a second, unmarked delegate key can hold the same instance whether
+	 * or not the first was marked. Aliasing is a property of the delegate, not of dirtiness; only a full delegate
+	 * scan would close it, and that is the cost the design bought its way out of.
+	 *
+	 * **When the answer is taken matters as much as what is scanned.** Every caller evaluates this at commit, on
+	 * the final key → value mapping — the removal loops of both merge paths and the discarded-producer sweep.
+	 * Asking mid transaction would answer from a mapping that is not final yet, so an alias introduced by a later
+	 * statement would be invisible and its layer released out from under it; {@link #put(Object, Object)} carries
+	 * the worked example of why that failure is silent.
 	 *
 	 * @param removedKey the key being removed (excluded from the survivor scan); pass `null` to exclude nothing
 	 *                   (used by the discarded-producer stash sweep, where the instance no longer lives under any

--- a/evita_engine/src/main/java/io/evitadb/index/map/MapChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/map/MapChanges.java
@@ -82,19 +82,29 @@ public class MapChanges<K, V>
 	 */
 	private int createdKeyCount;
 	/**
-	 * Identity set of {@link TransactionalLayerProducer} values that were both CREATED and REMOVED within this same
-	 * transaction. Such a key ends up in neither {@link #mapDelegate} nor {@link #modifiedKeys} (and
-	 * {@link #createdKeyCount} is decremented back), so the commit-time sweep in
-	 * {@link #createMergedMap(TransactionalLayerMaintainer)} (and {@link ProducerMapChanges#createMergedChampMap}) would
-	 * never visit it — leaving its nested diff layer orphaned and failing the commit with
-	 * `StaleTransactionMemoryException`. These instances are stashed here on removal and released at commit by
-	 * {@link #releaseOrphanedCreatedThenRemovedLayers(TransactionalLayerMaintainer)} (survivor-guarded), which keeps the
-	 * value's layer ALIVE for the rest of the transaction so read-after-remove callers still see their in-transaction
-	 * state. Identity-based (`==`) on purpose: a producer owns its layer per-instance, so two content-equal instances
-	 * (e.g. two empty bitmaps) are independent layer owners. Lazily allocated — null until the first such removal, so
-	 * the common (no created-then-removed) path stays allocation-free.
+	 * Identity set of {@link TransactionalLayerProducer} values this transaction discarded and the commit-time sweep
+	 * can therefore no longer reach. Three shapes put a value here, and they are the three the sweep is blind to:
+	 *
+	 * - a value both CREATED and REMOVED within this transaction — its key ends up in neither {@link #mapDelegate} nor
+	 *   {@link #modifiedKeys} (and {@link #createdKeyCount} is decremented back), so nothing visits it;
+	 * - a REPLACEMENT value (the key was overwritten, or removed and re-inserted) that is then REMOVED again — the
+	 *   base-map loop of {@link #createMergedMap(TransactionalLayerMaintainer)} visits the key, but the instance it
+	 *   finds under it is the delegate's ORIGINAL, so the replacement is never visited either;
+	 * - a value DISPLACED by a plain overwrite — the key survives, but the base-map loop skips it precisely because
+	 *   it is now in {@link #modifiedKeys}, and that loop merges the new value, so the displaced instance is
+	 *   visited by neither.
+	 *
+	 * In all three the discarded instance's nested diff layer would orphan and fail the commit with
+	 * `StaleTransactionMemoryException`. Such an instance is stashed here the moment the transaction discards it —
+	 * in {@link #remove(Object)} for the first two shapes, in {@link #put(Object, Object)} for the third — and
+	 * released at commit by {@link #releaseOrphanedDiscardedLayers(TransactionalLayerMaintainer)}
+	 * (survivor-guarded), which keeps the value's layer ALIVE for the rest of the transaction so read-after-remove
+	 * callers still see their in-transaction state. Identity-based (`==`) on purpose: a producer owns its layer
+	 * per-instance, so two content-equal instances (e.g. two empty bitmaps) are independent layer owners. Lazily
+	 * allocated — null until the first discard, so the common path — where no discarded value needs one — stays
+	 * allocation-free.
 	 */
-	@Nullable private Set<Object> createdThenRemovedProducers;
+	@Nullable private Set<Object> discardedProducers;
 	/**
 	 * Function used to wrap result of {@link TransactionalLayerProducer#createCopyWithMergedTransactionalMemory(Object, TransactionalLayerMaintainer)}
 	 * to a {@link TransactionalLayerProducer} instance.
@@ -102,7 +112,7 @@ public class MapChanges<K, V>
 	private final Function<Object, V> transactionalLayerWrapper;
 	/**
 	 * Undo journal recording the inverse of every mutation of this layer's own diff containers ({@link #modifiedKeys},
-	 * {@link #removedKeys}, {@link #createdThenRemovedProducers}, and — for {@link ProducerMapChanges} — its
+	 * {@link #removedKeys}, {@link #discardedProducers}, and — for {@link ProducerMapChanges} — its
 	 * value-mutated-key set) while a savepoint is open. It enables an `O(1)` {@link #snapshot()} and an
 	 * `O(intra-savepoint-ops)` {@link #restore(MapChangesMemento)} instead of deep-copying the whole accumulated diff per
 	 * per-entity savepoint (the rollback cliff). Only this layer's OWN state is journaled — nested producer VALUES are
@@ -211,6 +221,17 @@ public class MapChanges<K, V>
 		if (containsCreatedOrModified((K) key)) {
 			if (existing) {
 				originalValue = removeModifiedKey((K) key);
+				// The key's CURRENT value is a REPLACEMENT recorded in this transaction (the key was removed and
+				// re-inserted, or simply overwritten), and it is now removed again. The commit-time base-map loop in
+				// createMergedMap only ever sees the DELEGATE's original instance under this key, so it releases that
+				// one and never the replacement - whose nested diff layer would then orphan and fail the commit with
+				// StaleTransactionMemoryException. Stash it under the same survivor-guarded, commit-time release as
+				// the created-then-removed case below, for the same reason it is not released eagerly: remove()
+				// returns the value and callers legitimately read its live in-transaction state afterwards.
+				if (originalValue instanceof TransactionalStateProducer
+					&& originalValue != this.mapDelegate.get(key)) {
+					stashDiscardedProducer(originalValue);
+				}
 			} else {
 				// the key was CREATED and is now REMOVED within this same transaction: after removal it lives in
 				// neither the delegate nor the modified set, so the commit-time sweep would never visit it and its
@@ -218,12 +239,12 @@ public class MapChanges<K, V>
 				// the value and callers legitimately read its live in-transaction state afterwards (e.g.
 				// HierarchyIndex.makeOrphansRecursively iterates the removed TransactionalIntArray, then releases the
 				// layer itself). Instead the discarded producer instance is stashed and released at commit time by
-				// releaseOrphanedCreatedThenRemovedLayers - keeping the layer ALIVE for the rest of the transaction
+				// releaseOrphanedDiscardedLayers - keeping the layer ALIVE for the rest of the transaction
 				// while still guaranteeing it is swept (releaseLayer is idempotent, so a caller's explicit release is
 				// harmless).
 				originalValue = removeCreatedKey((K) key);
 				if (originalValue instanceof TransactionalStateProducer) {
-					stashCreatedThenRemovedProducer(originalValue);
+					stashDiscardedProducer(originalValue);
 				}
 			}
 		} else {
@@ -264,6 +285,15 @@ public class MapChanges<K, V>
 			) {
 				transactionalLayerProducer.removeLayer();
 			}
+		} else if (originalValue instanceof TransactionalStateProducer && originalValue != value) {
+			// A PLAIN overwrite, with no removal anywhere: the key now resolves to the new value, so the
+			// commit-time base-map loop skips it (it is in `modifiedKeys`) while the `modifiedKeys` loop merges
+			// the NEW value — the displaced instance is visited by neither, and its nested diff layer orphans.
+			// `ProducerMapChanges#createMergedChampMap` skips it in the same way. Stashed rather than released
+			// here for the same reason removals are: callers may still read the displaced value's live
+			// in-transaction state, and the commit-time release is survivor-guarded, so an instance a surviving
+			// key still references keeps its layer.
+			stashDiscardedProducer(originalValue);
 		}
 		return originalValue;
 	}
@@ -330,7 +360,7 @@ public class MapChanges<K, V>
 	 * intended `O(Δ·log₃₂N)` commit.
 	 *
 	 * @param removedKey the key being removed (excluded from the survivor scan); pass `null` to exclude nothing
-	 *                   (used by the created-then-removed stash sweep, where the instance no longer lives under any
+	 *                   (used by the discarded-producer stash sweep, where the instance no longer lives under any
 	 *                   single key)
 	 * @param instance   the producer instance whose continued reference is being tested
 	 * @return `true` if no surviving key references the very same instance (i.e. its layer is safe to release)
@@ -347,31 +377,33 @@ public class MapChanges<K, V>
 	}
 
 	/**
-	 * Stashes a {@link TransactionalLayerProducer} value that was created and then removed within the same transaction,
-	 * so its (possibly ALIVE) nested diff layer can be released at commit by
-	 * {@link #releaseOrphanedCreatedThenRemovedLayers(TransactionalLayerMaintainer)}. See {@link #createdThenRemovedProducers}.
+	 * Stashes a {@link TransactionalLayerProducer} value this transaction discarded — created-then-removed, a
+	 * replacement that was removed again, or one displaced by an overwrite — so its (possibly ALIVE) nested diff
+	 * layer can be released at commit by
+	 * {@link #releaseOrphanedDiscardedLayers(TransactionalLayerMaintainer)}. See {@link #discardedProducers}.
 	 *
 	 * @param producer the discarded producer instance to track for commit-time release
 	 */
-	private void stashCreatedThenRemovedProducer(@Nonnull Object producer) {
-		if (this.createdThenRemovedProducers == null) {
-			this.createdThenRemovedProducers = Collections.newSetFromMap(new IdentityHashMap<>(32));
+	private void stashDiscardedProducer(@Nonnull Object producer) {
+		if (this.discardedProducers == null) {
+			this.discardedProducers = Collections.newSetFromMap(new IdentityHashMap<>(32));
 		}
-		final boolean added = this.createdThenRemovedProducers.add(producer);
+		final boolean added = this.discardedProducers.add(producer);
 		if (added && this.undoJournal != null) {
 			// undo just this stash addition; the container's null-vs-set existence is normalized by restore() via the
-			// memento's createdThenRemovedWasNull flag
+			// memento's discardedProducersWasNull flag
 			this.undoJournal.push(() -> {
-				if (this.createdThenRemovedProducers != null) {
-					this.createdThenRemovedProducers.remove(producer);
+				if (this.discardedProducers != null) {
+					this.discardedProducers.remove(producer);
 				}
 			});
 		}
 	}
 
 	/**
-	 * Releases the nested diff layers of producer values that were CREATED and then REMOVED within this transaction (see
-	 * {@link #createdThenRemovedProducers}). A stashed instance is released only when no surviving key still references
+	 * Releases the nested diff layers of the producer values this transaction discarded — created-then-removed,
+	 * replacements that were removed again, and values displaced by an overwrite (see
+	 * {@link #discardedProducers}). A stashed instance is released only when no surviving key still references
 	 * the very same instance (identity-based), so a value re-inserted under another key — or shared with a surviving key
 	 * — keeps its layer and is swept normally. Invoked at the end of both commit paths
 	 * ({@link #createMergedMap(TransactionalLayerMaintainer)} and {@link ProducerMapChanges#createMergedChampMap}). The
@@ -379,11 +411,11 @@ public class MapChanges<K, V>
 	 *
 	 * @param transactionalLayer the maintainer used to drop the orphaned layers
 	 */
-	protected void releaseOrphanedCreatedThenRemovedLayers(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		if (this.createdThenRemovedProducers == null) {
+	protected void releaseOrphanedDiscardedLayers(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
+		if (this.discardedProducers == null) {
 			return;
 		}
-		for (final Object instance : this.createdThenRemovedProducers) {
+		for (final Object instance : this.discardedProducers) {
 			if (instance instanceof TransactionalStateProducer<?> transactionalLayerProducer
 				&& isInstanceNotReferencedBySurvivingKey(null, instance)) {
 				transactionalLayerProducer.removeLayer(transactionalLayer);
@@ -435,7 +467,7 @@ public class MapChanges<K, V>
 	 * ordinary way, which is what the {@link TransactionalLayerProducer} contract does.
 	 *
 	 * Everything a merger must not be trusted with stays here: the identity-based survivor scan that decides whether a
-	 * removed value's layer may be released, and {@link #releaseOrphanedCreatedThenRemovedLayers} for values that never
+	 * removed value's layer may be released, and {@link #releaseOrphanedDiscardedLayers} for values that never
 	 * appear in either loop.
 	 *
 	 * @param transactionalLayer the maintainer resolving committed state
@@ -494,8 +526,8 @@ public class MapChanges<K, V>
 			copy.put(key, mergeSurvivingValue(transactionalLayer, valueMerger, key, entry.getValue()));
 		}
 
-		// release the layers of producers created-then-removed within this transaction (invisible to both loops above)
-		releaseOrphanedCreatedThenRemovedLayers(transactionalLayer);
+		// release the layers of the producer values this transaction discarded (invisible to both loops above)
+		releaseOrphanedDiscardedLayers(transactionalLayer);
 
 		return copy;
 	}
@@ -564,8 +596,9 @@ public class MapChanges<K, V>
 		 * Releases the transactional layer of a value whose key does not survive the commit. Called only for a removed
 		 * value that is itself a transactional producer, and only when no surviving key still references it.
 		 *
-		 * A value both created and removed within the same transaction never reaches this method — it appears under no
-		 * surviving key at all, so {@link MapChanges} releases its layer directly, bypassing the merger.
+		 * A value this transaction discarded — created then removed, a replacement removed again, or one displaced by a
+		 * plain overwrite — never reaches this method: it is the value of no surviving key, so {@link MapChanges}
+		 * releases its layer directly from {@link MapChanges#discardedProducers}, bypassing the merger.
 		 *
 		 * @param key   the removed key
 		 * @param value the value that was mapped to it
@@ -659,9 +692,9 @@ public class MapChanges<K, V>
 	/**
 	 * Captures the current mutable diff state into an independent memento (see
 	 * {@link Snapshotable#snapshot()}). The three mutable containers ({@link #removedKeys},
-	 * {@link #modifiedKeys}, {@link #createdThenRemovedProducers}) are deep-copied so a later mutation of this layer
+	 * {@link #modifiedKeys}, {@link #discardedProducers}) are deep-copied so a later mutation of this layer
 	 * cannot corrupt the memento, while {@link #createdKeyCount} is copied by value. Producer **values** held inside
-	 * {@link #modifiedKeys} (and the instances stashed in {@link #createdThenRemovedProducers}) are captured BY
+	 * {@link #modifiedKeys} (and the instances stashed in {@link #discardedProducers}) are captured BY
 	 * REFERENCE only — their own nested diff layers are snapshotted by their own {@link Snapshotable}, coordinated by
 	 * the maintainer-level savepoint. The immutable {@link #mapDelegate} baseline and the stateless
 	 * {@link #transactionalLayerWrapper} are deliberately excluded — they are shared-immutable and never change during
@@ -676,11 +709,11 @@ public class MapChanges<K, V>
 			this.undoJournal = new UndoJournal();
 		}
 		// O(1): mark the journal and copy only the value-typed scalars (the createdKeyCount and the lazy
-		// createdThenRemovedProducers null-vs-set existence). The unbounded containers are rewound via the journal.
+		// discardedProducers null-vs-set existence). The unbounded containers are rewound via the journal.
 		return new BaseMapChangesMemento<>(
 			this.undoJournal.mark(),
 			this.createdKeyCount,
-			this.createdThenRemovedProducers == null
+			this.discardedProducers == null
 		);
 	}
 
@@ -688,7 +721,7 @@ public class MapChanges<K, V>
 	 * Resets this diff layer back to the exact state captured by the given memento (see
 	 * {@link Snapshotable#restore(Object)}). The two `final` containers ({@link #removedKeys}, {@link #modifiedKeys})
 	 * are reset IN PLACE via `clear()` + `addAll`/`putAll` (they cannot be reassigned), {@link #createdKeyCount} is
-	 * reassigned by value, and {@link #createdThenRemovedProducers} is rebuilt as a fresh identity-backed set (or set
+	 * reassigned by value, and {@link #discardedProducers} is rebuilt as a fresh identity-backed set (or set
 	 * to `null` when the memento captured `null`, preserving the lazy-allocation invariant). State is copied OUT of the
 	 * memento so the same memento can be restored more than once. Producer values are restored BY REFERENCE only —
 	 * their internal state is never touched here.
@@ -700,14 +733,14 @@ public class MapChanges<K, V>
 		final BaseMapChangesMemento<K, V> baseState = baseStateOf(memento);
 		UndoJournal.assertRestorable(this.undoJournal, baseState.mark());
 		// replay the recorded inverse operations in reverse down to the mark, rewinding modifiedKeys / removedKeys /
-		// createdThenRemovedProducers (and, for the producer subclass, its value-mutated-key set) to the snapshot state
+		// discardedProducers (and, for the producer subclass, its value-mutated-key set) to the snapshot state
 		if (this.undoJournal != null) {
 			this.undoJournal.rollbackTo(baseState.mark());
 		}
 		// restore the value-typed scalars directly and normalize the lazy container existence to the snapshot moment
 		this.createdKeyCount = baseState.createdKeyCount();
-		if (baseState.createdThenRemovedWasNull()) {
-			this.createdThenRemovedProducers = null;
+		if (baseState.discardedProducersWasNull()) {
+			this.discardedProducers = null;
 		}
 	}
 
@@ -839,7 +872,7 @@ public class MapChanges<K, V>
 	/**
 	 * Copies the given set into a fresh identity-backed set ({@link Collections#newSetFromMap(Map)} over an
 	 * {@link IdentityHashMap}), preserving the `==` membership semantics required by
-	 * {@link #createdThenRemovedProducers}. A plain content-equality {@link HashSet} would conflate two content-equal
+	 * {@link #discardedProducers}. A plain content-equality {@link HashSet} would conflate two content-equal
 	 * but distinct producer-layer owners (e.g. two empty bitmaps) and corrupt the orphan-release decision.
 	 *
 	 * @param source the identity set to copy (elements captured by reference)
@@ -862,15 +895,15 @@ public class MapChanges<K, V>
 			// are re-attached by the maintainer's savepoint machinery, exactly as for put/remove.
 			final Map<K, V> modifiedCopy = new HashMap<>(this.modifiedKeys);
 			final Set<K> removedCopy = new HashSet<>(this.removedKeys);
-			final Set<Object> stashCopy = this.createdThenRemovedProducers == null
+			final Set<Object> stashCopy = this.discardedProducers == null
 				? null
-				: copyIdentitySet(this.createdThenRemovedProducers);
+				: copyIdentitySet(this.discardedProducers);
 			this.undoJournal.push(() -> {
 				this.modifiedKeys.clear();
 				this.modifiedKeys.putAll(modifiedCopy);
 				this.removedKeys.clear();
 				this.removedKeys.addAll(removedCopy);
-				this.createdThenRemovedProducers = stashCopy == null ? null : copyIdentitySet(stashCopy);
+				this.discardedProducers = stashCopy == null ? null : copyIdentitySet(stashCopy);
 			});
 		}
 		this.createdKeyCount = 0;
@@ -882,14 +915,14 @@ public class MapChanges<K, V>
 			}
 			it.remove();
 		}
-		// drop the layers of any created-then-removed producers stashed for the deferred commit-time release
-		if (this.createdThenRemovedProducers != null) {
-			for (final Object instance : this.createdThenRemovedProducers) {
+		// drop the layers of any discarded producers stashed for the deferred commit-time release
+		if (this.discardedProducers != null) {
+			for (final Object instance : this.discardedProducers) {
 				if (instance instanceof TransactionalStateProducer<?> transactionalStateProducer) {
 					transactionalStateProducer.removeLayer(transactionalLayer);
 				}
 			}
-			this.createdThenRemovedProducers = null;
+			this.discardedProducers = null;
 		}
 		this.removedKeys.addAll(this.mapDelegate.keySet());
 	}
@@ -915,7 +948,7 @@ public class MapChanges<K, V>
 	 * shares this layer's undo journal) to support savepoint rollback.
 	 *
 	 * It carries only value-typed scalars: the {@link UndoJournal#mark()} to rewind the layer's containers to, the
-	 * {@link MapChanges#createdKeyCount}, and whether {@link MapChanges#createdThenRemovedProducers} was `null`
+	 * {@link MapChanges#createdKeyCount}, and whether {@link MapChanges#discardedProducers} was `null`
 	 * (unallocated) at snapshot time (to preserve the lazy-allocation invariant). The unbounded containers are rewound
 	 * via the journal, not copied here; the {@link MapChanges#mapDelegate} baseline and the value wrapper are excluded
 	 * (shared-immutable). Nested producer VALUES are never touched — their own layers are governed by their own
@@ -923,14 +956,14 @@ public class MapChanges<K, V>
 	 *
 	 * @param mark                      the {@link UndoJournal#mark()} to rewind the layer to on restore
 	 * @param createdKeyCount           value copy of {@link MapChanges#createdKeyCount}
-	 * @param createdThenRemovedWasNull whether {@link MapChanges#createdThenRemovedProducers} was `null` at snapshot time
+	 * @param discardedProducersWasNull whether {@link MapChanges#discardedProducers} was `null` at snapshot time
 	 * @param <K> key type
 	 * @param <V> value type
 	 */
 	public record BaseMapChangesMemento<K, V>(
 		int mark,
 		int createdKeyCount,
-		boolean createdThenRemovedWasNull
+		boolean discardedProducersWasNull
 	) implements MapChangesMemento<K, V> {
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/map/ProducerMapChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/map/ProducerMapChanges.java
@@ -157,7 +157,7 @@ public class ProducerMapChanges<K, V> extends MapChanges<K, V> {
 	 * Precedence is unchanged: removed > created/modified > dirty. A dirty key covered by a higher-precedence pass is
 	 * skipped here, and a dirty key that appears in NONE of the three (created and removed again within the same
 	 * transaction, its key already dropped from the map while an earlier flush had recorded it as dirty) is skipped too —
-	 * its layer is released by {@link #releaseOrphanedCreatedThenRemovedLayers}, exactly as in the full-map merge, which
+	 * its layer is released by {@link #releaseOrphanedDiscardedLayers}, exactly as in the full-map merge, which
 	 * would not have visited it either.
 	 *
 	 * @param transactionalLayer the maintainer used to commit nested producer values
@@ -223,8 +223,8 @@ public class ProducerMapChanges<K, V> extends MapChanges<K, V> {
 			}
 		}
 
-		// 4) release layers of producers created-then-removed within this transaction (in none of the sets walked above)
-		releaseOrphanedCreatedThenRemovedLayers(transactionalLayer);
+		// 4) release the layers of the producer values this transaction discarded (in none of the sets walked above)
+		releaseOrphanedDiscardedLayers(transactionalLayer);
 
 		return result;
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/membership/ReducedIndexMembership.java
+++ b/evita_engine/src/main/java/io/evitadb/index/membership/ReducedIndexMembership.java
@@ -417,9 +417,17 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 	}
 
 	/**
-	 * Returns `true` when this map already knows the reduced index, whether as covered or as residual. Used by
-	 * the load-time build to skip a primary key the type index advertises more than once — a group reduced
-	 * index is advertised once per referenced entity filed under it.
+	 * Returns `true` when this map already knows the reduced index, whether as covered or as residual.
+	 *
+	 * **Nothing in production consults it.** Both sites that fill a map — `EntityCollection#registerReducedIndex`
+	 * at load and `ReferenceIndexMutator#seedFromAdvertisedIndexes` on the write path — register every advertised
+	 * primary key unguarded, because the traversal cannot advertise one twice: a reduced index is filed in its
+	 * type index under exactly one referenced (or group) primary key, and the two families draw their keys from
+	 * one collection-wide sequence. A repeat is therefore a programming error, and {@link #registerIndex} and
+	 * {@link #registerIndexAsResidual} refuse it rather than letting a pre-check swallow it.
+	 *
+	 * What it is for is asking what a map holds without deciding anything — tests and the measurement harnesses
+	 * that reproduce the load-time build outside the engine.
 	 *
 	 * @param indexPrimaryKey primary key of the reduced index
 	 * @return `true` when the index is already known

--- a/evita_engine/src/main/java/io/evitadb/index/membership/ReducedIndexMembership.java
+++ b/evita_engine/src/main/java/io/evitadb/index/membership/ReducedIndexMembership.java
@@ -228,6 +228,30 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 	}
 
 	/**
+	 * Registers a reduced index as residual without deciding coverage for it — the load path's treatment of a
+	 * reference that is **not** currently partitioned.
+	 *
+	 * Such a reference's reduced indexes are never visited by the sibling walk, so covering them would buy
+	 * nothing and cost one entry per membership. Recording them as residual costs one bit each and preserves
+	 * the invariant the whole design rests on: **a slice is absent only when the reference has no reduced
+	 * indexes at all.** That is what makes it safe for maintenance to create a slice on demand — an absent
+	 * slice cannot be hiding indexes that were loaded before maintenance started watching.
+	 *
+	 * @param indexPrimaryKey primary key of the reduced index
+	 * @throws GenericEvitaInternalError when the index is already known to this map
+	 */
+	public void registerIndexAsResidual(int indexPrimaryKey) {
+		Assert.isPremiseValid(
+			!this.coveredIndexPrimaryKeys.contains(indexPrimaryKey)
+				&& !this.residualIndexPrimaryKeys.contains(indexPrimaryKey),
+			() -> new GenericEvitaInternalError(
+				"Reduced index " + indexPrimaryKey + " is already known to the membership map!"
+			)
+		);
+		this.residualIndexPrimaryKeys.add(indexPrimaryKey);
+	}
+
+	/**
 	 * Forgets a reduced index entirely — it was dropped from the collection. The index leaves both the
 	 * covered and the residual set, so a later caller sees it as "never known" and walks it if it ever
 	 * reappears advertised.
@@ -261,8 +285,15 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 				recordMembership(ownerPrimaryKey, indexPrimaryKey);
 			}
 		} else if (this.residualIndexPrimaryKeys.contains(indexPrimaryKey)) {
-			// a residual index only grows on insert, so it can never demote here
-			this.residualIndexPrimaryKeys.add(indexPrimaryKey);
+			// A residual index grows on insert and so cannot outgrow anything - but it may be residual for a
+			// reason other than size: a slice seeded from a reference's advertisement records every index as
+			// residual without inspecting it, because seeding cannot resolve them. Demoting here is what lets
+			// such a slice acquire coverage as its indexes are written, and it cannot oscillate: promotion
+			// needs `T` owners and demotion `T/2`, so the two boundaries never meet.
+			if (size <= this.demotionThreshold) {
+				this.residualIndexPrimaryKeys.remove(indexPrimaryKey);
+				addCoverage(indexPrimaryKey, membersAfter);
+			}
 		} else {
 			// first time this index is seen - decide from scratch
 			registerIndex(indexPrimaryKey, membersAfter);
@@ -291,6 +322,19 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 				addCoverage(indexPrimaryKey, membersAfter);
 			}
 		}
+	}
+
+	/**
+	 * Returns `true` when this map already knows the reduced index, whether as covered or as residual. Used by
+	 * the load-time build to skip a primary key the type index advertises more than once — a group reduced
+	 * index is advertised once per referenced entity filed under it.
+	 *
+	 * @param indexPrimaryKey primary key of the reduced index
+	 * @return `true` when the index is already known
+	 */
+	public boolean isKnown(int indexPrimaryKey) {
+		return this.coveredIndexPrimaryKeys.contains(indexPrimaryKey)
+			|| this.residualIndexPrimaryKeys.contains(indexPrimaryKey);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/membership/ReducedIndexMembership.java
+++ b/evita_engine/src/main/java/io/evitadb/index/membership/ReducedIndexMembership.java
@@ -1,0 +1,470 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.membership;
+
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
+import io.evitadb.core.transaction.memory.VoidTransactionMemoryProducer;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.bitmap.EmptyBitmap;
+import io.evitadb.index.bitmap.TransactionalBitmap;
+import io.evitadb.index.map.TransactionalMap;
+import io.evitadb.utils.Assert;
+import io.evitadb.utils.CollectionUtils;
+import io.evitadb.utils.MemoryMeasuringConstants;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.PrimitiveIterator.OfInt;
+
+/**
+ * Reverse lookup answering "which reduced indexes of ONE reference hold this owner entity?", for the reduced
+ * indexes small enough to be worth covering.
+ *
+ * # What it is for
+ *
+ * `ReevaluateExpressionExecutor#collectOwnersOfReducedIndexes` answers that question by walking **every**
+ * reduced index a reference advertises and intersecting each one's member bitmap against the affected owners.
+ * That costs `O(total reduced indexes)` on every cross-entity conditional-facet trigger, regardless of how
+ * many owners the trigger touches — measured at 0.78 ms on a production catalog as configured, and 81-113 ms
+ * one schema flag away (issue #1529). This structure removes that walk for the indexes it covers.
+ *
+ * # Why only SOME indexes are covered
+ *
+ * Cost is per **membership** while benefit is per **index**: covering a reduced index holding 21,467 owners
+ * costs 21,467 entries and saves exactly one probe. Covering everything measured at 274.7 MiB against
+ * 36.3 MiB for a size threshold that still removes 96 % of the walk. So an index is covered only while it
+ * holds at most {@link #getCoverageThreshold()} owners; larger ones stay {@link #getResidualIndexPrimaryKeys()
+ * on the walk}, and references whose indexes are all large disqualify themselves automatically without any
+ * per-reference heuristic.
+ *
+ * Promotion out of coverage happens above the threshold and demotion back only at half of it. The hysteresis
+ * is what makes a crossing `O(1)` amortised: an index cannot cross upwards again until half a threshold's
+ * worth of owners have been added, so the `O(T)` rebuild of its entries is paid at most once per `T/2`
+ * writes. In `WARM_UP` indexes only grow, so each crosses at most once.
+ *
+ * # The safety property — this structure is an ACCELERATOR, never an AUTHORITY
+ *
+ * A reduced index is consulted through this map **only** when it is covered; every other index the reference
+ * advertises must still be walked. Consequently a missing entry, a stale entry or an entirely unpopulated
+ * instance can only make the trigger **slower**, never wrong — the walk still finds what the map does not.
+ * The single way to produce a wrong answer is to claim coverage this map cannot honour, which is why
+ * {@link #getResidualIndexPrimaryKeys()} and {@link #getCoveredIndexPrimaryKeys()} are exposed as a pair and
+ * why every caller is expected to treat "advertised but in neither" as *walk it*.
+ *
+ * That property is what makes the structure safe to ship against transactional memory, and it is what
+ * `ReducedIndexMembershipCompletenessTest` asserts — against the reduced indexes themselves as ground truth,
+ * rather than against this map's own bookkeeping.
+ *
+ * # Derived state
+ *
+ * Nothing here is persisted: it is a function of the reduced indexes' membership bitmaps, and is rebuilt when
+ * a collection is loaded. See {@link io.evitadb.index.component.ReducedIndexMembershipMapComponent} for the
+ * transactional-lifecycle half of that arrangement.
+ *
+ * @author Claude (issue #1529 sibling-resolver optimization), FG Forrest a.s. (c) 2026
+ */
+public class ReducedIndexMembership implements VoidTransactionMemoryProducer<ReducedIndexMembership> {
+
+	/**
+	 * Default maximum number of owners a reduced index may hold and still be covered by the reverse map.
+	 *
+	 * Measured on a production catalog: at this value the map covers 96 % of the walk for 13 % of the memory a
+	 * blanket structure would cost. The curve is steeply concave — `T`=1 already removes 86 % — so the exact
+	 * value is not delicate; what matters is that it is small.
+	 */
+	public static final int DEFAULT_COVERAGE_THRESHOLD = 16;
+
+	/**
+	 * Maximum owners a covered reduced index may hold. Crossing above it promotes the index to the residual
+	 * set.
+	 */
+	private final int coverageThreshold;
+
+	/**
+	 * Owner count at or below which a residual reduced index is demoted back into coverage. Half of
+	 * {@link #coverageThreshold}, which is what makes a crossing `O(1)` amortised.
+	 */
+	private final int demotionThreshold;
+
+	/**
+	 * Owner primary key to the primary keys of the covered reduced indexes holding it. Holds an entry only
+	 * for owners that belong to at least one covered index.
+	 */
+	@Nonnull private final TransactionalMap<Integer, TransactionalBitmap> indexPrimaryKeysByOwner;
+
+	/**
+	 * Union of {@link #indexPrimaryKeysByOwner}'s keys, kept as a bitmap so the affected-owner set can be
+	 * intersected against it once per reference instead of probing the map once per affected owner. That
+	 * single intersection is what makes splitting the structure per reference cost 0.4 % in the sparse shape
+	 * rather than a multiple of the map lookups.
+	 */
+	@Nonnull private final TransactionalBitmap coveredOwners;
+
+	/**
+	 * Primary keys of the reduced indexes this map covers. Exposed so a caller can tell "covered" from
+	 * "never seen" — the latter must be walked.
+	 */
+	@Nonnull private final TransactionalBitmap coveredIndexPrimaryKeys;
+
+	/**
+	 * Primary keys of the reduced indexes known to be above the threshold. Iterated directly by the trigger,
+	 * which is why it is materialised rather than derived by filtering the reference's full advertisement —
+	 * deriving it would pay exactly the `O(total indexes)` traversal this structure exists to remove.
+	 */
+	@Nonnull private final TransactionalBitmap residualIndexPrimaryKeys;
+
+	/**
+	 * Creates an empty membership map with the default threshold.
+	 */
+	public ReducedIndexMembership() {
+		this(DEFAULT_COVERAGE_THRESHOLD);
+	}
+
+	/**
+	 * Creates an empty membership map.
+	 *
+	 * @param coverageThreshold maximum owners a covered reduced index may hold; must be positive
+	 */
+	public ReducedIndexMembership(int coverageThreshold) {
+		this.coverageThreshold = coverageThreshold;
+		this.demotionThreshold = Math.max(1, coverageThreshold / 2);
+		this.indexPrimaryKeysByOwner = new TransactionalMap<>(
+			CollectionUtils.createHashMap(64), TransactionalBitmap.class, TransactionalBitmap::new
+		);
+		this.coveredOwners = new TransactionalBitmap();
+		this.coveredIndexPrimaryKeys = new TransactionalBitmap();
+		this.residualIndexPrimaryKeys = new TransactionalBitmap();
+	}
+
+	/**
+	 * Reconstructs the map from already-merged state. Used by
+	 * {@link #createCopyWithMergedTransactionalMemory(TransactionalLayerMaintainer)}.
+	 *
+	 * @param coverageThreshold       maximum owners a covered reduced index may hold
+	 * @param indexPrimaryKeysByOwner merged owner to covered-index map
+	 * @param coveredOwners           merged covered-owner set
+	 * @param coveredIndexPrimaryKeys merged covered-index set
+	 * @param residualIndexPrimaryKeys merged residual-index set
+	 */
+	private ReducedIndexMembership(
+		int coverageThreshold,
+		@Nonnull Map<Integer, TransactionalBitmap> indexPrimaryKeysByOwner,
+		@Nonnull Bitmap coveredOwners,
+		@Nonnull Bitmap coveredIndexPrimaryKeys,
+		@Nonnull Bitmap residualIndexPrimaryKeys
+	) {
+		this.coverageThreshold = coverageThreshold;
+		this.demotionThreshold = Math.max(1, coverageThreshold / 2);
+		this.indexPrimaryKeysByOwner = new TransactionalMap<>(
+			indexPrimaryKeysByOwner, TransactionalBitmap.class, TransactionalBitmap::new
+		);
+		this.coveredOwners = new TransactionalBitmap(coveredOwners);
+		this.coveredIndexPrimaryKeys = new TransactionalBitmap(coveredIndexPrimaryKeys);
+		this.residualIndexPrimaryKeys = new TransactionalBitmap(residualIndexPrimaryKeys);
+	}
+
+	/**
+	 * Returns the maximum number of owners a reduced index may hold and still be covered.
+	 *
+	 * @return the coverage threshold
+	 */
+	public int getCoverageThreshold() {
+		return this.coverageThreshold;
+	}
+
+	/**
+	 * Registers a reduced index whose membership is already known in full — the load path, where indexes
+	 * arrive populated, and the only place coverage is decided for more than one owner at a time.
+	 *
+	 * The index must not already be known. Re-registering a covered index would have to forget its previous
+	 * entries, and the only membership available to do that with is the one being passed in — which is the
+	 * NEW truth, so any owner that left in between would keep an entry naming an index it no longer belongs
+	 * to. Rather than leave that silently stale, this refuses: a caller that wants to re-decide an index's
+	 * coverage must {@link #unregisterIndex(int, Bitmap) unregister} it first, with the membership it had.
+	 *
+	 * @param indexPrimaryKey primary key of the reduced index
+	 * @param members         the owners the reduced index currently holds
+	 * @throws GenericEvitaInternalError when the index is already known to this map
+	 */
+	public void registerIndex(int indexPrimaryKey, @Nonnull Bitmap members) {
+		Assert.isPremiseValid(
+			!this.coveredIndexPrimaryKeys.contains(indexPrimaryKey)
+				&& !this.residualIndexPrimaryKeys.contains(indexPrimaryKey),
+			() -> new GenericEvitaInternalError(
+				"Reduced index " + indexPrimaryKey + " is already known to the membership map - re-registering " +
+					"it would silently strand the entries built from its previous membership. Unregister it " +
+					"first, passing the membership it had."
+			)
+		);
+		if (members.size() > this.coverageThreshold) {
+			this.residualIndexPrimaryKeys.add(indexPrimaryKey);
+		} else if (!members.isEmpty()) {
+			addCoverage(indexPrimaryKey, members);
+		}
+	}
+
+	/**
+	 * Forgets a reduced index entirely — it was dropped from the collection. The index leaves both the
+	 * covered and the residual set, so a later caller sees it as "never known" and walks it if it ever
+	 * reappears advertised.
+	 *
+	 * @param indexPrimaryKey primary key of the reduced index that was dropped
+	 * @param members         the owners it held, so its entries can be forgotten in one pass over them rather
+	 *                        than a scan of every owner the reference knows
+	 */
+	public void unregisterIndex(int indexPrimaryKey, @Nonnull Bitmap members) {
+		dropCoverage(indexPrimaryKey, members);
+		this.residualIndexPrimaryKeys.remove(indexPrimaryKey);
+	}
+
+	/**
+	 * Records that an owner has entered a reduced index, and re-decides that index's coverage.
+	 *
+	 * @param indexPrimaryKey primary key of the reduced index the owner entered
+	 * @param ownerPrimaryKey primary key of the owner entity
+	 * @param membersAfter    the owners the reduced index holds AFTER the insert, used both for the size
+	 *                        decision and, on a crossing, to rebuild the index's entries
+	 */
+	public void ownerAdded(int indexPrimaryKey, int ownerPrimaryKey, @Nonnull Bitmap membersAfter) {
+		final int size = membersAfter.size();
+		if (this.coveredIndexPrimaryKeys.contains(indexPrimaryKey)) {
+			if (size > this.coverageThreshold) {
+				// promotion: the index has outgrown coverage, so its entries are removed in one pass over its
+				// own members - bounded by the threshold plus one, never by the reference's owner count
+				dropCoverage(indexPrimaryKey, membersAfter);
+				this.residualIndexPrimaryKeys.add(indexPrimaryKey);
+			} else {
+				recordMembership(ownerPrimaryKey, indexPrimaryKey);
+			}
+		} else if (this.residualIndexPrimaryKeys.contains(indexPrimaryKey)) {
+			// a residual index only grows on insert, so it can never demote here
+			this.residualIndexPrimaryKeys.add(indexPrimaryKey);
+		} else {
+			// first time this index is seen - decide from scratch
+			registerIndex(indexPrimaryKey, membersAfter);
+		}
+	}
+
+	/**
+	 * Records that an owner has left a reduced index, and re-decides that index's coverage.
+	 *
+	 * @param indexPrimaryKey primary key of the reduced index the owner left
+	 * @param ownerPrimaryKey primary key of the owner entity
+	 * @param membersAfter    the owners the reduced index holds AFTER the removal
+	 */
+	public void ownerRemoved(int indexPrimaryKey, int ownerPrimaryKey, @Nonnull Bitmap membersAfter) {
+		if (this.coveredIndexPrimaryKeys.contains(indexPrimaryKey)) {
+			forgetMembership(ownerPrimaryKey, indexPrimaryKey);
+			if (membersAfter.isEmpty()) {
+				unregisterIndex(indexPrimaryKey, membersAfter);
+			}
+		} else if (this.residualIndexPrimaryKeys.contains(indexPrimaryKey)) {
+			if (membersAfter.isEmpty()) {
+				unregisterIndex(indexPrimaryKey, membersAfter);
+			} else if (membersAfter.size() <= this.demotionThreshold) {
+				// demotion: shrunk far enough below the threshold that the hysteresis band is cleared
+				this.residualIndexPrimaryKeys.remove(indexPrimaryKey);
+				addCoverage(indexPrimaryKey, membersAfter);
+			}
+		}
+	}
+
+	/**
+	 * Returns the primary keys of the reduced indexes this map covers.
+	 *
+	 * @return covered reduced-index primary keys; never `null`
+	 */
+	@Nonnull
+	public Bitmap getCoveredIndexPrimaryKeys() {
+		return this.coveredIndexPrimaryKeys;
+	}
+
+	/**
+	 * Returns the primary keys of the reduced indexes left on the walk because they hold more owners than the
+	 * threshold allows.
+	 *
+	 * @return residual reduced-index primary keys; never `null`
+	 */
+	@Nonnull
+	public Bitmap getResidualIndexPrimaryKeys() {
+		return this.residualIndexPrimaryKeys;
+	}
+
+	/**
+	 * Returns the owners that belong to at least one covered reduced index, so the affected set can be
+	 * narrowed by a single intersection before any map lookup happens.
+	 *
+	 * @return covered owner primary keys; never `null`
+	 */
+	@Nonnull
+	public Bitmap getCoveredOwners() {
+		return this.coveredOwners;
+	}
+
+	/**
+	 * Returns the covered reduced indexes holding the given owner.
+	 *
+	 * @param ownerPrimaryKey primary key of the owner entity
+	 * @return the covered reduced-index primary keys, or {@link EmptyBitmap#INSTANCE} when the owner belongs
+	 * to no covered index
+	 */
+	@Nonnull
+	public Bitmap getIndexPrimaryKeys(int ownerPrimaryKey) {
+		final TransactionalBitmap indexes = this.indexPrimaryKeysByOwner.get(ownerPrimaryKey);
+		return indexes == null ? EmptyBitmap.INSTANCE : indexes;
+	}
+
+	/**
+	 * Returns `true` when the map holds no coverage and no residual knowledge at all, which is how a
+	 * collection that never fired a cross-entity trigger stays free of charge.
+	 *
+	 * @return `true` when nothing is known
+	 */
+	public boolean isEmpty() {
+		return this.coveredIndexPrimaryKeys.isEmpty() && this.residualIndexPrimaryKeys.isEmpty();
+	}
+
+	/**
+	 * Estimates the heap this map occupies, using the engine's own accounting so the figure is comparable
+	 * with every other index structure's.
+	 *
+	 * @return estimated size in bytes
+	 */
+	public long getHeapSizeInBytes() {
+		return MemoryMeasuringConstants.OBJECT_HEADER_SIZE +
+			2 * MemoryMeasuringConstants.INT_SIZE +
+			4 * MemoryMeasuringConstants.REFERENCE_SIZE +
+			this.indexPrimaryKeysByOwner.getHeapSizeInBytes(
+				key -> (long) MemoryMeasuringConstants.OBJECT_HEADER_SIZE + MemoryMeasuringConstants.INT_SIZE,
+				TransactionalBitmap::getHeapSizeInBytes
+			) +
+			this.coveredOwners.getHeapSizeInBytes() +
+			this.coveredIndexPrimaryKeys.getHeapSizeInBytes() +
+			this.residualIndexPrimaryKeys.getHeapSizeInBytes();
+	}
+
+	@Nonnull
+	@Override
+	public ReducedIndexMembership createCopyWithMergedTransactionalMemory(
+		@Nonnull TransactionalLayerMaintainer transactionalLayer
+	) {
+		return new ReducedIndexMembership(
+			this.coverageThreshold,
+			transactionalLayer.getStateCopyWithCommittedChanges(this.indexPrimaryKeysByOwner),
+			transactionalLayer.getStateCopyWithCommittedChanges(this.coveredOwners),
+			transactionalLayer.getStateCopyWithCommittedChanges(this.coveredIndexPrimaryKeys),
+			transactionalLayer.getStateCopyWithCommittedChanges(this.residualIndexPrimaryKeys)
+		);
+	}
+
+	@Override
+	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
+		this.indexPrimaryKeysByOwner.removeLayer(transactionalLayer);
+		this.coveredOwners.removeLayer(transactionalLayer);
+		this.coveredIndexPrimaryKeys.removeLayer(transactionalLayer);
+		this.residualIndexPrimaryKeys.removeLayer(transactionalLayer);
+	}
+
+	/*
+		PRIVATE METHODS
+	 */
+
+	/**
+	 * Brings a reduced index into coverage, recording one membership per owner it holds.
+	 *
+	 * @param indexPrimaryKey primary key of the reduced index
+	 * @param members         the owners it holds
+	 */
+	private void addCoverage(int indexPrimaryKey, @Nonnull Bitmap members) {
+		final OfInt it = members.iterator();
+		while (it.hasNext()) {
+			recordMembership(it.nextInt(), indexPrimaryKey);
+		}
+		this.coveredIndexPrimaryKeys.add(indexPrimaryKey);
+	}
+
+	/**
+	 * Removes a reduced index from coverage, forgetting every membership naming it.
+	 *
+	 * Iterates the index's OWN members rather than the reference's owners, which is what keeps a promotion
+	 * bounded by the threshold instead of by the size of the whole slice. The caller must therefore pass the
+	 * membership the coverage was built from — every entry this map holds for the index names an owner in
+	 * that set, because entries are only ever created from it and are removed in lockstep by
+	 * {@link #ownerRemoved(int, int, Bitmap)}.
+	 *
+	 * @param indexPrimaryKey primary key of the reduced index
+	 * @param members         the owners the index holds
+	 */
+	private void dropCoverage(int indexPrimaryKey, @Nonnull Bitmap members) {
+		if (!this.coveredIndexPrimaryKeys.contains(indexPrimaryKey)) {
+			return;
+		}
+		final OfInt it = members.iterator();
+		while (it.hasNext()) {
+			forgetMembership(it.nextInt(), indexPrimaryKey);
+		}
+		this.coveredIndexPrimaryKeys.remove(indexPrimaryKey);
+	}
+
+	/**
+	 * Records that an owner belongs to a covered reduced index.
+	 *
+	 * @param ownerPrimaryKey primary key of the owner entity
+	 * @param indexPrimaryKey primary key of the covered reduced index
+	 */
+	private void recordMembership(int ownerPrimaryKey, int indexPrimaryKey) {
+		final TransactionalBitmap existing = this.indexPrimaryKeysByOwner.get(ownerPrimaryKey);
+		if (existing == null) {
+			this.indexPrimaryKeysByOwner.put(
+				ownerPrimaryKey, new TransactionalBitmap(new BaseBitmap(indexPrimaryKey))
+			);
+			this.coveredOwners.add(ownerPrimaryKey);
+		} else {
+			existing.add(indexPrimaryKey);
+		}
+	}
+
+	/**
+	 * Forgets that an owner belongs to a covered reduced index, dropping the owner entirely when it was its
+	 * last one.
+	 *
+	 * @param ownerPrimaryKey primary key of the owner entity
+	 * @param indexPrimaryKey primary key of the covered reduced index
+	 */
+	private void forgetMembership(int ownerPrimaryKey, int indexPrimaryKey) {
+		final TransactionalBitmap existing = this.indexPrimaryKeysByOwner.get(ownerPrimaryKey);
+		if (existing == null) {
+			return;
+		}
+		existing.remove(indexPrimaryKey);
+		if (existing.isEmpty()) {
+			this.indexPrimaryKeysByOwner.remove(ownerPrimaryKey);
+			this.coveredOwners.remove(ownerPrimaryKey);
+		}
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/index/membership/ReducedIndexMembership.java
+++ b/evita_engine/src/main/java/io/evitadb/index/membership/ReducedIndexMembership.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.index.membership;
 
+import io.evitadb.api.index.EntityIndexType;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.VoidTransactionMemoryProducer;
@@ -36,7 +37,6 @@ import io.evitadb.utils.CollectionUtils;
 import io.evitadb.utils.MemoryMeasuringConstants;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.PrimitiveIterator.OfInt;
 
@@ -68,12 +68,37 @@ import java.util.PrimitiveIterator.OfInt;
  *
  * # The safety property — this structure is an ACCELERATOR, never an AUTHORITY
  *
- * A reduced index is consulted through this map **only** when it is covered; every other index the reference
- * advertises must still be walked. Consequently a missing entry, a stale entry or an entirely unpopulated
- * instance can only make the trigger **slower**, never wrong — the walk still finds what the map does not.
- * The single way to produce a wrong answer is to claim coverage this map cannot honour, which is why
- * {@link #getResidualIndexPrimaryKeys()} and {@link #getCoveredIndexPrimaryKeys()} are exposed as a pair and
- * why every caller is expected to treat "advertised but in neither" as *walk it*.
+ * The map is read as an index **selector**: it says which reduced indexes are worth probing for a given set of
+ * owners, and each selected index is then asked itself who is in it. Nothing recorded here is taken as an
+ * answer. So a stale entry can only send the probe at an index that turns out to hold no affected owner, an
+ * entry naming an index the collection no longer holds is dropped when that index fails to resolve, and an
+ * instance that decided coverage for nothing leaves every advertised index in the residual set — which is
+ * precisely the walk this structure exists to save. **Slower**, never wrong.
+ *
+ * What the map must never do is *omit* an index its reference advertises. The residual set is probed whole,
+ * but a covered index is probed only while some covered owner names it, so an owner that entered a covered
+ * index unrecorded is an owner the trigger will not consider. That is why `covered ∪ residual == advertised`
+ * is the invariant this structure is maintained against, why {@link #getResidualIndexPrimaryKeys()} and
+ * {@link #getCoveredIndexPrimaryKeys()} are exposed as a pair, and why the whole slice is discarded by the
+ * schema change that stops maintenance following its reference — see
+ * `EntityCollection#discardUnmaintainedReducedIndexMemberships`.
+ *
+ * Note what that invariant is **not**: the resolver never re-derives the advertisement to check it. Reading it
+ * would pay the very `O(total reduced indexes)` traversal the structure removes, so a slice that exists is
+ * probed exactly as it stands, and an index missing from both sets is simply never visited. Nothing at read
+ * time will notice. The extreme case is worth naming, because it reads as the harmless one: a slice that is
+ * **present with both sets empty**, while its reference still advertises indexes, makes the trigger skip every
+ * one of them — a wrong facet, not a slow one. Absence of the whole slice is the safe state; an empty slice is
+ * not.
+ *
+ * What enforces the invariant is therefore a test, not a runtime check:
+ * `ReducedIndexMembershipCompletenessTest#assertMembershipMatchesIndexes` compares `covered ∪ residual` against
+ * the reference's live advertisement, for every reference in every scope, and fails outright on exactly that
+ * state. **That assertion is the contract** — not the fact that
+ * `ReferenceIndexMutator#seedFromAdvertisedIndexes` happens to fill a fresh slice before anything reads it. A
+ * contract resting on one call site being reached is one refactor away from breaking silently, so a maintainer
+ * adding another site that builds, seeds or maintains a slice has no safety net downstream of it at run time:
+ * that test is what has to be made to fail first.
  *
  * That property is what makes the structure safe to ship against transactional memory, and it is what
  * `ReducedIndexMembershipCompletenessTest` asserts — against the reduced indexes themselves as ground truth,
@@ -88,6 +113,19 @@ import java.util.PrimitiveIterator.OfInt;
  * @author Claude (issue #1529 sibling-resolver optimization), FG Forrest a.s. (c) 2026
  */
 public class ReducedIndexMembership implements VoidTransactionMemoryProducer<ReducedIndexMembership> {
+
+	/**
+	 * The two families of `REFERENCED_*_TYPE` index a reference may own. Together they define what "advertised"
+	 * means for the `covered ∪ residual == advertised` invariant this structure is maintained against: both
+	 * advertise reduced indexes the cross-entity facet trigger consults, and neither stands in for the other.
+	 *
+	 * Shared by every site that builds or seeds a lookup — `EntityCollection#rebuildReducedIndexMembership` at
+	 * load and `ReferenceIndexMutator#seedFromAdvertisedIndexes` on the first write after a reference is raised
+	 * — so a third family could never be added to one of them and forgotten in the other.
+	 */
+	public static final EntityIndexType[] REFERENCED_TYPE_INDEX_FAMILIES = {
+		EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
+	};
 
 	/**
 	 * Default maximum number of owners a reduced index may hold and still be covered by the reverse map.
@@ -228,14 +266,15 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 	}
 
 	/**
-	 * Registers a reduced index as residual without deciding coverage for it — the load path's treatment of a
-	 * reference that is **not** currently partitioned.
+	 * Registers a reduced index as residual without deciding coverage for it — for the callers that cannot read
+	 * the index's members and so cannot decide.
 	 *
-	 * Such a reference's reduced indexes are never visited by the sibling walk, so covering them would buy
-	 * nothing and cost one entry per membership. Recording them as residual costs one bit each and preserves
-	 * the invariant the whole design rests on: **a slice is absent only when the reference has no reduced
-	 * indexes at all.** That is what makes it safe for maintenance to create a slice on demand — an absent
-	 * slice cannot be hiding indexes that were loaded before maintenance started watching.
+	 * Two do. Seeding a slice created after the collection was loaded
+	 * (`ReferenceIndexMutator#seedFromAdvertisedIndexes`) has only the reference's advertisement to work from,
+	 * and the load-time build has to record an advertised index it cannot resolve. Both need the same thing:
+	 * the index accounted for, so `covered ∪ residual == advertised` holds, and left on the probe, which is
+	 * where it was before this structure existed. {@link #ownerAdded} demotes such an index into coverage the
+	 * next time it is written, so nothing stays needlessly residual.
 	 *
 	 * @param indexPrimaryKey primary key of the reduced index
 	 * @throws GenericEvitaInternalError when the index is already known to this map
@@ -383,8 +422,11 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 	}
 
 	/**
-	 * Returns `true` when the map holds no coverage and no residual knowledge at all, which is how a
-	 * collection that never fired a cross-entity trigger stays free of charge.
+	 * Returns `true` when the map holds no coverage and no residual knowledge at all — the state a freshly
+	 * created slice is in before it is seeded, and the state it returns to once its reference's last reduced
+	 * index is dropped. A collection that never fires a cross-entity trigger holds no slice at all rather than
+	 * an empty one, so this is not the predicate for "this collection pays nothing"; that answer is the absence
+	 * of the whole slice, see `GlobalEntityIndex#getReducedIndexMembership`.
 	 *
 	 * @return `true` when nothing is known
 	 */

--- a/evita_engine/src/main/java/io/evitadb/index/membership/ReducedIndexMembership.java
+++ b/evita_engine/src/main/java/io/evitadb/index/membership/ReducedIndexMembership.java
@@ -24,9 +24,9 @@
 package io.evitadb.index.membership;
 
 import io.evitadb.api.index.EntityIndexType;
-import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.VoidTransactionMemoryProducer;
+import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.EmptyBitmap;
@@ -34,7 +34,7 @@ import io.evitadb.index.bitmap.TransactionalBitmap;
 import io.evitadb.index.map.TransactionalMap;
 import io.evitadb.utils.Assert;
 import io.evitadb.utils.CollectionUtils;
-import io.evitadb.utils.MemoryMeasuringConstants;
+import io.evitadb.utils.VMLayout;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
@@ -100,9 +100,9 @@ import java.util.PrimitiveIterator.OfInt;
  * adding another site that builds, seeds or maintains a slice has no safety net downstream of it at run time:
  * that test is what has to be made to fail first.
  *
- * That property is what makes the structure safe to ship against transactional memory, and it is what
- * `ReducedIndexMembershipCompletenessTest` asserts — against the reduced indexes themselves as ground truth,
- * rather than against this map's own bookkeeping.
+ * The accelerator property — **slower**, never wrong — is what makes the structure safe to ship against
+ * transactional memory, and that test is what holds it to it: against the reduced indexes themselves as ground
+ * truth, rather than against this map's own bookkeeping.
  *
  * # Derived state
  *
@@ -163,15 +163,32 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 	@Nonnull private final TransactionalBitmap coveredOwners;
 
 	/**
-	 * Primary keys of the reduced indexes this map covers. Exposed so a caller can tell "covered" from
-	 * "never seen" — the latter must be walked.
+	 * Primary keys of the reduced indexes this map covers. Exposed as a pair with
+	 * {@link #residualIndexPrimaryKeys} so a caller can tell "covered" from "residual", and so the union of the
+	 * two can be checked against the reference's advertisement.
+	 *
+	 * It is **not** a fall-back signal. A slice that exists is probed exactly as it stands — the resolver never
+	 * re-derives the advertisement, because reading it would pay the very traversal this structure removes — so
+	 * an index in neither set is not walked, it is never visited at all. Only the absence of the whole slice
+	 * restores the walk.
 	 */
 	@Nonnull private final TransactionalBitmap coveredIndexPrimaryKeys;
 
 	/**
-	 * Primary keys of the reduced indexes known to be above the threshold. Iterated directly by the trigger,
-	 * which is why it is materialised rather than derived by filtering the reference's full advertisement —
-	 * deriving it would pay exactly the `O(total indexes)` traversal this structure exists to remove.
+	 * Primary keys of the reduced indexes left on the walk. An index above the threshold is always here, but the
+	 * converse does not hold: size is only ONE of the reasons an index lands in this set, so reading membership
+	 * of it as "this index holds more than `T` owners" is wrong.
+	 *
+	 * - {@link #registerIndexAsResidual} records an index whose membership the caller could not read at all, so
+	 *   a slice seeded by `ReferenceIndexMutator#seedFromAdvertisedIndexes` has EVERY advertised index here
+	 *   regardless of size, and so does one whose index failed to resolve at load;
+	 * - {@link #registerIndex}'s third arm records an index that arrived holding nobody;
+	 * - a small index registered either way stays here until it is written again — only {@link #ownerAdded} and
+	 *   {@link #ownerRemoved} demote, so a slice whose indexes are never written again never converges.
+	 *
+	 * Iterated directly by the trigger, which is why it is materialised rather than derived by filtering the
+	 * reference's full advertisement — deriving it would pay exactly the `O(total indexes)` traversal this
+	 * structure exists to remove.
 	 */
 	@Nonnull private final TransactionalBitmap residualIndexPrimaryKeys;
 
@@ -244,6 +261,9 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 	 * to. Rather than leave that silently stale, this refuses: a caller that wants to re-decide an index's
 	 * coverage must {@link #unregisterIndex(int, Bitmap) unregister} it first, with the membership it had.
 	 *
+	 * An index arriving with an EMPTY membership is accounted for as residual rather than dropped — see the
+	 * third arm for why that state is unreachable and why it is nevertheless handled rather than raised on.
+	 *
 	 * @param indexPrimaryKey primary key of the reduced index
 	 * @param members         the owners the reduced index currently holds
 	 * @throws GenericEvitaInternalError when the index is already known to this map
@@ -262,6 +282,23 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 			this.residualIndexPrimaryKeys.add(indexPrimaryKey);
 		} else if (!members.isEmpty()) {
 			addCoverage(indexPrimaryKey, members);
+		} else {
+			// An advertised index holding nobody. Upstream it does not arise: `ReferenceIndexMutator
+			// #referenceRemovalPerComponent` un-advertises the reduced index in the same synchronous step in
+			// which its last owner leaves, because `ReferencedTypeEntityIndex` counts owners per (index,
+			// referenced entity) tuple and drops the advertisement on the 1 -> 0 crossing. So an index that is
+			// advertised has an owner, and this arm is dead.
+			// It is accounted for rather than raised on all the same. The only caller that could reach it is the
+			// load path (`EntityCollection#registerReducedIndex`), where refusing would take the whole catalog
+			// offline over an index that holds nobody - and one that holds nobody can hold no affected owner
+			// either, so the trigger skipping it produces no wrong answer. Recording it as residual is not a
+			// silent skip: it accounts for the index, keeps `covered ∪ residual == advertised` true
+			// UNCONDITIONALLY rather than by inherited argument, and leaves it on the probe, which is where it
+			// was before this structure existed. Coverage would be the wrong half - an index with no owners
+			// records no owner entry, so it would be selected for no probe at all. The cost when it fires is one
+			// probe that yields nothing; the lockstep itself is asserted, not argued, by
+			// `ReducedIndexMembershipCompletenessTest#assertMembershipMatchesIndexes`.
+			this.residualIndexPrimaryKeys.add(indexPrimaryKey);
 		}
 	}
 
@@ -326,9 +363,10 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 		} else if (this.residualIndexPrimaryKeys.contains(indexPrimaryKey)) {
 			// A residual index grows on insert and so cannot outgrow anything - but it may be residual for a
 			// reason other than size: a slice seeded from a reference's advertisement records every index as
-			// residual without inspecting it, because seeding cannot resolve them. Demoting here is what lets
-			// such a slice acquire coverage as its indexes are written, and it cannot oscillate: promotion
-			// needs `T` owners and demotion `T/2`, so the two boundaries never meet.
+			// residual without inspecting it, because seeding cannot resolve them, and `registerIndex` records
+			// an index that arrived with no members the same way. Demoting here is what lets such a
+			// slice acquire coverage as its indexes are written, and it cannot oscillate: promotion needs `T`
+			// owners and demotion `T/2`, so the two boundaries never meet.
 			if (size <= this.demotionThreshold) {
 				this.residualIndexPrimaryKeys.remove(indexPrimaryKey);
 				addCoverage(indexPrimaryKey, membersAfter);
@@ -341,6 +379,17 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 
 	/**
 	 * Records that an owner has left a reduced index, and re-decides that index's coverage.
+	 *
+	 * **Unregistering on an empty `membersAfter` is correct only because of an upstream lockstep**, and the two
+	 * sites do not otherwise mention each other: `ReferenceIndexMutator#referenceRemovalPerComponent`
+	 * un-advertises the same reduced index a few lines before it reaches this method, on the 1 -> 0 crossing of
+	 * `ReferencedTypeEntityIndex`'s per-tuple owner counter. So what is dropped here is an index the reference
+	 * no longer advertises either, and `covered ∪ residual == advertised` survives the drop. A change that
+	 * defers or conditions that un-advertise leaves an advertised index in neither set — after which the trigger
+	 * never visits it — so it is the one remaining way to break the invariant, and
+	 * `ReducedIndexMembershipCompletenessTest#assertMembershipMatchesIndexes` is what catches it. Keeping such
+	 * an index accounted instead is not the answer: {@link #unregisterIndex(int, Bitmap)} has no other caller,
+	 * so it would leak one residual entry per dropped index for the life of the collection.
 	 *
 	 * @param indexPrimaryKey primary key of the reduced index the owner left
 	 * @param ownerPrimaryKey primary key of the owner entity
@@ -361,6 +410,10 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 				addCoverage(indexPrimaryKey, membersAfter);
 			}
 		}
+		// An index in neither set falls through deliberately, and must NOT raise. This path's job is to absorb
+		// drift: the map is an accelerator whose entries are allowed to be stale, so a removal naming an index
+		// it never knew about has nothing to correct. Raising would convert benign staleness into a failed
+		// commit, which is a strictly worse trade than the wasted call.
 	}
 
 	/**
@@ -387,8 +440,10 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 	}
 
 	/**
-	 * Returns the primary keys of the reduced indexes left on the walk because they hold more owners than the
-	 * threshold allows.
+	 * Returns the primary keys of the reduced indexes left on the walk — those known to hold more owners than
+	 * the threshold allows, AND those accounted for without their membership being readable. A caller must not
+	 * infer a size from membership of this set; see {@link #residualIndexPrimaryKeys} for the full list of ways
+	 * an index arrives here.
 	 *
 	 * @return residual reduced-index primary keys; never `null`
 	 */
@@ -435,17 +490,22 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 	}
 
 	/**
-	 * Estimates the heap this map occupies, using the engine's own accounting so the figure is comparable
-	 * with every other index structure's.
+	 * Estimates the heap this map occupies, through {@link VMLayout} — the accounting the enclosing sum uses.
+	 * The figure is added straight into `GlobalEntityIndex#getHeapSizeInBytes`, whose other terms are all
+	 * {@link VMLayout}-based, so measuring this one against different header and reference widths would report
+	 * a single number assembled from two models.
 	 *
 	 * @return estimated size in bytes
 	 */
 	public long getHeapSizeInBytes() {
-		return MemoryMeasuringConstants.OBJECT_HEADER_SIZE +
-			2 * MemoryMeasuringConstants.INT_SIZE +
-			4 * MemoryMeasuringConstants.REFERENCE_SIZE +
+		final VMLayout layout = VMLayout.current();
+		// the map charges its own keys: an owner primary key is boxed once per entry and held here alone
+		final long boxedInteger = layout.sizeOfObject(Integer.BYTES);
+		// the two thresholds, plus the indexPrimaryKeysByOwner / coveredOwners / coveredIndexPrimaryKeys /
+		// residualIndexPrimaryKeys slots
+		return layout.sizeOfObject(2L * Integer.BYTES + 4L * layout.referenceSize()) +
 			this.indexPrimaryKeysByOwner.getHeapSizeInBytes(
-				key -> (long) MemoryMeasuringConstants.OBJECT_HEADER_SIZE + MemoryMeasuringConstants.INT_SIZE,
+				key -> boxedInteger,
 				TransactionalBitmap::getHeapSizeInBytes
 			) +
 			this.coveredOwners.getHeapSizeInBytes() +
@@ -544,6 +604,12 @@ public class ReducedIndexMembership implements VoidTransactionMemoryProducer<Red
 	private void forgetMembership(int ownerPrimaryKey, int indexPrimaryKey) {
 		final TransactionalBitmap existing = this.indexPrimaryKeysByOwner.get(ownerPrimaryKey);
 		if (existing == null) {
+			// Reachable and correct, so it must not raise. The promotion path is where it happens: `ownerAdded`
+			// hands `dropCoverage` the membership AFTER the insert, which includes the owner that has just
+			// crossed the index above the threshold - and that owner never got an entry,
+			// because the promotion branch replaced the `recordMembership` call that would have made one. Every
+			// other member of the set does have one. Raising here would fail the very commit that promotes an
+			// index out of coverage.
 			return;
 		}
 		existing.remove(indexPrimaryKey);

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
@@ -347,10 +347,10 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 			new EntityIndexKey(EntityIndexType.GLOBAL, scope)
 		);
 		// Reduced indexes exist for EVERY reference indexed at FOR_FILTERING or above - the local path creates
-		// them behind `isIndexedReferenceForFiltering` (EntityIndexLocalMutationExecutor:2652 and its peers), and
-		// a production catalog can hold two orders of magnitude more of them for FOR_FILTERING references than
-		// for partitioned ones. What is restricted to FOR_FILTERING_AND_PARTITIONING is the maintenance of
-		// FACETS inside them, which is what this flag actually governs. Reading it as "no index exists" is
+		// them behind `isIndexedReferenceForFiltering` (`EntityIndexLocalMutationExecutor#unindexReferences` and
+		// its peers), and a production catalog can hold two orders of magnitude more of them for FOR_FILTERING
+		// references than for partitioned ones. What is restricted to FOR_FILTERING_AND_PARTITIONING is the
+		// maintenance of FACETS inside them, which is what this flag governs. Reading it as "no index exists" is
 		// wrong and load-bearing: it makes the cross-entity walk's cost look bounded by the current schema when
 		// in fact a client raising one reference to FOR_FILTERING_AND_PARTITIONING widens that walk over
 		// partitions that already exist, with no reindexing and no entity writes (issue #1529).
@@ -556,9 +556,14 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 	 * holding it. Shared by both halves of the accelerated resolution: the residual set — the indexes holding
 	 * more owners than covering them is worth — and the covered indexes selected by
 	 * {@link #collectOwnersFromMembership}. Iterating a named set rather than filtering the reference's
-	 * advertisement is the whole point: the residual set is small by construction (`<= M / T` for `M` total
-	 * memberships) and the selected set is bounded by the affected owners, while the advertisement is bounded
-	 * by neither.
+	 * advertisement is the whole point: the selected set is bounded by the affected owners, while the
+	 * advertisement is bounded by nothing.
+	 *
+	 * The residual set is bounded only for the indexes that earned their place by SIZE — at most `M / T` of
+	 * them for `M` total memberships and a threshold of `T`. It carries indexes registered for other reasons
+	 * too (see {@link ReducedIndexMembership#getResidualIndexPrimaryKeys()}), and a freshly seeded slice is the
+	 * limiting case: every advertised index is residual, so this probes the whole advertisement and buys
+	 * nothing until {@link ReducedIndexMembership#ownerAdded} has demoted the small ones as they are written.
 	 *
 	 * @param target           access to the entity collection's index store
 	 * @param siblingSchema    the reference whose reduced indexes are probed
@@ -575,25 +580,59 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 	) {
 		final OfInt it = indexPrimaryKeys.iterator();
 		while (it.hasNext()) {
-			final int reducedIndexPK = it.nextInt();
-			final EntityIndex probedIndex = target.getIndexByPrimaryKeyIfExists(reducedIndexPK);
-			// Not an unexpected state: the empty-index sweep drops a reduced index the moment its last owner
-			// leaves, so a set naming it can legitimately outlive it. The unaccelerated walk skips such a key
-			// the same way - an index that holds nobody cannot hold an affected owner either.
-			if (probedIndex == null) {
-				continue;
-			}
-			final int[] owners = and(getRoaringBitmap(probedIndex.getAllPrimaryKeys()), affected).toArray();
-			if (owners.length == 0) {
-				continue;
-			}
-			// resolved once per index, after the intersection, exactly as the unaccelerated walk does
-			final SiblingReducedIndex sibling = new SiblingReducedIndex(
-				target.getOrCreateIndexByPrimaryKey(reducedIndexPK), siblingSchema
-			);
-			for (final int owner : owners) {
-				addSibling(result, owner, sibling);
-			}
+			probeReducedIndexForAffectedOwners(target, siblingSchema, it.nextInt(), affected, result);
+		}
+	}
+
+	/**
+	 * Probes a single reduced index and records, for every affected owner it holds, the index holding it.
+	 *
+	 * This is the whole body of both resolutions: the accelerated one reaches it once per index named by
+	 * {@link #collectOwnersOfProbedIndexes}, the unaccelerated walk once per index the reference advertises
+	 * ({@link #collectOwnersOfReducedIndexes}). They differ in how they arrive at the primary key and in
+	 * nothing that happens to it afterwards, which is why the two paths cannot drift apart in what a probe
+	 * means.
+	 *
+	 * @param target         access to the entity collection's index store
+	 * @param siblingSchema  the reference whose reduced index is probed
+	 * @param reducedIndexPK primary key of the reduced index to probe
+	 * @param affected       roaring bitmap of affected owner PKs, intersected against the index
+	 * @param result         accumulator, keyed by owner PK
+	 */
+	private static void probeReducedIndexForAffectedOwners(
+		@Nonnull IndexMutationTarget target,
+		@Nonnull ReferenceSchemaContract siblingSchema,
+		int reducedIndexPK,
+		@Nonnull PersistentRoaringBitmap affected,
+		@Nonnull Map<Integer, List<SiblingReducedIndex>> result
+	) {
+		final EntityIndex probedIndex = target.getIndexByPrimaryKeyIfExists(reducedIndexPK);
+		// Not an unexpected state, and not the empty-index sweep that drops it either - that sweep fires on
+		// `EntityIndex#isEmpty()`, a conjunction in which the owner bitmap is one term among several. What
+		// retires a reduced index the moment its last owner leaves is the advertisement:
+		// `ReferencedTypeEntityIndex` counts owners per (index, referenced entity) tuple and un-advertises
+		// on the 1 -> 0 crossing, in the same synchronous step. A set naming an index that no longer
+		// resolves is therefore a stale SELECTOR entry, which this structure's contract tolerates by design
+		// - nothing it records is an answer, and an index the collection does not hold can hold no affected
+		// owner. The unaccelerated walk skips such a key the same way.
+		if (probedIndex == null) {
+			return;
+		}
+		final int[] owners = and(getRoaringBitmap(probedIndex.getAllPrimaryKeys()), affected).toArray();
+		if (owners.length == 0) {
+			return;
+		}
+		// Re-fetch through the registering accessor, and only for partitions that really hold an
+		// affected owner. That registration is what enrols the index in the "dirty" set, and hence
+		// what gets its transactional layer swept at commit - mutating the plainly-read instance
+		// instead leaves the layer stranded and the whole transaction dies with
+		// StaleTransactionMemoryException. Doing it after the intersection keeps every untouched
+		// partition out of the dirty set.
+		final SiblingReducedIndex sibling = new SiblingReducedIndex(
+			target.getOrCreateIndexByPrimaryKey(reducedIndexPK), siblingSchema
+		);
+		for (final int owner : owners) {
+			addSibling(result, owner, sibling);
 		}
 	}
 
@@ -650,28 +689,11 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		// second time into the same map and allocate an `int[]` per entry - and this traversal runs over
 		// *every* partition the reference advertises, on every trigger that reaches it without a reverse
 		// lookup, so those per-partition allocations are the bulk of the walk's constant factor.
-		referencedTypeIndex.forEachReferenceIndexPrimaryKey(reducedIndexPK -> {
-			final EntityIndex probedIndex = target.getIndexByPrimaryKeyIfExists(reducedIndexPK);
-			if (probedIndex == null) {
-				return;
-			}
-			final int[] owners = and(getRoaringBitmap(probedIndex.getAllPrimaryKeys()), affected).toArray();
-			if (owners.length == 0) {
-				return;
-			}
-			// Re-fetch through the registering accessor, and only for partitions that really hold an
-			// affected owner. That registration is what enrols the index in the "dirty" set, and hence
-			// what gets its transactional layer swept at commit - mutating the plainly-read instance
-			// instead leaves the layer stranded and the whole transaction dies with
-			// StaleTransactionMemoryException. Doing it after the intersection keeps every untouched
-			// partition out of the dirty set.
-			final SiblingReducedIndex sibling = new SiblingReducedIndex(
-				target.getOrCreateIndexByPrimaryKey(reducedIndexPK), siblingSchema
-			);
-			for (final int owner : owners) {
-				addSibling(result, owner, sibling);
-			}
-		});
+		referencedTypeIndex.forEachReferenceIndexPrimaryKey(
+			reducedIndexPK -> probeReducedIndexForAffectedOwners(
+				target, siblingSchema, reducedIndexPK, affected, result
+			)
+		);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
@@ -631,27 +631,13 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		final SiblingReducedIndex sibling = new SiblingReducedIndex(
 			target.getOrCreateIndexByPrimaryKey(reducedIndexPK), siblingSchema
 		);
+		// Appended without a duplicate check, because one reduced index primary key reaches this method at
+		// most once per sibling reference and a `SiblingReducedIndex` carries that reference's own schema -
+		// so no owner can be offered the same pair twice. The three producers each guarantee it: the covered
+		// half collects into a bitmap before probing, the residual set IS a bitmap and is disjoint from the
+		// covered one, and the unaccelerated walk's two families advertise disjoint primary keys.
 		for (final int owner : owners) {
-			addSibling(result, owner, sibling);
-		}
-	}
-
-	/**
-	 * Records one `(owner, reduced index)` pair into the accumulator.
-	 *
-	 * @param result  accumulator, keyed by owner PK
-	 * @param owner   primary key of the affected owner
-	 * @param sibling the reduced index holding it, already resolved through the registering accessor
-	 */
-	private static void addSibling(
-		@Nonnull Map<Integer, List<SiblingReducedIndex>> result,
-		int owner,
-		@Nonnull SiblingReducedIndex sibling
-	) {
-		final List<SiblingReducedIndex> indexes = result.computeIfAbsent(owner, __ -> new ArrayList<>(4));
-		// references sharing a reduced group index resolve to the same instance more than once
-		if (!indexes.contains(sibling)) {
-			indexes.add(sibling);
+			result.computeIfAbsent(owner, __ -> new ArrayList<>(4)).add(sibling);
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
@@ -45,6 +45,7 @@ import io.evitadb.dataType.Scope;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.EntityIndex;
 import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.api.index.EntityIndexType;
 import io.evitadb.index.HistogramIndex;
 import io.evitadb.index.ReducedGroupEntityIndex;
@@ -52,6 +53,9 @@ import io.evitadb.index.ReferencedTypeEntityIndex;
 import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
+import com.carrotsearch.hppc.IntObjectHashMap;
+import com.carrotsearch.hppc.IntObjectMap;
+import io.evitadb.index.membership.ReducedIndexMembership;
 import io.evitadb.index.bitmap.EmptyBitmap;
 import io.evitadb.index.facet.FacetGroupIndex;
 import io.evitadb.index.facet.FacetIdIndex;
@@ -75,6 +79,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.PrimitiveIterator.OfInt;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
@@ -457,19 +462,143 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		final Map<Integer, List<SiblingReducedIndex>> result =
 			CollectionUtils.createHashMap(affectedOwnerPKs.size());
 		final PersistentRoaringBitmap affected = getRoaringBitmap(affectedOwnerPKs);
+		final EntityIndex globalIndex = target.getIndexIfExists(new EntityIndexKey(EntityIndexType.GLOBAL, scope));
+		final GlobalEntityIndex membershipHolder =
+			globalIndex instanceof final GlobalEntityIndex typed ? typed : null;
 		for (final ReferenceSchemaContract siblingSchema : target.getEntitySchema().getReferences().values()) {
 			if (siblingSchema.getName().equals(mutatedReferenceName) ||
 				siblingSchema.getReferenceIndexType(scope) != ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING) {
 				continue;
 			}
-			collectOwnersOfReducedIndexes(
-				target, scope, EntityIndexType.REFERENCED_ENTITY_TYPE, siblingSchema, affected, result
-			);
-			collectOwnersOfReducedIndexes(
-				target, scope, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE, siblingSchema, affected, result
-			);
+			// The reverse lookup covers the reduced indexes small enough to be worth an entry each, and names
+			// the rest in a residual set that is iterated DIRECTLY - filtering the reference's full
+			// advertisement instead would pay the very `O(total reduced indexes)` traversal this exists to
+			// remove. When a reference has no lookup at all - it gained its partitioning flag after the
+			// collection was loaded, and the engine does not rebuild indexes for a schema change (issue #409)
+			// - the walk below runs over every advertised index exactly as it did before this structure
+			// existed. Correct either way; only the speed differs.
+			final ReducedIndexMembership membership = membershipHolder == null ?
+				null : membershipHolder.getReducedIndexMembership(siblingSchema.getName());
+			if (membership == null) {
+				collectOwnersOfReducedIndexes(
+					target, scope, EntityIndexType.REFERENCED_ENTITY_TYPE, siblingSchema, affected, result
+				);
+				collectOwnersOfReducedIndexes(
+					target, scope, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE, siblingSchema, affected, result
+				);
+			} else {
+				collectOwnersFromMembership(target, siblingSchema, membership, affected, result);
+				collectOwnersOfResidualIndexes(
+					target, siblingSchema, membership.getResidualIndexPrimaryKeys(), affected, result
+				);
+			}
 		}
 		return result;
+	}
+
+	/**
+	 * Contributes the owners the reverse lookup already knows about, without probing a single reduced index.
+	 *
+	 * The affected set is intersected against the lookup's covered-owner union **once**, so only owners that
+	 * can possibly hit are looked up — which is what keeps the per-reference split as cheap as a single map
+	 * merged across the collection (measured 0.4 % apart in the sparse shape).
+	 *
+	 * @param target         access to the entity collection's index store
+	 * @param siblingSchema  the reference whose lookup is consulted
+	 * @param membership     the reference's reverse lookup
+	 * @param affected       roaring bitmap of affected owner PKs
+	 * @param result         accumulator, keyed by owner PK
+	 */
+	private static void collectOwnersFromMembership(
+		@Nonnull IndexMutationTarget target,
+		@Nonnull ReferenceSchemaContract siblingSchema,
+		@Nonnull ReducedIndexMembership membership,
+		@Nonnull PersistentRoaringBitmap affected,
+		@Nonnull Map<Integer, List<SiblingReducedIndex>> result
+	) {
+		final Bitmap coveredOwners = membership.getCoveredOwners();
+		if (coveredOwners.isEmpty()) {
+			return;
+		}
+		// One resolution per reduced index rather than one per (owner, index) pair. The registering accessor
+		// is what enrols an index in the dirty set, so calling it once is enough - and a covered index is
+		// named by up to `T` owners, so resolving per pair would repeat a transactional-layer lookup that the
+		// dense shape performs hundreds of thousands of times.
+		final IntObjectMap<SiblingReducedIndex> resolved = new IntObjectHashMap<>(64);
+		for (final int owner : and(getRoaringBitmap(coveredOwners), affected).toArray()) {
+			final Bitmap reducedIndexPKs = membership.getIndexPrimaryKeys(owner);
+			final OfInt it = reducedIndexPKs.iterator();
+			while (it.hasNext()) {
+				final int reducedIndexPK = it.nextInt();
+				SiblingReducedIndex sibling = resolved.get(reducedIndexPK);
+				if (sibling == null) {
+					sibling = new SiblingReducedIndex(
+						target.getOrCreateIndexByPrimaryKey(reducedIndexPK), siblingSchema
+					);
+					resolved.put(reducedIndexPK, sibling);
+				}
+				addSibling(result, owner, sibling);
+			}
+		}
+	}
+
+	/**
+	 * Probes the reduced indexes the reverse lookup deliberately left on the walk — the ones holding more
+	 * owners than covering them is worth. Iterates the residual set itself rather than filtering the
+	 * reference's advertisement, which is the whole point: the set is small by construction (`<= M / T` for
+	 * `M` total memberships) while the advertisement is not.
+	 *
+	 * @param target        access to the entity collection's index store
+	 * @param siblingSchema the reference whose residual indexes are probed
+	 * @param residual      primary keys of the reduced indexes left on the walk
+	 * @param affected      roaring bitmap of affected owner PKs, intersected against each index
+	 * @param result        accumulator, keyed by owner PK
+	 */
+	private static void collectOwnersOfResidualIndexes(
+		@Nonnull IndexMutationTarget target,
+		@Nonnull ReferenceSchemaContract siblingSchema,
+		@Nonnull Bitmap residual,
+		@Nonnull PersistentRoaringBitmap affected,
+		@Nonnull Map<Integer, List<SiblingReducedIndex>> result
+	) {
+		final OfInt it = residual.iterator();
+		while (it.hasNext()) {
+			final int reducedIndexPK = it.nextInt();
+			final EntityIndex probedIndex = target.getIndexByPrimaryKeyIfExists(reducedIndexPK);
+			if (probedIndex == null) {
+				continue;
+			}
+			final int[] owners = and(getRoaringBitmap(probedIndex.getAllPrimaryKeys()), affected).toArray();
+			if (owners.length == 0) {
+				continue;
+			}
+			// resolved once per index, after the intersection, exactly as the unaccelerated walk does
+			final SiblingReducedIndex sibling = new SiblingReducedIndex(
+				target.getOrCreateIndexByPrimaryKey(reducedIndexPK), siblingSchema
+			);
+			for (final int owner : owners) {
+				addSibling(result, owner, sibling);
+			}
+		}
+	}
+
+	/**
+	 * Records one `(owner, reduced index)` pair into the accumulator.
+	 *
+	 * @param result  accumulator, keyed by owner PK
+	 * @param owner   primary key of the affected owner
+	 * @param sibling the reduced index holding it, already resolved through the registering accessor
+	 */
+	private static void addSibling(
+		@Nonnull Map<Integer, List<SiblingReducedIndex>> result,
+		int owner,
+		@Nonnull SiblingReducedIndex sibling
+	) {
+		final List<SiblingReducedIndex> indexes = result.computeIfAbsent(owner, __ -> new ArrayList<>(4));
+		// references sharing a reduced group index resolve to the same instance more than once
+		if (!indexes.contains(sibling)) {
+			indexes.add(sibling);
+		}
 	}
 
 	/**
@@ -521,15 +650,11 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 			// instead leaves the layer stranded and the whole transaction dies with
 			// StaleTransactionMemoryException. Doing it after the intersection keeps every untouched
 			// partition out of the dirty set.
-			final EntityIndex reducedIndex = target.getOrCreateIndexByPrimaryKey(reducedIndexPK);
-			final SiblingReducedIndex sibling = new SiblingReducedIndex(reducedIndex, siblingSchema);
+			final SiblingReducedIndex sibling = new SiblingReducedIndex(
+				target.getOrCreateIndexByPrimaryKey(reducedIndexPK), siblingSchema
+			);
 			for (final int owner : owners) {
-				final List<SiblingReducedIndex> indexes =
-					result.computeIfAbsent(owner, __ -> new ArrayList<>(4));
-				// references sharing a reduced group index resolve to the same instance more than once
-				if (!indexes.contains(sibling)) {
-					indexes.add(sibling);
-				}
+				addSibling(result, owner, sibling);
 			}
 		});
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
@@ -53,15 +53,13 @@ import io.evitadb.index.ReferencedTypeEntityIndex;
 import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
-import com.carrotsearch.hppc.IntObjectHashMap;
-import com.carrotsearch.hppc.IntObjectMap;
-import io.evitadb.index.membership.ReducedIndexMembership;
 import io.evitadb.index.bitmap.EmptyBitmap;
 import io.evitadb.index.facet.FacetGroupIndex;
 import io.evitadb.index.facet.FacetIdIndex;
 import io.evitadb.index.facet.FacetReferenceIndex;
 import io.evitadb.index.hierarchy.predicate.HierarchyFilteringPredicate;
 import io.evitadb.index.invertedIndex.ValueToRecord;
+import io.evitadb.index.membership.ReducedIndexMembership;
 import io.evitadb.index.mutation.local.ReferenceIndexMutator;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
 import io.evitadb.utils.Assert;
@@ -79,9 +77,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.PrimitiveIterator.OfInt;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.PrimitiveIterator.OfInt;
 import java.util.Set;
 import java.util.function.ObjIntConsumer;
 import java.util.function.Supplier;
@@ -437,11 +435,22 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 	 * {@link #applyFacetToReducedIndexes} and are deliberately left out here.
 	 *
 	 * The membership direction available on the indexes is `referenced entity -> reduced index -> owner PKs`,
-	 * so the map is built by walking the `REFERENCED_ENTITY_TYPE` / `REFERENCED_GROUP_ENTITY_TYPE` index of
-	 * every partitioned reference and intersecting each reduced index's member bitmap with the affected
-	 * owners. That is one pass over the collection's reduced indexes per trigger, which is why it happens
-	 * once here rather than per `(owner, reference)` entry, and why it is skipped outright when nothing is
-	 * affected. Reading the owners' reference containers instead would be a storage read per owner.
+	 * so a reduced index can only be attributed to an owner by intersecting the index's own member bitmap with
+	 * the affected owners. What differs between the two paths below is only *how many* indexes are intersected;
+	 * every emitted pair comes out of such an intersection either way, which is what keeps the accelerated path
+	 * an accelerator. Either way it is one pass per trigger, which is why it happens once here rather than per
+	 * `(owner, reference)` entry, and why it is skipped outright when nothing is affected. Reading the owners'
+	 * reference containers instead would be a storage read per owner.
+	 *
+	 * Per partitioned sibling reference, one of two paths runs:
+	 *
+	 * - **no reverse lookup** — every reduced index the reference advertises is walked, through its
+	 *   `REFERENCED_ENTITY_TYPE` and `REFERENCED_GROUP_ENTITY_TYPE` index. This is what the trigger did before
+	 *   {@link ReducedIndexMembership} existed and remains the correct-but-unaccelerated baseline;
+	 * - **a reverse lookup exists** — the indexes it covers are narrowed to those named for the affected
+	 *   owners ({@link #collectOwnersFromMembership}) and the ones it left residual are probed whole, both
+	 *   through {@link #collectOwnersOfProbedIndexes}. The reference's full advertisement is never read, which
+	 *   is the `O(total reduced indexes)` traversal this removes.
 	 *
 	 * @param target               access to the entity collection's schema and index store
 	 * @param scope                the scope whose indexes are inspected
@@ -462,9 +471,10 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		final Map<Integer, List<SiblingReducedIndex>> result =
 			CollectionUtils.createHashMap(affectedOwnerPKs.size());
 		final PersistentRoaringBitmap affected = getRoaringBitmap(affectedOwnerPKs);
-		final EntityIndex globalIndex = target.getIndexIfExists(new EntityIndexKey(EntityIndexType.GLOBAL, scope));
-		final GlobalEntityIndex membershipHolder =
-			globalIndex instanceof final GlobalEntityIndex typed ? typed : null;
+		final GlobalEntityIndex membershipHolder = asGlobalEntityIndexIfExists(
+			target.getIndexIfExists(new EntityIndexKey(EntityIndexType.GLOBAL, scope)),
+			() -> EntityIndexType.GLOBAL + "/" + scope
+		);
 		for (final ReferenceSchemaContract siblingSchema : target.getEntitySchema().getReferences().values()) {
 			if (siblingSchema.getName().equals(mutatedReferenceName) ||
 				siblingSchema.getReferenceIndexType(scope) != ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING) {
@@ -473,10 +483,11 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 			// The reverse lookup covers the reduced indexes small enough to be worth an entry each, and names
 			// the rest in a residual set that is iterated DIRECTLY - filtering the reference's full
 			// advertisement instead would pay the very `O(total reduced indexes)` traversal this exists to
-			// remove. When a reference has no lookup at all - it gained its partitioning flag after the
-			// collection was loaded, and the engine does not rebuild indexes for a schema change (issue #409)
-			// - the walk below runs over every advertised index exactly as it did before this structure
-			// existed. Correct either way; only the speed differs.
+			// remove. A reference can legitimately have no lookup at all: it gained its partitioning flag
+			// after the collection was loaded and the engine does not rebuild indexes for a schema change
+			// (issue #409), or a schema change discarded a lookup nothing maintains any more, or no write has
+			// yet created one. In every such case the walk below runs over every advertised index exactly as
+			// it did before this structure existed. Correct either way; only the speed differs.
 			final ReducedIndexMembership membership = membershipHolder == null ?
 				null : membershipHolder.getReducedIndexMembership(siblingSchema.getName());
 			if (membership == null) {
@@ -488,7 +499,7 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 				);
 			} else {
 				collectOwnersFromMembership(target, siblingSchema, membership, affected, result);
-				collectOwnersOfResidualIndexes(
+				collectOwnersOfProbedIndexes(
 					target, siblingSchema, membership.getResidualIndexPrimaryKeys(), affected, result
 				);
 			}
@@ -497,7 +508,17 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 	}
 
 	/**
-	 * Contributes the owners the reverse lookup already knows about, without probing a single reduced index.
+	 * Narrows the probe to the reduced indexes the reverse lookup names for the affected owners.
+	 *
+	 * The lookup is used here as an index **selector** and nothing more: it decides *which* reduced indexes
+	 * are worth looking at, and each selected index is then asked itself who is in it, exactly as the
+	 * residual half and the unaccelerated walk do. That is what keeps the structure an accelerator rather
+	 * than an authority — a stale entry can only send the probe at an index that turns out to hold no
+	 * affected owner, and an entry naming an index the collection no longer holds resolves to `null` and is
+	 * dropped. Emitting the map's `(owner, index)` pairs directly would instead write a facet into a
+	 * partition the owner had already left, and would raise from the middle of an index mutation for an
+	 * index that no longer exists. The saving the structure is measured on — not visiting *every* partition
+	 * — is untouched, because the intersection is paid only for the indexes actually selected.
 	 *
 	 * The affected set is intersected against the lookup's covered-owner union **once**, so only owners that
 	 * can possibly hit are looked up — which is what keeps the per-reference split as cheap as a single map
@@ -520,51 +541,45 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		if (coveredOwners.isEmpty()) {
 			return;
 		}
-		// One resolution per reduced index rather than one per (owner, index) pair. The registering accessor
-		// is what enrols an index in the dirty set, so calling it once is enough - and a covered index is
-		// named by up to `T` owners, so resolving per pair would repeat a transactional-layer lookup that the
-		// dense shape performs hundreds of thousands of times.
-		final IntObjectMap<SiblingReducedIndex> resolved = new IntObjectHashMap<>(64);
+		// the union of the indexes named for the affected covered owners - a covered index is named by up to
+		// `T` owners, so collecting the distinct keys before probing turns `O(affected owners)` index
+		// resolutions into `O(indexes actually named)` ones
+		final BaseBitmap selectedIndexPKs = new BaseBitmap();
 		for (final int owner : and(getRoaringBitmap(coveredOwners), affected).toArray()) {
-			final Bitmap reducedIndexPKs = membership.getIndexPrimaryKeys(owner);
-			final OfInt it = reducedIndexPKs.iterator();
-			while (it.hasNext()) {
-				final int reducedIndexPK = it.nextInt();
-				SiblingReducedIndex sibling = resolved.get(reducedIndexPK);
-				if (sibling == null) {
-					sibling = new SiblingReducedIndex(
-						target.getOrCreateIndexByPrimaryKey(reducedIndexPK), siblingSchema
-					);
-					resolved.put(reducedIndexPK, sibling);
-				}
-				addSibling(result, owner, sibling);
-			}
+			selectedIndexPKs.addAll(membership.getIndexPrimaryKeys(owner));
 		}
+		collectOwnersOfProbedIndexes(target, siblingSchema, selectedIndexPKs, affected, result);
 	}
 
 	/**
-	 * Probes the reduced indexes the reverse lookup deliberately left on the walk — the ones holding more
-	 * owners than covering them is worth. Iterates the residual set itself rather than filtering the
-	 * reference's advertisement, which is the whole point: the set is small by construction (`<= M / T` for
-	 * `M` total memberships) while the advertisement is not.
+	 * Probes a named set of reduced indexes and records, for every affected owner they hold, the index
+	 * holding it. Shared by both halves of the accelerated resolution: the residual set — the indexes holding
+	 * more owners than covering them is worth — and the covered indexes selected by
+	 * {@link #collectOwnersFromMembership}. Iterating a named set rather than filtering the reference's
+	 * advertisement is the whole point: the residual set is small by construction (`<= M / T` for `M` total
+	 * memberships) and the selected set is bounded by the affected owners, while the advertisement is bounded
+	 * by neither.
 	 *
-	 * @param target        access to the entity collection's index store
-	 * @param siblingSchema the reference whose residual indexes are probed
-	 * @param residual      primary keys of the reduced indexes left on the walk
-	 * @param affected      roaring bitmap of affected owner PKs, intersected against each index
-	 * @param result        accumulator, keyed by owner PK
+	 * @param target           access to the entity collection's index store
+	 * @param siblingSchema    the reference whose reduced indexes are probed
+	 * @param indexPrimaryKeys primary keys of the reduced indexes to probe
+	 * @param affected         roaring bitmap of affected owner PKs, intersected against each index
+	 * @param result           accumulator, keyed by owner PK
 	 */
-	private static void collectOwnersOfResidualIndexes(
+	private static void collectOwnersOfProbedIndexes(
 		@Nonnull IndexMutationTarget target,
 		@Nonnull ReferenceSchemaContract siblingSchema,
-		@Nonnull Bitmap residual,
+		@Nonnull Bitmap indexPrimaryKeys,
 		@Nonnull PersistentRoaringBitmap affected,
 		@Nonnull Map<Integer, List<SiblingReducedIndex>> result
 	) {
-		final OfInt it = residual.iterator();
+		final OfInt it = indexPrimaryKeys.iterator();
 		while (it.hasNext()) {
 			final int reducedIndexPK = it.nextInt();
 			final EntityIndex probedIndex = target.getIndexByPrimaryKeyIfExists(reducedIndexPK);
+			// Not an unexpected state: the empty-index sweep drops a reduced index the moment its last owner
+			// leaves, so a set naming it can legitimately outlive it. The unaccelerated walk skips such a key
+			// the same way - an index that holds nobody cannot hold an affected owner either.
 			if (probedIndex == null) {
 				continue;
 			}
@@ -633,8 +648,8 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		}
 		// One pass over the advertising map. The per-referenced-PK accessors would box every key, hash it a
 		// second time into the same map and allocate an `int[]` per entry - and this traversal runs over
-		// *every* partition of the collection on *every* trigger, so those per-partition allocations are
-		// the bulk of the walk's constant factor.
+		// *every* partition the reference advertises, on every trigger that reaches it without a reverse
+		// lookup, so those per-partition allocations are the bulk of the walk's constant factor.
 		referencedTypeIndex.forEachReferenceIndexPrimaryKey(reducedIndexPK -> {
 			final EntityIndex probedIndex = target.getIndexByPrimaryKeyIfExists(reducedIndexPK);
 			if (probedIndex == null) {
@@ -2428,6 +2443,33 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		@Nonnull Supplier<String> contextSupplier
 	) {
 		return index == null ? null : asReferencedTypeEntityIndex(index, contextSupplier);
+	}
+
+	/**
+	 * Asserts that the given index is a {@link GlobalEntityIndex} and returns the cast, or `null` when there
+	 * is no index at all. Absence is a legitimate state - a scope no entity has entered yet - while an index
+	 * registered under a `GLOBAL` key and turning out to be something else is a programming error that must
+	 * surface rather than be read as "absent".
+	 *
+	 * @param index           index to check, may be `null`
+	 * @param contextSupplier lazily evaluated description of the expected index location
+	 * @return the cast index, or `null` when there is none
+	 */
+	@Nullable
+	private static GlobalEntityIndex asGlobalEntityIndexIfExists(
+		@Nullable EntityIndex index,
+		@Nonnull Supplier<String> contextSupplier
+	) {
+		if (index == null) {
+			return null;
+		}
+		if (!(index instanceof final GlobalEntityIndex gei)) {
+			throw new GenericEvitaInternalError(
+				"Expected GlobalEntityIndex for " + contextSupplier.get() +
+					" but got " + index.getClass().getSimpleName()
+			);
+		}
+		return gei;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
@@ -343,7 +343,14 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		final EntityIndex globalIndex = target.getOrCreateIndex(
 			new EntityIndexKey(EntityIndexType.GLOBAL, scope)
 		);
-		// Reduced indexes only exist when the reference uses FOR_FILTERING_AND_PARTITIONING indexing.
+		// Reduced indexes exist for EVERY reference indexed at FOR_FILTERING or above - the local path creates
+		// them behind `isIndexedReferenceForFiltering` (EntityIndexLocalMutationExecutor:2652 and its peers), and
+		// a production catalog can hold two orders of magnitude more of them for FOR_FILTERING references than
+		// for partitioned ones. What is restricted to FOR_FILTERING_AND_PARTITIONING is the maintenance of
+		// FACETS inside them, which is what this flag actually governs. Reading it as "no index exists" is
+		// wrong and load-bearing: it makes the cross-entity walk's cost look bounded by the current schema when
+		// in fact a client raising one reference to FOR_FILTERING_AND_PARTITIONING widens that walk over
+		// partitions that already exist, with no reindexing and no entity writes (issue #1529).
 		final boolean targetReduced =
 			refSchema.getReferenceIndexType(scope) == ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING;
 		// The reference owns up to two *independent* families of reduced indexes, and which of them exist is

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
@@ -631,11 +631,23 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		final SiblingReducedIndex sibling = new SiblingReducedIndex(
 			target.getOrCreateIndexByPrimaryKey(reducedIndexPK), siblingSchema
 		);
-		// Appended without a duplicate check, because one reduced index primary key reaches this method at
-		// most once per sibling reference and a `SiblingReducedIndex` carries that reference's own schema -
-		// so no owner can be offered the same pair twice. The three producers each guarantee it: the covered
-		// half collects into a bitmap before probing, the residual set IS a bitmap and is disjoint from the
-		// covered one, and the unaccelerated walk's two families advertise disjoint primary keys.
+		// Appended without a duplicate check. One reduced index primary key reaches this method at most once
+		// per sibling reference and a `SiblingReducedIndex` carries that reference's own schema, so an owner
+		// is not normally offered the same pair twice: the covered half collects its selected keys into a
+		// bitmap before probing, the residual set IS a bitmap, and the unaccelerated walk's two families draw
+		// their primary keys from one collection-wide sequence and never collide.
+		// What that argument does NOT cover is the seam between the two accelerated halves. The covered half
+		// selects out of the owner -> index map, never out of `ReducedIndexMembership#getCoveredIndexPrimaryKeys`,
+		// and it never intersects the two - so an entry naming an index that has since been promoted to residual
+		// puts that index in front of both halves. `dropCoverage` forgets one entry per member of the membership
+		// handed to it, so such an entry survives a promotion whenever the entry was built from a membership the
+		// index did not actually have. **No engine path is known to produce that state**: every caller passes
+		// `referenceIndex.getAllPrimaryKeys()`, the live membership, so entries and members move in lockstep. It
+		// is constructible through `ReducedIndexMembership`'s own API, which is what
+		// `ReducedIndexMembershipTest#promotionKeepsAnEntryBuiltFromDriftedMembership` pins - and it is harmless
+		// if it ever arises, because `ReferenceIndexMutator#applyFacetDecisionMatrix` short-circuits through pure
+		// reads when the facet is already in its target bucket and so never reaches `addFacet` or
+		// `removeFromCurrentGroup`.
 		for (final int owner : owners) {
 			result.computeIfAbsent(owner, __ -> new ArrayList<>(4)).add(sibling);
 		}

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/ReferenceIndexMutator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/ReferenceIndexMutator.java
@@ -51,12 +51,14 @@ import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.AbstractReducedEntityIndex;
 import io.evitadb.index.EntityIndex;
 import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.api.index.EntityIndexType;
 import io.evitadb.index.HistogramCapableEntityIndex;
 import io.evitadb.index.HistogramIndex;
 import io.evitadb.index.ReducedEntityIndex;
 import io.evitadb.index.ReducedGroupEntityIndex;
 import io.evitadb.index.ReferencedTypeEntityIndex;
+import io.evitadb.index.membership.ReducedIndexMembership;
 import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.facet.FacetGroupIndex;
 import io.evitadb.index.facet.FacetIdIndex;
@@ -798,13 +800,14 @@ public interface ReferenceIndexMutator {
 		);
 
 		// index entity primary key into the reduced index and populate with existing data
+		final boolean entityFirstIndexedInTargetIndex;
 		if (referenceIndex instanceof ReducedGroupEntityIndex rgei) {
 			// group indexes need cardinality tracking — use two-arg version
 			// `entityFirstIndexedInTargetIndex` is true only when this insert causes the entity to
 			// enter this group reduced index for the first time (cardinality 0 -> 1); subsequent
 			// references contributing to the same group still need per-reference indexing (facets,
 			// reference attributes) but must skip entity-level data that was already populated
-			final boolean entityFirstIndexedInTargetIndex =
+			entityFirstIndexedInTargetIndex =
 				rgei.insertPrimaryKeyIfMissing(entityPrimaryKey, referenceKey.primaryKey())
 					== CardinalityChange.BOUNDARY_CROSSED;
 			indexAllExistingData(
@@ -816,7 +819,7 @@ public interface ReferenceIndexMutator {
 				existingDataSupplierFactory
 			);
 		} else {
-			final boolean entityFirstIndexedInTargetIndex =
+			entityFirstIndexedInTargetIndex =
 				referenceIndex.insertPrimaryKeyIfMissing(entityPrimaryKey);
 			// REI indexes are keyed per-reference so no duplicate refs can land here; always run the
 			// full entity-level + reference-level population when the entity is freshly inserted
@@ -830,6 +833,11 @@ public interface ReferenceIndexMutator {
 					existingDataSupplierFactory
 				);
 			}
+		}
+		// the owner-membership boundary the cross-entity facet trigger's reverse lookup is maintained from -
+		// exactly the 0 -> 1 transition, for both index families, and for no other event
+		if (entityFirstIndexedInTargetIndex) {
+			recordOwnerEnteredReducedIndex(executor, referenceSchema, referenceIndex, entityPrimaryKey);
 		}
 
 		// add facet to reduced index
@@ -962,13 +970,14 @@ public interface ReferenceIndexMutator {
 		);
 
 		// remove entity primary key from the reduced index
+		final boolean entityFullyRemovedFromTargetIndex;
 		if (referenceIndex instanceof ReducedGroupEntityIndex rgei) {
 			// group indexes need cardinality tracking — use two-arg version
 			// `entityFullyRemovedFromTargetIndex` is true only when this removal causes the entity
 			// to leave this group reduced index entirely (cardinality 1 -> 0); earlier removals on
 			// the same (entity, RGEI) pair still need per-reference cleanup (facets, reference
 			// attributes) but must skip entity-level data that other references still rely on
-			final boolean entityFullyRemovedFromTargetIndex =
+			entityFullyRemovedFromTargetIndex =
 				rgei.removePrimaryKey(entityPrimaryKey, referenceKey.primaryKey())
 					== CardinalityChange.BOUNDARY_CROSSED;
 			removeAllExistingData(
@@ -980,7 +989,7 @@ public interface ReferenceIndexMutator {
 				existingDataSupplierFactory
 			);
 		} else {
-			final boolean entityFullyRemovedFromTargetIndex =
+			entityFullyRemovedFromTargetIndex =
 				referenceIndex.removePrimaryKey(entityPrimaryKey);
 			if (entityFullyRemovedFromTargetIndex) {
 				removeAllExistingData(
@@ -992,6 +1001,10 @@ public interface ReferenceIndexMutator {
 					existingDataSupplierFactory
 				);
 			}
+		}
+		// the symmetric 1 -> 0 boundary; see the insert counterpart
+		if (entityFullyRemovedFromTargetIndex) {
+			recordOwnerLeftReducedIndex(executor, referenceSchema, referenceIndex, entityPrimaryKey);
 		}
 	}
 
@@ -1239,6 +1252,137 @@ public interface ReferenceIndexMutator {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Records that an owner entity has entered a reduced index, into the reverse lookup the cross-entity
+	 * conditional-facet trigger consults instead of walking every reduced index of the collection.
+	 *
+	 * Maintained **only** for references indexed at {@link ReferenceIndexType#FOR_FILTERING_AND_PARTITIONING},
+	 * because those are the only ones the trigger's sibling walk visits. A reference raised to that level
+	 * without a reindex therefore has no slice here at all, and its reduced indexes are walked exactly as they
+	 * were before — correct, merely unaccelerated, which is the intended behaviour for a schema change the
+	 * engine does not rebuild indexes for (issue #409).
+	 *
+	 * @param executor          the mutation executor, which owns the global index the lookup hangs off
+	 * @param referenceSchema   schema of the reference whose reduced index was joined
+	 * @param referenceIndex    the reduced index the owner entered
+	 * @param entityPrimaryKey  primary key of the owner entity
+	 */
+	private static void recordOwnerEnteredReducedIndex(
+		@Nonnull EntityIndexLocalMutationExecutor executor,
+		@Nonnull ReferenceSchemaContract referenceSchema,
+		@Nonnull AbstractReducedEntityIndex referenceIndex,
+		int entityPrimaryKey
+	) {
+		final Scope scope = executor.getScope();
+		if (!isIndexedReferenceForFilteringAndPartitioning(referenceSchema, scope)) {
+			return;
+		}
+		final GlobalEntityIndex globalIndex = resolveGlobalIndex(executor, scope);
+		ReducedIndexMembership membership =
+			globalIndex.getReducedIndexMembership(referenceSchema.getName());
+		if (membership == null) {
+			membership = globalIndex.getOrCreateReducedIndexMembership(referenceSchema.getName());
+			seedFromAdvertisedIndexes(executor, referenceSchema, scope, membership);
+		}
+		membership.ownerAdded(
+			referenceIndex.getPrimaryKey(), entityPrimaryKey, referenceIndex.getAllPrimaryKeys()
+		);
+	}
+
+	/**
+	 * Seeds a freshly created membership map with every reduced index the reference already advertises,
+	 * recorded as residual.
+	 *
+	 * This is what keeps the map honest when a slice is created outside the load-time build — a reference that
+	 * only became partitioned after the collection was loaded, say. Without it the slice would know about the
+	 * one index being written and nothing else, and the trigger would skip every index that already existed:
+	 * a **wrong facet**, not a slow one. Recording them as residual instead leaves them on the walk, which is
+	 * exactly where they were before the map existed.
+	 *
+	 * Seeding cannot decide coverage, because it has no way to resolve a reduced index from its primary key
+	 * here. It does not need to: {@link ReducedIndexMembership#ownerAdded} demotes a small residual index into
+	 * coverage the next time it is written, so a seeded slice acquires coverage as its indexes are touched.
+	 *
+	 * @param executor        the mutation executor
+	 * @param referenceSchema schema of the reference being seeded
+	 * @param scope           the scope whose indexes are inspected
+	 * @param membership      the freshly created map to seed
+	 */
+	private static void seedFromAdvertisedIndexes(
+		@Nonnull EntityIndexLocalMutationExecutor executor,
+		@Nonnull ReferenceSchemaContract referenceSchema,
+		@Nonnull Scope scope,
+		@Nonnull ReducedIndexMembership membership
+	) {
+		// both families advertise reduced indexes the trigger consults, and neither stands in for the other;
+		// allocated here rather than held as a constant because this runs once per reference per collection
+		final EntityIndexType[] families = {
+			EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
+		};
+		for (final EntityIndexType family : families) {
+			final EntityIndex typeIndex = executor.getIndexIfExists(
+				new EntityIndexKey(family, scope, referenceSchema.getName())
+			);
+			if (!(typeIndex instanceof final ReferencedTypeEntityIndex typedTypeIndex)) {
+				continue;
+			}
+			typedTypeIndex.forEachReferenceIndexPrimaryKey(reducedIndexPk -> {
+				if (!membership.isKnown(reducedIndexPk)) {
+					membership.registerIndexAsResidual(reducedIndexPk);
+				}
+			});
+		}
+	}
+
+	/**
+	 * Records that an owner entity has left a reduced index. Symmetric counterpart of
+	 * {@link #recordOwnerEnteredReducedIndex}; see that method for why only partitioned references are kept.
+	 *
+	 * @param executor          the mutation executor, which owns the global index the lookup hangs off
+	 * @param referenceSchema   schema of the reference whose reduced index was left
+	 * @param referenceIndex    the reduced index the owner left
+	 * @param entityPrimaryKey  primary key of the owner entity
+	 */
+	private static void recordOwnerLeftReducedIndex(
+		@Nonnull EntityIndexLocalMutationExecutor executor,
+		@Nonnull ReferenceSchemaContract referenceSchema,
+		@Nonnull AbstractReducedEntityIndex referenceIndex,
+		int entityPrimaryKey
+	) {
+		final Scope scope = executor.getScope();
+		if (!isIndexedReferenceForFilteringAndPartitioning(referenceSchema, scope)) {
+			return;
+		}
+		final GlobalEntityIndex globalIndex = resolveGlobalIndex(executor, scope);
+		final ReducedIndexMembership membership =
+			globalIndex.getReducedIndexMembership(referenceSchema.getName());
+		if (membership == null) {
+			// nothing was ever recorded for this reference - the index is walked, so there is nothing to undo
+			return;
+		}
+		membership.ownerRemoved(
+			referenceIndex.getPrimaryKey(), entityPrimaryKey, referenceIndex.getAllPrimaryKeys()
+		);
+	}
+
+	/**
+	 * Resolves the collection's global index for the given scope, which is where the reduced-index membership
+	 * lookup lives.
+	 *
+	 * @param executor the mutation executor
+	 * @param scope    the scope whose global index is resolved
+	 * @return the global index, never `null`
+	 */
+	@Nonnull
+	private static GlobalEntityIndex resolveGlobalIndex(
+		@Nonnull EntityIndexLocalMutationExecutor executor,
+		@Nonnull Scope scope
+	) {
+		return (GlobalEntityIndex) executor.getOrCreateIndex(
+			new EntityIndexKey(EntityIndexType.GLOBAL, scope)
+		);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/ReferenceIndexMutator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/ReferenceIndexMutator.java
@@ -1244,8 +1244,9 @@ public interface ReferenceIndexMutator {
 	/**
 	 * Collects every {@link AbstractReducedEntityIndex} the owning entity is currently a member of - one entry
 	 * per unique index instance, across both the entity and the group path, restricted to references indexed at
-	 * {@link ReferenceIndexType#FOR_FILTERING_AND_PARTITIONING} level (the only ones for which reduced indexes
-	 * exist at all).
+	 * {@link ReferenceIndexType#FOR_FILTERING_AND_PARTITIONING} level - the only ones whose reduced indexes carry
+	 * facets. Reduced indexes themselves exist for every reference indexed at {@link ReferenceIndexType#FOR_FILTERING}
+	 * or above, so this restriction narrows the collected set and does not merely describe what is there.
 	 *
 	 * Resolution is delegated to {@link #forEachUniqueReferenceIndex} so this shares one traversal - including
 	 * its representative-key resolution and its identity dedup of shared

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/ReferenceIndexMutator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/ReferenceIndexMutator.java
@@ -154,6 +154,14 @@ import static io.evitadb.utils.Assert.isPremiseValid;
  * `isIndexedForGroupComponent`: evaluate whether a reference schema is configured for the requested
  * indexing level or component in the given scope, used heavily as guards throughout the other methods.
  *
+ * **Reduced-index membership maintenance** — `recordOwnerEnteredReducedIndex`,
+ * `recordOwnerLeftReducedIndex`, `seedFromAdvertisedIndexes`, `hasReducedIndexMembership`: keep the reverse
+ * lookup the cross-entity conditional-facet trigger consults
+ * ({@link io.evitadb.index.membership.ReducedIndexMembership}) in step with the reduced indexes the lifecycle
+ * operations above have just changed. Both boundaries are gated on the collection declaring a conditional
+ * facet and on the reference being indexed for partitioning, so a collection that can never fire the trigger
+ * pays a single bit test here and nothing else.
+ *
  * ## Thread safety
  *
  * All methods are stateless and operate on data provided via their parameters. Thread safety is delegated
@@ -1258,11 +1266,25 @@ public interface ReferenceIndexMutator {
 	 * Records that an owner entity has entered a reduced index, into the reverse lookup the cross-entity
 	 * conditional-facet trigger consults instead of walking every reduced index of the collection.
 	 *
-	 * Maintained **only** for references indexed at {@link ReferenceIndexType#FOR_FILTERING_AND_PARTITIONING},
-	 * because those are the only ones the trigger's sibling walk visits. A reference raised to that level
-	 * without a reindex therefore has no slice here at all, and its reduced indexes are walked exactly as they
-	 * were before — correct, merely unaccelerated, which is the intended behaviour for a schema change the
-	 * engine does not rebuild indexes for (issue #409).
+	 * Maintained **only** for a collection that declares a conditional facet in the scope — the trigger cannot
+	 * fire anywhere else, so a lookup built there would be maintained on every write for a reader that never
+	 * comes. That gate is the same one `EntityCollection#rebuildReducedIndexMembership` applies at load, and the
+	 * two must agree: a collection skipped at load and maintained on write would carry a lookup whose contents
+	 * begin at an arbitrary moment in its life.
+	 *
+	 * Within such a collection it is maintained **only** for references indexed at
+	 * {@link ReferenceIndexType#FOR_FILTERING_AND_PARTITIONING}, because those are the only ones the trigger's
+	 * sibling walk visits. A reference that has never been indexed at that level therefore has no slice at all,
+	 * and its reduced indexes are walked exactly as they were before — correct, merely unaccelerated, which is
+	 * the intended behaviour for a schema change the engine does not rebuild indexes for (issue #409).
+	 *
+	 * A reference that was *lowered* out of that level does have a slice, built while it was still watched, and it
+	 * must not be trusted if the reference is raised again. Nothing is done about that here: both gates read the
+	 * schema and nothing else, so maintenance can only ever stop at a **schema change**, and that is where such a
+	 * lookup is dropped — `EntityCollection#discardUnmaintainedReducedIndexMemberships`, hung off `exchangeSchema`
+	 * so that a reflected reference resolved without passing through `updateSchema` is covered too. Keeping the
+	 * write path free of that removal is deliberate: it costs a lookup per reference write, and a structural
+	 * removal from a transactional map is work worth confining to a rare, discrete event.
 	 *
 	 * @param executor          the mutation executor, which owns the global index the lookup hangs off
 	 * @param referenceSchema   schema of the reference whose reduced index was joined
@@ -1276,6 +1298,11 @@ public interface ReferenceIndexMutator {
 		int entityPrimaryKey
 	) {
 		final Scope scope = executor.getScope();
+		if (!executor.getEntitySchema().declaresConditionalFacetInScope(scope)) {
+			// memoized on the schema, so this is a bit test - the trigger never fires here, and the load-time
+			// build skips such a collection for the same reason, so there is nothing to maintain or to discard
+			return;
+		}
 		if (!isIndexedReferenceForFilteringAndPartitioning(referenceSchema, scope)) {
 			return;
 		}
@@ -1316,19 +1343,21 @@ public interface ReferenceIndexMutator {
 		@Nonnull Scope scope,
 		@Nonnull ReducedIndexMembership membership
 	) {
-		// both families advertise reduced indexes the trigger consults, and neither stands in for the other;
-		// allocated here rather than held as a constant because this runs once per reference per collection
-		final EntityIndexType[] families = {
-			EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
-		};
-		for (final EntityIndexType family : families) {
-			final EntityIndex typeIndex = executor.getIndexIfExists(
-				new EntityIndexKey(family, scope, referenceSchema.getName())
-			);
-			if (!(typeIndex instanceof final ReferencedTypeEntityIndex typedTypeIndex)) {
+		for (final EntityIndexType family : ReducedIndexMembership.REFERENCED_TYPE_INDEX_FAMILIES) {
+			final EntityIndexKey typeIndexKey = new EntityIndexKey(family, scope, referenceSchema.getName());
+			// absence is legitimate - the reference has no partitions of this family yet - but an index
+			// registered under a REFERENCED_*_TYPE key is a ReferencedTypeEntityIndex by construction, so any
+			// other type is a programming error and must not be skipped silently
+			final EntityIndex typeIndex = executor.getIndexIfExists(typeIndexKey);
+			if (typeIndex == null) {
 				continue;
 			}
-			typedTypeIndex.forEachReferenceIndexPrimaryKey(reducedIndexPk -> {
+			isPremiseValid(
+				typeIndex instanceof ReferencedTypeEntityIndex,
+				() -> "Invalid type of the index (`" + typeIndex.getClass() + "`) registered under `" +
+					typeIndexKey + "`."
+			);
+			((ReferencedTypeEntityIndex) typeIndex).forEachReferenceIndexPrimaryKey(reducedIndexPk -> {
 				if (!membership.isKnown(reducedIndexPk)) {
 					membership.registerIndexAsResidual(reducedIndexPk);
 				}
@@ -1337,8 +1366,47 @@ public interface ReferenceIndexMutator {
 	}
 
 	/**
+	 * Tells whether the reference carries a reverse lookup in this scope, **without** enrolling the global
+	 * index for modification, so a reference that holds no lookup pays two map lookups and nothing at commit.
+	 * That is the state of every partitioned reference of a conditional-facet collection until its first
+	 * recorded insert, and again after a schema change discards its lookup.
+	 *
+	 * Deliberately answers `boolean` rather than handing back the lookup itself. The index was read through
+	 * {@link EntityIndexLocalMutationExecutor#getIndexIfExists(EntityIndexKey)}, which does **not** enrol it
+	 * in the dirty set, so nothing would sweep its transactional layer at commit; writing through an object
+	 * obtained here would strand that layer and fail the commit with a `StaleTransactionMemoryException`
+	 * after the version already reached disk. Returning a boolean makes that mistake unavailable rather than
+	 * merely forbidden — a caller that needs to write must re-read through {@link #resolveGlobalIndex}.
+	 *
+	 * @param executor        the mutation executor, which owns the global index the lookup hangs off
+	 * @param referenceSchema schema of the reference whose lookup is probed
+	 * @param scope           the scope whose lookup is probed
+	 * @return `true` when the reference carries a lookup in this scope
+	 */
+	private static boolean hasReducedIndexMembership(
+		@Nonnull EntityIndexLocalMutationExecutor executor,
+		@Nonnull ReferenceSchemaContract referenceSchema,
+		@Nonnull Scope scope
+	) {
+		final EntityIndexKey globalIndexKey = new EntityIndexKey(EntityIndexType.GLOBAL, scope);
+		// absence is legitimate - the scope holds no entity yet - but an index registered under a GLOBAL key is
+		// a GlobalEntityIndex by construction, so any other type is a programming error
+		final EntityIndex globalIndex = executor.getIndexIfExists(globalIndexKey);
+		if (globalIndex == null) {
+			return false;
+		}
+		isPremiseValid(
+			globalIndex instanceof GlobalEntityIndex,
+			() -> "Invalid type of the index (`" + globalIndex.getClass() + "`) registered under `" +
+				globalIndexKey + "`."
+		);
+		return ((GlobalEntityIndex) globalIndex).getReducedIndexMembership(referenceSchema.getName()) != null;
+	}
+
+	/**
 	 * Records that an owner entity has left a reduced index. Symmetric counterpart of
-	 * {@link #recordOwnerEnteredReducedIndex}; see that method for why only partitioned references are kept.
+	 * {@link #recordOwnerEnteredReducedIndex}; see that method for why only partitioned references are kept, and
+	 * where a lookup that maintenance has stopped following is dropped instead.
 	 *
 	 * @param executor          the mutation executor, which owns the global index the lookup hangs off
 	 * @param referenceSchema   schema of the reference whose reduced index was left
@@ -1352,16 +1420,31 @@ public interface ReferenceIndexMutator {
 		int entityPrimaryKey
 	) {
 		final Scope scope = executor.getScope();
+		if (!executor.getEntitySchema().declaresConditionalFacetInScope(scope)) {
+			// see the insert counterpart: a bit test on the schema, and the only gate a collection without a
+			// conditional facet ever reaches
+			return;
+		}
 		if (!isIndexedReferenceForFilteringAndPartitioning(referenceSchema, scope)) {
 			return;
 		}
-		final GlobalEntityIndex globalIndex = resolveGlobalIndex(executor, scope);
-		final ReducedIndexMembership membership =
-			globalIndex.getReducedIndexMembership(referenceSchema.getName());
-		if (membership == null) {
-			// nothing was ever recorded for this reference - the index is walked, so there is nothing to undo
+		if (!hasReducedIndexMembership(executor, referenceSchema, scope)) {
+			// Nothing was ever recorded for this reference - the index is walked, so there is nothing to undo.
+			// Probed through the non-registering accessor on purpose: a removal is the one boundary that can
+			// arrive before any insert has created the lookup, and it arrives again for every reference of a
+			// collection whose lookups a schema change has just discarded. Enrolling the global index for
+			// modification on those would buy nothing and cost its merge at commit.
 			return;
 		}
+		// re-read through the registering accessor - that registration is what enrols the global index in the
+		// dirty set, and hence what gets its transactional layer swept at commit
+		final ReducedIndexMembership membership = resolveGlobalIndex(executor, scope)
+			.getReducedIndexMembership(referenceSchema.getName());
+		isPremiseValid(
+			membership != null,
+			() -> "The reduced-index membership lookup of `" + referenceSchema.getName() +
+				"` disappeared between the probe and the registration."
+		);
 		membership.ownerRemoved(
 			referenceIndex.getPrimaryKey(), entityPrimaryKey, referenceIndex.getAllPrimaryKeys()
 		);

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/ReferenceIndexMutator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/ReferenceIndexMutator.java
@@ -58,11 +58,11 @@ import io.evitadb.index.HistogramIndex;
 import io.evitadb.index.ReducedEntityIndex;
 import io.evitadb.index.ReducedGroupEntityIndex;
 import io.evitadb.index.ReferencedTypeEntityIndex;
-import io.evitadb.index.membership.ReducedIndexMembership;
 import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.facet.FacetGroupIndex;
 import io.evitadb.index.facet.FacetIdIndex;
 import io.evitadb.index.facet.FacetReferenceIndex;
+import io.evitadb.index.membership.ReducedIndexMembership;
 import io.evitadb.index.mutation.local.EntityIndexLocalMutationExecutor.RepresentativeReferenceKeys;
 import io.evitadb.index.mutation.local.dataAccess.ExistingAttributeValueSupplier;
 import io.evitadb.index.mutation.local.dataAccess.ExistingDataSupplierFactory;
@@ -155,8 +155,8 @@ import static io.evitadb.utils.Assert.isPremiseValid;
  * indexing level or component in the given scope, used heavily as guards throughout the other methods.
  *
  * **Reduced-index membership maintenance** — `recordOwnerEnteredReducedIndex`,
- * `recordOwnerLeftReducedIndex`, `seedFromAdvertisedIndexes`, `hasReducedIndexMembership`: keep the reverse
- * lookup the cross-entity conditional-facet trigger consults
+ * `recordOwnerLeftReducedIndex`, `isReducedIndexMembershipMaintained`, `seedFromAdvertisedIndexes`,
+ * `hasReducedIndexMembership`: keep the reverse lookup the cross-entity conditional-facet trigger consults
  * ({@link io.evitadb.index.membership.ReducedIndexMembership}) in step with the reduced indexes the lifecycle
  * operations above have just changed. Both boundaries are gated on the collection declaring a conditional
  * facet and on the reference being indexed for partitioning, so a collection that can never fire the trigger
@@ -947,7 +947,12 @@ public interface ReferenceIndexMutator {
 		int referencedPrimaryKey,
 		@Nonnull ExistingDataSupplierFactory existingDataSupplierFactory
 	) {
-		// remove reduced index PK → referenced primary key mapping from the type index
+		// Remove reduced index PK → referenced primary key mapping from the type index. This is unconditional
+		// and it happens FIRST, which is what `ReducedIndexMembership#ownerRemoved` relies on: the counter
+		// behind it drops the index from the reference's advertisement on the 1 -> 0 crossing, in the same
+		// synchronous step in which the membership map forgets it below, so `covered ∪ residual == advertised`
+		// holds across the removal. Deferring or conditioning this un-advertise would leave an advertised index
+		// in neither of that map's sets - a reduced index the cross-entity facet trigger then never visits.
 		final int pkForReferenceTypeIndex = referenceIndex.getPrimaryKey();
 		referenceTypeIndex.removePrimaryKey(pkForReferenceTypeIndex, referencedPrimaryKey);
 
@@ -1298,12 +1303,7 @@ public interface ReferenceIndexMutator {
 		int entityPrimaryKey
 	) {
 		final Scope scope = executor.getScope();
-		if (!executor.getEntitySchema().declaresConditionalFacetInScope(scope)) {
-			// memoized on the schema, so this is a bit test - the trigger never fires here, and the load-time
-			// build skips such a collection for the same reason, so there is nothing to maintain or to discard
-			return;
-		}
-		if (!isIndexedReferenceForFilteringAndPartitioning(referenceSchema, scope)) {
+		if (!isReducedIndexMembershipMaintained(executor, referenceSchema, scope)) {
 			return;
 		}
 		final GlobalEntityIndex globalIndex = resolveGlobalIndex(executor, scope);
@@ -1316,6 +1316,32 @@ public interface ReferenceIndexMutator {
 		membership.ownerAdded(
 			referenceIndex.getPrimaryKey(), entityPrimaryKey, referenceIndex.getAllPrimaryKeys()
 		);
+	}
+
+	/**
+	 * Tells whether the reverse lookup of this reference is kept current in this scope — the pair of gates both
+	 * maintenance boundaries open with, in the order they evaluate them.
+	 *
+	 * The first is memoized on the schema, so a collection that declares no conditional facet pays a bit test and
+	 * nothing else: the trigger never fires there, and `EntityCollection#rebuildReducedIndexMembership` skips such
+	 * a collection at load for the same reason, so there is nothing to maintain and nothing to discard. The second
+	 * confines the lookup to the references the trigger's sibling walk actually visits.
+	 *
+	 * Both read the schema and nothing else, which is what makes maintenance stoppable only at a schema change —
+	 * see {@link #recordOwnerEnteredReducedIndex} for where a lookup nothing maintains any more is dropped.
+	 *
+	 * @param executor        the mutation executor, which carries the entity schema
+	 * @param referenceSchema schema of the reference whose lookup would be maintained
+	 * @param scope           the scope the write lands in
+	 * @return `true` when a write to this reference has to be recorded into the lookup
+	 */
+	private static boolean isReducedIndexMembershipMaintained(
+		@Nonnull EntityIndexLocalMutationExecutor executor,
+		@Nonnull ReferenceSchemaContract referenceSchema,
+		@Nonnull Scope scope
+	) {
+		return executor.getEntitySchema().declaresConditionalFacetInScope(scope)
+			&& isIndexedReferenceForFilteringAndPartitioning(referenceSchema, scope);
 	}
 
 	/**
@@ -1420,12 +1446,7 @@ public interface ReferenceIndexMutator {
 		int entityPrimaryKey
 	) {
 		final Scope scope = executor.getScope();
-		if (!executor.getEntitySchema().declaresConditionalFacetInScope(scope)) {
-			// see the insert counterpart: a bit test on the schema, and the only gate a collection without a
-			// conditional facet ever reaches
-			return;
-		}
-		if (!isIndexedReferenceForFilteringAndPartitioning(referenceSchema, scope)) {
+		if (!isReducedIndexMembershipMaintained(executor, referenceSchema, scope)) {
 			return;
 		}
 		if (!hasReducedIndexMembership(executor, referenceSchema, scope)) {

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/ReferenceIndexMutator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/ReferenceIndexMutator.java
@@ -1358,6 +1358,12 @@ public interface ReferenceIndexMutator {
 	 * here. It does not need to: {@link ReducedIndexMembership#ownerAdded} demotes a small residual index into
 	 * coverage the next time it is written, so a seeded slice acquires coverage as its indexes are touched.
 	 *
+	 * Each advertised key is registered unguarded. The map is empty — the sole caller
+	 * {@link #recordOwnerEnteredReducedIndex} seeds only on the branch that just created it, and applies
+	 * `ownerAdded` afterwards — and a reduced index is filed in its type index under exactly one referenced or
+	 * group primary key, so no key arrives twice. A repeat would be a corrupt advertisement, and
+	 * {@link ReducedIndexMembership#registerIndexAsResidual} refuses one rather than letting it pass unnoticed.
+	 *
 	 * @param executor        the mutation executor
 	 * @param referenceSchema schema of the reference being seeded
 	 * @param scope           the scope whose indexes are inspected
@@ -1383,11 +1389,9 @@ public interface ReferenceIndexMutator {
 				() -> "Invalid type of the index (`" + typeIndex.getClass() + "`) registered under `" +
 					typeIndexKey + "`."
 			);
-			((ReferencedTypeEntityIndex) typeIndex).forEachReferenceIndexPrimaryKey(reducedIndexPk -> {
-				if (!membership.isKnown(reducedIndexPk)) {
-					membership.registerIndexAsResidual(reducedIndexPk);
-				}
-			});
+			((ReferencedTypeEntityIndex) typeIndex).forEachReferenceIndexPrimaryKey(
+				membership::registerIndexAsResidual
+			);
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
@@ -1524,7 +1524,7 @@ public final class ContainerizedLocalMutationExecutor
 				verifyReferenceAttributes(
 					targetEntityScope, this.entityContainer, this.referencesStorageContainer,
 					inputMutations, missingMandatedAttributes, mutationCollector,
-					implicitMutationBehavior
+					implicitMutationBehavior, true
 				);
 			}
 
@@ -1611,7 +1611,8 @@ public final class ContainerizedLocalMutationExecutor
 							inputMutations,
 							missingMandatedAttributes,
 							mutationCollector,
-							implicitMutationBehavior
+							implicitMutationBehavior,
+							false
 						);
 					}
 
@@ -2649,6 +2650,10 @@ public final class ContainerizedLocalMutationExecutor
 	 * @param missingMandatedAttributes A list to collect information about missing mandated attributes.
 	 * @param mutationCollector The collector for recording attribute mutations.
 	 * @param implicitMutations The set of implicit mutation behaviors to consider during the verification process.
+	 * @param scanAllReferences True for a brand-new entity, whose every reference must be verified. False for an
+	 *                          existing one, where only the references the mutations touched are re-verified - see
+	 *                          {@link #collectTouchedReferences} for why, and for the conditions that send this path
+	 *                          back to the full scan anyway.
 	 * @throws MandatoryAttributesNotProvidedException If mandatory attributes are missing and cannot be resolved.
 	 */
 	private void verifyReferenceAttributes(
@@ -2658,7 +2663,8 @@ public final class ContainerizedLocalMutationExecutor
 		@Nonnull List<? extends LocalMutation<?, ?>> inputMutations,
 		@Nonnull List<Object> missingMandatedAttributes,
 		@Nonnull MutationCollector mutationCollector,
-		@Nonnull EnumSet<ImplicitMutationBehavior> implicitMutations
+		@Nonnull EnumSet<ImplicitMutationBehavior> implicitMutations,
+		boolean scanAllReferences
 	) throws MandatoryAttributesNotProvidedException {
 		if (referencesStoragePart == null) {
 			return;
@@ -2693,39 +2699,174 @@ public final class ContainerizedLocalMutationExecutor
 				);
 			}
 		};
-		ReferenceSchema referenceSchema = null;
-		for (Reference reference : referencesStoragePart.getReferences()) {
-			if (reference.exists()) {
-				if (referenceSchema == null ||
-					!referenceSchema.getName().equals(reference.getReferenceName())) {
-					referenceSchema = entitySchema.getReferenceOrThrowException(reference.getReferenceName());
-				}
-				// skip references whose schema declares no mandatory / default-valued attributes -
-				// there is nothing to verify or default here, so we avoid probing the reference attributes
-				// for the common case
-				if (referenceSchema.getNonNullableOrDefaultValueAttributes().isEmpty()) {
-					continue;
-				}
-				missingReferenceMandatedAttribute.clear();
-				// point the shared handler at the reference currently being verified
-				currentReferenceKey[0] = reference.getReferenceKey();
+		// An existing entity only needs the references the mutations actually touched re-verified - EXCEPT when the
+		// batch added an entity locale. `processReferenceAttributesWithDefaultValue` iterates the entity locales for
+		// every localized mandatory / default-valued attribute, so a new entity locale makes references the batch
+		// never touched non-compliant in that locale. Falling back to the full scan there is deliberate: the partial
+		// alternative (re-scanning everything against only the added locales) would have to exclude the references
+		// verified by the touched pass, and the two key forms cannot be compared reliably enough to make that
+		// exclusion safe. Adding an entity locale is rare, and the full scan is what used to happen unconditionally.
+		final List<Reference> touchedReferences = scanAllReferences || hasAddedEntityLocale() ?
+			null : collectTouchedReferences(referencesStoragePart, inputMutations);
 
-				// probe the reference directly for each mandatory / default-valued schema attribute instead of
-				// materializing the full key set of the reference (a HashSet per reference on the hot path)
-				processReferenceAttributesWithDefaultValue(
-					referenceSchema, entityLocales, reference, missingAttributeHandler
-				);
-
-				if (!missingReferenceMandatedAttribute.isEmpty()) {
-					missingMandatedAttributes.add(
-						new MissingReferenceAttribute(
-							referenceSchema.getName(),
-							new ArrayList<>(missingReferenceMandatedAttribute)
-						)
+		if (touchedReferences == null) {
+			ReferenceSchema referenceSchema = null;
+			for (Reference reference : referencesStoragePart.getReferences()) {
+				if (reference.exists()) {
+					if (referenceSchema == null ||
+						!referenceSchema.getName().equals(reference.getReferenceName())) {
+						referenceSchema = entitySchema.getReferenceOrThrowException(reference.getReferenceName());
+					}
+					verifySingleReferenceAttributes(
+						referenceSchema, entityLocales, reference, currentReferenceKey,
+						missingReferenceMandatedAttribute, missingMandatedAttributes, missingAttributeHandler
 					);
 				}
 			}
+		} else {
+			for (final Reference reference : touchedReferences) {
+				verifySingleReferenceAttributes(
+					entitySchema.getReferenceOrThrowException(reference.getReferenceName()),
+					entityLocales, reference, currentReferenceKey,
+					missingReferenceMandatedAttribute, missingMandatedAttributes, missingAttributeHandler
+				);
+			}
 		}
+	}
+
+	/**
+	 * Verifies a single reference against the mandatory / default-valued attributes its schema declares, recording
+	 * any that are missing and emitting default-value mutations for the rest.
+	 *
+	 * Extracted so the full scan and the touched-references-only scan share one implementation - the two paths must
+	 * never diverge in what they consider compliant.
+	 *
+	 * @param referenceSchema                  schema of the verified reference
+	 * @param entityLocales                    locales the entity declares, probed for localized attributes
+	 * @param reference                        the reference being verified
+	 * @param currentReferenceKey              single-element holder pointing the shared handler at this reference
+	 * @param missingReferenceMandatedAttribute scratch list the handler accumulates missing attributes into
+	 * @param missingMandatedAttributes        output list of missing mandatory attributes across all references
+	 * @param missingAttributeHandler          handler invoked for each missing / defaulted attribute
+	 */
+	private static void verifySingleReferenceAttributes(
+		@Nonnull ReferenceSchema referenceSchema,
+		@Nonnull Set<Locale> entityLocales,
+		@Nonnull Reference reference,
+		@Nonnull ReferenceKey[] currentReferenceKey,
+		@Nonnull List<AttributeKey> missingReferenceMandatedAttribute,
+		@Nonnull List<Object> missingMandatedAttributes,
+		@Nonnull MissingAttributeHandler missingAttributeHandler
+	) {
+		// skip references whose schema declares no mandatory / default-valued attributes -
+		// there is nothing to verify or default here, so we avoid probing the reference attributes
+		// for the common case
+		if (referenceSchema.getNonNullableOrDefaultValueAttributes().isEmpty()) {
+			return;
+		}
+		missingReferenceMandatedAttribute.clear();
+		// point the shared handler at the reference currently being verified
+		currentReferenceKey[0] = reference.getReferenceKey();
+
+		// probe the reference directly for each mandatory / default-valued schema attribute instead of
+		// materializing the full key set of the reference (a HashSet per reference on the hot path)
+		processReferenceAttributesWithDefaultValue(
+			referenceSchema, entityLocales, reference, missingAttributeHandler
+		);
+
+		if (!missingReferenceMandatedAttribute.isEmpty()) {
+			missingMandatedAttributes.add(
+				new MissingReferenceAttribute(
+					referenceSchema.getName(),
+					new ArrayList<>(missingReferenceMandatedAttribute)
+				)
+			);
+		}
+	}
+
+	/**
+	 * Tells whether this entity application added an entity-scoped locale.
+	 *
+	 * Only {@link LocaleScope#ENTITY} counts: it is registered solely when the entity's own locale set actually
+	 * changed, so an attribute written in a locale the entity already declares does not trigger it.
+	 *
+	 * @return true when at least one added locale carries {@link LocaleScope#ENTITY}
+	 */
+	private boolean hasAddedEntityLocale() {
+		if (this.addedLocales == null) {
+			return false;
+		}
+		for (final EnumSet<LocaleScope> scopes : this.addedLocales.values()) {
+			if (scopes.contains(LocaleScope.ENTITY)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Resolves the references named by the incoming mutations, so an existing entity can be verified without walking
+	 * its whole reference container.
+	 *
+	 * This is the point of the optimization: a nested application on an *entangled* entity - one reached through a
+	 * reflected reference - carries a handful of mutations while the entity itself may hold thousands of references
+	 * accumulated from every entity that points at it. Scanning all of them per application made bulk ingest cost
+	 * grow with catalog size (issue #1531).
+	 *
+	 * Resolution is by binary search over the (name, primary key)-ordered container. **Returns `null` whenever any
+	 * key cannot be resolved unambiguously**, which makes the caller fall back to the full scan - the incremental
+	 * path must never verify less than the full one would.
+	 *
+	 * @param referencesStoragePart the container to resolve against
+	 * @param inputMutations        mutations applied to this entity in this batch
+	 * @return the touched, still-existing references, or null when the caller must scan everything
+	 */
+	@Nullable
+	private List<Reference> collectTouchedReferences(
+		@Nonnull ReferencesStoragePart referencesStoragePart,
+		@Nonnull List<? extends LocalMutation<?, ?>> inputMutations
+	) {
+		List<Reference> result = null;
+		Set<ReferenceKey> seen = null;
+		for (final LocalMutation<?, ?> inputMutation : inputMutations) {
+			if (!(inputMutation instanceof final ReferenceMutation<?> referenceMutation)) {
+				continue;
+			}
+			final ReferenceKey referenceKey =
+				getReferenceKeyManager().getAssignedReferenceKey(referenceMutation.getReferenceKey());
+			// only a key resolved to a concrete reference can be looked up without ambiguity; anything else
+			// (an unassigned or generic key) sends the caller back to the full scan
+			if (!referenceKey.isKnownInternalPrimaryKey()) {
+				return null;
+			}
+			if (seen == null) {
+				seen = CollectionUtils.createHashSet(inputMutations.size());
+				result = new ArrayList<>(inputMutations.size());
+			}
+			if (!seen.add(referenceKey)) {
+				continue;
+			}
+			final Optional<ReferenceContract> reference = referencesStoragePart.findReference(referenceKey);
+			// A mutation naming a reference the container cannot produce means our key is stale, not that there is
+			// nothing to verify: `ReferenceKeyManager#reassignReferenceKey` only mirrors a reassignment into
+			// `assignedPrimaryKeys` when the old key is present in `createdReferenceKeys`, so a reference whose
+			// already-positive internal id is reassigned outside that path leaves us holding the pre-reassignment
+			// key. Falling back to the full scan is the only safe reading - silently verifying fewer references
+			// than before would surface as a missing default value, with no exception anywhere.
+			if (reference.isEmpty()) {
+				return null;
+			}
+			// the container is the sole owner of these instances, so this is the concrete type it stores
+			if (!(reference.get() instanceof final Reference resolvedReference)) {
+				return null;
+			}
+			// a dropped reference is still returned by the lookup and is simply not verified, exactly as the full
+			// scan skips it - this is not the stale-key case above
+			if (resolvedReference.exists()) {
+				result.add(resolvedReference);
+			}
+		}
+		return result == null ? List.of() : result;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
@@ -2648,8 +2648,9 @@ public final class ContainerizedLocalMutationExecutor
 	 * makes an already-stored reference non-compliant — a reference attribute newly made mandatory, or newly
 	 * given a default value — is therefore not detected by a later upsert that touches a *different* reference
 	 * of the same entity, where it once would have been repaired (or refused) by that unrelated write. Such an
-	 * entity is repaired by writing the reference itself. That is the narrowing issue #1531 made deliberately;
-	 * the conditions that still send the check back over the whole container are listed on
+	 * entity is repaired by writing the reference itself. That is the narrowing issue #1531 made deliberately.
+	 * Three conditions still send the check back over the whole container: an entity-scoped locale added by the
+	 * batch ({@link #hasAddedEntityLocale()}), decided here, plus the two unresolvable-key conditions listed on
 	 * {@link #collectTouchedReferences}.
 	 *
 	 * @param scope The scope of the current operation.
@@ -2661,8 +2662,10 @@ public final class ContainerizedLocalMutationExecutor
 	 * @param implicitMutations The set of implicit mutation behaviors to consider during the verification process.
 	 * @param scanAllReferences True for a brand-new entity, whose every reference must be verified. False for an
 	 *                          existing one, where only the references the mutations touched are re-verified - see
-	 *                          {@link #collectTouchedReferences} for why, and for the conditions that send this path
-	 *                          back to the full scan anyway.
+	 *                          {@link #collectTouchedReferences} for why, and for the two unresolvable-key
+	 *                          conditions that send this path back to the full scan anyway. An added entity-scoped
+	 *                          locale ({@link #hasAddedEntityLocale()}) is a third such condition, and this method
+	 *                          decides it rather than that one.
 	 * @throws MandatoryAttributesNotProvidedException If mandatory attributes are missing and cannot be resolved.
 	 */
 	private void verifyReferenceAttributes(
@@ -2824,14 +2827,18 @@ public final class ContainerizedLocalMutationExecutor
 	 *
 	 * Resolution is by binary search over the (name, primary key)-ordered container. **Returns `null` whenever any
 	 * key cannot be resolved unambiguously**, which makes the caller fall back to the full scan - the incremental
-	 * path must never verify less than the full one would. Exactly two conditions do that:
+	 * path must never verify less than the full one would. Exactly two conditions make THIS method return `null`:
 	 *
 	 * - the key carries no known internal primary key, so it names no single reference to look up;
 	 * - the container holds no slot for the key at all, which means the key is stale rather than that there is
 	 *   nothing to verify.
 	 *
-	 * A reference the batch **removed** is neither: its slot resolves, so the key is proved current, and it is
-	 * skipped exactly as the full scan skips it on its own `exists()` check. A batch containing a removal
+	 * They are not the whole fall-back set. {@link #verifyReferenceAttributes} adds a third condition of its own
+	 * and evaluates it BEFORE calling this method at all - an entity-scoped locale added by the batch
+	 * ({@link #hasAddedEntityLocale()}) - so an audit of what still reaches the full scan has to read both sites.
+	 *
+	 * A reference the batch **removed** is none of the three: its slot resolves, so the key is proved current, and
+	 * it is skipped exactly as the full scan skips it on its own `exists()` check. A batch containing a removal
 	 * therefore stays on the incremental path.
 	 *
 	 * @param referencesStoragePart the container to resolve against

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
@@ -2643,6 +2643,15 @@ public final class ContainerizedLocalMutationExecutor
 	 * and ensures all mandatory attributes are accounted for. It checks for missing attributes,
 	 * processes attributes with default values, and updates the mutation collector if necessary.
 	 *
+	 * On an existing entity the verification covers the references the batch touched, not the whole container:
+	 * an untouched reference is trusted to have been compliant when it was last written. A schema change that
+	 * makes an already-stored reference non-compliant — a reference attribute newly made mandatory, or newly
+	 * given a default value — is therefore not detected by a later upsert that touches a *different* reference
+	 * of the same entity, where it once would have been repaired (or refused) by that unrelated write. Such an
+	 * entity is repaired by writing the reference itself. That is the narrowing issue #1531 made deliberately;
+	 * the conditions that still send the check back over the whole container are listed on
+	 * {@link #collectTouchedReferences}.
+	 *
 	 * @param scope The scope of the current operation.
 	 * @param entityStorageContainer The container representing the entity's body storage.
 	 * @param referencesStoragePart The container holding the entity's references storage, which may be null.
@@ -2815,7 +2824,15 @@ public final class ContainerizedLocalMutationExecutor
 	 *
 	 * Resolution is by binary search over the (name, primary key)-ordered container. **Returns `null` whenever any
 	 * key cannot be resolved unambiguously**, which makes the caller fall back to the full scan - the incremental
-	 * path must never verify less than the full one would.
+	 * path must never verify less than the full one would. Exactly two conditions do that:
+	 *
+	 * - the key carries no known internal primary key, so it names no single reference to look up;
+	 * - the container holds no slot for the key at all, which means the key is stale rather than that there is
+	 *   nothing to verify.
+	 *
+	 * A reference the batch **removed** is neither: its slot resolves, so the key is proved current, and it is
+	 * skipped exactly as the full scan skips it on its own `exists()` check. A batch containing a removal
+	 * therefore stays on the incremental path.
 	 *
 	 * @param referencesStoragePart the container to resolve against
 	 * @param inputMutations        mutations applied to this entity in this batch
@@ -2846,22 +2863,21 @@ public final class ContainerizedLocalMutationExecutor
 			if (!seen.add(referenceKey)) {
 				continue;
 			}
-			final Optional<ReferenceContract> reference = referencesStoragePart.findReference(referenceKey);
-			// A mutation naming a reference the container cannot produce means our key is stale, not that there is
-			// nothing to verify: `ReferenceKeyManager#reassignReferenceKey` only mirrors a reassignment into
-			// `assignedPrimaryKeys` when the old key is present in `createdReferenceKeys`, so a reference whose
-			// already-positive internal id is reassigned outside that path leaves us holding the pre-reassignment
-			// key. Falling back to the full scan is the only safe reading - silently verifying fewer references
-			// than before would surface as a missing default value, with no exception anywhere.
-			if (reference.isEmpty()) {
+			// resolved including a dropped reference on purpose: the two cases below are different verdicts, and
+			// `findReference` cannot tell them apart
+			final Reference resolvedReference = referencesStoragePart.findReferenceIncludingDropped(referenceKey);
+			// A mutation naming a reference the container holds no slot for at all means our key is stale, not
+			// that there is nothing to verify: `ReferenceKeyManager#reassignReferenceKey` only mirrors a
+			// reassignment into `assignedPrimaryKeys` when the old key is present in `createdReferenceKeys`, so a
+			// reference whose already-positive internal id is reassigned outside that path leaves us holding the
+			// pre-reassignment key. Falling back to the full scan is the only safe reading - silently verifying
+			// fewer references than before would surface as a missing default value, with no exception anywhere.
+			if (resolvedReference == null) {
 				return null;
 			}
-			// the container is the sole owner of these instances, so this is the concrete type it stores
-			if (!(reference.get() instanceof final Reference resolvedReference)) {
-				return null;
-			}
-			// a dropped reference is still returned by the lookup and is simply not verified, exactly as the full
-			// scan skips it - this is not the stale-key case above
+			// A reference the batch dropped is skipped rather than verified, exactly as the full scan skips it on
+			// its own `exists()` check - and unlike the stale key above, the slot proves the key resolved, so the
+			// batch stays on the incremental path instead of paying the whole-container scan for every removal.
 			if (resolvedReference.exists()) {
 				result.add(resolvedReference);
 			}

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/entity/ReferencesStoragePart.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/entity/ReferencesStoragePart.java
@@ -667,6 +667,26 @@ public class ReferencesStoragePart implements EntityStoragePart {
 	}
 
 	/**
+	 * Finds the reference identified by `referenceKey` in this container, **including one that has been
+	 * dropped**.
+	 *
+	 * {@link #findReference(ReferenceKey)} collapses "this container never held such a reference" and "it held
+	 * one and the batch removed it" into the same empty result, which is the right reading for a caller that
+	 * wants a usable reference. A caller that needs to tell a *stale key* from a *removal* cannot use it: a
+	 * batch removing a reference would look indistinguishable from one naming a key the container cannot
+	 * resolve. This accessor answers the position question instead and leaves the `exists()` decision to the
+	 * caller.
+	 *
+	 * @param referenceKey the key to locate
+	 * @return the reference the key resolves to, dropped or not, or `null` when the container holds none
+	 */
+	@Nullable
+	public Reference findReferenceIncludingDropped(@Nonnull ReferenceKey referenceKey) {
+		final int index = findReferenceIndex(referenceKey);
+		return index < 0 ? null : getReferences()[index];
+	}
+
+	/**
 	 * Finds a reference within the storage part that matches the given `referenceSchema`, `referenceKey`,
 	 * and the required `representativeAttributeValues`. If no matching reference is found, an exception
 	 * is thrown.

--- a/evita_engine/src/main/java/module-info.java
+++ b/evita_engine/src/main/java/module-info.java
@@ -79,6 +79,7 @@ module evita.engine {
 	exports io.evitadb.index.hierarchy.predicate;
 	exports io.evitadb.index.list;
 	exports io.evitadb.index.map;
+	exports io.evitadb.index.membership;
 	exports io.evitadb.index.price;
 	exports io.evitadb.index.price.model;
 	exports io.evitadb.index.price.model.priceRecord;

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReducedIndexMembershipCompletenessTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReducedIndexMembershipCompletenessTest.java
@@ -29,9 +29,13 @@ import io.evitadb.api.EntityCollectionContract;
 import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.configuration.EvitaConfiguration;
 import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.exception.MandatoryAttributesNotProvidedException;
 import io.evitadb.api.index.EntityIndexType;
 import io.evitadb.api.query.expression.ExpressionFactory;
+import io.evitadb.api.requestResponse.data.EntityEditor.EntityBuilder;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
 import io.evitadb.api.requestResponse.data.structure.EntityReference;
+import io.evitadb.api.requestResponse.data.structure.RepresentativeReferenceKey;
 import io.evitadb.api.statistics.CatalogStatisticsComponent;
 import io.evitadb.api.requestResponse.schema.Cardinality;
 import io.evitadb.api.requestResponse.schema.ReferenceIndexedComponents;
@@ -39,12 +43,16 @@ import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
 import io.evitadb.core.Evita;
 import io.evitadb.core.collection.EntityCollection;
 import io.evitadb.dataType.Scope;
+import io.evitadb.dataType.expression.Expression;
 import io.evitadb.index.EntityIndex;
 import io.evitadb.index.EntityIndexKey;
 import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.index.ReferencedTypeEntityIndex;
+import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.membership.ReducedIndexMembership;
+import io.evitadb.utils.CollectionUtils;
+import io.evitadb.utils.ExceptionUtils;
 import io.evitadb.test.EvitaTestSupport;
 import io.evitadb.test.EvitaTestSupport.TestPaths;
 import org.junit.jupiter.api.AfterEach;
@@ -52,19 +60,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import javax.annotation.Nonnull;
-import java.util.HashMap;
+import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.PrimitiveIterator.OfInt;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.Consumer;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static io.evitadb.api.query.Query.query;
@@ -81,6 +90,10 @@ import static io.evitadb.test.TestTags.CONTRACT;
 import static io.evitadb.test.TestTags.FACET;
 import static io.evitadb.test.TestTags.INDEXING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.awaitility.Awaitility.await;
 
@@ -103,16 +116,36 @@ import static org.awaitility.Awaitility.await;
  *   an owner missing from it is an owner the trigger will never consider;
  * - no covered index holds more owners than the threshold allows, which is what bounds the memory.
  *
- * It runs after each of the boundary classes in turn: bulk load, a later join, a departure, an entity removed
- * outright, a threshold crossing in each direction, and a catalog reloaded from disk — the last because the
- * lookup is derived state that is never persisted, and a reload that failed to rebuild it would leave a
- * collection permanently unaccelerated (or, worse, half-accelerated) with nothing else to show for it.
+ * It runs over **every scope**, and it refuses to pass vacuously: a scope whose global index is absent must
+ * also advertise no reduced indexes, or the assertion fails rather than returning silently. Both halves matter,
+ * because the `ARCHIVED` half of the rebuild loop and of the maintenance hooks is otherwise unasserted end to
+ * end.
  *
- * {@link #referenceRaisedToPartitionedStillRegistersOwners} covers the other half of the contract, and the
- * half that would be a wrong answer rather than a slow one: the lookup is an **accelerator, never an
- * authority**, so a reference whose indexes it does not know must still be walked in full. That is exactly
- * what a `ReferenceIndexType` raised on an already-populated collection produces — the engine does not rebuild
- * indexes for a schema change (issue #409) — and the facet must still reach every index it owes.
+ * It runs after each of the boundary classes in turn: bulk load, a later join, a departure, an entity removed
+ * outright, a threshold crossing in each direction, an entity moved between scopes, a schema change that ends
+ * maintenance, a rolled-back write, and a catalog reloaded from disk — the last because the lookup is derived
+ * state that is never persisted, and a reload that failed to rebuild it would leave a collection permanently
+ * unaccelerated (or, worse, half-accelerated) with nothing else to show for it.
+ *
+ * The other half of the contract is the one that would be a wrong answer rather than a slow one: the lookup is
+ * an **accelerator, never an authority**, so a reference whose indexes it does not know must still be walked in
+ * full. That is exactly what a `ReferenceIndexType` raised on an already-populated collection produces — the
+ * engine does not rebuild indexes for a schema change (issue #409) — and the facet must still reach every index
+ * it owes.
+ *
+ * Several tests attack it, each from a state in which the lookup is absent, incomplete or simply false.
+ * {@link #reloadThenRaiseReferenceToPartitionedStillReachesEveryIndex} and
+ * {@link #referenceLoweredAndRaisedAgainStillReachesEveryIndex} drive the reference across the index level the
+ * maintenance hooks are gated on; {@link #conditionalFacetDroppedAndReDeclaredStillReachesEveryIndex} drives
+ * the *other* gate, the collection's last conditional facet, across the same boundary; and
+ * {@link #siblingWalkSurvivesAStaleCoveredEntry} feeds the lookup entries that are simply false. In all of them
+ * the facet must still reach every partition it owes.
+ *
+ * The gates are pure functions of the schema, so a schema change is the only event that can end maintenance —
+ * which is why the discard hangs off `EntityCollection#exchangeSchema`. That placement is itself asserted
+ * rather than argued: {@link #reflectedReferenceLoweredFromTheSourceCollectionDiscardsItsLookup} lowers a
+ * reference in the collection a **reflected** one reflects, an adoption path that never passes through
+ * `updateSchema`, and requires the reflected reference's lookup to be gone.
  *
  * @author Claude (issue #1529 sibling-resolver optimization), FG Forrest a.s. (c) 2026
  */
@@ -127,21 +160,47 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 	private static final String ENTITY_BRAND = "brand";
 	private static final String ENTITY_PARAMETER = "parameter";
 	private static final String ENTITY_PARAMETER_VALUE = "parameterValue";
+	private static final String ENTITY_TAG = "tag";
 
 	private static final String REF_CATEGORIES = "categories";
 	private static final String REF_BRAND = "brand";
 	private static final String REF_PARAMETER_VALUES = "parameterValues";
+	private static final String REF_TAGS = "tags";
+	/** Reference on the CATEGORY collection pointing back at products - the source of the reflected one below. */
+	private static final String REF_PRODUCTS = "products";
+	/** Reflected counterpart on the PRODUCT collection; it inherits its index type from {@link #REF_PRODUCTS}. */
+	private static final String REF_REFLECTED_CATEGORIES = "categoriesReflected";
 	private static final String ATTR_INPUT_WIDGET_TYPE = "inputWidgetType";
+	private static final String ATTR_TAG_NOTE = "tagNote";
 
 	private static final int PARAMETER_PK = 100;
 	private static final int PARAM_VALUE_PK = 10;
 	private static final int BRAND_PK = 7;
+	private static final int SECOND_BRAND_PK = 8;
+	private static final int TAG_PK = 55;
+
+	/**
+	 * Primary key of the product every rollback test writes and expects to disappear again.
+	 */
+	private static final int REVERTED_PRODUCT_PK = 900;
+
+	/**
+	 * Category the reverted product joins, so the rollback has a brand-new reduced index to undo as well as an
+	 * entry in an existing one.
+	 */
+	private static final int REVERTED_CATEGORY_PK = 24;
 
 	/**
 	 * Comfortably more than `ReducedIndexMembership.DEFAULT_COVERAGE_THRESHOLD`, so a category can be pushed
 	 * over the coverage boundary and pulled back under it within one test.
 	 */
 	private static final int OVER_THRESHOLD = 25;
+
+	/**
+	 * A storage primary key no index of the test catalog can ever hold — index primary keys are handed out
+	 * from zero upwards — so a lookup entry naming it is guaranteed to be unresolvable.
+	 */
+	private static final int UNRESOLVABLE_INDEX_PK = Integer.MAX_VALUE - 1;
 
 	private TestPaths paths;
 	private Evita evita;
@@ -217,8 +276,8 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 		// one category grows past the coverage threshold - it must leave coverage for the walk
 		upsertProducts(1, OVER_THRESHOLD, 1);
 		assertMembershipMatchesIndexes();
-		assertTrue(
-			residualOf(REF_CATEGORIES).size() > 0,
+		assertFalse(
+			residualOf(REF_CATEGORIES).isEmpty(),
 			"a category of " + OVER_THRESHOLD + " owners must have been promoted out of coverage"
 		);
 		// ... and shrinks back far enough to be demoted into coverage again
@@ -227,6 +286,350 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 			tx(session -> session.deleteEntity(ENTITY_PRODUCT, productPk));
 		}
 		assertMembershipMatchesIndexes();
+		// the demotion has to be asserted directly: a permanently-residual index satisfies the completeness
+		// assertion perfectly well, so without this a regression that dropped the demotion branch would leave
+		// this test green while its own name became false
+		assertTrue(
+			residualOf(REF_CATEGORIES).isEmpty(),
+			"the shared category now holds a single owner and must have been demoted back into coverage"
+		);
+		assertFalse(
+			coveredOf(REF_CATEGORIES).isEmpty(),
+			"the shared category's reduced index must be covered after the shrink"
+		);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+	@DisplayName("archiving an owner moves its membership between scopes, and restoring moves it back")
+	void archivingAnOwnerMovesItsMembershipBetweenScopes(CatalogState state) {
+		prepare(state, "CHECKBOX");
+		upsertProducts(1, 5, 1);
+		assertMembershipMatchesIndexes();
+		assertTrue(
+			coveredOwnersOf(REF_CATEGORIES, Scope.LIVE).contains(3),
+			"the owner must be covered in LIVE before it is archived, or the move below proves nothing"
+		);
+
+		tx(session -> session.archiveEntity(ENTITY_PRODUCT, 3));
+
+		assertMembershipMatchesIndexes();
+		assertFalse(
+			coveredOwnersOf(REF_CATEGORIES, Scope.LIVE).contains(3),
+			"an archived owner left every LIVE reduced index, so the LIVE lookup must have forgotten it - a "
+				+ "retained entry names a partition the owner is no longer in, which is a wrong facet"
+		);
+		assertTrue(
+			coveredOwnersOf(REF_CATEGORIES, Scope.ARCHIVED).contains(3),
+			"the ARCHIVED lookup must know the owner it just gained - without it the ARCHIVED trigger applies "
+				+ "no facet to the owner's partition at all"
+		);
+
+		tx(session -> session.restoreEntity(ENTITY_PRODUCT, 3));
+
+		assertMembershipMatchesIndexes();
+		assertTrue(
+			coveredOwnersOf(REF_CATEGORIES, Scope.LIVE).contains(3),
+			"a restored owner must be known to the LIVE lookup again"
+		);
+		assertFalse(
+			coveredOwnersOf(REF_CATEGORIES, Scope.ARCHIVED).contains(3),
+			"the ARCHIVED lookup must have forgotten the restored owner"
+		);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+	@DisplayName("a collection declaring no conditional facet grows no lookup on write either")
+	void collectionWithoutConditionalFacetGrowsNoLookupOnWrite(CatalogState state) {
+		// The load-time build skips such a collection outright, and maintenance has to agree: the cross-entity
+		// trigger can never fire here, so every entry written on the write path would be maintained for a reader
+		// that never comes - and `categories` IS partitioned, so without the gate the writes below would build a
+		// full lookup for it.
+		prepare(state, "CHECKBOX", EnumSet.noneOf(Scope.class));
+		upsertProducts(1, 5, 1);
+
+		assertMembershipMatchesIndexes();
+		final EntityCollection collection = (EntityCollection) getProductCollection();
+		for (final Scope scope : Scope.values()) {
+			for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
+				assertNull(
+					membershipOf(reference.getName(), scope),
+					"scope " + scope + ", reference `" + reference.getName() + "`: no reference of this "
+						+ "collection declares a conditional facet, so the trigger never fires and a lookup here "
+						+ "is maintained on every write for nobody"
+				);
+			}
+		}
+	}
+
+	@Test
+	@DisplayName("a reflected reference lowered by the OTHER collection's schema change loses its lookup")
+	void reflectedReferenceLoweredFromTheSourceCollectionDiscardsItsLookup() {
+		// The placement of the discard is what this test exists for. A reflected reference inherits its index type
+		// from the reference it reflects, which lives in ANOTHER collection - and when that one changes, this
+		// collection adopts the new schema through `notifyAboutExternalReferenceUpdate` -> `exchangeSchema`,
+		// never through its own `updateSchema`. A discard hooked on `updateSchema` would therefore never fire for
+		// a reflected reference, and the lookup would be trusted again the moment the source raises it back.
+		prepareReflected();
+		assertNotNull(
+			membershipOf(REF_REFLECTED_CATEGORIES, Scope.LIVE),
+			"the reflected reference inherits FOR_FILTERING_AND_PARTITIONING, so its lookup must have been built"
+		);
+		assertMembershipMatchesIndexes();
+
+		// the schema change happens on the CATEGORY collection, not on this one
+		setCategoryProductsIndexing(false);
+
+		assertNull(
+			membershipOf(REF_REFLECTED_CATEGORIES, Scope.LIVE),
+			"the reflected reference is no longer partitioned, so nothing maintains its lookup and it must have "
+				+ "been discarded - a lookup kept here is trusted again the moment the source reference is raised"
+		);
+		assertMembershipMatchesIndexes();
+
+		// a partition created while nothing was watching the reflected reference ...
+		upsertCategoryWithProducts(2, 1, 5);
+		// ... and the source raises it again
+		setCategoryProductsIndexing(true);
+		fireCrossEntityTrigger();
+
+		assertMembershipMatchesIndexes();
+		assertEquals(
+			5, countInPartitionWithFacetSelected(REF_REFLECTED_CATEGORIES, 2),
+			"the partition that appeared while the reflected reference was merely filterable must receive the "
+				+ "facet too - the lookup could not have recorded it, so it must not have been trusted"
+		);
+	}
+
+	@Test
+	@DisplayName("dropping the collection's last conditional facet and re-declaring it still reaches every index")
+	void conditionalFacetDroppedAndReDeclaredStillReachesEveryIndex() {
+		// The third instance of one defect class: maintenance is gated on the collection declaring a conditional
+		// facet, so dropping the last one stops it while the reduced indexes go on changing - and re-declaring it
+		// would put the trigger back on a lookup frozen at the moment the facet went away. The first two instances
+		// were a reference raised after a reload and a reference lowered and raised again.
+		prepare(CatalogState.ALIVE, "INTERVAL_INPUT");
+		upsertProducts(1, 5, 1);
+		assertNotNull(membershipOf(REF_CATEGORIES, Scope.LIVE), "the lookup must exist before the facet is dropped");
+
+		setConditionalFacet(false);
+		// a category the lookup has never seen, created while nothing is watching it
+		upsertProducts(6, 10, 2);
+		setConditionalFacet(true);
+
+		fireCrossEntityTrigger();
+
+		assertEquals(
+			5, countInCategoryWithFacetSelected(1),
+			"the category the lookup knew must still receive the facet"
+		);
+		assertEquals(
+			5, countInCategoryWithFacetSelected(2),
+			"the category whose index appeared while the collection had no conditional facet must receive the "
+				+ "facet too - the lookup could not have recorded it, so it must not have been trusted"
+		);
+	}
+
+	@Test
+	@DisplayName("a COMMITTED write that discards a lookup leaves the catalog usable")
+	void committedLoweringDiscardsTheLookupWithoutBreakingTheCommit() {
+		// The discard is the only production path that removes a whole slice from the transactional map holding
+		// them, and a removal whose nested diff layers are not swept fails the commit AFTER the version has
+		// reached disk - which suspends the catalog and leaves a version on disk nobody can trust. The rolled-back
+		// twin of this test cannot see that: a rejected transaction throws its layers away wholesale. This one
+		// commits.
+		prepare(CatalogState.ALIVE, "CHECKBOX");
+		upsertProducts(1, 5, 1);
+		assertFalse(coveredOf(REF_CATEGORIES).isEmpty(), "the lookup must hold coverage before it is discarded");
+
+		setCategoriesIndexing(false);
+		// the write that fires the discard, and commits
+		upsertProducts(6, 6, 2);
+
+		assertNull(
+			membershipOf(REF_CATEGORIES, Scope.LIVE),
+			"the lookup of a reference that is no longer partitioned must have been discarded"
+		);
+		assertMembershipMatchesIndexes();
+		// a suspended catalog refuses the next write, and a failed commit would have suspended it
+		upsertProducts(7, 7, 2);
+		assertEquals(
+			2, countInCategoryWithFacetSelected(2),
+			"the catalog must still answer queries over the partition written after the discard"
+		);
+	}
+
+	@Test
+	@DisplayName("a lookup created and discarded inside ONE transaction leaves the catalog usable")
+	void lookupCreatedAndDiscardedInOneTransactionLeavesTheCatalogUsable() {
+		// The created-then-removed shape: the slice is created by the first write of this transaction, so its key
+		// lives only in the transaction's diff layer and never in the committed map - the case a commit-time
+		// sweep that only walks the committed map cannot see. Driven here through the public API alone, by
+		// lowering the reference in the same transaction that created the slice.
+		prepare(CatalogState.ALIVE, "CHECKBOX");
+		assertNull(
+			membershipOf(REF_CATEGORIES, Scope.LIVE),
+			"no product has been written yet, so no lookup may exist - or this test proves nothing"
+		);
+
+		tx(session -> {
+			// (1) creates the lookup for `categories` and records this owner in it
+			session.createNewEntity(ENTITY_PRODUCT, 1)
+				.setReference(REF_CATEGORIES, 1)
+				.setReference(REF_BRAND, BRAND_PK)
+				.setReference(
+					REF_PARAMETER_VALUES, PARAM_VALUE_PK,
+					whichIs -> whichIs.setGroup(ENTITY_PARAMETER, PARAMETER_PK)
+				)
+				.upsertVia(session);
+			// (2) lowers the reference, so the next write cannot keep the lookup current any more
+			session.getEntitySchemaOrThrowException(ENTITY_PRODUCT)
+				.openForWrite()
+				.withReferenceToEntity(
+					REF_CATEGORIES, ENTITY_CATEGORY, Cardinality.ZERO_OR_MORE,
+					whichIs -> whichIs.indexedForFiltering()
+				)
+				.updateVia(session);
+			// (3) discards the lookup created in step (1), in the same transaction
+			session.createNewEntity(ENTITY_PRODUCT, 2)
+				.setReference(REF_CATEGORIES, 2)
+				.setReference(REF_BRAND, BRAND_PK)
+				.setReference(
+					REF_PARAMETER_VALUES, PARAM_VALUE_PK,
+					whichIs -> whichIs.setGroup(ENTITY_PARAMETER, PARAMETER_PK)
+				)
+				.upsertVia(session);
+		});
+
+		assertNull(
+			membershipOf(REF_CATEGORIES, Scope.LIVE),
+			"the lookup created and discarded inside the transaction must not survive it"
+		);
+		assertMembershipMatchesIndexes();
+		// the commit above must have completed: a failed one suspends the catalog and the next write is refused
+		upsertProducts(3, 3, 2);
+		assertMembershipMatchesIndexes();
+	}
+
+	@Test
+	@DisplayName("a reverted transaction that lowered a reference leaves its lookup intact")
+	void revertedLoweringLeavesTheLookupIntact() {
+		// Lowering a reference out of partitioning DISCARDS its lookup - the only production path that removes a
+		// whole slice from the map holding them. Here the lowering happens inside a transaction that is then
+		// refused, after every index has already been mutated, so the removal has to rewind with everything else.
+		// A removal that failed to rewind would leave the reference permanently unaccelerated - and, because a
+		// stranded diff layer fails the NEXT commit rather than this one, would surface far from its cause.
+		//
+		// `ALIVE` only: in `WARMING_UP` a schema change is applied immediately and belongs to no rewind unit, so
+		// there would be nothing for the refused write to take back.
+		prepare(CatalogState.ALIVE, "CHECKBOX");
+		upsertProducts(1, 5, 1);
+		assertMembershipMatchesIndexes();
+		final Set<Integer> coveredBefore = coveredOf(REF_CATEGORIES);
+		assertFalse(coveredBefore.isEmpty(), "the lookup must hold coverage before the write, or nothing is lost");
+
+		// the `tags` reference is missing its mandatory attribute, and consistency is verified only after the
+		// schema change - and hence the discard - has already run
+		assertRefusedForMissingMandatoryAttribute(
+			() -> tx(session -> {
+				session.getEntitySchemaOrThrowException(ENTITY_PRODUCT)
+					.openForWrite()
+					.withReferenceToEntity(
+						REF_CATEGORIES, ENTITY_CATEGORY, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs.indexedForFiltering()
+					)
+					.updateVia(session);
+				session.createNewEntity(ENTITY_PRODUCT, REVERTED_PRODUCT_PK)
+					.setReference(REF_TAGS, TAG_PK)
+					.upsertVia(session);
+			})
+		);
+
+		assertNotNull(
+			membershipOf(REF_CATEGORIES, Scope.LIVE),
+			"the discard was part of a transaction that never happened, so the lookup must still be there"
+		);
+		assertEquals(
+			coveredBefore, coveredOf(REF_CATEGORIES),
+			"the rewound lookup must hold exactly the coverage it held before the refused transaction"
+		);
+		assertMembershipMatchesIndexes();
+
+		// A rewind that left a transactional layer behind fails the NEXT commit, not this one, and would be
+		// invisible here otherwise - so a further write is required to succeed.
+		upsertProducts(6, 7, 1);
+		assertMembershipMatchesIndexes();
+		assertTrue(
+			coveredOwnersOf(REF_CATEGORIES, Scope.LIVE).contains(6),
+			"the lookup must still be maintained after the refused transaction"
+		);
+	}
+
+	@Test
+	@DisplayName("a scope declaring no conditional facet grows no lookup when the catalog is loaded")
+	void archivedScopeWithoutConditionalFacetGrowsNoSlice() {
+		// the conditional facet is declared in LIVE only, so the ARCHIVED trigger never fires and the ARCHIVED
+		// half of the load-time build must do nothing at all
+		prepare(CatalogState.ALIVE, "CHECKBOX", EnumSet.of(Scope.LIVE));
+		upsertProducts(1, 5, 1);
+		tx(session -> session.archiveEntity(ENTITY_PRODUCT, 3));
+
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		awaitCatalogLoaded();
+
+		assertMembershipMatchesIndexes();
+		assertNotNull(
+			membershipOf(REF_CATEGORIES, Scope.LIVE),
+			"the LIVE scope declares the conditional facet, so its lookup must have been rebuilt"
+		);
+		final EntityCollection collection = (EntityCollection) getProductCollection();
+		for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
+			assertNull(
+				membershipOf(reference.getName(), Scope.ARCHIVED),
+				"reference `" + reference.getName() + "`: the ARCHIVED scope declares no conditional facet, so "
+					+ "building a lookup for it costs memory the trigger will never read"
+			);
+		}
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+	@DisplayName("a reverted write leaves the lookup matching the indexes")
+	void revertedWriteLeavesTheLookupMatchingTheIndexes(CatalogState state) {
+		// The two states rewind through two entirely different mechanisms and only the structures each one knows
+		// about come back: `ALIVE` restores the transactional diff layers through the savepoint maintainer, while
+		// `WARMING_UP` replays the inverses the structures journalled into the `WarmUpSavepoint` - warm-up writes
+		// went in place, so there is no layer to throw away. A structure hooked into one and not the other looks
+		// perfectly correct until the other path runs.
+		prepare(state, "CHECKBOX");
+		upsertProducts(1, 5, 1);
+		assertMembershipMatchesIndexes();
+
+		// the failing entity joins a brand-new reduced index AND an existing one, so the rewind has both an
+		// index registration and a plain membership entry to undo. The `tags` reference is missing its mandatory
+		// attribute, and consistency is verified only after every index has already been mutated.
+		assertRefusedForMissingMandatoryAttribute(
+			() -> tx(session -> session.createNewEntity(ENTITY_PRODUCT, REVERTED_PRODUCT_PK)
+				.setReference(REF_CATEGORIES, 1)
+				.setReference(REF_CATEGORIES, REVERTED_CATEGORY_PK)
+				.setReference(REF_TAGS, TAG_PK)
+				.upsertVia(session))
+		);
+
+		assertMembershipMatchesIndexes();
+		assertFalse(
+			coveredOwnersOf(REF_CATEGORIES, Scope.LIVE).contains(REVERTED_PRODUCT_PK),
+			"the reverted owner must be gone from the lookup - it is gone from the indexes, so an entry naming "
+				+ "it would send the trigger at a partition that no longer holds it"
+		);
+
+		// a later write must still succeed: a rewind that left a diff layer behind fails the NEXT commit, not
+		// this one, and would otherwise be invisible here
+		upsertProducts(6, 7, 1);
+		assertMembershipMatchesIndexes();
+		assertTrue(coveredOwnersOf(REF_CATEGORIES, Scope.LIVE).contains(6));
 	}
 
 	@Test
@@ -243,41 +646,137 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 
 		assertMembershipMatchesIndexes();
 		assertMembershipEngaged(REF_CATEGORIES);
-		assertTrue(
-			coveredOf(REF_CATEGORIES).size() > 0,
+		assertFalse(
+			coveredOf(REF_CATEGORIES).isEmpty(),
 			"a reloaded collection must regain COVERAGE, not merely a residual list - the load-time build "
 				+ "resolves each index and decides coverage, unlike the seeding maintenance does"
 		);
 	}
 
 	@Test
-	@DisplayName("a reference raised to partitioned after load is still walked in full")
-	void referenceRaisedToPartitionedStillRegistersOwners() {
-		// `brand` starts out merely filterable, so the trigger's sibling walk never visits its reduced index
+	@DisplayName("every reference the lookup is keyed by is still declared by the schema")
+	void everyReferenceNameInTheLookupIsInTheSchema() {
+		prepare(CatalogState.ALIVE, "CHECKBOX");
+		upsertProducts(1, 5, 1);
+
+		final EntityCollection collection = (EntityCollection) getProductCollection();
+		final Set<String> declared = collection.getSchema().getReferences().keySet();
+		for (final Scope scope : Scope.values()) {
+			final GlobalEntityIndex globalIndex = globalIndexOf(scope);
+			if (globalIndex == null) {
+				continue;
+			}
+			for (final String referenceName : globalIndex.getReducedIndexMembershipReferenceNames()) {
+				assertTrue(
+					declared.contains(referenceName),
+					"scope " + scope + ": the lookup is keyed by `" + referenceName + "`, which the schema no "
+						+ "longer declares - such a slice is never read and never freed"
+				);
+			}
+		}
+		assertFalse(
+			globalIndexOf(Scope.LIVE).getReducedIndexMembershipReferenceNames().isEmpty(),
+			"the LIVE global index must hold at least one lookup here, or the loop above asserts nothing"
+		);
+	}
+
+	@Test
+	@DisplayName("a reference raised to partitioned after a RELOAD still reaches every index")
+	void reloadThenRaiseReferenceToPartitionedStillReachesEveryIndex() {
+		// Same schema change as the test above, but with a catalog reload in between. That is the difference
+		// that matters: were the load-time build to register a non-partitioned reference's reduced indexes, a
+		// slice would EXIST, and the trigger would take the accelerated branch over it instead of walking -
+		// while the maintenance hooks, gated on partitioning, recorded nothing into it. Every index created
+		// after the load would then be in neither the covered nor the residual set, and silently skipped.
 		prepare(CatalogState.ALIVE, "INTERVAL_INPUT");
 		upsertProducts(1, 5, 1);
 
-		// raise it, exactly as a client would, and WITHOUT the reindex that would rebuild anything
-		tx(session -> session.getEntitySchemaOrThrowException(ENTITY_PRODUCT)
-			.openForWrite()
-			.withReferenceToEntity(
-				REF_BRAND, ENTITY_BRAND, Cardinality.ZERO_OR_ONE,
-				whichIs -> whichIs.indexedForFilteringAndPartitioning()
-			)
-			.updateVia(session));
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		awaitCatalogLoaded();
 
-		// now fire the cross-entity trigger: the group entity starts satisfying the expression
-		tx(session -> session.getEntity(ENTITY_PARAMETER, PARAMETER_PK, entityFetchAllContent())
-			.orElseThrow()
-			.openForWrite()
-			.setAttribute(ATTR_INPUT_WIDGET_TYPE, "CHECKBOX")
-			.upsertVia(session));
+		// a reduced index created AFTER the load, while `brand` is still merely filterable
+		tx(session -> session.createNewEntity(ENTITY_BRAND, SECOND_BRAND_PK).upsertVia(session));
+		upsertProducts(6, 10, 1, SECOND_BRAND_PK);
 
-		// the facet must have reached the brand's reduced index even though the lookup never knew it -
-		// this is the accelerator-not-authority contract, and its failure would be a wrong answer
+		raiseBrandToPartitioned();
+		fireCrossEntityTrigger();
+
 		assertEquals(
-			5, countInBrandWithFacetSelected(),
-			"every product must survive selecting the facet inside the raised reference's index"
+			5, countInBrandWithFacetSelected(BRAND_PK),
+			"the brand the load saw must still receive the facet"
+		);
+		assertEquals(
+			5, countInBrandWithFacetSelected(SECOND_BRAND_PK),
+			"the brand created after the load must receive the facet too - a reference the lookup does not "
+				+ "cover is walked in full, and a raise without a reindex is exactly that case"
+		);
+	}
+
+	@Test
+	@DisplayName("a reference lowered and raised again still reaches the indexes created in between")
+	void referenceLoweredAndRaisedAgainStillReachesEveryIndex() {
+		// The lookup is maintained only while the reference is indexed for partitioning. Lowering it stops the
+		// hooks; the reduced indexes go on changing regardless; raising it back puts the trigger on the
+		// accelerated branch again. Anything the lookup missed in between is an index the trigger would never
+		// visit - a wrong facet, not a slow one - so the lookup has to be discarded the moment it stops being
+		// able to keep up.
+		prepare(CatalogState.ALIVE, "INTERVAL_INPUT");
+		upsertProducts(1, 5, 1);
+		assertTrue(
+			coveredOwnersOf(REF_CATEGORIES, Scope.LIVE).contains(1),
+			"the owners must be covered before the reference is lowered, or the lookup has nothing to lose"
+		);
+
+		setCategoriesIndexing(false);
+		// a brand-new reduced index for a category the lookup has never seen, created while nothing is watching
+		upsertProducts(6, 10, 2);
+		setCategoriesIndexing(true);
+
+		fireCrossEntityTrigger();
+
+		assertEquals(
+			5, countInCategoryWithFacetSelected(1),
+			"the category the lookup knew must still receive the facet"
+		);
+		assertEquals(
+			5, countInCategoryWithFacetSelected(2),
+			"the category whose index appeared while the reference was merely filterable must receive the "
+				+ "facet too - the lookup could not have recorded it, so it must not have been trusted"
+		);
+	}
+
+	@Test
+	@DisplayName("the sibling walk survives a covered entry naming a reduced index that no longer exists")
+	void siblingWalkSurvivesAStaleCoveredEntry() {
+		// The map's own contract is that nothing it records is an answer: it selects which reduced indexes are
+		// worth probing, and each index is then asked itself who is in it. This drives it into the two states
+		// that contract exists to survive - an entry naming an index the collection does not hold, and an owner
+		// recorded against an index it is not a member of - and asserts the trigger neither fails nor writes a
+		// facet anywhere it does not belong. The entries are injected rather than provoked because every
+		// production route into them is closed; the guard is what keeps the next closed route from mattering.
+		prepare(CatalogState.ALIVE, "INTERVAL_INPUT");
+		upsertProducts(1, 5, 1);
+		upsertProducts(6, 10, 2);
+
+		final ReducedIndexMembership membership = membershipOf(REF_CATEGORIES, Scope.LIVE);
+		assertNotNull(membership, "the lookup must exist, or there is nothing to make stale");
+		// an index that does not exist, recorded as holding owners that do exist
+		membership.registerIndex(UNRESOLVABLE_INDEX_PK, new BaseBitmap(1, 2, 3));
+		// ... and owners recorded against the reduced index of a category they were never filed under
+		final int categoryTwoIndexPk = reducedIndexPkOf(REF_CATEGORIES, 2);
+		membership.ownerAdded(categoryTwoIndexPk, 1, new BaseBitmap(1, 6, 7, 8, 9, 10));
+
+		fireCrossEntityTrigger();
+
+		assertEquals(
+			5, countInCategoryWithFacetSelected(1),
+			"the products of the first category must survive selecting the facet"
+		);
+		assertEquals(
+			5, countInCategoryWithFacetSelected(2),
+			"the second category must hold exactly its own products - an owner the lookup wrongly named must "
+				+ "not gain a facet in a partition it is not in"
 		);
 	}
 
@@ -286,23 +785,42 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 	 */
 
 	/**
-	 * Asserts, for every reference of the product collection and in every scope, that the reverse lookup
-	 * agrees exactly with the reduced indexes it summarises.
+	 * Asserts that the reverse lookup agrees exactly with the reduced indexes it summarises, in **every** scope.
 	 *
 	 * Ground truth is read from the collection's own indexes; the lookup's bookkeeping is never used to
 	 * check itself.
 	 */
 	private void assertMembershipMatchesIndexes() {
+		for (final Scope scope : Scope.values()) {
+			assertMembershipMatchesIndexes(scope);
+		}
+	}
+
+	/**
+	 * Asserts, for every reference of the product collection in one scope, that the reverse lookup agrees
+	 * exactly with the reduced indexes it summarises.
+	 *
+	 * @param scope the scope whose indexes and lookups are compared
+	 */
+	private void assertMembershipMatchesIndexes(@Nonnull Scope scope) {
 		final EntityCollection collection = (EntityCollection) getProductCollection();
-		final EntityIndex globalIndex = collection.getIndexByKeyIfExists(
-			new EntityIndexKey(EntityIndexType.GLOBAL, Scope.LIVE)
-		);
-		if (!(globalIndex instanceof final GlobalEntityIndex typedGlobalIndex)) {
+		final GlobalEntityIndex typedGlobalIndex = globalIndexOf(scope);
+		if (typedGlobalIndex == null) {
+			// A scope with no global index holds no entities, and an empty index is swept away rather than kept.
+			// That is legitimate - but only while the scope also advertises no reduced index, so it is asserted
+			// rather than assumed. Returning silently here is how the whole class could pass vacuously.
+			for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
+				assertTrue(
+					advertisedReducedIndexes(collection, reference.getName(), scope).isEmpty(),
+					"scope " + scope + ", reference `" + reference.getName() + "`: reduced indexes are "
+						+ "advertised but there is no global index to hold their lookup"
+				);
+			}
 			return;
 		}
 		for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
 			final String referenceName = reference.getName();
-			final Set<Integer> advertised = advertisedReducedIndexes(collection, referenceName);
+			final Set<Integer> advertised = advertisedReducedIndexes(collection, referenceName, scope);
 			final ReducedIndexMembership membership =
 				typedGlobalIndex.getReducedIndexMembership(referenceName);
 			if (membership == null) {
@@ -319,26 +837,30 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 			known.addAll(residual);
 			assertEquals(
 				new TreeSet<>(advertised), known,
-				"reference `" + referenceName + "`: covered u residual must equal the advertised indexes"
+				"scope " + scope + ", reference `" + referenceName
+					+ "`: covered u residual must equal the advertised indexes"
 			);
 			assertTrue(
-				disjoint(covered, residual),
-				"reference `" + referenceName + "`: an index cannot be both covered and residual"
+				Collections.disjoint(covered, residual),
+				"scope " + scope + ", reference `" + referenceName
+					+ "`: an index cannot be both covered and residual"
 			);
 
 			// every covered index's entries must name exactly its members, in both directions
-			final Map<Integer, Set<Integer>> expected = new HashMap<>(covered.size());
+			final Map<Integer, Set<Integer>> expected = CollectionUtils.createHashMap(covered.size());
 			for (final Integer indexPk : covered) {
 				final EntityIndex reducedIndex = collection.getIndexByPrimaryKeyIfExists(indexPk);
-				assertTrue(
-					reducedIndex != null,
-					"reference `" + referenceName + "`: covered index " + indexPk + " does not exist"
+				assertNotNull(
+					reducedIndex,
+					"scope " + scope + ", reference `" + referenceName + "`: covered index " + indexPk
+						+ " does not exist"
 				);
 				final Bitmap members = reducedIndex.getAllPrimaryKeys();
 				assertTrue(
 					members.size() <= membership.getCoverageThreshold(),
-					"reference `" + referenceName + "`: covered index " + indexPk + " holds " + members.size()
-						+ " owners, above the coverage threshold of " + membership.getCoverageThreshold()
+					"scope " + scope + ", reference `" + referenceName + "`: covered index " + indexPk
+						+ " holds " + members.size() + " owners, above the coverage threshold of "
+						+ membership.getCoverageThreshold()
 				);
 				final OfInt it = members.iterator();
 				while (it.hasNext()) {
@@ -348,12 +870,13 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 			final Set<Integer> coveredOwners = toSet(membership.getCoveredOwners());
 			assertEquals(
 				new TreeSet<>(expected.keySet()), new TreeSet<>(coveredOwners),
-				"reference `" + referenceName + "`: coveredOwners must be exactly the owners of covered indexes"
+				"scope " + scope + ", reference `" + referenceName
+					+ "`: coveredOwners must be exactly the owners of covered indexes"
 			);
 			for (final Map.Entry<Integer, Set<Integer>> entry : expected.entrySet()) {
 				assertEquals(
 					entry.getValue(), toSet(membership.getIndexPrimaryKeys(entry.getKey())),
-					"reference `" + referenceName + "`: owner " + entry.getKey() +
+					"scope " + scope + ", reference `" + referenceName + "`: owner " + entry.getKey() +
 						" must name exactly the covered indexes holding it"
 				);
 			}
@@ -361,8 +884,8 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 	}
 
 	/**
-	 * Asserts that the lookup is not merely *correct* but actually *engaged* for the given reference — it
-	 * exists, and it accounts for every index the reference advertises.
+	 * Asserts that the lookup is not merely *correct* but actually *engaged* for the given reference in the LIVE
+	 * scope — it exists, and it accounts for every index the reference advertises.
 	 *
 	 * Kept separate from {@link #assertMembershipMatchesIndexes} on purpose. Absence of a lookup is correct
 	 * behaviour and that method rightly tolerates it, which means a regression that stopped the lookup being
@@ -372,14 +895,14 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 	 * @param referenceName the partitioned reference expected to be accelerated
 	 */
 	private void assertMembershipEngaged(@Nonnull String referenceName) {
-		final ReducedIndexMembership membership = membershipOf(referenceName);
-		assertTrue(
-			membership != null,
+		final ReducedIndexMembership membership = membershipOf(referenceName, Scope.LIVE);
+		assertNotNull(
+			membership,
 			"reference `" + referenceName + "` must have a membership lookup - without one the trigger falls "
 				+ "back to walking every reduced index, which is the cost this structure exists to remove"
 		);
 		final EntityCollection collection = (EntityCollection) getProductCollection();
-		final Set<Integer> advertised = advertisedReducedIndexes(collection, referenceName);
+		final Set<Integer> advertised = advertisedReducedIndexes(collection, referenceName, Scope.LIVE);
 		final Set<Integer> known = new TreeSet<>(toSet(membership.getCoveredIndexPrimaryKeys()));
 		known.addAll(toSet(membership.getResidualIndexPrimaryKeys()));
 		assertEquals(
@@ -389,24 +912,63 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 	}
 
 	/**
+	 * Asserts the given work is refused because a mandatory reference attribute is missing, whichever wrapper the
+	 * write path puts around the refusal — the transactional path wraps where the warm-up path does not.
+	 *
+	 * @param work the write expected to be refused
+	 */
+	private static void assertRefusedForMissingMandatoryAttribute(@Nonnull Executable work) {
+		final Throwable thrown = assertThrows(
+			RuntimeException.class, work,
+			"the upsert omits a mandatory reference attribute and must be refused"
+		);
+		assertNotNull(
+			ExceptionUtils.findInCauseChain(thrown, MandatoryAttributesNotProvidedException.class),
+			"the write must fail on the missing mandatory reference attribute, but failed with: "
+				+ messageChainOf(thrown)
+		);
+	}
+
+	/**
+	 * Joins the messages of a throwable and its causes, so an assertion can look for a phrase wherever in the
+	 * chain the write path happened to put it.
+	 *
+	 * @param throwable the throwable to flatten
+	 * @return the concatenated messages
+	 */
+	@Nonnull
+	private static String messageChainOf(@Nonnull Throwable throwable) {
+		final StringBuilder result = new StringBuilder(256);
+		Throwable current = throwable;
+		while (current != null) {
+			result.append(current.getClass().getSimpleName()).append(": ").append(current.getMessage())
+				.append(" | ");
+			current = current.getCause();
+		}
+		return result.toString();
+	}
+
+	/**
 	 * Reads the reduced indexes a reference advertises, from the reference's own type indexes — the ground
 	 * truth the lookup is checked against.
 	 *
 	 * @param collection    the collection to inspect
 	 * @param referenceName reference whose advertisement is read
+	 * @param scope         the scope whose type indexes are read
 	 * @return advertised reduced-index primary keys
 	 */
 	@Nonnull
 	private static Set<Integer> advertisedReducedIndexes(
 		@Nonnull EntityCollection collection,
-		@Nonnull String referenceName
+		@Nonnull String referenceName,
+		@Nonnull Scope scope
 	) {
-		final Set<Integer> advertised = new HashSet<>(64);
+		final Set<Integer> advertised = CollectionUtils.createHashSet(64);
 		for (final EntityIndexType family : new EntityIndexType[]{
 			EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
 		}) {
 			final EntityIndex typeIndex = collection.getIndexByKeyIfExists(
-				new EntityIndexKey(family, Scope.LIVE, referenceName)
+				new EntityIndexKey(family, scope, referenceName)
 			);
 			if (typeIndex instanceof final ReferencedTypeEntityIndex typedTypeIndex) {
 				typedTypeIndex.forEachReferenceIndexPrimaryKey(advertised::add);
@@ -432,40 +994,77 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 	}
 
 	/**
-	 * Returns `true` when the two sets share no element.
+	 * Returns the covered reduced-index primary keys of a reference's LIVE lookup.
 	 *
-	 * @param left  first set
-	 * @param right second set
-	 * @return `true` when disjoint
+	 * @param referenceName reference to read
+	 * @return covered index primary keys, empty when there is no lookup
 	 */
-	private static boolean disjoint(@Nonnull Set<Integer> left, @Nonnull Set<Integer> right) {
-		for (final Integer value : left) {
-			if (right.contains(value)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
 	@Nonnull
 	private Set<Integer> coveredOf(@Nonnull String referenceName) {
-		final ReducedIndexMembership membership = membershipOf(referenceName);
+		final ReducedIndexMembership membership = membershipOf(referenceName, Scope.LIVE);
 		return membership == null ? Set.of() : toSet(membership.getCoveredIndexPrimaryKeys());
 	}
 
+	/**
+	 * Returns the residual reduced-index primary keys of a reference's LIVE lookup.
+	 *
+	 * @param referenceName reference to read
+	 * @return residual index primary keys, empty when there is no lookup
+	 */
 	@Nonnull
 	private Set<Integer> residualOf(@Nonnull String referenceName) {
-		final ReducedIndexMembership membership = membershipOf(referenceName);
+		final ReducedIndexMembership membership = membershipOf(referenceName, Scope.LIVE);
 		return membership == null ? Set.of() : toSet(membership.getResidualIndexPrimaryKeys());
 	}
 
-	private ReducedIndexMembership membershipOf(@Nonnull String referenceName) {
+	/**
+	 * Returns the owners a reference's lookup covers in the given scope.
+	 *
+	 * @param referenceName reference to read
+	 * @param scope         the scope whose lookup is read
+	 * @return covered owner primary keys, empty when there is no lookup
+	 */
+	@Nonnull
+	private Set<Integer> coveredOwnersOf(@Nonnull String referenceName, @Nonnull Scope scope) {
+		final ReducedIndexMembership membership = membershipOf(referenceName, scope);
+		return membership == null ? Set.of() : toSet(membership.getCoveredOwners());
+	}
+
+	/**
+	 * Returns a reference's reverse lookup in the given scope, or `null` when it has none.
+	 *
+	 * @param referenceName reference to read
+	 * @param scope         the scope whose lookup is read
+	 * @return the lookup, or `null`
+	 */
+	@Nullable
+	private ReducedIndexMembership membershipOf(@Nonnull String referenceName, @Nonnull Scope scope) {
+		final GlobalEntityIndex globalIndex = globalIndexOf(scope);
+		return globalIndex == null ? null : globalIndex.getReducedIndexMembership(referenceName);
+	}
+
+	/**
+	 * Returns the product collection's global index in the given scope, failing when the key resolves to
+	 * something that is not one — an index registered under a `GLOBAL` key is a {@link GlobalEntityIndex} by
+	 * construction, so anything else is a programming error and must not be read as "absent".
+	 *
+	 * @param scope the scope whose global index is read
+	 * @return the global index, or `null` when the scope holds none
+	 */
+	@Nullable
+	private GlobalEntityIndex globalIndexOf(@Nonnull Scope scope) {
 		final EntityCollection collection = (EntityCollection) getProductCollection();
 		final EntityIndex globalIndex = collection.getIndexByKeyIfExists(
-			new EntityIndexKey(EntityIndexType.GLOBAL, Scope.LIVE)
+			new EntityIndexKey(EntityIndexType.GLOBAL, scope)
 		);
-		return globalIndex instanceof final GlobalEntityIndex typed
-			? typed.getReducedIndexMembership(referenceName) : null;
+		if (globalIndex == null) {
+			return null;
+		}
+		assertTrue(
+			globalIndex instanceof GlobalEntityIndex,
+			"scope " + scope + ": the GLOBAL index key resolved to " + globalIndex.getClass().getName()
+		);
+		return (GlobalEntityIndex) globalIndex;
 	}
 
 	/**
@@ -501,49 +1100,85 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 	}
 
 	/**
-	 * Creates the schema and fixture entities and brings the catalog to the requested state.
+	 * Creates the schema and fixture entities in both scopes and brings the catalog to the requested state.
 	 *
 	 * @param state      target catalog state
 	 * @param widgetType initial value of the group entity's attribute, which decides whether the conditional
 	 *                   facet is on
 	 */
 	private void prepare(@Nonnull CatalogState state, @Nonnull String widgetType) {
+		prepare(state, widgetType, EnumSet.of(Scope.LIVE, Scope.ARCHIVED));
+	}
+
+	/**
+	 * Creates the schema and fixture entities and brings the catalog to the requested state.
+	 *
+	 * @param state                   target catalog state
+	 * @param widgetType              initial value of the group entity's attribute, which decides whether the
+	 *                                conditional facet is on
+	 * @param conditionalFacetScopes  scopes in which the conditional facet is declared. `ARCHIVED` is what makes
+	 *                                the archived half of the trigger — and hence of the lookup — reachable at
+	 *                                all; an empty set makes the collection one the trigger can never fire for,
+	 *                                which is the state the lookup must never be built in
+	 */
+	private void prepare(
+		@Nonnull CatalogState state,
+		@Nonnull String widgetType,
+		@Nonnull Set<Scope> conditionalFacetScopes
+	) {
 		this.evita.updateCatalog(
 			TEST_CATALOG,
 			(Consumer<EvitaSessionContract>) session -> {
 				session.defineEntitySchema(ENTITY_CATEGORY).updateVia(session);
 				session.defineEntitySchema(ENTITY_BRAND).updateVia(session);
+				session.defineEntitySchema(ENTITY_TAG).updateVia(session);
 				session.defineEntitySchema(ENTITY_PARAMETER_VALUE).updateVia(session);
 				session.defineEntitySchema(ENTITY_PARAMETER)
 					.withAttribute(
-						ATTR_INPUT_WIDGET_TYPE, String.class, whichIs -> whichIs.filterable().nullable()
+						ATTR_INPUT_WIDGET_TYPE, String.class,
+						whichIs -> whichIs.filterableInScope(Scope.LIVE, Scope.ARCHIVED).nullable()
 					)
 					.updateVia(session);
 				session.defineEntitySchema(ENTITY_PRODUCT)
 					.withReferenceToEntity(
 						REF_CATEGORIES, ENTITY_CATEGORY, Cardinality.ZERO_OR_MORE,
-						whichIs -> whichIs.indexedForFilteringAndPartitioning()
+						whichIs -> whichIs
+							.indexedForFilteringAndPartitioningInScope(Scope.LIVE, Scope.ARCHIVED)
 					)
 					// starts merely filterable so it can be raised later, without a reindex
 					.withReferenceToEntity(
 						REF_BRAND, ENTITY_BRAND, Cardinality.ZERO_OR_ONE,
-						whichIs -> whichIs.indexedForFiltering()
+						whichIs -> whichIs.indexedForFilteringInScope(Scope.LIVE, Scope.ARCHIVED)
+					)
+					// never written by a passing test: it exists so a write can be refused AFTER every index has
+					// already been mutated, which is the only shape in which a rewind has anything to rewind
+					.withReferenceToEntity(
+						REF_TAGS, ENTITY_TAG, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs
+							.indexedForFilteringInScope(Scope.LIVE, Scope.ARCHIVED)
+							.withAttribute(ATTR_TAG_NOTE, String.class, thatIs -> {
+							})
 					)
 					.withReferenceToEntity(
 						REF_PARAMETER_VALUES, ENTITY_PARAMETER_VALUE, Cardinality.ZERO_OR_MORE,
-						whichIs -> whichIs
-							.indexedForFiltering()
-							.indexedWithComponents(
-								ReferenceIndexedComponents.REFERENCED_ENTITY,
-								ReferenceIndexedComponents.REFERENCED_GROUP_ENTITY
-							)
-							.withGroupTypeRelatedToEntity(ENTITY_PARAMETER)
-							.facetedPartially(
-								ExpressionFactory.parse(
-									"$reference.groupEntity?.attributes['" + ATTR_INPUT_WIDGET_TYPE
-										+ "'] == 'CHECKBOX'"
+						whichIs -> {
+							whichIs
+								.indexedForFilteringInScope(Scope.LIVE, Scope.ARCHIVED)
+								.indexedWithComponentsInScope(
+									Scope.LIVE,
+									ReferenceIndexedComponents.REFERENCED_ENTITY,
+									ReferenceIndexedComponents.REFERENCED_GROUP_ENTITY
 								)
-							)
+								.indexedWithComponentsInScope(
+									Scope.ARCHIVED,
+									ReferenceIndexedComponents.REFERENCED_ENTITY,
+									ReferenceIndexedComponents.REFERENCED_GROUP_ENTITY
+								)
+								.withGroupTypeRelatedToEntity(ENTITY_PARAMETER);
+							for (final Scope facetScope : conditionalFacetScopes) {
+								whichIs.facetedPartiallyInScope(facetScope, conditionalFacetExpression());
+							}
+						}
 					)
 					.updateVia(session);
 
@@ -551,6 +1186,7 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 					session.createNewEntity(ENTITY_CATEGORY, pk).upsertVia(session);
 				}
 				session.createNewEntity(ENTITY_BRAND, BRAND_PK).upsertVia(session);
+				session.createNewEntity(ENTITY_TAG, TAG_PK).upsertVia(session);
 				session.createNewEntity(ENTITY_PARAMETER_VALUE, PARAM_VALUE_PK).upsertVia(session);
 				session.createNewEntity(ENTITY_PARAMETER, PARAMETER_PK)
 					.setAttribute(ATTR_INPUT_WIDGET_TYPE, widgetType)
@@ -564,19 +1200,44 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 	}
 
 	/**
-	 * Upserts a run of products, each filed under one shared category plus its own, so both the many-owner
-	 * and the single-owner shapes exist at once.
+	 * Builds the conditional-facet expression the fixture declares — the group entity's widget type deciding
+	 * whether the facet applies.
 	 *
-	 * @param fromPk          first product primary key, inclusive
-	 * @param toPk            last product primary key, inclusive
-	 * @param sharedCategory  category every product joins
+	 * @return the parsed expression
+	 */
+	@Nonnull
+	private static Expression conditionalFacetExpression() {
+		return ExpressionFactory.parse(
+			"$reference.groupEntity?.attributes['" + ATTR_INPUT_WIDGET_TYPE + "'] == 'CHECKBOX'"
+		);
+	}
+
+	/**
+	 * Upserts a run of products under one shared category and the default brand.
+	 *
+	 * @param fromPk         first product primary key, inclusive
+	 * @param toPk           last product primary key, inclusive
+	 * @param sharedCategory category every product joins
 	 */
 	private void upsertProducts(int fromPk, int toPk, int sharedCategory) {
+		upsertProducts(fromPk, toPk, sharedCategory, BRAND_PK);
+	}
+
+	/**
+	 * Upserts a run of products, each filed under one shared category and one brand, and each carrying the
+	 * conditionally-faceted reference so the cross-entity trigger reaches it.
+	 *
+	 * @param fromPk         first product primary key, inclusive
+	 * @param toPk           last product primary key, inclusive
+	 * @param sharedCategory category every product joins
+	 * @param brandPk        brand every product joins
+	 */
+	private void upsertProducts(int fromPk, int toPk, int sharedCategory, int brandPk) {
 		for (int pk = fromPk; pk <= toPk; pk++) {
 			final int productPk = pk;
 			tx(session -> session.createNewEntity(ENTITY_PRODUCT, productPk)
 				.setReference(REF_CATEGORIES, sharedCategory)
-				.setReference(REF_BRAND, BRAND_PK)
+				.setReference(REF_BRAND, brandPk)
 				.setReference(
 					REF_PARAMETER_VALUES, PARAM_VALUE_PK,
 					whichIs -> whichIs.setGroup(ENTITY_PARAMETER, PARAMETER_PK)
@@ -585,25 +1246,229 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 		}
 	}
 
+	/**
+	 * Runs one unit of write work against the test catalog — a transaction in `ALIVE`, a plain bulk write in
+	 * `WARMING_UP`.
+	 *
+	 * @param work the write to perform
+	 */
 	private void tx(@Nonnull Consumer<EvitaSessionContract> work) {
 		this.evita.updateCatalog(TEST_CATALOG, work);
 	}
 
 	/**
-	 * Counts products of {@link #BRAND_PK} surviving a selection of the conditional facet — the query that is
+	 * Raises `brand` to `FOR_FILTERING_AND_PARTITIONING` exactly as a client would, and **without** the reindex
+	 * that would rebuild anything (issue #409).
+	 */
+	private void raiseBrandToPartitioned() {
+		tx(session -> session.getEntitySchemaOrThrowException(ENTITY_PRODUCT)
+			.openForWrite()
+			.withReferenceToEntity(
+				REF_BRAND, ENTITY_BRAND, Cardinality.ZERO_OR_ONE,
+				whichIs -> whichIs.indexedForFilteringAndPartitioning()
+			)
+			.updateVia(session));
+	}
+
+	/**
+	 * Creates the reflected-reference fixture: `category.products` is the indexed, partitioned source, and the
+	 * product collection carries a **reflected** counterpart that inherits its index type from it. The product
+	 * collection also declares the conditional facet, so its reduced-index membership lookup is maintained.
+	 *
+	 * The reflected reference deliberately sets no indexing of its own — that is what makes its index type follow
+	 * the source reference, and hence what makes a schema change on the other collection change this one.
+	 */
+	private void prepareReflected() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			(Consumer<EvitaSessionContract>) session -> {
+				session.defineEntitySchema(ENTITY_PARAMETER_VALUE).updateVia(session);
+				session.defineEntitySchema(ENTITY_PARAMETER)
+					.withAttribute(
+						ATTR_INPUT_WIDGET_TYPE, String.class,
+						whichIs -> whichIs.filterableInScope(Scope.LIVE).nullable()
+					)
+					.updateVia(session);
+				session.defineEntitySchema(ENTITY_PRODUCT)
+					.withReferenceToEntity(
+						REF_PARAMETER_VALUES, ENTITY_PARAMETER_VALUE, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs
+							.indexedForFilteringInScope(Scope.LIVE)
+							.indexedWithComponentsInScope(
+								Scope.LIVE,
+								ReferenceIndexedComponents.REFERENCED_ENTITY,
+								ReferenceIndexedComponents.REFERENCED_GROUP_ENTITY
+							)
+							.withGroupTypeRelatedToEntity(ENTITY_PARAMETER)
+							.facetedPartiallyInScope(Scope.LIVE, conditionalFacetExpression())
+					)
+					.withReflectedReferenceToEntity(
+						REF_REFLECTED_CATEGORIES, ENTITY_CATEGORY, REF_PRODUCTS,
+						whichIs -> whichIs.withCardinality(Cardinality.ZERO_OR_MORE)
+					)
+					.updateVia(session);
+				session.defineEntitySchema(ENTITY_CATEGORY)
+					.withReferenceToEntity(
+						REF_PRODUCTS, ENTITY_PRODUCT, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs.indexedForFilteringAndPartitioningInScope(Scope.LIVE)
+					)
+					.updateVia(session);
+
+				session.createNewEntity(ENTITY_PARAMETER_VALUE, PARAM_VALUE_PK).upsertVia(session);
+				session.createNewEntity(ENTITY_PARAMETER, PARAMETER_PK)
+					.setAttribute(ATTR_INPUT_WIDGET_TYPE, "INTERVAL_INPUT")
+					.upsertVia(session);
+				for (int pk = 1; pk <= 5; pk++) {
+					session.createNewEntity(ENTITY_PRODUCT, pk)
+						.setReference(
+							REF_PARAMETER_VALUES, PARAM_VALUE_PK,
+							whichIs -> whichIs.setGroup(ENTITY_PARAMETER, PARAMETER_PK)
+						)
+						.upsertVia(session);
+				}
+				session.goLiveAndClose();
+			}
+		);
+		// the reflected reference on the products is populated from the category side
+		upsertCategoryWithProducts(1, 1, 5);
+	}
+
+	/**
+	 * Creates a category referencing a run of products, which is what populates the products' reflected reference
+	 * — and hence what creates the reduced indexes the product collection's lookup summarises.
+	 *
+	 * @param categoryPk primary key of the category to create
+	 * @param fromPk     first referenced product primary key, inclusive
+	 * @param toPk       last referenced product primary key, inclusive
+	 */
+	private void upsertCategoryWithProducts(int categoryPk, int fromPk, int toPk) {
+		tx(session -> {
+			final EntityBuilder category = session.createNewEntity(ENTITY_CATEGORY, categoryPk);
+			for (int pk = fromPk; pk <= toPk; pk++) {
+				category.setReference(REF_PRODUCTS, pk);
+			}
+			category.upsertVia(session);
+		});
+	}
+
+	/**
+	 * Switches the CATEGORY collection's `products` reference between partitioned and merely filterable. The
+	 * product collection's reflected counterpart inherits whichever it is, so this is a schema change on one
+	 * collection that changes the indexing of another.
+	 *
+	 * @param partitioned `true` to index the source reference for filtering and partitioning
+	 */
+	private void setCategoryProductsIndexing(boolean partitioned) {
+		tx(session -> session.getEntitySchemaOrThrowException(ENTITY_CATEGORY)
+			.openForWrite()
+			.withReferenceToEntity(
+				REF_PRODUCTS, ENTITY_PRODUCT, Cardinality.ZERO_OR_MORE,
+				whichIs -> {
+					if (partitioned) {
+						whichIs.indexedForFilteringAndPartitioning();
+					} else {
+						whichIs.indexedForFiltering();
+					}
+				}
+			)
+			.updateVia(session));
+	}
+
+	/**
+	 * Declares or drops the collection's only conditional facet, which is the gate the whole lookup is maintained
+	 * behind — dropping it makes this a collection the cross-entity trigger can never fire for.
+	 *
+	 * @param declared `true` to declare the conditional facet in `LIVE`, `false` to drop it
+	 */
+	private void setConditionalFacet(boolean declared) {
+		tx(session -> session.getEntitySchemaOrThrowException(ENTITY_PRODUCT)
+			.openForWrite()
+			.withReferenceToEntity(
+				REF_PARAMETER_VALUES, ENTITY_PARAMETER_VALUE, Cardinality.ZERO_OR_MORE,
+				whichIs -> {
+					if (declared) {
+						whichIs.facetedPartiallyInScope(Scope.LIVE, conditionalFacetExpression());
+					} else {
+						whichIs.nonFaceted();
+					}
+				}
+			)
+			.updateVia(session));
+	}
+
+	/**
+	 * Switches `categories` between partitioned and merely filterable. Lowering it is what stops the membership
+	 * maintenance hooks firing while the reduced indexes keep changing underneath them.
+	 *
+	 * @param partitioned `true` to index the reference for filtering and partitioning, `false` for filtering only
+	 */
+	private void setCategoriesIndexing(boolean partitioned) {
+		tx(session -> session.getEntitySchemaOrThrowException(ENTITY_PRODUCT)
+			.openForWrite()
+			.withReferenceToEntity(
+				REF_CATEGORIES, ENTITY_CATEGORY, Cardinality.ZERO_OR_MORE,
+				whichIs -> {
+					if (partitioned) {
+						whichIs.indexedForFilteringAndPartitioning();
+					} else {
+						whichIs.indexedForFiltering();
+					}
+				}
+			)
+			.updateVia(session));
+	}
+
+	/**
+	 * Fires the cross-entity conditional-facet trigger by making the group entity start satisfying the
+	 * expression the faceted reference is conditioned on.
+	 */
+	private void fireCrossEntityTrigger() {
+		tx(session -> session.getEntity(ENTITY_PARAMETER, PARAMETER_PK, entityFetchAllContent())
+			.orElseThrow()
+			.openForWrite()
+			.setAttribute(ATTR_INPUT_WIDGET_TYPE, "CHECKBOX")
+			.upsertVia(session));
+	}
+
+	/**
+	 * Counts products of the given brand surviving a selection of the conditional facet — the query that is
 	 * evaluated against the brand's reduced index, and therefore the one that exposes a facet the trigger
 	 * failed to write there.
 	 *
+	 * @param brandPk primary key of the brand whose partition is queried
 	 * @return number of matching products
 	 */
-	private int countInBrandWithFacetSelected() {
+	private int countInBrandWithFacetSelected(int brandPk) {
+		return countInPartitionWithFacetSelected(REF_BRAND, brandPk);
+	}
+
+	/**
+	 * Counts products of the given category surviving a selection of the conditional facet.
+	 *
+	 * @param categoryPk primary key of the category whose partition is queried
+	 * @return number of matching products
+	 */
+	private int countInCategoryWithFacetSelected(int categoryPk) {
+		return countInPartitionWithFacetSelected(REF_CATEGORIES, categoryPk);
+	}
+
+	/**
+	 * Counts products of one partition surviving a selection of the conditional facet — the query that is
+	 * evaluated against that partition's reduced index, and therefore the one that exposes a facet the trigger
+	 * failed to write there, or wrote there without the owner belonging to the partition.
+	 *
+	 * @param referenceName  reference whose partition is queried
+	 * @param referencedPk   primary key of the referenced entity naming the partition
+	 * @return number of matching products
+	 */
+	private int countInPartitionWithFacetSelected(@Nonnull String referenceName, int referencedPk) {
 		return this.evita.queryCatalog(
 			TEST_CATALOG,
 			(Function<EvitaSessionContract, Integer>) session -> session.query(
 				query(
 					collection(ENTITY_PRODUCT),
 					filterBy(
-						referenceHaving(REF_BRAND, entityPrimaryKeyInSet(BRAND_PK)),
+						referenceHaving(referenceName, entityPrimaryKeyInSet(referencedPk)),
 						userFilter(facetHaving(REF_PARAMETER_VALUES, entityPrimaryKeyInSet(PARAM_VALUE_PK)))
 					),
 					require(page(1, 1))
@@ -613,6 +1478,36 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 		);
 	}
 
+	/**
+	 * Returns the storage primary key of the reduced index holding one referenced entity's partition — the
+	 * identity the reverse lookup records, and therefore the one a fabricated entry has to name to be
+	 * indistinguishable from a real one.
+	 *
+	 * @param referenceName reference owning the partition
+	 * @param referencedPk  primary key of the referenced entity naming the partition
+	 * @return the reduced index's storage primary key
+	 */
+	private int reducedIndexPkOf(@Nonnull String referenceName, int referencedPk) {
+		final EntityCollection collection = (EntityCollection) getProductCollection();
+		final EntityIndex reducedIndex = collection.getIndexByKeyIfExists(
+			new EntityIndexKey(
+				EntityIndexType.REFERENCED_ENTITY, Scope.LIVE,
+				new RepresentativeReferenceKey(new ReferenceKey(referenceName, referencedPk))
+			)
+		);
+		assertNotNull(
+			reducedIndex,
+			"reference `" + referenceName + "` has no reduced index for " + referencedPk
+		);
+		return reducedIndex.getPrimaryKey();
+	}
+
+	/**
+	 * Resolves the product collection of the test catalog, which is the collection every assertion here reads
+	 * its ground truth out of.
+	 *
+	 * @return the product collection; never `null`
+	 */
 	@Nonnull
 	private EntityCollectionContract getProductCollection() {
 		final CatalogContract catalog = this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReducedIndexMembershipCompletenessTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReducedIndexMembershipCompletenessTest.java
@@ -270,6 +270,48 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 
 	@ParameterizedTest(name = "{0}")
 	@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+	@DisplayName("the last owner leaving a reduced index leaves the lookup complete")
+	void lastOwnerLeavingAReducedIndexKeepsTheLookupComplete(CatalogState state) {
+		// The one state the lookup cannot account for: an index holding nobody lands in neither the covered nor
+		// the residual set. Whether that is reachable is decided upstream rather than in the map - the reduced
+		// index is un-advertised in the same synchronous step in which its last owner leaves, so
+		// `covered u residual == advertised` survives the drop only for as long as those two move together.
+		// This constructs the state through the write path, by both routes into it, and lets the union assertion
+		// answer the question rather than arguing it. A failure here is not an assertion to relax: it is the
+		// invariant, and this is the case it exists for.
+		prepare(state, "CHECKBOX");
+		upsertProducts(1, 3, 1);
+		// two categories held by exactly one product each, so either can be emptied without disturbing the rest
+		upsertProducts(4, 4, 2);
+		upsertProducts(5, 5, 3);
+		assertMembershipMatchesIndexes();
+		assertTrue(
+			coveredOwnersOf(REF_CATEGORIES, Scope.LIVE).contains(4),
+			"the sole owner of its category must be covered before it leaves, or emptying that index proves "
+				+ "nothing"
+		);
+		assertFalse(coveredOf(REF_CATEGORIES).isEmpty(), "the lookup must hold coverage before the removals");
+
+		// the ordinary reference removal empties the index of category 2 ...
+		tx(session -> session.getEntity(ENTITY_PRODUCT, 4, entityFetchAllContent())
+			.orElseThrow()
+			.openForWrite()
+			.removeReference(REF_CATEGORIES, 2)
+			.upsertVia(session));
+		assertMembershipMatchesIndexes();
+
+		// ... and deleting the entity outright empties the index of category 3, reaching the same state through
+		// the entirely-removed path rather than through a reference mutation
+		tx(session -> session.deleteEntity(ENTITY_PRODUCT, 5));
+		assertMembershipMatchesIndexes();
+		assertFalse(
+			coveredOwnersOf(REF_CATEGORIES, Scope.LIVE).contains(5),
+			"the deleted owner must be gone from the lookup as well as from the indexes"
+		);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
 	@DisplayName("crossing the coverage threshold in both directions keeps the lookup exact")
 	void thresholdCrossingBothWaysMatches(CatalogState state) {
 		prepare(state, "CHECKBOX");
@@ -654,6 +696,32 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 	}
 
 	@Test
+	@DisplayName("a catalog reloaded after the last owner left rebuilds a complete lookup")
+	void reloadAfterTheLastOwnerLeftRebuildsACompleteLookup() {
+		// The load path is the only caller of `ReducedIndexMembership#registerIndex`, and therefore the only one
+		// that can reach its empty-membership arm at all. Whether it does rests on the same lockstep the write
+		// path is driven across above: an index the reference still advertises after its last owner left would
+		// be handed to `registerIndex` with an empty membership, land in neither set, and break the union
+		// assertion below - a reduced index the trigger would then never visit.
+		prepare(CatalogState.ALIVE, "CHECKBOX");
+		upsertProducts(1, 3, 1);
+		upsertProducts(4, 4, 2);
+		tx(session -> session.getEntity(ENTITY_PRODUCT, 4, entityFetchAllContent())
+			.orElseThrow()
+			.openForWrite()
+			.removeReference(REF_CATEGORIES, 2)
+			.upsertVia(session));
+		assertMembershipMatchesIndexes();
+
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		awaitCatalogLoaded();
+
+		assertMembershipMatchesIndexes();
+		assertMembershipEngaged(REF_CATEGORIES);
+	}
+
+	@Test
 	@DisplayName("every reference the lookup is keyed by is still declared by the schema")
 	void everyReferenceNameInTheLookupIsInTheSchema() {
 		prepare(CatalogState.ALIVE, "CHECKBOX");
@@ -747,6 +815,67 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 	}
 
 	@Test
+	@DisplayName("the sibling walk reaches a partition the lookup left residual")
+	void siblingWalkReachesAResidualPartition() {
+		// The residual half of the accelerated resolution, and production's common case: a partition larger than
+		// the coverage threshold is exactly the one coverage declines to hold entries for. Every other test that
+		// fires the trigger with a lookup in place has an empty residual set, so the residual probe could be
+		// dropped from `ReevaluateExpressionExecutor#resolveSiblingReducedIndexes` and the suite would stay
+		// green. Here the single category holds more owners than the threshold, so it is residual and
+		// `coveredOwners` is empty - the covered half returns immediately and the residual probe is the only
+		// path by which the facet can reach the partition.
+		prepare(CatalogState.ALIVE, "INTERVAL_INPUT");
+		upsertProducts(1, OVER_THRESHOLD, 1);
+		assertFalse(
+			residualOf(REF_CATEGORIES).isEmpty(),
+			"a category of " + OVER_THRESHOLD + " owners must have been promoted out of coverage"
+		);
+		assertTrue(
+			coveredOf(REF_CATEGORIES).isEmpty(),
+			"no other category is written here, so the covered half must have nothing to contribute"
+		);
+
+		fireCrossEntityTrigger();
+
+		assertEquals(
+			OVER_THRESHOLD, countInCategoryWithFacetSelected(1),
+			"the residual partition must receive the facet - no covered-owner entry names it, so nothing else "
+				+ "selects it for the probe"
+		);
+	}
+
+	@Test
+	@DisplayName("one trigger reaches a covered and a residual partition together")
+	void siblingWalkReachesACoveredAndAResidualPartitionInOneTrigger() {
+		// The mixed shape, so neither half of the accelerated resolution can be satisfied by the other: one
+		// category is above the coverage threshold and hence residual, the other is small and covered. Removing
+		// either half fails exactly one of the two assertions below, which is what tells them apart.
+		prepare(CatalogState.ALIVE, "INTERVAL_INPUT");
+		upsertProducts(1, OVER_THRESHOLD, 1);
+		upsertProducts(OVER_THRESHOLD + 1, OVER_THRESHOLD + 5, 2);
+		assertFalse(
+			residualOf(REF_CATEGORIES).isEmpty(),
+			"the category of " + OVER_THRESHOLD + " owners must have been promoted out of coverage"
+		);
+		assertFalse(
+			coveredOf(REF_CATEGORIES).isEmpty(),
+			"the category of five owners must be covered, or the two halves are not both exercised"
+		);
+		assertMembershipMatchesIndexes();
+
+		fireCrossEntityTrigger();
+
+		assertEquals(
+			OVER_THRESHOLD, countInCategoryWithFacetSelected(1),
+			"the residual partition must receive the facet"
+		);
+		assertEquals(
+			5, countInCategoryWithFacetSelected(2),
+			"the covered partition must receive the facet in the same trigger"
+		);
+	}
+
+	@Test
 	@DisplayName("the sibling walk survives a covered entry naming a reduced index that no longer exists")
 	void siblingWalkSurvivesAStaleCoveredEntry() {
 		// The map's own contract is that nothing it records is an answer: it selects which reduced indexes are
@@ -821,6 +950,7 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 		for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
 			final String referenceName = reference.getName();
 			final Set<Integer> advertised = advertisedReducedIndexes(collection, referenceName, scope);
+			assertEveryAdvertisedIndexHoldsAnOwner(collection, referenceName, scope, advertised);
 			final ReducedIndexMembership membership =
 				typedGlobalIndex.getReducedIndexMembership(referenceName);
 			if (membership == null) {
@@ -880,6 +1010,45 @@ class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
 						" must name exactly the covered indexes holding it"
 				);
 			}
+		}
+	}
+
+	/**
+	 * Asserts the upstream lockstep the whole lookup rests on: a reference advertises a reduced index only while
+	 * that index holds at least one owner.
+	 *
+	 * `ReferenceIndexMutator#referenceRemovalPerComponent` un-advertises on the 1 → 0 crossing of
+	 * `ReferencedTypeEntityIndex`'s per-tuple owner counter, in the same synchronous step in which the reduced
+	 * index loses its last owner — and every arm of `ReducedIndexMembership` that accounts for an index assumes
+	 * exactly that. Asserting it here tests the lockstep **directly**, at every boundary state this class
+	 * already drives, rather than waiting for its downstream symptom. It is also the assertion that keeps the
+	 * union check honest: were the two to decouple, `covered ∪ residual == advertised` would start failing with
+	 * no wrong facet behind it, and this says which of the two moved.
+	 *
+	 * @param collection    the collection to inspect
+	 * @param referenceName reference whose advertisement is checked
+	 * @param scope         the scope whose indexes are read
+	 * @param advertised    the reduced-index primary keys the reference advertises
+	 */
+	private static void assertEveryAdvertisedIndexHoldsAnOwner(
+		@Nonnull EntityCollection collection,
+		@Nonnull String referenceName,
+		@Nonnull Scope scope,
+		@Nonnull Set<Integer> advertised
+	) {
+		for (final Integer indexPk : advertised) {
+			final EntityIndex reducedIndex = collection.getIndexByPrimaryKeyIfExists(indexPk);
+			assertNotNull(
+				reducedIndex,
+				"scope " + scope + ", reference `" + referenceName + "`: advertised index " + indexPk
+					+ " does not exist"
+			);
+			assertFalse(
+				reducedIndex.getAllPrimaryKeys().isEmpty(),
+				"scope " + scope + ", reference `" + referenceName + "`: advertised index " + indexPk
+					+ " holds no owners - the advertisement and the index's membership must be dropped in the "
+					+ "same step, or the lookup is left accounting for an index nothing can be found in"
+			);
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReducedIndexMembershipCompletenessTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReducedIndexMembershipCompletenessTest.java
@@ -1,0 +1,621 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.indexing;
+
+import io.evitadb.api.CatalogContract;
+import io.evitadb.api.CatalogState;
+import io.evitadb.api.EntityCollectionContract;
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.index.EntityIndexType;
+import io.evitadb.api.query.expression.ExpressionFactory;
+import io.evitadb.api.requestResponse.data.structure.EntityReference;
+import io.evitadb.api.statistics.CatalogStatisticsComponent;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.ReferenceIndexedComponents;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
+import io.evitadb.core.Evita;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.dataType.Scope;
+import io.evitadb.index.EntityIndex;
+import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.GlobalEntityIndex;
+import io.evitadb.index.ReferencedTypeEntityIndex;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.membership.ReducedIndexMembership;
+import io.evitadb.test.EvitaTestSupport;
+import io.evitadb.test.EvitaTestSupport.TestPaths;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.PrimitiveIterator.OfInt;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.entityFetchAllContent;
+import static io.evitadb.api.query.QueryConstraints.entityPrimaryKeyInSet;
+import static io.evitadb.api.query.QueryConstraints.facetHaving;
+import static io.evitadb.api.query.QueryConstraints.filterBy;
+import static io.evitadb.api.query.QueryConstraints.page;
+import static io.evitadb.api.query.QueryConstraints.referenceHaving;
+import static io.evitadb.api.query.QueryConstraints.require;
+import static io.evitadb.api.query.QueryConstraints.userFilter;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.FACET;
+import static io.evitadb.test.TestTags.INDEXING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Attacks the **quantifier** behind {@link ReducedIndexMembership}, not the mechanism.
+ *
+ * The reverse lookup that `ReevaluateExpressionExecutor#resolveSiblingReducedIndexes` consults instead of
+ * walking every reduced index of a collection rests on one claim: *every* boundary at which an owner enters
+ * or leaves a reduced index updates it. A test that drives a few upserts and then reads a facet back
+ * demonstrates the mechanism working; it says nothing about the quantifier, and would pass unchanged while an
+ * entire class of boundary went unhooked. That is the failure this class exists to catch.
+ *
+ * So every assertion here is made against **ground truth** — the reduced indexes themselves, read back from
+ * the collection — and never against the map's own bookkeeping. {@link #assertMembershipMatchesIndexes} is the
+ * whole point of the class:
+ *
+ * - the indexes a reference advertises are exactly `covered ∪ residual`, so none can be silently skipped;
+ * - every covered index's entries name exactly its members, in both directions;
+ * - `coveredOwners` is exactly the key set of the lookup, since the walk narrows the affected set with it and
+ *   an owner missing from it is an owner the trigger will never consider;
+ * - no covered index holds more owners than the threshold allows, which is what bounds the memory.
+ *
+ * It runs after each of the boundary classes in turn: bulk load, a later join, a departure, an entity removed
+ * outright, a threshold crossing in each direction, and a catalog reloaded from disk — the last because the
+ * lookup is derived state that is never persisted, and a reload that failed to rebuild it would leave a
+ * collection permanently unaccelerated (or, worse, half-accelerated) with nothing else to show for it.
+ *
+ * {@link #referenceRaisedToPartitionedStillRegistersOwners} covers the other half of the contract, and the
+ * half that would be a wrong answer rather than a slow one: the lookup is an **accelerator, never an
+ * authority**, so a reference whose indexes it does not know must still be walked in full. That is exactly
+ * what a `ReferenceIndexType` raised on an already-populated collection produces — the engine does not rebuild
+ * indexes for a schema change (issue #409) — and the facet must still reach every index it owes.
+ *
+ * @author Claude (issue #1529 sibling-resolver optimization), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Reduced-index membership — completeness against the indexes themselves")
+@Tag(CONTRACT)
+@Tag(INDEXING)
+@Tag(FACET)
+class ReducedIndexMembershipCompletenessTest implements EvitaTestSupport {
+
+	private static final String ENTITY_PRODUCT = "product";
+	private static final String ENTITY_CATEGORY = "category";
+	private static final String ENTITY_BRAND = "brand";
+	private static final String ENTITY_PARAMETER = "parameter";
+	private static final String ENTITY_PARAMETER_VALUE = "parameterValue";
+
+	private static final String REF_CATEGORIES = "categories";
+	private static final String REF_BRAND = "brand";
+	private static final String REF_PARAMETER_VALUES = "parameterValues";
+	private static final String ATTR_INPUT_WIDGET_TYPE = "inputWidgetType";
+
+	private static final int PARAMETER_PK = 100;
+	private static final int PARAM_VALUE_PK = 10;
+	private static final int BRAND_PK = 7;
+
+	/**
+	 * Comfortably more than `ReducedIndexMembership.DEFAULT_COVERAGE_THRESHOLD`, so a category can be pushed
+	 * over the coverage boundary and pulled back under it within one test.
+	 */
+	private static final int OVER_THRESHOLD = 25;
+
+	private TestPaths paths;
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() {
+		this.paths = createTestPaths("ReducedIndexMembershipCompletenessTest");
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.defineCatalog(TEST_CATALOG);
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.evita.close();
+		cleanupTestPaths(this.paths);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+	@DisplayName("bulk load leaves the lookup matching every reduced index")
+	void bulkLoadMatches(CatalogState state) {
+		prepare(state, "CHECKBOX");
+		upsertProducts(1, 12, 1);
+		assertMembershipMatchesIndexes();
+		assertMembershipEngaged(REF_CATEGORIES);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+	@DisplayName("an owner joining a reduced index later is recorded")
+	void ownerJoiningLaterIsRecorded(CatalogState state) {
+		prepare(state, "CHECKBOX");
+		upsertProducts(1, 5, 1);
+		assertMembershipMatchesIndexes();
+		// the owner joins a second category it was not a member of
+		tx(session -> session.getEntity(ENTITY_PRODUCT, 1, entityFetchAllContent())
+			.orElseThrow()
+			.openForWrite()
+			.setReference(REF_CATEGORIES, 2)
+			.upsertVia(session));
+		assertMembershipMatchesIndexes();
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+	@DisplayName("an owner leaving a reduced index is forgotten")
+	void ownerLeavingIsForgotten(CatalogState state) {
+		prepare(state, "CHECKBOX");
+		upsertProducts(1, 5, 1);
+		tx(session -> session.getEntity(ENTITY_PRODUCT, 1, entityFetchAllContent())
+			.orElseThrow()
+			.openForWrite()
+			.removeReference(REF_CATEGORIES, 1)
+			.upsertVia(session));
+		assertMembershipMatchesIndexes();
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+	@DisplayName("removing the entity outright leaves nothing behind")
+	void entityRemovalIsForgotten(CatalogState state) {
+		prepare(state, "CHECKBOX");
+		upsertProducts(1, 5, 1);
+		tx(session -> session.deleteEntity(ENTITY_PRODUCT, 3));
+		assertMembershipMatchesIndexes();
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+	@DisplayName("crossing the coverage threshold in both directions keeps the lookup exact")
+	void thresholdCrossingBothWaysMatches(CatalogState state) {
+		prepare(state, "CHECKBOX");
+		// one category grows past the coverage threshold - it must leave coverage for the walk
+		upsertProducts(1, OVER_THRESHOLD, 1);
+		assertMembershipMatchesIndexes();
+		assertTrue(
+			residualOf(REF_CATEGORIES).size() > 0,
+			"a category of " + OVER_THRESHOLD + " owners must have been promoted out of coverage"
+		);
+		// ... and shrinks back far enough to be demoted into coverage again
+		for (int pk = 2; pk <= OVER_THRESHOLD; pk++) {
+			final int productPk = pk;
+			tx(session -> session.deleteEntity(ENTITY_PRODUCT, productPk));
+		}
+		assertMembershipMatchesIndexes();
+	}
+
+	@Test
+	@DisplayName("a catalog reloaded from disk rebuilds the lookup it never persisted")
+	void reloadRebuildsTheLookup() {
+		prepare(CatalogState.ALIVE, "CHECKBOX");
+		upsertProducts(1, 12, 1);
+		assertMembershipMatchesIndexes();
+
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		// the catalog is loaded on the service pool, so `new Evita` returns while it is still BEING_ACTIVATED
+		awaitCatalogLoaded();
+
+		assertMembershipMatchesIndexes();
+		assertMembershipEngaged(REF_CATEGORIES);
+		assertTrue(
+			coveredOf(REF_CATEGORIES).size() > 0,
+			"a reloaded collection must regain COVERAGE, not merely a residual list - the load-time build "
+				+ "resolves each index and decides coverage, unlike the seeding maintenance does"
+		);
+	}
+
+	@Test
+	@DisplayName("a reference raised to partitioned after load is still walked in full")
+	void referenceRaisedToPartitionedStillRegistersOwners() {
+		// `brand` starts out merely filterable, so the trigger's sibling walk never visits its reduced index
+		prepare(CatalogState.ALIVE, "INTERVAL_INPUT");
+		upsertProducts(1, 5, 1);
+
+		// raise it, exactly as a client would, and WITHOUT the reindex that would rebuild anything
+		tx(session -> session.getEntitySchemaOrThrowException(ENTITY_PRODUCT)
+			.openForWrite()
+			.withReferenceToEntity(
+				REF_BRAND, ENTITY_BRAND, Cardinality.ZERO_OR_ONE,
+				whichIs -> whichIs.indexedForFilteringAndPartitioning()
+			)
+			.updateVia(session));
+
+		// now fire the cross-entity trigger: the group entity starts satisfying the expression
+		tx(session -> session.getEntity(ENTITY_PARAMETER, PARAMETER_PK, entityFetchAllContent())
+			.orElseThrow()
+			.openForWrite()
+			.setAttribute(ATTR_INPUT_WIDGET_TYPE, "CHECKBOX")
+			.upsertVia(session));
+
+		// the facet must have reached the brand's reduced index even though the lookup never knew it -
+		// this is the accelerator-not-authority contract, and its failure would be a wrong answer
+		assertEquals(
+			5, countInBrandWithFacetSelected(),
+			"every product must survive selecting the facet inside the raised reference's index"
+		);
+	}
+
+	/*
+		ASSERTIONS
+	 */
+
+	/**
+	 * Asserts, for every reference of the product collection and in every scope, that the reverse lookup
+	 * agrees exactly with the reduced indexes it summarises.
+	 *
+	 * Ground truth is read from the collection's own indexes; the lookup's bookkeeping is never used to
+	 * check itself.
+	 */
+	private void assertMembershipMatchesIndexes() {
+		final EntityCollection collection = (EntityCollection) getProductCollection();
+		final EntityIndex globalIndex = collection.getIndexByKeyIfExists(
+			new EntityIndexKey(EntityIndexType.GLOBAL, Scope.LIVE)
+		);
+		if (!(globalIndex instanceof final GlobalEntityIndex typedGlobalIndex)) {
+			return;
+		}
+		for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
+			final String referenceName = reference.getName();
+			final Set<Integer> advertised = advertisedReducedIndexes(collection, referenceName);
+			final ReducedIndexMembership membership =
+				typedGlobalIndex.getReducedIndexMembership(referenceName);
+			if (membership == null) {
+				// Always legitimate, and deliberately so: with no lookup the trigger walks every index the
+				// reference advertises, which is what it did before this structure existed. Absence costs
+				// speed, never correctness - that is the accelerator-not-authority contract. What must never
+				// happen is a lookup that EXISTS and is incomplete, which is what the rest of this asserts.
+				continue;
+			}
+			final Set<Integer> covered = toSet(membership.getCoveredIndexPrimaryKeys());
+			final Set<Integer> residual = toSet(membership.getResidualIndexPrimaryKeys());
+
+			final Set<Integer> known = new TreeSet<>(covered);
+			known.addAll(residual);
+			assertEquals(
+				new TreeSet<>(advertised), known,
+				"reference `" + referenceName + "`: covered u residual must equal the advertised indexes"
+			);
+			assertTrue(
+				disjoint(covered, residual),
+				"reference `" + referenceName + "`: an index cannot be both covered and residual"
+			);
+
+			// every covered index's entries must name exactly its members, in both directions
+			final Map<Integer, Set<Integer>> expected = new HashMap<>(covered.size());
+			for (final Integer indexPk : covered) {
+				final EntityIndex reducedIndex = collection.getIndexByPrimaryKeyIfExists(indexPk);
+				assertTrue(
+					reducedIndex != null,
+					"reference `" + referenceName + "`: covered index " + indexPk + " does not exist"
+				);
+				final Bitmap members = reducedIndex.getAllPrimaryKeys();
+				assertTrue(
+					members.size() <= membership.getCoverageThreshold(),
+					"reference `" + referenceName + "`: covered index " + indexPk + " holds " + members.size()
+						+ " owners, above the coverage threshold of " + membership.getCoverageThreshold()
+				);
+				final OfInt it = members.iterator();
+				while (it.hasNext()) {
+					expected.computeIfAbsent(it.nextInt(), __ -> new TreeSet<>()).add(indexPk);
+				}
+			}
+			final Set<Integer> coveredOwners = toSet(membership.getCoveredOwners());
+			assertEquals(
+				new TreeSet<>(expected.keySet()), new TreeSet<>(coveredOwners),
+				"reference `" + referenceName + "`: coveredOwners must be exactly the owners of covered indexes"
+			);
+			for (final Map.Entry<Integer, Set<Integer>> entry : expected.entrySet()) {
+				assertEquals(
+					entry.getValue(), toSet(membership.getIndexPrimaryKeys(entry.getKey())),
+					"reference `" + referenceName + "`: owner " + entry.getKey() +
+						" must name exactly the covered indexes holding it"
+				);
+			}
+		}
+	}
+
+	/**
+	 * Asserts that the lookup is not merely *correct* but actually *engaged* for the given reference — it
+	 * exists, and it accounts for every index the reference advertises.
+	 *
+	 * Kept separate from {@link #assertMembershipMatchesIndexes} on purpose. Absence of a lookup is correct
+	 * behaviour and that method rightly tolerates it, which means a regression that stopped the lookup being
+	 * built at all would leave every correctness assertion green while the optimization quietly did nothing.
+	 * This is the assertion that would fail instead.
+	 *
+	 * @param referenceName the partitioned reference expected to be accelerated
+	 */
+	private void assertMembershipEngaged(@Nonnull String referenceName) {
+		final ReducedIndexMembership membership = membershipOf(referenceName);
+		assertTrue(
+			membership != null,
+			"reference `" + referenceName + "` must have a membership lookup - without one the trigger falls "
+				+ "back to walking every reduced index, which is the cost this structure exists to remove"
+		);
+		final EntityCollection collection = (EntityCollection) getProductCollection();
+		final Set<Integer> advertised = advertisedReducedIndexes(collection, referenceName);
+		final Set<Integer> known = new TreeSet<>(toSet(membership.getCoveredIndexPrimaryKeys()));
+		known.addAll(toSet(membership.getResidualIndexPrimaryKeys()));
+		assertEquals(
+			new TreeSet<>(advertised), known,
+			"reference `" + referenceName + "`: the lookup must account for every advertised index"
+		);
+	}
+
+	/**
+	 * Reads the reduced indexes a reference advertises, from the reference's own type indexes — the ground
+	 * truth the lookup is checked against.
+	 *
+	 * @param collection    the collection to inspect
+	 * @param referenceName reference whose advertisement is read
+	 * @return advertised reduced-index primary keys
+	 */
+	@Nonnull
+	private static Set<Integer> advertisedReducedIndexes(
+		@Nonnull EntityCollection collection,
+		@Nonnull String referenceName
+	) {
+		final Set<Integer> advertised = new HashSet<>(64);
+		for (final EntityIndexType family : new EntityIndexType[]{
+			EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
+		}) {
+			final EntityIndex typeIndex = collection.getIndexByKeyIfExists(
+				new EntityIndexKey(family, Scope.LIVE, referenceName)
+			);
+			if (typeIndex instanceof final ReferencedTypeEntityIndex typedTypeIndex) {
+				typedTypeIndex.forEachReferenceIndexPrimaryKey(advertised::add);
+			}
+		}
+		return advertised;
+	}
+
+	/**
+	 * Materialises a bitmap as a set, so assertion failures print something a reader can act on.
+	 *
+	 * @param bitmap the bitmap to materialise
+	 * @return its contents
+	 */
+	@Nonnull
+	private static Set<Integer> toSet(@Nonnull Bitmap bitmap) {
+		final Set<Integer> result = new TreeSet<>();
+		final OfInt it = bitmap.iterator();
+		while (it.hasNext()) {
+			result.add(it.nextInt());
+		}
+		return result;
+	}
+
+	/**
+	 * Returns `true` when the two sets share no element.
+	 *
+	 * @param left  first set
+	 * @param right second set
+	 * @return `true` when disjoint
+	 */
+	private static boolean disjoint(@Nonnull Set<Integer> left, @Nonnull Set<Integer> right) {
+		for (final Integer value : left) {
+			if (right.contains(value)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Nonnull
+	private Set<Integer> coveredOf(@Nonnull String referenceName) {
+		final ReducedIndexMembership membership = membershipOf(referenceName);
+		return membership == null ? Set.of() : toSet(membership.getCoveredIndexPrimaryKeys());
+	}
+
+	@Nonnull
+	private Set<Integer> residualOf(@Nonnull String referenceName) {
+		final ReducedIndexMembership membership = membershipOf(referenceName);
+		return membership == null ? Set.of() : toSet(membership.getResidualIndexPrimaryKeys());
+	}
+
+	private ReducedIndexMembership membershipOf(@Nonnull String referenceName) {
+		final EntityCollection collection = (EntityCollection) getProductCollection();
+		final EntityIndex globalIndex = collection.getIndexByKeyIfExists(
+			new EntityIndexKey(EntityIndexType.GLOBAL, Scope.LIVE)
+		);
+		return globalIndex instanceof final GlobalEntityIndex typed
+			? typed.getReducedIndexMembership(referenceName) : null;
+	}
+
+	/**
+	 * Blocks until the reopened catalog has finished loading. `new Evita(...)` returns while the catalog is
+	 * still `BEING_ACTIVATED` on the service pool, and the reverse lookup is rebuilt at the very end of that
+	 * load — so reading it any earlier would be a race, not a measurement.
+	 */
+	private void awaitCatalogLoaded() {
+		await()
+			.atMost(30, TimeUnit.SECONDS)
+			.pollInterval(50, TimeUnit.MILLISECONDS)
+			.until(
+				() -> !this.evita.management()
+					.getCatalogStatistics(TEST_CATALOG, EnumSet.of(CatalogStatisticsComponent.IDENTITY))
+					.identity()
+					.unusable()
+			);
+	}
+
+	/*
+		FIXTURE
+	 */
+
+	@Nonnull
+	private EvitaConfiguration getEvitaConfiguration() {
+		return newTestEvitaConfigurationBuilder(this.paths)
+			.server(
+				ServerOptions.builder()
+					.closeSessionsAfterSecondsOfInactivity(-1)
+					.build()
+			)
+			.build();
+	}
+
+	/**
+	 * Creates the schema and fixture entities and brings the catalog to the requested state.
+	 *
+	 * @param state      target catalog state
+	 * @param widgetType initial value of the group entity's attribute, which decides whether the conditional
+	 *                   facet is on
+	 */
+	private void prepare(@Nonnull CatalogState state, @Nonnull String widgetType) {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			(Consumer<EvitaSessionContract>) session -> {
+				session.defineEntitySchema(ENTITY_CATEGORY).updateVia(session);
+				session.defineEntitySchema(ENTITY_BRAND).updateVia(session);
+				session.defineEntitySchema(ENTITY_PARAMETER_VALUE).updateVia(session);
+				session.defineEntitySchema(ENTITY_PARAMETER)
+					.withAttribute(
+						ATTR_INPUT_WIDGET_TYPE, String.class, whichIs -> whichIs.filterable().nullable()
+					)
+					.updateVia(session);
+				session.defineEntitySchema(ENTITY_PRODUCT)
+					.withReferenceToEntity(
+						REF_CATEGORIES, ENTITY_CATEGORY, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs.indexedForFilteringAndPartitioning()
+					)
+					// starts merely filterable so it can be raised later, without a reindex
+					.withReferenceToEntity(
+						REF_BRAND, ENTITY_BRAND, Cardinality.ZERO_OR_ONE,
+						whichIs -> whichIs.indexedForFiltering()
+					)
+					.withReferenceToEntity(
+						REF_PARAMETER_VALUES, ENTITY_PARAMETER_VALUE, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs
+							.indexedForFiltering()
+							.indexedWithComponents(
+								ReferenceIndexedComponents.REFERENCED_ENTITY,
+								ReferenceIndexedComponents.REFERENCED_GROUP_ENTITY
+							)
+							.withGroupTypeRelatedToEntity(ENTITY_PARAMETER)
+							.facetedPartially(
+								ExpressionFactory.parse(
+									"$reference.groupEntity?.attributes['" + ATTR_INPUT_WIDGET_TYPE
+										+ "'] == 'CHECKBOX'"
+								)
+							)
+					)
+					.updateVia(session);
+
+				for (int pk = 1; pk <= OVER_THRESHOLD; pk++) {
+					session.createNewEntity(ENTITY_CATEGORY, pk).upsertVia(session);
+				}
+				session.createNewEntity(ENTITY_BRAND, BRAND_PK).upsertVia(session);
+				session.createNewEntity(ENTITY_PARAMETER_VALUE, PARAM_VALUE_PK).upsertVia(session);
+				session.createNewEntity(ENTITY_PARAMETER, PARAMETER_PK)
+					.setAttribute(ATTR_INPUT_WIDGET_TYPE, widgetType)
+					.upsertVia(session);
+
+				if (state == CatalogState.ALIVE) {
+					session.goLiveAndClose();
+				}
+			}
+		);
+	}
+
+	/**
+	 * Upserts a run of products, each filed under one shared category plus its own, so both the many-owner
+	 * and the single-owner shapes exist at once.
+	 *
+	 * @param fromPk          first product primary key, inclusive
+	 * @param toPk            last product primary key, inclusive
+	 * @param sharedCategory  category every product joins
+	 */
+	private void upsertProducts(int fromPk, int toPk, int sharedCategory) {
+		for (int pk = fromPk; pk <= toPk; pk++) {
+			final int productPk = pk;
+			tx(session -> session.createNewEntity(ENTITY_PRODUCT, productPk)
+				.setReference(REF_CATEGORIES, sharedCategory)
+				.setReference(REF_BRAND, BRAND_PK)
+				.setReference(
+					REF_PARAMETER_VALUES, PARAM_VALUE_PK,
+					whichIs -> whichIs.setGroup(ENTITY_PARAMETER, PARAMETER_PK)
+				)
+				.upsertVia(session));
+		}
+	}
+
+	private void tx(@Nonnull Consumer<EvitaSessionContract> work) {
+		this.evita.updateCatalog(TEST_CATALOG, work);
+	}
+
+	/**
+	 * Counts products of {@link #BRAND_PK} surviving a selection of the conditional facet — the query that is
+	 * evaluated against the brand's reduced index, and therefore the one that exposes a facet the trigger
+	 * failed to write there.
+	 *
+	 * @return number of matching products
+	 */
+	private int countInBrandWithFacetSelected() {
+		return this.evita.queryCatalog(
+			TEST_CATALOG,
+			(Function<EvitaSessionContract, Integer>) session -> session.query(
+				query(
+					collection(ENTITY_PRODUCT),
+					filterBy(
+						referenceHaving(REF_BRAND, entityPrimaryKeyInSet(BRAND_PK)),
+						userFilter(facetHaving(REF_PARAMETER_VALUES, entityPrimaryKeyInSet(PARAM_VALUE_PK)))
+					),
+					require(page(1, 1))
+				),
+				EntityReference.class
+			).getTotalRecordCount()
+		);
+	}
+
+	@Nonnull
+	private EntityCollectionContract getProductCollection() {
+		final CatalogContract catalog = this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		return catalog.getCollectionForEntity(ENTITY_PRODUCT).orElseThrow();
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReducedIndexMembershipDuplicateAdvertisementTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReducedIndexMembershipDuplicateAdvertisementTest.java
@@ -1,0 +1,886 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.indexing;
+
+import io.evitadb.api.CatalogContract;
+import io.evitadb.api.CatalogState;
+import io.evitadb.api.EntityCollectionContract;
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.index.EntityIndexType;
+import io.evitadb.api.query.expression.ExpressionFactory;
+import io.evitadb.api.statistics.CatalogStatisticsComponent;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.ReferenceIndexedComponents;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
+import io.evitadb.core.Evita;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.dataType.Scope;
+import io.evitadb.dataType.expression.Expression;
+import io.evitadb.index.EntityIndex;
+import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.GlobalEntityIndex;
+import io.evitadb.index.ReferencedTypeEntityIndex;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.facet.FacetGroupIndex;
+import io.evitadb.index.facet.FacetIdIndex;
+import io.evitadb.index.facet.FacetReferenceIndex;
+import io.evitadb.index.membership.ReducedIndexMembership;
+import io.evitadb.test.EvitaTestSupport;
+import io.evitadb.test.EvitaTestSupport.TestPaths;
+import io.evitadb.utils.CollectionUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.PrimitiveIterator.OfInt;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static io.evitadb.api.query.QueryConstraints.entityFetchAllContent;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.FACET;
+import static io.evitadb.test.TestTags.INDEXING;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Attacks the premise the reduced-index membership lookup is built on: that a reference advertises each of
+ * its reduced indexes **exactly once**.
+ *
+ * Both sites that fill the lookup — `EntityCollection#registerReducedIndex` at load and
+ * `ReferenceIndexMutator#seedFromAdvertisedIndexes` on the first write after a reference is raised — hand
+ * every advertised primary key straight to {@link ReducedIndexMembership#registerIndex} /
+ * {@link ReducedIndexMembership#registerIndexAsResidual}, both of which **refuse** a key they already hold.
+ * A reference that advertised one index twice would therefore not build a slightly wrong lookup: it would
+ * take the collection offline at load, or abort the transaction that met it.
+ *
+ * That premise is structural — a reduced index is filed in its type index under exactly one referenced (or
+ * group) primary key — but the structure it rests on is the **group** family, which the rest of the
+ * conditional-facet suite exercises only for references that are not partitioned. A reference that is
+ * `FOR_FILTERING_AND_PARTITIONING` *and* indexes {@link ReferenceIndexedComponents#REFERENCED_GROUP_ENTITY}
+ * owns two families of reduced indexes feeding one lookup, and one {@link io.evitadb.index.ReducedGroupEntityIndex}
+ * is shared by every one of an owner's references that resolves to the same group — which is exactly the shape
+ * a duplicate advertisement would arise in. This class drives that shape through every event that rewrites an
+ * advertisement and asserts the premise directly, rather than waiting for the refusal downstream of it.
+ *
+ * {@link #assertAdvertisementNeverRepeats()} is the assertion that matters: the completeness check
+ * `ReducedIndexMembershipCompletenessTest#assertMembershipMatchesIndexes` reads the advertisement into a
+ * {@link Set}, so a repeated key collapses there and cannot be seen.
+ *
+ * @author Claude (issue #1529 sibling-resolver optimization), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Reduced-index membership — the advertisement never repeats a primary key")
+@Tag(CONTRACT)
+@Tag(INDEXING)
+@Tag(FACET)
+class ReducedIndexMembershipDuplicateAdvertisementTest implements EvitaTestSupport {
+
+	private static final String ENTITY_PRODUCT = "product";
+	private static final String ENTITY_CATEGORY = "category";
+	private static final String ENTITY_PARAMETER = "parameter";
+	private static final String ENTITY_PARAMETER_VALUE = "parameterValue";
+
+	private static final String REF_CATEGORIES = "categories";
+	private static final String REF_PARAMETER_VALUES = "parameterValues";
+	private static final String REF_SIBLING_VALUES = "siblingValues";
+	private static final String ATTR_INPUT_WIDGET_TYPE = "inputWidgetType";
+
+	/**
+	 * Parameter (group) entities. Two of them, so a reference can be moved from one group to another — the
+	 * event that retires one {@link io.evitadb.index.ReducedGroupEntityIndex} and creates another.
+	 */
+	private static final int GROUP_A_PK = 100;
+	private static final int GROUP_B_PK = 101;
+
+	/**
+	 * Parameter values. Three of them share {@link #GROUP_A_PK}, which is what makes one group reduced index
+	 * hold the owners of several distinct references — the sharing the removed de-duplication scan was once
+	 * justified by.
+	 */
+	private static final int VALUE_ONE_PK = 10;
+	private static final int VALUE_TWO_PK = 11;
+	private static final int VALUE_THREE_PK = 12;
+
+	private static final int CATEGORY_COUNT = 3;
+	private static final int PRODUCT_COUNT = 6;
+
+	private TestPaths paths;
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() {
+		this.paths = createTestPaths("ReducedIndexMembershipDuplicateAdvertisementTest");
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.defineCatalog(TEST_CATALOG);
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.evita.close();
+		cleanupTestPaths(this.paths);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+	@DisplayName("no event that rewrites an advertisement makes it repeat a primary key")
+	void advertisementNeverRepeatsAPrimaryKey(CatalogState state) {
+		prepare(state, "CHECKBOX");
+		writeTheRichFixture();
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+
+		// a reference moved to another group: the owner leaves one group partition and enters another, so both
+		// group reduced indexes are rewritten and one of them may be retired outright
+		tx(session -> session.getEntity(ENTITY_PRODUCT, 1, entityFetchAllContent())
+			.orElseThrow()
+			.openForWrite()
+			.setReference(
+				REF_PARAMETER_VALUES, VALUE_ONE_PK,
+				whichIs -> whichIs.setGroup(ENTITY_PARAMETER, GROUP_B_PK)
+			)
+			.upsertVia(session));
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+
+		// a reference removed outright, so its entity partition loses an owner and its group partition may lose
+		// one too - but only if no other reference of the same owner resolves to the same group
+		tx(session -> session.getEntity(ENTITY_PRODUCT, 2, entityFetchAllContent())
+			.orElseThrow()
+			.openForWrite()
+			.removeReference(REF_PARAMETER_VALUES, VALUE_TWO_PK)
+			.upsertVia(session));
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+
+		// the owner leaves every LIVE index and enters the ARCHIVED ones, which builds a second, independent
+		// advertisement in the other scope
+		tx(session -> session.archiveEntity(ENTITY_PRODUCT, 3));
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+
+		tx(session -> session.restoreEntity(ENTITY_PRODUCT, 3));
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+
+		// the owner disappears entirely
+		tx(session -> session.deleteEntity(ENTITY_PRODUCT, 4));
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+
+		// ... and comes back under the same primary key, re-creating partitions that were just retired
+		upsertProduct(4, 1, VALUE_ONE_PK, GROUP_A_PK);
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@EnumSource(value = CatalogState.class, names = {"WARMING_UP", "ALIVE"})
+	@DisplayName("the trigger fans out to a sibling owning both reduced-index families")
+	void triggerFansOutToASiblingOwningBothIndexFamilies(CatalogState state) {
+		// `ReevaluateExpressionExecutor#probeReducedIndexForAffectedOwners` appends each `(owner, partition)`
+		// pair without a duplicate check, on the premise that one reduced index primary key reaches it at most
+		// once per sibling reference — which for the unaccelerated walk rests on the two families advertising
+		// disjoint primary keys, and for the accelerated one on the covered and residual sets being disjoint.
+		// A sibling that is partitioned, grouped and indexes both components is the shape where both halves of
+		// that premise are exercised at once, with several owners and a group partition reached through more
+		// than one of each owner's references.
+		prepare(state, "INTERVAL_INPUT");
+		writeTheRichFixture();
+		assertFalse(
+			isFacetedIn(siblingEntityPartition(VALUE_ONE_PK), VALUE_ONE_PK, 1),
+			"the expression does not match yet, so nothing may be faceted before the trigger fires"
+		);
+
+		turnWidgetTypeInto("CHECKBOX");
+
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+		for (int pk = 1; pk <= PRODUCT_COUNT; pk++) {
+			assertTrue(
+				isFacetedIn(siblingEntityPartition(VALUE_ONE_PK), VALUE_ONE_PK, pk),
+				"product " + pk + " must carry the facet in the sibling's entity partition of "
+					+ VALUE_ONE_PK
+			);
+			assertTrue(
+				isFacetedIn(siblingEntityPartition(VALUE_TWO_PK), VALUE_TWO_PK, pk),
+				"product " + pk + " must carry the facet in the sibling's entity partition of "
+					+ VALUE_TWO_PK
+			);
+			assertTrue(
+				isFacetedIn(siblingGroupPartition(), VALUE_ONE_PK, pk),
+				"product " + pk + " must carry the facet in the sibling's GROUP partition - the group family "
+					+ "is resolved by the same walk and must not be skipped"
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("a catalog reloaded with a grouped, partitioned reference rebuilds both families of its lookup")
+	void reloadRebuildsBothFamiliesOfTheLookup() {
+		// `EntityCollection#rebuildReducedIndexMembership` registers the REFERENCED_ENTITY_TYPE and the
+		// REFERENCED_GROUP_ENTITY_TYPE families into ONE lookup, and `ReducedIndexMembership#registerIndex`
+		// refuses a primary key it already holds - so a reference owning both families is the shape in which a
+		// repeated advertisement would refuse the whole catalog at load rather than merely mis-account for it.
+		prepare(CatalogState.ALIVE, "CHECKBOX");
+		writeTheRichFixture();
+		assertAdvertisementNeverRepeats();
+
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		// the catalog is loaded on the service pool, so `new Evita` returns while it is still BEING_ACTIVATED
+		awaitCatalogLoaded();
+
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+		assertBothFamiliesAreAccountedFor();
+	}
+
+	@Test
+	@DisplayName("warm-up writes, go-live and a reload leave the lookup built exactly once")
+	void warmUpWritesThenGoLiveThenReloadKeepTheLookupIntact() {
+		// In WARM_UP the lookup is built by the WRITE path, so the collection reaches go-live already holding a
+		// slice for every partitioned reference. Go-live hands those indexes to a new catalog instance rather
+		// than reloading them; a reload afterwards is the one moment the load-time build meets a collection
+		// whose slices were filled by someone else.
+		prepare(CatalogState.WARMING_UP, "CHECKBOX");
+		writeTheRichFixture();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+
+		tx(EvitaSessionContract::goLiveAndClose);
+
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+
+		// a write after go-live, so the transactional half of the maintenance is exercised over a lookup built
+		// entirely in warm-up
+		upsertProduct(PRODUCT_COUNT + 1, 2, VALUE_THREE_PK, GROUP_B_PK);
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		awaitCatalogLoaded();
+
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+		assertBothFamiliesAreAccountedFor();
+	}
+
+	@Test
+	@DisplayName("lowering and raising a grouped reference re-seeds its lookup from both families")
+	void loweringAndRaisingAGroupedReferenceReSeedsFromBothFamilies() {
+		// Lowering the reference below FOR_FILTERING_AND_PARTITIONING discards its lookup
+		// (`EntityCollection#discardUnmaintainedReducedIndexMemberships`); raising it back leaves the next write
+		// to rebuild one through `ReferenceIndexMutator#seedFromAdvertisedIndexes`, which registers EVERY
+		// advertised key of BOTH families as residual, unguarded. That is the only production route into
+		// `registerIndexAsResidual` on the write path, and it runs against an advertisement that is already
+		// fully populated - the richest input the method ever sees.
+		prepare(CatalogState.ALIVE, "CHECKBOX");
+		writeTheRichFixture();
+		assertNotNull(
+			membershipOf(REF_PARAMETER_VALUES, Scope.LIVE),
+			"the grouped, partitioned reference must hold a lookup before it is lowered, or the discard below "
+				+ "has nothing to discard"
+		);
+
+		setParameterValuesPartitioned(false);
+		assertTrue(
+			membershipOf(REF_PARAMETER_VALUES, Scope.LIVE) == null,
+			"lowering the reference must discard its lookup - a frozen lookup trusted again after the raise "
+				+ "would make the trigger skip every partition created in between"
+		);
+
+		// partitions created while nothing is watching, in both families: a new value under a new group
+		upsertProduct(PRODUCT_COUNT + 1, 3, VALUE_THREE_PK, GROUP_B_PK);
+
+		setParameterValuesPartitioned(true);
+		// the first write after the raise is what re-seeds the lookup
+		upsertProduct(PRODUCT_COUNT + 2, 3, VALUE_THREE_PK, GROUP_B_PK);
+
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+		assertBothFamiliesAreAccountedFor();
+	}
+
+	@Test
+	@DisplayName("re-grouping onto a group that already has a partition keeps the advertisement single-valued")
+	void reGroupingOntoAnExistingGroupKeepsTheAdvertisementSingleValued() {
+		// The sharing the removed de-duplication scan was justified by, driven directly: several of one owner's
+		// references resolve to ONE ReducedGroupEntityIndex. Moving a reference onto a group another of the same
+		// owner's references already uses files that one group index under the same group primary key a second
+		// time - the closest production comes to advertising an index twice.
+		prepare(CatalogState.ALIVE, "CHECKBOX");
+		tx(session -> session.createNewEntity(ENTITY_PRODUCT, 1)
+			.setReference(REF_CATEGORIES, 1)
+			.setReference(
+				REF_PARAMETER_VALUES, VALUE_ONE_PK,
+				whichIs -> whichIs.setGroup(ENTITY_PARAMETER, GROUP_A_PK)
+			)
+			.setReference(
+				REF_PARAMETER_VALUES, VALUE_TWO_PK,
+				whichIs -> whichIs.setGroup(ENTITY_PARAMETER, GROUP_B_PK)
+			)
+			.upsertVia(session));
+		assertAdvertisementNeverRepeats();
+
+		// the second reference joins the group the first one is already filed under
+		tx(session -> session.getEntity(ENTITY_PRODUCT, 1, entityFetchAllContent())
+			.orElseThrow()
+			.openForWrite()
+			.setReference(
+				REF_PARAMETER_VALUES, VALUE_TWO_PK,
+				whichIs -> whichIs.setGroup(ENTITY_PARAMETER, GROUP_A_PK)
+			)
+			.upsertVia(session));
+
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+
+		// ... and leaves it again, so the shared group index loses one of its two contributors while keeping the
+		// other - the state in which a premature un-advertise would show up
+		tx(session -> session.getEntity(ENTITY_PRODUCT, 1, entityFetchAllContent())
+			.orElseThrow()
+			.openForWrite()
+			.setReference(
+				REF_PARAMETER_VALUES, VALUE_TWO_PK,
+				whichIs -> whichIs.setGroup(ENTITY_PARAMETER, GROUP_B_PK)
+			)
+			.upsertVia(session));
+
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+
+		this.evita.close();
+		this.evita = new Evita(getEvitaConfiguration());
+		awaitCatalogLoaded();
+
+		assertAdvertisementNeverRepeats();
+		assertMembershipAccountsForEveryAdvertisedIndex();
+	}
+
+	/*
+		ASSERTIONS
+	 */
+
+	/**
+	 * Asserts, for every reference of the product collection, in every scope and both reduced-index families,
+	 * that {@link ReferencedTypeEntityIndex#forEachReferenceIndexPrimaryKey} emits each primary key **at most
+	 * once**.
+	 *
+	 * This is the premise both fill sites rest on, asserted directly. Counting is what makes it an assertion at
+	 * all: every other reader of the advertisement collects it into a {@link Set}, where a repeat is
+	 * indistinguishable from a single emission.
+	 */
+	private void assertAdvertisementNeverRepeats() {
+		final EntityCollection collection = (EntityCollection) getProductCollection();
+		for (final Scope scope : Scope.values()) {
+			for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
+				for (final EntityIndexType family : ReducedIndexMembership.REFERENCED_TYPE_INDEX_FAMILIES) {
+					final EntityIndex typeIndex = collection.getIndexByKeyIfExists(
+						new EntityIndexKey(family, scope, reference.getName())
+					);
+					if (!(typeIndex instanceof final ReferencedTypeEntityIndex typedTypeIndex)) {
+						continue;
+					}
+					final List<Integer> emitted = new ArrayList<>(64);
+					typedTypeIndex.forEachReferenceIndexPrimaryKey(emitted::add);
+					final Set<Integer> distinct = new TreeSet<>(emitted);
+					assertEquals(
+						distinct.size(), emitted.size(),
+						"scope " + scope + ", reference `" + reference.getName() + "`, family " + family
+							+ ": the advertisement emitted " + emitted.size() + " primary keys but only "
+							+ distinct.size() + " are distinct (" + emitted + ") - both fill sites hand every "
+							+ "emitted key straight to ReducedIndexMembership, which refuses a key it already "
+							+ "holds, so a repeat takes the catalog offline at load or aborts the transaction "
+							+ "that met it"
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Asserts the invariant the lookup is maintained against — `covered ∪ residual == advertised` — for every
+	 * reference that holds one, in every scope.
+	 *
+	 * An absent lookup is legitimate and skipped: with none the trigger walks the whole advertisement, which is
+	 * what it did before the structure existed.
+	 */
+	private void assertMembershipAccountsForEveryAdvertisedIndex() {
+		final EntityCollection collection = (EntityCollection) getProductCollection();
+		for (final Scope scope : Scope.values()) {
+			final GlobalEntityIndex globalIndex = globalIndexOf(scope);
+			if (globalIndex == null) {
+				continue;
+			}
+			for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
+				final ReducedIndexMembership membership =
+					globalIndex.getReducedIndexMembership(reference.getName());
+				if (membership == null) {
+					continue;
+				}
+				final Set<Integer> covered = toSet(membership.getCoveredIndexPrimaryKeys());
+				final Set<Integer> residual = toSet(membership.getResidualIndexPrimaryKeys());
+				final Set<Integer> known = new TreeSet<>(covered);
+				known.addAll(residual);
+				assertEquals(
+					new TreeSet<>(advertisedReducedIndexes(collection, reference.getName(), scope)), known,
+					"scope " + scope + ", reference `" + reference.getName()
+						+ "`: covered u residual must equal the advertised indexes"
+				);
+				assertTrue(
+					Collections.disjoint(covered, residual),
+					"scope " + scope + ", reference `" + reference.getName()
+						+ "`: an index cannot be both covered and residual"
+				);
+			}
+		}
+	}
+
+	/**
+	 * Asserts that the lookup of the grouped, partitioned reference accounts for indexes of **both** families —
+	 * without it every other assertion here would hold vacuously over a group family that was never built.
+	 */
+	private void assertBothFamiliesAreAccountedFor() {
+		final EntityCollection collection = (EntityCollection) getProductCollection();
+		final ReducedIndexMembership membership = membershipOf(REF_PARAMETER_VALUES, Scope.LIVE);
+		assertNotNull(
+			membership,
+			"reference `" + REF_PARAMETER_VALUES + "` must hold a lookup, or the family check below asserts "
+				+ "nothing"
+		);
+		for (final EntityIndexType family : ReducedIndexMembership.REFERENCED_TYPE_INDEX_FAMILIES) {
+			final EntityIndex typeIndex = collection.getIndexByKeyIfExists(
+				new EntityIndexKey(family, Scope.LIVE, REF_PARAMETER_VALUES)
+			);
+			assertTrue(
+				typeIndex instanceof ReferencedTypeEntityIndex,
+				"reference `" + REF_PARAMETER_VALUES + "` must own a " + family + " index - it is declared "
+					+ "with both indexed components, and a missing family makes the whole premise untested"
+			);
+			final Set<Integer> advertised = new TreeSet<>();
+			((ReferencedTypeEntityIndex) typeIndex).forEachReferenceIndexPrimaryKey(advertised::add);
+			assertFalse(
+				advertised.isEmpty(),
+				"family " + family + " of `" + REF_PARAMETER_VALUES + "` advertises nothing"
+			);
+			final Set<Integer> known = new TreeSet<>(toSet(membership.getCoveredIndexPrimaryKeys()));
+			known.addAll(toSet(membership.getResidualIndexPrimaryKeys()));
+			assertTrue(
+				known.containsAll(advertised),
+				"family " + family + " of `" + REF_PARAMETER_VALUES + "`: the lookup must account for every "
+					+ "index this family advertises - " + advertised + " against " + known
+			);
+		}
+	}
+
+	/**
+	 * Tells whether the given product is recorded in `index` as a facet of `facetPk` under
+	 * {@link #GROUP_A_PK}, for the conditionally faceted reference.
+	 *
+	 * @param index     the partition to inspect; `null` when it does not exist at all
+	 * @param facetPk   primary key of the faceted parameter value
+	 * @param productPk primary key of the owner expected to be faceted
+	 * @return `true` when the owner carries the facet there
+	 */
+	private static boolean isFacetedIn(@Nullable EntityIndex index, int facetPk, int productPk) {
+		if (index == null) {
+			return false;
+		}
+		final FacetReferenceIndex facetReferenceIndex =
+			index.getFacetingEntities().get(REF_PARAMETER_VALUES);
+		if (facetReferenceIndex == null) {
+			return false;
+		}
+		final FacetGroupIndex facetGroupIndex = facetReferenceIndex.getFacetsInGroup(GROUP_A_PK);
+		if (facetGroupIndex == null) {
+			return false;
+		}
+		final FacetIdIndex facetIdIndex = facetGroupIndex.getFacetIdIndex(facetPk);
+		return facetIdIndex != null && facetIdIndex.getRecords().contains(productPk);
+	}
+
+	/**
+	 * The sibling reference's entity-side partition, keyed by the referenced parameter value.
+	 *
+	 * @param valuePk primary key of the referenced parameter value naming the partition
+	 * @return the partition, or `null` when it does not exist
+	 */
+	@Nullable
+	private EntityIndex siblingEntityPartition(int valuePk) {
+		return IndexingTestSupport.getReferencedEntityIndex(
+			getProductCollection(), Scope.LIVE, REF_SIBLING_VALUES, valuePk
+		);
+	}
+
+	/**
+	 * The sibling reference's group-side partition, keyed by {@link #GROUP_A_PK}.
+	 *
+	 * @return the partition, or `null` when it does not exist
+	 */
+	@Nullable
+	private EntityIndex siblingGroupPartition() {
+		return IndexingTestSupport.getReferencedGroupEntityIndex(
+			getProductCollection(), Scope.LIVE, REF_SIBLING_VALUES, GROUP_A_PK
+		);
+	}
+
+	/*
+		FIXTURE
+	 */
+
+	/**
+	 * Writes the shape every assertion here needs: several owners spread over a few categories, each carrying
+	 * two parameter-value references filed under one shared group, so one group reduced index is reached
+	 * through more than one of an owner's references.
+	 */
+	private void writeTheRichFixture() {
+		for (int pk = 1; pk <= PRODUCT_COUNT; pk++) {
+			final int categoryPk = ((pk - 1) % CATEGORY_COUNT) + 1;
+			final int productPk = pk;
+			tx(session -> session.createNewEntity(ENTITY_PRODUCT, productPk)
+				.setReference(REF_CATEGORIES, categoryPk)
+				.setReference(
+					REF_PARAMETER_VALUES, VALUE_ONE_PK,
+					whichIs -> whichIs.setGroup(ENTITY_PARAMETER, GROUP_A_PK)
+				)
+				.setReference(
+					REF_PARAMETER_VALUES, VALUE_TWO_PK,
+					whichIs -> whichIs.setGroup(ENTITY_PARAMETER, GROUP_A_PK)
+				)
+				// two sibling references under ONE group, so the sibling's group reduced index is reached
+				// through more than one of this owner's references
+				.setReference(
+					REF_SIBLING_VALUES, VALUE_ONE_PK,
+					whichIs -> whichIs.setGroup(ENTITY_PARAMETER, GROUP_A_PK)
+				)
+				.setReference(
+					REF_SIBLING_VALUES, VALUE_TWO_PK,
+					whichIs -> whichIs.setGroup(ENTITY_PARAMETER, GROUP_A_PK)
+				)
+				.upsertVia(session));
+		}
+	}
+
+	/**
+	 * Upserts one product with a single category and a single grouped parameter value.
+	 *
+	 * @param productPk  primary key of the product
+	 * @param categoryPk category the product joins
+	 * @param valuePk    parameter value the product references
+	 * @param groupPk    group the parameter-value reference is filed under
+	 */
+	private void upsertProduct(int productPk, int categoryPk, int valuePk, int groupPk) {
+		tx(session -> session.createNewEntity(ENTITY_PRODUCT, productPk)
+			.setReference(REF_CATEGORIES, categoryPk)
+			.setReference(
+				REF_PARAMETER_VALUES, valuePk,
+				whichIs -> whichIs.setGroup(ENTITY_PARAMETER, groupPk)
+			)
+			.upsertVia(session));
+	}
+
+	/**
+	 * Switches the grouped reference between partitioned and merely filterable. Lowering it discards its
+	 * lookup; raising it back leaves the next write to re-seed one from the advertisement.
+	 *
+	 * @param partitioned `true` to index the reference for filtering and partitioning
+	 */
+	private void setParameterValuesPartitioned(boolean partitioned) {
+		tx(session -> session.getEntitySchemaOrThrowException(ENTITY_PRODUCT)
+			.openForWrite()
+			.withReferenceToEntity(
+				REF_PARAMETER_VALUES, ENTITY_PARAMETER_VALUE, Cardinality.ZERO_OR_MORE,
+				whichIs -> {
+					if (partitioned) {
+						whichIs.indexedForFilteringAndPartitioningInScope(Scope.LIVE, Scope.ARCHIVED);
+					} else {
+						whichIs.indexedForFilteringInScope(Scope.LIVE, Scope.ARCHIVED);
+					}
+				}
+			)
+			.updateVia(session));
+	}
+
+	/**
+	 * Creates the schema and the fixture entities and brings the catalog to the requested state.
+	 *
+	 * The reference that carries the conditional facet is itself partitioned **and** grouped **and** indexes
+	 * both components, which is the shape in which one lookup is fed by two families of reduced indexes.
+	 *
+	 * @param state      target catalog state
+	 * @param widgetType initial value of the group entity's attribute, which decides whether the facet applies
+	 */
+	private void prepare(@Nonnull CatalogState state, @Nonnull String widgetType) {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			(Consumer<EvitaSessionContract>) session -> {
+				session.defineEntitySchema(ENTITY_CATEGORY).updateVia(session);
+				session.defineEntitySchema(ENTITY_PARAMETER_VALUE).updateVia(session);
+				session.defineEntitySchema(ENTITY_PARAMETER)
+					.withAttribute(
+						ATTR_INPUT_WIDGET_TYPE, String.class,
+						whichIs -> whichIs.filterableInScope(Scope.LIVE, Scope.ARCHIVED).nullable()
+					)
+					.updateVia(session);
+				session.defineEntitySchema(ENTITY_PRODUCT)
+					.withReferenceToEntity(
+						REF_CATEGORIES, ENTITY_CATEGORY, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs
+							.indexedForFilteringAndPartitioningInScope(Scope.LIVE, Scope.ARCHIVED)
+					)
+					.withReferenceToEntity(
+						REF_PARAMETER_VALUES, ENTITY_PARAMETER_VALUE, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs
+							.indexedForFilteringAndPartitioningInScope(Scope.LIVE, Scope.ARCHIVED)
+							.indexedWithComponentsInScope(
+								Scope.LIVE,
+								ReferenceIndexedComponents.REFERENCED_ENTITY,
+								ReferenceIndexedComponents.REFERENCED_GROUP_ENTITY
+							)
+							.indexedWithComponentsInScope(
+								Scope.ARCHIVED,
+								ReferenceIndexedComponents.REFERENCED_ENTITY,
+								ReferenceIndexedComponents.REFERENCED_GROUP_ENTITY
+							)
+							.withGroupTypeRelatedToEntity(ENTITY_PARAMETER)
+							.facetedPartiallyInScope(Scope.LIVE, conditionalFacetExpression())
+							.facetedPartiallyInScope(Scope.ARCHIVED, conditionalFacetExpression())
+					)
+					// the SIBLING the cross-entity trigger fans out to: same shape - partitioned, grouped, both
+					// components - so the resolver's walk over it covers the REFERENCED_ENTITY_TYPE and the
+					// REFERENCED_GROUP_ENTITY_TYPE family in one resolution, which is where the claim that the
+					// two families advertise disjoint primary keys is actually paid
+					.withReferenceToEntity(
+						REF_SIBLING_VALUES, ENTITY_PARAMETER_VALUE, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs
+							.indexedForFilteringAndPartitioningInScope(Scope.LIVE, Scope.ARCHIVED)
+							.indexedWithComponentsInScope(
+								Scope.LIVE,
+								ReferenceIndexedComponents.REFERENCED_ENTITY,
+								ReferenceIndexedComponents.REFERENCED_GROUP_ENTITY
+							)
+							.indexedWithComponentsInScope(
+								Scope.ARCHIVED,
+								ReferenceIndexedComponents.REFERENCED_ENTITY,
+								ReferenceIndexedComponents.REFERENCED_GROUP_ENTITY
+							)
+							.withGroupTypeRelatedToEntity(ENTITY_PARAMETER)
+					)
+					.updateVia(session);
+
+				for (int pk = 1; pk <= CATEGORY_COUNT; pk++) {
+					session.createNewEntity(ENTITY_CATEGORY, pk).upsertVia(session);
+				}
+				for (final int pk : new int[]{VALUE_ONE_PK, VALUE_TWO_PK, VALUE_THREE_PK}) {
+					session.createNewEntity(ENTITY_PARAMETER_VALUE, pk).upsertVia(session);
+				}
+				for (final int pk : new int[]{GROUP_A_PK, GROUP_B_PK}) {
+					session.createNewEntity(ENTITY_PARAMETER, pk)
+						.setAttribute(ATTR_INPUT_WIDGET_TYPE, widgetType)
+						.upsertVia(session);
+				}
+
+				if (state == CatalogState.ALIVE) {
+					session.goLiveAndClose();
+				}
+			}
+		);
+	}
+
+	/**
+	 * Builds the conditional-facet expression the fixture declares — the group entity's widget type deciding
+	 * whether the facet applies.
+	 *
+	 * @return the parsed expression
+	 */
+	@Nonnull
+	private static Expression conditionalFacetExpression() {
+		return ExpressionFactory.parse(
+			"$reference.groupEntity?.attributes['" + ATTR_INPUT_WIDGET_TYPE + "'] == 'CHECKBOX'"
+		);
+	}
+
+	/**
+	 * Rewrites {@link #GROUP_A_PK}'s attribute, which is what fires the cross-entity conditional-facet trigger
+	 * and therefore what drives the sibling resolution this class exercises.
+	 *
+	 * @param widgetType new value of the group entity's attribute
+	 */
+	private void turnWidgetTypeInto(@Nonnull String widgetType) {
+		tx(session -> session.getEntity(ENTITY_PARAMETER, GROUP_A_PK, entityFetchAllContent())
+			.orElseThrow()
+			.openForWrite()
+			.setAttribute(ATTR_INPUT_WIDGET_TYPE, widgetType)
+			.upsertVia(session));
+	}
+
+	/**
+	 * Runs one unit of write work against the test catalog — a transaction in `ALIVE`, a plain bulk write in
+	 * `WARMING_UP`.
+	 *
+	 * @param work the write to perform
+	 */
+	private void tx(@Nonnull Consumer<EvitaSessionContract> work) {
+		this.evita.updateCatalog(TEST_CATALOG, work);
+	}
+
+	/**
+	 * Blocks until the reopened catalog has finished loading — `new Evita(...)` returns while the catalog is
+	 * still `BEING_ACTIVATED` on the service pool, and the lookup is rebuilt at the very end of that load.
+	 */
+	private void awaitCatalogLoaded() {
+		await()
+			.atMost(30, TimeUnit.SECONDS)
+			.pollInterval(50, TimeUnit.MILLISECONDS)
+			.until(
+				() -> !this.evita.management()
+					.getCatalogStatistics(TEST_CATALOG, EnumSet.of(CatalogStatisticsComponent.IDENTITY))
+					.identity()
+					.unusable()
+			);
+	}
+
+	/**
+	 * Builds the configuration every instance in this test is opened with. Session inactivity timeout is
+	 * disabled so a catalog closed and reopened mid-test cannot lose a session underneath an assertion.
+	 *
+	 * @return configuration rooted at this test's own temporary paths
+	 */
+	@Nonnull
+	private EvitaConfiguration getEvitaConfiguration() {
+		return newTestEvitaConfigurationBuilder(this.paths)
+			.server(
+				ServerOptions.builder()
+					.closeSessionsAfterSecondsOfInactivity(-1)
+					.build()
+			)
+			.build();
+	}
+
+	/**
+	 * Reads the reduced indexes a reference advertises, from the reference's own type indexes.
+	 *
+	 * @param collection    the collection to inspect
+	 * @param referenceName reference whose advertisement is read
+	 * @param scope         the scope whose type indexes are read
+	 * @return advertised reduced-index primary keys
+	 */
+	@Nonnull
+	private static Set<Integer> advertisedReducedIndexes(
+		@Nonnull EntityCollection collection,
+		@Nonnull String referenceName,
+		@Nonnull Scope scope
+	) {
+		final Set<Integer> advertised = CollectionUtils.createHashSet(64);
+		for (final EntityIndexType family : ReducedIndexMembership.REFERENCED_TYPE_INDEX_FAMILIES) {
+			final EntityIndex typeIndex = collection.getIndexByKeyIfExists(
+				new EntityIndexKey(family, scope, referenceName)
+			);
+			if (typeIndex instanceof final ReferencedTypeEntityIndex typedTypeIndex) {
+				typedTypeIndex.forEachReferenceIndexPrimaryKey(advertised::add);
+			}
+		}
+		return advertised;
+	}
+
+	/**
+	 * Materialises a bitmap as a set, so assertion failures print something a reader can act on.
+	 *
+	 * @param bitmap the bitmap to materialise
+	 * @return its contents
+	 */
+	@Nonnull
+	private static Set<Integer> toSet(@Nonnull Bitmap bitmap) {
+		final Set<Integer> result = new TreeSet<>();
+		final OfInt it = bitmap.iterator();
+		while (it.hasNext()) {
+			result.add(it.nextInt());
+		}
+		return result;
+	}
+
+	/**
+	 * Returns a reference's reverse lookup in the given scope, or `null` when it has none.
+	 *
+	 * @param referenceName reference to read
+	 * @param scope         the scope whose lookup is read
+	 * @return the lookup, or `null`
+	 */
+	@Nullable
+	private ReducedIndexMembership membershipOf(@Nonnull String referenceName, @Nonnull Scope scope) {
+		final GlobalEntityIndex globalIndex = globalIndexOf(scope);
+		return globalIndex == null ? null : globalIndex.getReducedIndexMembership(referenceName);
+	}
+
+	/**
+	 * Returns the product collection's global index in the given scope.
+	 *
+	 * @param scope the scope whose global index is read
+	 * @return the global index, or `null` when the scope holds none
+	 */
+	@Nullable
+	private GlobalEntityIndex globalIndexOf(@Nonnull Scope scope) {
+		final EntityCollection collection = (EntityCollection) getProductCollection();
+		final EntityIndex globalIndex = collection.getIndexByKeyIfExists(
+			new EntityIndexKey(EntityIndexType.GLOBAL, scope)
+		);
+		if (globalIndex == null) {
+			return null;
+		}
+		assertTrue(
+			globalIndex instanceof GlobalEntityIndex,
+			"scope " + scope + ": the GLOBAL index key resolved to " + globalIndex.getClass().getName()
+		);
+		return (GlobalEntityIndex) globalIndex;
+	}
+
+	/**
+	 * Resolves the product collection of the test catalog.
+	 *
+	 * @return the product collection; never `null`
+	 */
+	@Nonnull
+	private EntityCollectionContract getProductCollection() {
+		final CatalogContract catalog = this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		return catalog.getCollectionForEntity(ENTITY_PRODUCT).orElseThrow();
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReferenceAttributeVerificationScopeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReferenceAttributeVerificationScopeTest.java
@@ -71,7 +71,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * For an **existing** entity that check no longer walks the whole reference container - it verifies only the
  * references the incoming mutations named (issue #1531). That narrowing is safe only because the per-reference
  * verdict depends on nothing entity-scoped except the entity's locale set, and the implementation falls back to the
- * full scan whenever a locale is added, and whenever a mutation names a reference by a key that cannot be resolved
+ * full scan whenever the entity's OWN locale set gains a locale - an attribute written in a locale the entity
+ * already declares does not fall back - and whenever a mutation names a reference by a key that cannot be resolved
  * against the container at all.
  *
  * **These tests attack the narrowing, not the mechanism.** The load-bearing one is

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReferenceAttributeVerificationScopeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReferenceAttributeVerificationScopeTest.java
@@ -1,0 +1,305 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.indexing;
+
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.exception.MandatoryAttributesNotProvidedException;
+import io.evitadb.api.requestResponse.data.ReferenceContract;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.core.Evita;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import io.evitadb.test.EvitaTestSupport.TestPaths;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Locale;
+import java.util.Optional;
+
+import static io.evitadb.api.query.QueryConstraints.entityFetchAllContent;
+import static io.evitadb.test.TestConstants.TEST_CATALOG;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Pins the verification scope of {@link io.evitadb.index.mutation.storagePart.ContainerizedLocalMutationExecutor}'s
+ * reference-attribute check.
+ *
+ * For an **existing** entity that check no longer walks the whole reference container - it verifies only the
+ * references the incoming mutations named (issue #1531). That narrowing is safe only because the per-reference
+ * verdict depends on nothing entity-scoped except the entity's locale set, and the implementation falls back to the
+ * full scan whenever a locale is added.
+ *
+ * **These tests attack the narrowing, not the mechanism.** The load-bearing one is
+ * {@link #untouchedReferencesAreDefaultedWhenEntityLocaleAppears()}: it mutates an entity attribute only, naming no
+ * reference at all, and demands that references the batch never touched acquire their localized defaults in the new
+ * locale. Remove the locale fallback and that test fails - which is the point, because the failure it guards against
+ * is silent.
+ *
+ * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(CONTRACT)
+@Tag(INDEXING)
+@Tag(REFERENCE)
+@DisplayName("Reference attribute verification — scope of the existing-entity check")
+class ReferenceAttributeVerificationScopeTest implements EvitaTestSupport {
+	private static final String REFERENCE_CATEGORIES = "categories";
+	private static final String ATTRIBUTE_NOTE = "note";
+	private static final String ATTRIBUTE_LABEL = "label";
+	private static final String ATTRIBUTE_MANDATORY = "mandatoryNote";
+	private static final Locale ENGLISH = Locale.ENGLISH;
+	private static final Locale GERMAN = Locale.GERMAN;
+
+	private TestPaths paths;
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() {
+		this.paths = createTestPaths("ReferenceAttributeVerificationScopeTest");
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.defineCatalog(TEST_CATALOG);
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.evita.close();
+		cleanupTestPaths(this.paths);
+	}
+
+	@Test
+	@DisplayName("a reference the batch never named is defaulted when the same batch adds an entity locale")
+	void untouchedReferencesAreDefaultedWhenEntityLocaleAppears() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				defineSchema(session, false);
+				session.upsertEntity(
+					session.createNewEntity(Entities.CATEGORY, 1)
+				);
+				session.upsertEntity(
+					session.createNewEntity(Entities.CATEGORY, 2)
+				);
+				// the product is created carrying ENGLISH only - both references get their ENGLISH default
+				session.upsertEntity(
+					session.createNewEntity(Entities.PRODUCT, 10)
+						.setAttribute(ATTRIBUTE_LABEL, ENGLISH, "english label")
+						.setReference(REFERENCE_CATEGORIES, 1)
+						.setReference(REFERENCE_CATEGORIES, 2)
+				);
+			}
+		);
+
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				// a MIXED batch: it introduces a new entity locale and touches exactly ONE reference (category 1).
+				// The reference container therefore becomes dirty, the existing-entity check runs, and the question
+				// is whether the reference it did NOT touch (category 2) is still defaulted in the new locale.
+				session.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+					.orElseThrow()
+					.openForWrite()
+					.setAttribute(ATTRIBUTE_LABEL, GERMAN, "deutsches label")
+					.setReference(
+						REFERENCE_CATEGORIES, 1,
+						whichIs -> whichIs.setAttribute(ATTRIBUTE_NOTE, ENGLISH, "touched")
+					)
+					.upsertVia(session);
+			}
+		);
+
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity product = session
+					.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+					.orElseThrow();
+				// category 2 was NOT named by the batch - it must still acquire the new locale's default, because
+				// the added entity locale is what made it non-compliant
+				assertEquals(
+					"default note", findReference(product, 2).getAttribute(ATTRIBUTE_NOTE, GERMAN),
+					"the untouched reference is missing its GERMAN default - the existing-entity check skipped a " +
+						"reference that the newly added entity locale made non-compliant"
+				);
+				assertEquals(
+					"default note", findReference(product, 2).getAttribute(ATTRIBUTE_NOTE, ENGLISH),
+					"the untouched reference lost its ENGLISH default"
+				);
+				// the touched reference keeps the value the batch set and gains the new locale's default
+				assertEquals(
+					"touched", findReference(product, 1).getAttribute(ATTRIBUTE_NOTE, ENGLISH),
+					"the touched reference lost the value the batch set"
+				);
+				assertEquals(
+					"default note", findReference(product, 1).getAttribute(ATTRIBUTE_NOTE, GERMAN),
+					"the touched reference is missing its GERMAN default"
+				);
+			}
+		);
+	}
+
+	@Test
+	@DisplayName("a reference added to an existing entity is still defaulted")
+	void referenceAddedToExistingEntityIsDefaulted() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				defineSchema(session, false);
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, 1));
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, 2));
+				session.upsertEntity(
+					session.createNewEntity(Entities.PRODUCT, 10)
+						.setAttribute(ATTRIBUTE_LABEL, ENGLISH, "english label")
+						.setReference(REFERENCE_CATEGORIES, 1)
+				);
+			}
+		);
+
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+					.orElseThrow()
+					.openForWrite()
+					.setReference(REFERENCE_CATEGORIES, 2)
+					.upsertVia(session);
+			}
+		);
+
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity product = session
+					.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+					.orElseThrow();
+				assertEquals(
+					"default note", findReference(product, 2).getAttribute(ATTRIBUTE_NOTE, ENGLISH),
+					"the newly added reference was not verified"
+				);
+				assertEquals(
+					"default note", findReference(product, 1).getAttribute(ATTRIBUTE_NOTE, ENGLISH),
+					"the pre-existing reference lost its default"
+				);
+			}
+		);
+	}
+
+	@Test
+	@DisplayName("a mandatory attribute missing on a touched reference still fails the update")
+	void missingMandatoryAttributeOnTouchedReferenceStillThrows() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				defineSchema(session, true);
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, 1));
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, 2));
+				session.upsertEntity(
+					session.createNewEntity(Entities.PRODUCT, 10)
+						.setAttribute(ATTRIBUTE_LABEL, ENGLISH, "english label")
+						.setReference(
+							REFERENCE_CATEGORIES, 1,
+							whichIs -> whichIs.setAttribute(ATTRIBUTE_MANDATORY, "provided")
+						)
+				);
+			}
+		);
+
+		assertThrows(
+			MandatoryAttributesNotProvidedException.class,
+			() -> this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						// the mandatory attribute is deliberately omitted on the reference being added
+						.setReference(REFERENCE_CATEGORIES, 2)
+						.upsertVia(session);
+				}
+			),
+			"adding a reference without its mandatory attribute must still be refused"
+		);
+	}
+
+	/**
+	 * Defines a product schema whose `categories` reference carries a localized, default-valued attribute - the shape
+	 * that couples reference compliance to the entity's locale set.
+	 *
+	 * @param session      session to define the schema through
+	 * @param withMandatory when true the reference also declares a non-nullable attribute with no default value
+	 */
+	private static void defineSchema(
+		@Nonnull io.evitadb.api.EvitaSessionContract session,
+		boolean withMandatory
+	) {
+		session.defineEntitySchema(Entities.CATEGORY).updateVia(session);
+		session.defineEntitySchema(Entities.PRODUCT)
+			.withAttribute(ATTRIBUTE_LABEL, String.class, whichIs -> whichIs.localized().nullable())
+			.withReferenceToEntity(
+				REFERENCE_CATEGORIES, Entities.CATEGORY, Cardinality.ZERO_OR_MORE,
+				whichIs -> {
+					whichIs.indexed()
+						.withAttribute(
+							ATTRIBUTE_NOTE, String.class,
+							thatIs -> thatIs.localized().withDefaultValue("default note")
+						);
+					if (withMandatory) {
+						whichIs.withAttribute(ATTRIBUTE_MANDATORY, String.class, thatIs -> {
+						});
+					}
+				}
+			)
+			.updateVia(session);
+	}
+
+	/**
+	 * Returns the product's reference to the given category, failing the test when it is absent.
+	 *
+	 * @param product     the fetched product
+	 * @param categoryPk  primary key of the referenced category
+	 * @return the reference, never null
+	 */
+	@Nonnull
+	private static ReferenceContract findReference(@Nonnull SealedEntity product, int categoryPk) {
+		final Optional<ReferenceContract> reference = product.getReference(REFERENCE_CATEGORIES, categoryPk);
+		assertNotNull(reference.orElse(null), "reference to category " + categoryPk + " is missing entirely");
+		return reference.orElseThrow();
+	}
+
+	@Nonnull
+	private EvitaConfiguration getEvitaConfiguration() {
+		return newTestEvitaConfigurationBuilder(this.paths)
+			.server(ServerOptions.builder().closeSessionsAfterSecondsOfInactivity(-1).build())
+			.build();
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReferenceAttributeVerificationScopeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReferenceAttributeVerificationScopeTest.java
@@ -23,12 +23,22 @@
 
 package io.evitadb.api.functional.indexing;
 
+import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.configuration.EvitaConfiguration;
 import io.evitadb.api.configuration.ServerOptions;
 import io.evitadb.api.exception.MandatoryAttributesNotProvidedException;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.api.requestResponse.data.ReferenceContract;
 import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.data.mutation.EntityMutation.EntityExistence;
+import io.evitadb.api.requestResponse.data.mutation.EntityUpsertMutation;
+import io.evitadb.api.requestResponse.data.mutation.attribute.UpsertAttributeMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceAttributeMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
 import io.evitadb.core.Evita;
 import io.evitadb.test.Entities;
 import io.evitadb.test.EvitaTestSupport;
@@ -41,7 +51,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Locale;
-import java.util.Optional;
+import java.util.Set;
 
 import static io.evitadb.api.query.QueryConstraints.entityFetchAllContent;
 import static io.evitadb.test.TestConstants.TEST_CATALOG;
@@ -50,7 +60,9 @@ import static io.evitadb.test.TestTags.INDEXING;
 import static io.evitadb.test.TestTags.REFERENCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Pins the verification scope of {@link io.evitadb.index.mutation.storagePart.ContainerizedLocalMutationExecutor}'s
@@ -59,13 +71,24 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * For an **existing** entity that check no longer walks the whole reference container - it verifies only the
  * references the incoming mutations named (issue #1531). That narrowing is safe only because the per-reference
  * verdict depends on nothing entity-scoped except the entity's locale set, and the implementation falls back to the
- * full scan whenever a locale is added.
+ * full scan whenever a locale is added, and whenever a mutation names a reference by a key that cannot be resolved
+ * against the container at all.
  *
  * **These tests attack the narrowing, not the mechanism.** The load-bearing one is
  * {@link #untouchedReferencesAreDefaultedWhenEntityLocaleAppears()}: it mutates an entity attribute only, naming no
  * reference at all, and demands that references the batch never touched acquire their localized defaults in the new
  * locale. Remove the locale fallback and that test fails - which is the point, because the failure it guards against
  * is silent.
+ *
+ * The three scope tests below are written as a differential against one shared scenario - a reference schema that
+ * gains a default-valued attribute after the entity was written, leaving every existing reference of that entity
+ * non-compliant. Whether an untouched reference is repaired then reads out directly as whether the batch took the
+ * incremental path or the full scan, through the public API and with no knowledge of internals:
+ *
+ * - {@link #untouchedReferenceKeepsItsGapAfterTheSchemaGainsADefaultValuedAttribute()} — the incremental path;
+ * - {@link #batchNamingAReferenceWithAGenericKeyVerifiesEverything()} — the unresolvable-key fallback;
+ * - {@link #batchRemovingAReferenceVerifiesOnlyTheReferencesItNamed()} — a removal, which resolves and therefore
+ *   does *not* fall back, and is the case most easily confused with the one above.
  *
  * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
@@ -78,6 +101,13 @@ class ReferenceAttributeVerificationScopeTest implements EvitaTestSupport {
 	private static final String ATTRIBUTE_NOTE = "note";
 	private static final String ATTRIBUTE_LABEL = "label";
 	private static final String ATTRIBUTE_MANDATORY = "mandatoryNote";
+	/**
+	 * Attribute added to the reference schema *after* the entity was written, so every existing reference becomes
+	 * non-compliant without any of them being touched. Deliberately non-localized, so the locale fallback plays no
+	 * part in whether it is repaired.
+	 */
+	private static final String ATTRIBUTE_LATE_NOTE = "lateNote";
+	private static final String LATE_NOTE_DEFAULT = "late default";
 	private static final Locale ENGLISH = Locale.ENGLISH;
 	private static final Locale GERMAN = Locale.GERMAN;
 
@@ -164,6 +194,7 @@ class ReferenceAttributeVerificationScopeTest implements EvitaTestSupport {
 					"default note", findReference(product, 1).getAttribute(ATTRIBUTE_NOTE, GERMAN),
 					"the touched reference is missing its GERMAN default"
 				);
+				assertEveryReferenceCompliant(product, schemaOf(session));
 			}
 		);
 	}
@@ -210,6 +241,7 @@ class ReferenceAttributeVerificationScopeTest implements EvitaTestSupport {
 					"default note", findReference(product, 1).getAttribute(ATTRIBUTE_NOTE, ENGLISH),
 					"the pre-existing reference lost its default"
 				);
+				assertEveryReferenceCompliant(product, schemaOf(session));
 			}
 		);
 	}
@@ -251,6 +283,295 @@ class ReferenceAttributeVerificationScopeTest implements EvitaTestSupport {
 		);
 	}
 
+	@Test
+	@DisplayName("a reference the batch never named keeps a gap the schema opened after it was written")
+	void untouchedReferenceKeepsItsGapAfterTheSchemaGainsADefaultValuedAttribute() {
+		createProductWithTwoCategories();
+		addLateDefaultValuedAttributeToReferenceSchema();
+
+		// an ordinary builder-driven upsert: the mutation carries the reference's resolved internal key, so the
+		// incremental path takes it and category 2 is never looked at
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+					.orElseThrow()
+					.openForWrite()
+					.setReference(
+						REFERENCE_CATEGORIES, 1,
+						whichIs -> whichIs.setAttribute(ATTRIBUTE_NOTE, ENGLISH, "touched")
+					)
+					.upsertVia(session);
+			}
+		);
+
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity product = session
+					.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+					.orElseThrow();
+				assertEquals(
+					LATE_NOTE_DEFAULT, findReference(product, 1).getAttribute(ATTRIBUTE_LATE_NOTE),
+					"the touched reference must be brought up to date with the schema"
+				);
+				// This is the narrowing, stated as behaviour rather than as prose: an untouched reference is
+				// trusted to have been compliant when it was last written, so a schema change that makes it
+				// non-compliant is not repaired by a later upsert of a sibling reference. Before #1531 the full
+				// scan repaired it. The two tests below pin the fallbacks that still do.
+				assertNull(
+					findReference(product, 2).getAttribute(ATTRIBUTE_LATE_NOTE),
+					"the untouched reference must be left exactly as it was written"
+				);
+			}
+		);
+	}
+
+	@Test
+	@DisplayName("a batch naming a reference by a generic key verifies every reference")
+	void batchNamingAReferenceWithAGenericKeyVerifiesEverything() {
+		createProductWithTwoCategories();
+		addLateDefaultValuedAttributeToReferenceSchema();
+
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.upsertEntity(
+					new EntityUpsertMutation(
+						Entities.PRODUCT, 10, EntityExistence.MUST_EXIST,
+						new ReferenceAttributeMutation(
+							// the two-argument constructor yields internalPrimaryKey == 0, which the key manager
+							// cannot translate - exactly the condition the fallback tests
+							new ReferenceKey(REFERENCE_CATEGORIES, 1),
+							new UpsertAttributeMutation(new AttributeKey(ATTRIBUTE_NOTE, ENGLISH), "touched")
+						)
+					)
+				);
+			}
+		);
+
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity product = session
+					.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+					.orElseThrow();
+				assertEquals(
+					"touched", findReference(product, 1).getAttribute(ATTRIBUTE_NOTE, ENGLISH),
+					"the hand-built mutation did not reach the reference it named"
+				);
+				assertEquals(
+					LATE_NOTE_DEFAULT, findReference(product, 2).getAttribute(ATTRIBUTE_LATE_NOTE),
+					"an unresolvable key must send the whole batch back to the full scan, which repairs every " +
+						"reference - the incremental path must never verify less than the full one would"
+				);
+				assertEveryReferenceCompliant(product, schemaOf(session));
+			}
+		);
+	}
+
+	@Test
+	@DisplayName("a batch removing a reference verifies only the references it named")
+	void batchRemovingAReferenceVerifiesOnlyTheReferencesItNamed() {
+		createProductWithTwoCategories();
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, 3));
+				session.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+					.orElseThrow()
+					.openForWrite()
+					.setReference(REFERENCE_CATEGORIES, 3)
+					.upsertVia(session);
+			}
+		);
+		addLateDefaultValuedAttributeToReferenceSchema();
+
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+					.orElseThrow()
+					.openForWrite()
+					.removeReference(REFERENCE_CATEGORIES, 1)
+					.upsertVia(session);
+			}
+		);
+
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity product = session
+					.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+					.orElseThrow();
+				assertTrue(
+					product.getReference(REFERENCE_CATEGORIES, 1).isEmpty(),
+					"the removal itself must have taken effect, or the batch under test never happened"
+				);
+				// A removed reference is *resolvable* - the container still holds its dropped slot - so the batch
+				// keeps the incremental path and verifies only what it named. It is the reference the key cannot
+				// resolve AT ALL that means the resolver is holding a stale key and must fall back; the two look
+				// identical through `findReference`, which answers empty for both, and telling them apart is what
+				// keeps every removal off the whole-container scan.
+				assertNull(
+					findReference(product, 2).getAttribute(ATTRIBUTE_LATE_NOTE),
+					"a batch removing a reference must not re-verify the references it never named"
+				);
+				assertNull(
+					findReference(product, 3).getAttribute(ATTRIBUTE_LATE_NOTE),
+					"a batch removing a reference must not re-verify the references it never named"
+				);
+			}
+		);
+	}
+
+	@Test
+	@DisplayName("a reference the batch never named is not re-checked against an attribute the schema newly mandates")
+	void untouchedReferenceIsNotRecheckedAgainstANewlyMandatedAttribute() {
+		createProductWithTwoCategories();
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.getEntitySchemaOrThrowException(Entities.PRODUCT)
+					.openForWrite()
+					.withReferenceToEntity(
+						REFERENCE_CATEGORIES, Entities.CATEGORY, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs.withAttribute(ATTRIBUTE_MANDATORY, String.class, thatIs -> {
+						})
+					)
+					.updateVia(session);
+			}
+		);
+
+		// the touched reference provides the newly mandated value, the untouched one cannot - and is not asked
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+					.orElseThrow()
+					.openForWrite()
+					.setReference(
+						REFERENCE_CATEGORIES, 1,
+						whichIs -> whichIs.setAttribute(ATTRIBUTE_MANDATORY, "provided")
+					)
+					.upsertVia(session);
+			}
+		);
+
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity product = session
+					.getEntity(Entities.PRODUCT, 10, entityFetchAllContent())
+					.orElseThrow();
+				assertEquals(
+					"provided", findReference(product, 1).getAttribute(ATTRIBUTE_MANDATORY),
+					"the touched reference must carry the value the batch set"
+				);
+				// The silent half of the narrowing, and the reason it is worth a test of its own: the entity is
+				// left holding a reference that violates a mandatory constraint, with no exception anywhere. The
+				// full scan would have refused the whole upsert instead.
+				assertNull(
+					findReference(product, 2).getAttribute(ATTRIBUTE_MANDATORY),
+					"the untouched reference must be left exactly as it was written"
+				);
+			}
+		);
+	}
+
+	/*
+		ASSERTIONS
+	 */
+
+	/**
+	 * Asserts the invariant the full scan enforces, expressed without reference to *which* path ran: every existing
+	 * reference of the entity carries a value for every attribute its schema declares mandatory or default-valued,
+	 * in every locale the entity declares.
+	 *
+	 * Written this way on purpose. A test built on it attacks the quantifier rather than the mechanism, so it keeps
+	 * its meaning whatever the set of fallbacks turns out to be.
+	 *
+	 * @param product the fetched entity, with all its references
+	 * @param schema  the entity schema the references are verified against
+	 */
+	private static void assertEveryReferenceCompliant(
+		@Nonnull SealedEntity product,
+		@Nonnull EntitySchemaContract schema
+	) {
+		final Set<Locale> locales = product.getLocales();
+		for (final ReferenceContract reference : product.getReferences()) {
+			final ReferenceSchemaContract referenceSchema =
+				schema.getReferenceOrThrowException(reference.getReferenceName());
+			for (final AttributeSchemaContract attributeSchema : referenceSchema.getAttributes().values()) {
+				if (attributeSchema.isNullable() && attributeSchema.getDefaultValue() == null) {
+					continue;
+				}
+				final String attributeName = attributeSchema.getName();
+				if (attributeSchema.isLocalized()) {
+					for (final Locale locale : locales) {
+						assertNotNull(
+							reference.getAttribute(attributeName, locale),
+							"reference " + reference.getReferenceKey() + " carries no `" + attributeName
+								+ "` in " + locale
+						);
+					}
+				} else {
+					assertNotNull(
+						reference.getAttribute(attributeName),
+						"reference " + reference.getReferenceKey() + " carries no `" + attributeName + "`"
+					);
+				}
+			}
+		}
+	}
+
+	/*
+		FIXTURE
+	 */
+
+	/**
+	 * Creates the base schema plus a product carrying two references, both compliant with the schema as it stands
+	 * at that moment. This is the state every fallback test opens a gap in.
+	 */
+	private void createProductWithTwoCategories() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				defineSchema(session, false);
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, 1));
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, 2));
+				session.upsertEntity(
+					session.createNewEntity(Entities.PRODUCT, 10)
+						.setAttribute(ATTRIBUTE_LABEL, ENGLISH, "english label")
+						.setReference(REFERENCE_CATEGORIES, 1)
+						.setReference(REFERENCE_CATEGORIES, 2)
+				);
+			}
+		);
+	}
+
+	/**
+	 * Adds a non-localized, default-valued attribute to the `categories` reference schema, which leaves every
+	 * reference already written non-compliant without touching any of them.
+	 */
+	private void addLateDefaultValuedAttributeToReferenceSchema() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.getEntitySchemaOrThrowException(Entities.PRODUCT)
+					.openForWrite()
+					.withReferenceToEntity(
+						REFERENCE_CATEGORIES, Entities.CATEGORY, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs.withAttribute(
+							ATTRIBUTE_LATE_NOTE, String.class,
+							thatIs -> thatIs.nullable().withDefaultValue(LATE_NOTE_DEFAULT)
+						)
+					)
+					.updateVia(session);
+			}
+		);
+	}
+
 	/**
 	 * Defines a product schema whose `categories` reference carries a localized, default-valued attribute - the shape
 	 * that couples reference compliance to the entity's locale set.
@@ -259,7 +580,7 @@ class ReferenceAttributeVerificationScopeTest implements EvitaTestSupport {
 	 * @param withMandatory when true the reference also declares a non-nullable attribute with no default value
 	 */
 	private static void defineSchema(
-		@Nonnull io.evitadb.api.EvitaSessionContract session,
+		@Nonnull EvitaSessionContract session,
 		boolean withMandatory
 	) {
 		session.defineEntitySchema(Entities.CATEGORY).updateVia(session);
@@ -283,6 +604,17 @@ class ReferenceAttributeVerificationScopeTest implements EvitaTestSupport {
 	}
 
 	/**
+	 * Returns the product entity schema as the session sees it.
+	 *
+	 * @param session the reading session
+	 * @return the product schema
+	 */
+	@Nonnull
+	private static EntitySchemaContract schemaOf(@Nonnull EvitaSessionContract session) {
+		return session.getEntitySchemaOrThrowException(Entities.PRODUCT);
+	}
+
+	/**
 	 * Returns the product's reference to the given category, failing the test when it is absent.
 	 *
 	 * @param product     the fetched product
@@ -291,11 +623,18 @@ class ReferenceAttributeVerificationScopeTest implements EvitaTestSupport {
 	 */
 	@Nonnull
 	private static ReferenceContract findReference(@Nonnull SealedEntity product, int categoryPk) {
-		final Optional<ReferenceContract> reference = product.getReference(REFERENCE_CATEGORIES, categoryPk);
-		assertNotNull(reference.orElse(null), "reference to category " + categoryPk + " is missing entirely");
-		return reference.orElseThrow();
+		return product.getReference(REFERENCE_CATEGORIES, categoryPk)
+			.orElseThrow(
+				() -> new AssertionError("reference to category " + categoryPk + " is missing entirely")
+			);
 	}
 
+	/**
+	 * Builds the engine configuration these tests boot against. Session inactivity closing is disabled so a
+	 * session held open across several assertions is never reclaimed underneath them.
+	 *
+	 * @return the configuration; never `null`
+	 */
 	@Nonnull
 	private EvitaConfiguration getEvitaConfiguration() {
 		return newTestEvitaConfigurationBuilder(this.paths)

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/EntityIndexReloadPlanSymmetryTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/EntityIndexReloadPlanSymmetryTest.java
@@ -32,6 +32,7 @@ import io.evitadb.index.component.GroupCardinalityComponent;
 import io.evitadb.index.component.HistogramIndexMapComponent;
 import io.evitadb.index.component.IndexComponent;
 import io.evitadb.index.component.PriceIndexComponent;
+import io.evitadb.index.component.ReducedIndexMembershipMapComponent;
 import io.evitadb.index.component.ReferenceTypeCardinalityComponent;
 import io.evitadb.index.component.TrigramIndexMapComponent;
 import io.evitadb.index.component.loader.AttributeCardinalityIndexMapLoader;
@@ -219,6 +220,14 @@ class EntityIndexReloadPlanSymmetryTest {
 			// but has no on-disk footprint — the reload plan intentionally omits a price loader
 			return null;
 		}
+		if (component instanceof ReducedIndexMembershipMapComponent) {
+			// the reduced-index membership lookup is derived state: every entry is a function of the membership
+			// bitmaps of the collection's reduced indexes, which are persisted in their own right. It writes no
+			// storage part and announces no manifest key, so there is nothing on disk for a loader to read back -
+			// it is re-derived at load by EntityCollection#rebuildReducedIndexMembership. It registers here only
+			// for the transactional-layer half of the IndexComponent contract.
+			return null;
+		}
 		if (component instanceof TrigramIndexMapComponent) {
 			// a trigram index is derived state: it writes no storage part and announces no manifest key, and is
 			// re-derived from the reloaded shared value trees by the finalizer of GlobalEntityIndex.reloadPlan()
@@ -247,14 +256,17 @@ class EntityIndexReloadPlanSymmetryTest {
 			HistogramIndexMapComponent.class,
 			GroupCardinalityComponent.class,
 			ReferenceTypeCardinalityComponent.class,
-			TrigramIndexMapComponent.class
+			TrigramIndexMapComponent.class,
+			ReducedIndexMembershipMapComponent.class
 		);
 		// the components that deliberately have no loader, each for a reason stated at its arm of
 		// `expectedLoaderFor`: price is subclass-dispatched and symmetry is asserted by the per-subclass tests,
-		// and the trigram map is derived state with no on-disk footprint at all
+		// while the trigram map and the reduced-index membership map are derived state with no on-disk
+		// footprint at all
 		final Set<Class<? extends IndexComponent>> componentsWithoutLoader = Set.of(
 			PriceIndexComponent.class,
-			TrigramIndexMapComponent.class
+			TrigramIndexMapComponent.class,
+			ReducedIndexMembershipMapComponent.class
 		);
 		for (final Class<? extends IndexComponent> componentClass : knownComponents) {
 			if (componentsWithoutLoader.contains(componentClass)) {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/map/TransactionalMapTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/map/TransactionalMapTest.java
@@ -1482,17 +1482,34 @@ class TransactionalMapTest {
 			// per owner, drops the entry when the owner leaves its last covered index, re-creates it when the owner
 			// joins another, and drops it again when that one goes - all inside one entity mutation. Every such
 			// second removal used to orphan the re-inserted bitmap's layer and suspend the catalog at commit.
+			//
+			// The delegate's own instance is mutated first so that BOTH discarded instances carry a live layer:
+			// without that, the re-insert has nothing to dispose of and the test agrees with its code whatever the
+			// code does. It also makes the read-after-remove assertion below reachable.
+			final TransactionalBitmap displaced = new TransactionalBitmap(1);
 			final Map<String, TransactionalBitmap> delegate = new LinkedHashMap<>();
-			delegate.put("a", new TransactionalBitmap(1));
+			delegate.put("a", displaced);
 			final TransactionalMap<String, TransactionalBitmap> map = producerMap(delegate);
 
 			assertStateAfterCommit(
 				map,
 				original -> {
+					// open an ALIVE nested layer on the instance the delegate holds
+					displaced.add(2);
 					// drop the original entry, then put a fresh producer instance back under the same key
-					original.remove("a");
+					final TransactionalBitmap removed = original.remove("a");
+					assertSame(displaced, removed, "remove() must hand back the instance the delegate held");
 					final TransactionalBitmap reinserted = new TransactionalBitmap(5);
 					original.put("a", reinserted);
+					// The read-after-remove every discard site in `MapChanges` promises: the write that discarded
+					// the instance must not take its layer with it, or a caller holding the reference - as
+					// `HierarchyIndex#makeOrphansRecursively` does across recursive removes - silently reverts to
+					// the pre-transaction content.
+					assertArrayEquals(
+						new int[]{1, 2}, removed.getArray(),
+						"the displaced instance must still report its live in-transaction state after the "
+							+ "re-insert that discarded it"
+					);
 					// open an ALIVE nested layer on the re-inserted instance, leaving its content unchanged
 					reinserted.add(6);
 					reinserted.remove(6);
@@ -1503,6 +1520,52 @@ class TransactionalMapTest {
 					assertEquals(1, original.size());
 					assertArrayEquals(new int[]{1}, original.get("a").getArray());
 					assertTrue(committed.isEmpty());
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("a value displaced by a re-insert keeps its layer when the alias appears afterwards")
+		void shouldNotReleaseLayerOfADisplacedValueWhenTheAliasAppearsAfterTheReinsert() {
+			// `MapChanges#put` stashes the displaced instance and lets the identity-based survivor guard run at
+			// commit, on the final key -> value mapping. The statement order below is what that buys and is the
+			// whole point: the alias under "b" is introduced AFTER the re-insert, so a guard evaluated at the
+			// moment of the put would not see it and would release a layer a surviving key still needs. Swapping
+			// the last two statements exercises the same code with the alias already in place, so the two orders
+			// must agree - an outcome that depends on statement order inside one transaction is the failure this
+			// pins. The plain-overwrite arm is the same arm and carries the same guarantee.
+			final TransactionalBitmap displaced = new TransactionalBitmap(1);
+			final Map<String, TransactionalBitmap> delegate = new LinkedHashMap<>();
+			delegate.put("a", displaced);
+			final TransactionalMap<String, TransactionalBitmap> map = producerMap(delegate);
+
+			assertStateAfterCommit(
+				map,
+				original -> {
+					// open an ALIVE nested layer on the instance the delegate holds
+					displaced.add(2);
+					// remove the key and put a different instance back under it - the displaced instance is
+					// stashed here, not released
+					original.remove("a");
+					original.put("a", new TransactionalBitmap(9));
+					// ... and only now does a surviving key start referencing the displaced instance
+					original.put("b", displaced);
+				},
+				(original, committed) -> {
+					assertEquals(1, original.size());
+					assertArrayEquals(new int[]{1}, original.get("a").getArray());
+					assertEquals(2, committed.size());
+					assertArrayEquals(new int[]{9}, committed.get("a").getArray());
+					// Releasing the layer here instead would be SILENT: with the layer gone
+					// `verifyLayerWasFullySwept` finds nothing to complain about and
+					// `TransactionalBitmap#createCopyWithMergedTransactionalMemory` answers a null layer with the
+					// unmerged instance, so the transaction would commit having dropped the mutation. That is why
+					// this asserts the committed content rather than expecting a throw.
+					assertArrayEquals(
+						new int[]{1, 2}, committed.get("b").getArray(),
+						"the alias introduced after the re-insert must carry the in-transaction mutation - the "
+							+ "survivor guard is evaluated at commit, on the final mapping"
+					);
 				}
 			);
 		}
@@ -1535,6 +1598,46 @@ class TransactionalMapTest {
 					assertTrue(committed.containsKey("b"));
 					assertFalse(committed.containsKey("a"));
 					assertArrayEquals(new int[]{7, 8}, committed.get("b").getArray());
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("a delegate aliasing one producer across two keys is outside the survivor scan's premise")
+		void shouldLoseTheSharedLayerWhenTheDelegateAliasesOneInstanceAcrossTwoKeys() {
+			// `MapChanges#isInstanceNotReferencedBySurvivingKey` scans the in-transaction diff layer alone, on the
+			// premise that a committed or constructed delegate mints one producer instance per key and therefore
+			// never holds a cross-key alias. That premise is stated in the method contract and enforced nowhere:
+			// the only thing that could enforce it is a full delegate scan, which would make producer-map removals
+			// `O(removed * N)` and defeat the `O(d * log32 N)` commit the persistent map exists for.
+			//
+			// This pins what a violation costs, so a change that starts aliasing producers across delegate keys
+			// fails here rather than losing data silently at a customer's commit. Removing "a" finds no surviving
+			// reference in the diff layer, releases the shared layer, and the still-mapped "b" is then merged from
+			// a null layer - committing the pre-transaction content with nothing raised. It is order-dependent as
+			// well: merging "b" before visiting the removed "a" would commit `{7, 8}` instead, and only the
+			// delegate's `LinkedHashMap` ordering decides which happens. An outcome that turns on iteration order
+			// is exactly why the premise is load-bearing rather than a nicety.
+			final TransactionalBitmap shared = new TransactionalBitmap(7);
+			final Map<String, TransactionalBitmap> delegate = new LinkedHashMap<>();
+			delegate.put("a", shared);
+			delegate.put("b", shared);
+			final TransactionalMap<String, TransactionalBitmap> map = producerMap(delegate);
+
+			assertStateAfterCommit(
+				map,
+				original -> {
+					shared.add(8);
+					original.remove("a");
+				},
+				(original, committed) -> {
+					assertEquals(2, original.size());
+					assertEquals(1, committed.size());
+					assertArrayEquals(
+						new int[]{7}, committed.get("b").getArray(),
+						"the surviving key commits the pre-transaction content, because the layer its value owns "
+							+ "was released together with the removed key the scan could not see past"
+					);
 				}
 			);
 		}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/map/TransactionalMapTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/map/TransactionalMapTest.java
@@ -1272,8 +1272,10 @@ class TransactionalMapTest {
 	/**
 	 * Tests covering the production shape `TransactionalMap<String, TransactionalBitmap>` (values that are
 	 * themselves {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer}s). They focus on the
-	 * lifecycle of a value's nested transactional layer when the holding key is mutated and then removed within
-	 * one transaction. A leaked (never-released) inner layer surfaces as a
+	 * lifecycle of a value's nested transactional layer when the holding key is mutated and then removed,
+	 * overwritten, or removed and re-inserted within one transaction — every shape in which the commit-time
+	 * sweep can lose sight of an instance the transaction has discarded. A leaked (never-released) inner layer
+	 * surfaces as a
 	 * {@link io.evitadb.core.exception.StaleTransactionMemoryException} thrown by the layer-sweep
 	 * verification performed inside {@link io.evitadb.utils.AssertionUtils#assertStateAfterCommit}.
 	 *
@@ -1381,6 +1383,126 @@ class TransactionalMapTest {
 					assertEquals(1, committed.size());
 					assertTrue(committed.containsKey("a"));
 					assertFalse(committed.containsKey("z"));
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("a value displaced by a plain overwrite sweeps cleanly")
+		void shouldReleaseLayerOfAValueDisplacedByAPlainOverwrite() {
+			// No removal anywhere: the key is simply overwritten with a different producer instance. At commit the
+			// base-map loop skips the key because it is now in modifiedKeys, and the modifiedKeys loop merges the NEW
+			// value - so the displaced instance is visited by neither, and its nested layer orphans.
+			final Map<String, TransactionalBitmap> delegate = new LinkedHashMap<>();
+			delegate.put("a", new TransactionalBitmap(1));
+			final TransactionalMap<String, TransactionalBitmap> map = producerMap(delegate);
+
+			assertStateAfterCommit(
+				map,
+				original -> {
+					// open an ALIVE nested layer on the instance the delegate holds
+					original.get("a").add(2);
+					// ... then displace it, with no intervening remove
+					original.put("a", new TransactionalBitmap(9));
+				},
+				(original, committed) -> {
+					assertEquals(1, original.size());
+					assertArrayEquals(new int[]{1}, original.get("a").getArray());
+					assertEquals(1, committed.size());
+					assertArrayEquals(new int[]{9}, committed.get("a").getArray());
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("a value displaced by an overwrite is kept when a surviving key still references it")
+		void shouldNotReleaseLayerOfADisplacedValueStillReferencedBySurvivingKey() {
+			// The survivor guard has to hold for the overwrite path too: the displaced instance is aliased under a
+			// second key introduced in this transaction, so its layer must be committed with that key rather than
+			// released as orphaned.
+			final TransactionalBitmap shared = new TransactionalBitmap(1);
+			final Map<String, TransactionalBitmap> delegate = new LinkedHashMap<>();
+			delegate.put("a", shared);
+			final TransactionalMap<String, TransactionalBitmap> map = producerMap(delegate);
+
+			assertStateAfterCommit(
+				map,
+				original -> {
+					shared.add(2);
+					// the displaced instance survives under another key ...
+					original.put("b", shared);
+					// ... while "a" is overwritten with a different one
+					original.put("a", new TransactionalBitmap(9));
+				},
+				(original, committed) -> {
+					assertEquals(1, original.size());
+					assertEquals(2, committed.size());
+					assertArrayEquals(new int[]{9}, committed.get("a").getArray());
+					assertArrayEquals(
+						new int[]{1, 2}, committed.get("b").getArray(),
+						"the surviving alias must carry the in-transaction mutation, so its layer must have been "
+							+ "committed rather than released"
+					);
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("a replacement value removed again within one transaction sweeps cleanly")
+		void shouldReleaseLayerOfAReplacementValueThatIsRemovedAgain() {
+			// The key survives the overwrite, so the commit-time base-map loop DOES visit it - but the instance it
+			// finds under the key is the delegate's original, never the replacement. Without an explicit stash the
+			// replacement's nested layer is visited by nobody and the commit fails on the stale-layer sweep.
+			final Map<String, TransactionalBitmap> delegate = new LinkedHashMap<>();
+			delegate.put("a", new TransactionalBitmap(1));
+			final TransactionalMap<String, TransactionalBitmap> map = producerMap(delegate);
+
+			assertStateAfterCommit(
+				map,
+				original -> {
+					final TransactionalBitmap replacement = new TransactionalBitmap(2);
+					original.put("a", replacement);
+					// open an ALIVE nested layer on the replacement instance
+					replacement.add(3);
+					replacement.remove(3);
+					original.remove("a");
+				},
+				(original, committed) -> {
+					assertEquals(1, original.size());
+					assertArrayEquals(new int[]{1}, original.get("a").getArray());
+					assertTrue(committed.isEmpty());
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("a value re-inserted after removal and removed again within one transaction sweeps cleanly")
+		void shouldReleaseLayerOfAReinsertedValueThatIsRemovedAgain() {
+			// The production shape behind this: the reduced-index membership lookup of issue #1529 holds one bitmap
+			// per owner, drops the entry when the owner leaves its last covered index, re-creates it when the owner
+			// joins another, and drops it again when that one goes - all inside one entity mutation. Every such
+			// second removal used to orphan the re-inserted bitmap's layer and suspend the catalog at commit.
+			final Map<String, TransactionalBitmap> delegate = new LinkedHashMap<>();
+			delegate.put("a", new TransactionalBitmap(1));
+			final TransactionalMap<String, TransactionalBitmap> map = producerMap(delegate);
+
+			assertStateAfterCommit(
+				map,
+				original -> {
+					// drop the original entry, then put a fresh producer instance back under the same key
+					original.remove("a");
+					final TransactionalBitmap reinserted = new TransactionalBitmap(5);
+					original.put("a", reinserted);
+					// open an ALIVE nested layer on the re-inserted instance, leaving its content unchanged
+					reinserted.add(6);
+					reinserted.remove(6);
+					// ... and drop it again
+					original.remove("a");
+				},
+				(original, committed) -> {
+					assertEquals(1, original.size());
+					assertArrayEquals(new int[]{1}, original.get("a").getArray());
+					assertTrue(committed.isEmpty());
 				}
 			);
 		}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/membership/ReducedIndexMembershipTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/membership/ReducedIndexMembershipTest.java
@@ -120,15 +120,21 @@ class ReducedIndexMembershipTest {
 		}
 
 		@Test
-		@DisplayName("an index with no members enters neither set and stays unknown")
-		void registerIndexWithNoMembersLeavesItUnknown() {
+		@DisplayName("an index with no members is recorded as residual")
+		void registerIndexWithNoMembersRecordsItAsResidual() {
 			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
 			tested.registerIndex(INDEX_PK, EmptyBitmap.INSTANCE);
 
-			// deliberate, and load-bearing for the caller: the only consumer treats "not covered, not residual" as
-			// "walk it", so an empty index must not be made to look like a suppressed one
-			assertFalse(tested.isKnown(INDEX_PK));
-			assertTrue(tested.isEmpty());
+			// Accounted for rather than dropped, which is what makes `covered u residual == advertised` hold on
+			// this class's own terms instead of resting on an argument about the un-advertise lockstep upstream.
+			// Residual is the right half: coverage of an index holding nobody would record no owner entry, so the
+			// index would be selected for no probe at all - and an index in NEITHER set is never visited, since
+			// only the absence of the whole slice restores the walk. The cost when it fires is one probe that
+			// yields nothing.
+			assertTrue(tested.isKnown(INDEX_PK));
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getResidualIndexPrimaryKeys()));
+			assertEquals(Set.of(), toSet(tested.getCoveredIndexPrimaryKeys()));
+			assertTrue(tested.getCoveredOwners().isEmpty());
 		}
 
 		@Test
@@ -181,8 +187,9 @@ class ReducedIndexMembershipTest {
 			tested.unregisterIndex(INDEX_PK + 1, EmptyBitmap.INSTANCE);
 			assertFalse(tested.isKnown(INDEX_PK + 1));
 
-			// an index that was never known is a silent no-op, not a raise - `ownerRemoved` reaches this for an
-			// index the map declined to cover
+			// an index that was never known is a silent no-op, not a raise. Production cannot reach it -
+			// `ownerRemoved`'s two calls are both inside a `contains(...)` test - but the method is public and
+			// the map is an accelerator, so a caller unregistering something twice must not fail a commit over it
 			tested.unregisterIndex(INDEX_PK + 2, new BaseBitmap(9));
 			assertTrue(tested.isEmpty());
 		}
@@ -293,6 +300,14 @@ class ReducedIndexMembershipTest {
 		@Test
 		@DisplayName("the last owner leaving forgets the index entirely")
 		void lastOwnerRemovalForgetsTheIndexEntirely() {
+			// Forgetting is the contract here, and the reason lives upstream rather than in this class:
+			// `ReferenceIndexMutator#referenceRemovalPerComponent` un-advertises the reduced index in the same
+			// synchronous step in which its last owner leaves, so what is dropped here is an index the reference
+			// no longer advertises either - and `covered u residual == advertised` stays true. Keeping such an
+			// index accounted would leak one residual entry per dropped index for the life of the collection and
+			// break that equality in the other direction, which is why this arm does NOT follow the empty-membership
+			// arm of `registerIndex` into residual. The lockstep is asserted rather than argued, end to end, by
+			// `ReducedIndexMembershipCompletenessTest#lastOwnerLeavingAReducedIndexKeepsTheLookupComplete`.
 			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
 			tested.registerIndex(INDEX_PK, new BaseBitmap(1, 2));
 			tested.registerIndex(INDEX_PK + 1, new BaseBitmap(1));

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/membership/ReducedIndexMembershipTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/membership/ReducedIndexMembershipTest.java
@@ -1,0 +1,436 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.membership;
+
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.bitmap.EmptyBitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.PrimitiveIterator.OfInt;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
+import static io.evitadb.utils.AssertionUtils.assertStateAfterRollback;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the state machine of {@link ReducedIndexMembership} directly, at the boundaries the functional suites
+ * cannot reach reliably.
+ *
+ * The functional counterpart, `ReducedIndexMembershipCompletenessTest`, drives this structure through real writes and
+ * checks the result against the reduced indexes themselves. That is the right test for the *quantifier* — "every
+ * boundary maintains the lookup" — but it can only reach the coverage threshold through tens of entities, and cannot
+ * reach the premise guards at all, because the engine never re-registers a known index. This class covers what is
+ * left: the exact boundary value, the hysteresis band, the guards, and the transactional lifecycle.
+ *
+ * The properties asserted here are the ones the structure's own invariant rests on:
+ *
+ * - `covered` and `residual` stay disjoint, and an index leaving coverage leaves no entry behind. Neither is
+ *   detectable from the outside — the resolver probes each selected index and intersects its real members, so an
+ *   entry naming an index the owner has left costs a wasted probe and nothing more — which is exactly why it has to
+ *   be asserted here: an entry left behind is memory that coverage was dropped to reclaim, and the bookkeeping drift
+ *   it starts is what eventually loses an index from **both** sets;
+ * - a crossing is paid at most once per half a threshold's worth of writes, which is the amortised-`O(1)` claim the
+ *   class javadoc makes and nothing else measures;
+ * - commit carries every sub-structure forward and rollback rewinds every sub-structure, together. A partial rewind is
+ *   the single way this structure can end up claiming coverage it cannot honour.
+ *
+ * @author Claude (issue #1529 sibling-resolver optimization), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("ReducedIndexMembership")
+@Tag(INDEXING)
+@Tag(TRANSACTION)
+class ReducedIndexMembershipTest {
+
+	/**
+	 * Small threshold used by the boundary tests, so a crossing costs four owners rather than sixteen.
+	 */
+	private static final int SMALL_THRESHOLD = 4;
+
+	/**
+	 * Primary key standing for the reduced index under test; the value itself carries no meaning.
+	 */
+	private static final int INDEX_PK = 1_000;
+
+	/**
+	 * Tests pinning where an index lands when it first becomes known, and the premise guards that stop it being
+	 * re-decided behind entries built from a membership that has since moved on.
+	 */
+	@Nested
+	@DisplayName("Registration and the coverage boundary")
+	class Registration {
+
+		@Test
+		@DisplayName("an index of exactly the threshold is covered")
+		void registerIndexAtThresholdIsCovered() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			tested.registerIndex(INDEX_PK, new BaseBitmap(1, 2, 3, 4));
+
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getCoveredIndexPrimaryKeys()));
+			assertEquals(Set.of(), toSet(tested.getResidualIndexPrimaryKeys()));
+			assertEquals(Set.of(1, 2, 3, 4), toSet(tested.getCoveredOwners()));
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getIndexPrimaryKeys(3)));
+			assertTrue(tested.isKnown(INDEX_PK));
+		}
+
+		@Test
+		@DisplayName("an index one owner above the threshold is residual")
+		void registerIndexAboveThresholdIsResidual() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			tested.registerIndex(INDEX_PK, new BaseBitmap(1, 2, 3, 4, 5));
+
+			assertEquals(Set.of(), toSet(tested.getCoveredIndexPrimaryKeys()));
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getResidualIndexPrimaryKeys()));
+			assertTrue(tested.getCoveredOwners().isEmpty());
+			assertTrue(tested.isKnown(INDEX_PK));
+		}
+
+		@Test
+		@DisplayName("an index with no members enters neither set and stays unknown")
+		void registerIndexWithNoMembersLeavesItUnknown() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			tested.registerIndex(INDEX_PK, EmptyBitmap.INSTANCE);
+
+			// deliberate, and load-bearing for the caller: the only consumer treats "not covered, not residual" as
+			// "walk it", so an empty index must not be made to look like a suppressed one
+			assertFalse(tested.isKnown(INDEX_PK));
+			assertTrue(tested.isEmpty());
+		}
+
+		@Test
+		@DisplayName("re-registering a covered index raises rather than stranding its entries")
+		void reRegisteringAKnownIndexRaises() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			tested.registerIndex(INDEX_PK, new BaseBitmap(1, 2));
+
+			assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tested.registerIndex(INDEX_PK, new BaseBitmap(2, 3)),
+				"re-registering a covered index must refuse - the entries built from its previous membership " +
+					"could not be forgotten from the new membership alone"
+			);
+			assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tested.registerIndexAsResidual(INDEX_PK),
+				"a covered index must not be silently downgraded to residual behind its own entries"
+			);
+		}
+
+		@Test
+		@DisplayName("re-registering a residual index raises")
+		void reRegisteringAKnownIndexAsResidualRaises() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			tested.registerIndexAsResidual(INDEX_PK);
+
+			assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tested.registerIndexAsResidual(INDEX_PK)
+			);
+			assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tested.registerIndex(INDEX_PK, new BaseBitmap(1))
+			);
+		}
+
+		@Test
+		@DisplayName("unregistering clears coverage, residual knowledge, and an index never known")
+		void unregisterIndexClearsBothSets() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			tested.registerIndex(INDEX_PK, new BaseBitmap(1, 2));
+			tested.registerIndexAsResidual(INDEX_PK + 1);
+
+			tested.unregisterIndex(INDEX_PK, new BaseBitmap(1, 2));
+			assertFalse(tested.isKnown(INDEX_PK));
+			assertTrue(tested.getCoveredOwners().isEmpty());
+			assertSame(EmptyBitmap.INSTANCE, tested.getIndexPrimaryKeys(1));
+
+			tested.unregisterIndex(INDEX_PK + 1, EmptyBitmap.INSTANCE);
+			assertFalse(tested.isKnown(INDEX_PK + 1));
+
+			// an index that was never known is a silent no-op, not a raise - `ownerRemoved` reaches this for an
+			// index the map declined to cover
+			tested.unregisterIndex(INDEX_PK + 2, new BaseBitmap(9));
+			assertTrue(tested.isEmpty());
+		}
+
+		@Test
+		@DisplayName("an owner belonging to no covered index reads back as the empty bitmap")
+		void unknownOwnerReturnsEmptyBitmap() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			// the identity the sibling resolver iterates without a null check
+			assertSame(EmptyBitmap.INSTANCE, tested.getIndexPrimaryKeys(42));
+		}
+	}
+
+	/**
+	 * Tests driving an index across the coverage boundary in both directions, which is where an entry can be left
+	 * behind naming an index the walk will also visit — or one that no longer exists.
+	 */
+	@Nested
+	@DisplayName("Crossings and hysteresis")
+	class Crossings {
+
+		@Test
+		@DisplayName("promotion out of coverage leaves no entry naming the promoted index")
+		void promotionKeepsNoEntriesBehind() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			final Set<Integer> members = new TreeSet<>();
+			for (int owner = 1; owner <= SMALL_THRESHOLD + 1; owner++) {
+				members.add(owner);
+				tested.ownerAdded(INDEX_PK, owner, bitmapOf(members));
+			}
+
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getResidualIndexPrimaryKeys()));
+			assertEquals(Set.of(), toSet(tested.getCoveredIndexPrimaryKeys()));
+			assertTrue(
+				tested.getCoveredOwners().isEmpty(),
+				"a promoted index must leave no owner behind - an entry naming an index the walk also visits " +
+					"would apply the facet twice, and one naming a dropped index would fail the write"
+			);
+			for (int owner = 1; owner <= SMALL_THRESHOLD + 1; owner++) {
+				assertTrue(tested.getIndexPrimaryKeys(owner).isEmpty());
+			}
+		}
+
+		@Test
+		@DisplayName("the hysteresis band is crossed once, not once per write")
+		void hysteresisBandDoesNotOscillate() {
+			// the shipped threshold, because the amortisation claim is made about this value
+			final int threshold = ReducedIndexMembership.DEFAULT_COVERAGE_THRESHOLD;
+			final int demotion = threshold / 2;
+			final ReducedIndexMembership tested = new ReducedIndexMembership(threshold);
+			final Set<Integer> members = new TreeSet<>();
+			for (int owner = 1; owner <= threshold + 1; owner++) {
+				members.add(owner);
+				tested.ownerAdded(INDEX_PK, owner, bitmapOf(members));
+			}
+			assertTrue(tested.getResidualIndexPrimaryKeys().contains(INDEX_PK));
+
+			// shrinking through the band must not re-cover the index until the demotion threshold is reached
+			for (int owner = threshold + 1; owner > demotion + 1; owner--) {
+				members.remove(owner);
+				tested.ownerRemoved(INDEX_PK, owner, bitmapOf(members));
+				assertTrue(
+					tested.getResidualIndexPrimaryKeys().contains(INDEX_PK),
+					"index re-covered at " + members.size() + " owners, above the demotion threshold of " + demotion
+				);
+				assertTrue(tested.getCoveredOwners().isEmpty());
+			}
+
+			// exactly at the demotion threshold it comes back into coverage, with every owner it holds
+			members.remove(demotion + 1);
+			tested.ownerRemoved(INDEX_PK, demotion + 1, bitmapOf(members));
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getCoveredIndexPrimaryKeys()));
+			assertEquals(Set.of(), toSet(tested.getResidualIndexPrimaryKeys()));
+			assertEquals(members, toSet(tested.getCoveredOwners()));
+
+			// and growing back needs the full band again, so the crossing cost is amortised over `T/2` writes
+			for (int owner = demotion + 1; owner <= threshold; owner++) {
+				members.add(owner);
+				tested.ownerAdded(INDEX_PK, owner, bitmapOf(members));
+				assertTrue(
+					tested.getCoveredIndexPrimaryKeys().contains(INDEX_PK),
+					"index promoted at " + members.size() + " owners, at or below the threshold of " + threshold
+				);
+			}
+			members.add(threshold + 1);
+			tested.ownerAdded(INDEX_PK, threshold + 1, bitmapOf(members));
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getResidualIndexPrimaryKeys()));
+		}
+
+		@Test
+		@DisplayName("a threshold of one still demotes at one owner rather than at zero")
+		void demotionThresholdFloorIsOneForThresholdOne() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(1);
+			tested.ownerAdded(INDEX_PK, 1, new BaseBitmap(1));
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getCoveredIndexPrimaryKeys()));
+
+			tested.ownerAdded(INDEX_PK, 2, new BaseBitmap(1, 2));
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getResidualIndexPrimaryKeys()));
+			assertTrue(tested.getCoveredOwners().isEmpty());
+
+			// `Math.max(1, 1 / 2)` is what keeps this reachable at all - a floor of zero would demote only on the
+			// removal that also unregisters the index, so a threshold of one would never cover anything again
+			tested.ownerRemoved(INDEX_PK, 2, new BaseBitmap(1));
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getCoveredIndexPrimaryKeys()));
+			assertEquals(Set.of(1), toSet(tested.getCoveredOwners()));
+		}
+
+		@Test
+		@DisplayName("the last owner leaving forgets the index entirely")
+		void lastOwnerRemovalForgetsTheIndexEntirely() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			tested.registerIndex(INDEX_PK, new BaseBitmap(1, 2));
+			tested.registerIndex(INDEX_PK + 1, new BaseBitmap(1));
+
+			tested.ownerRemoved(INDEX_PK + 1, 1, EmptyBitmap.INSTANCE);
+			assertFalse(tested.isKnown(INDEX_PK + 1));
+			assertTrue(
+				tested.getCoveredOwners().contains(1),
+				"owner 1 still belongs to a covered index, so it must stay in the covered-owner union"
+			);
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getIndexPrimaryKeys(1)));
+
+			tested.ownerRemoved(INDEX_PK, 1, new BaseBitmap(2));
+			assertFalse(tested.getCoveredOwners().contains(1));
+			assertSame(EmptyBitmap.INSTANCE, tested.getIndexPrimaryKeys(1));
+
+			tested.ownerRemoved(INDEX_PK, 2, EmptyBitmap.INSTANCE);
+			assertFalse(tested.isKnown(INDEX_PK));
+			assertTrue(tested.isEmpty());
+		}
+	}
+
+	/**
+	 * Tests verifying that all four sub-structures merge on commit and rewind on rollback together. A partial
+	 * rewind is the one way this structure can claim coverage it cannot honour.
+	 */
+	@Nested
+	@DisplayName("Transactional lifecycle")
+	class TransactionalLifecycle {
+
+		@Test
+		@DisplayName("commit carries every sub-structure forward together")
+		void commitCarriesEveryStructureForward() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			tested.registerIndex(INDEX_PK, new BaseBitmap(1, 2));
+
+			assertStateAfterCommit(
+				tested,
+				original -> {
+					original.ownerAdded(INDEX_PK, 3, new BaseBitmap(1, 2, 3));
+					original.ownerRemoved(INDEX_PK, 1, new BaseBitmap(2, 3));
+					original.registerIndexAsResidual(INDEX_PK + 1);
+				},
+				(original, committed) -> {
+					// the original instance keeps the pre-transaction state, as every transactional structure does
+					assertEquals(Set.of(1, 2), toSet(original.getCoveredOwners()));
+					assertEquals(Set.of(), toSet(original.getResidualIndexPrimaryKeys()));
+
+					assertEquals(Set.of(2, 3), toSet(committed.getCoveredOwners()));
+					assertEquals(Set.of(INDEX_PK), toSet(committed.getCoveredIndexPrimaryKeys()));
+					assertEquals(Set.of(INDEX_PK + 1), toSet(committed.getResidualIndexPrimaryKeys()));
+					assertEquals(Set.of(INDEX_PK), toSet(committed.getIndexPrimaryKeys(3)));
+					assertSame(EmptyBitmap.INSTANCE, committed.getIndexPrimaryKeys(1));
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("rollback rewinds every sub-structure together")
+		void rollbackLeavesNothingBehind() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			tested.registerIndex(INDEX_PK, new BaseBitmap(1, 2));
+
+			assertStateAfterRollback(
+				tested,
+				original -> {
+					original.ownerAdded(INDEX_PK, 3, new BaseBitmap(1, 2, 3));
+					original.ownerAdded(INDEX_PK, 4, new BaseBitmap(1, 2, 3, 4));
+					// pushed over the threshold inside the transaction, so the rewind has to restore coverage too
+					original.ownerAdded(INDEX_PK, 5, new BaseBitmap(1, 2, 3, 4, 5));
+					original.registerIndexAsResidual(INDEX_PK + 1);
+				},
+				(original, notCommitted) -> {
+					// a partial rewind here is the one way this structure claims coverage it cannot honour, so all
+					// four sub-structures are checked rather than the two the promotion happened to touch
+					assertEquals(Set.of(INDEX_PK), toSet(original.getCoveredIndexPrimaryKeys()));
+					assertEquals(Set.of(), toSet(original.getResidualIndexPrimaryKeys()));
+					assertEquals(Set.of(1, 2), toSet(original.getCoveredOwners()));
+					assertEquals(Set.of(INDEX_PK), toSet(original.getIndexPrimaryKeys(1)));
+					assertSame(EmptyBitmap.INSTANCE, original.getIndexPrimaryKeys(5));
+				}
+			);
+		}
+	}
+
+	/**
+	 * Tests guarding the heap estimate this structure contributes to the owning index's own reporting.
+	 */
+	@Nested
+	@DisplayName("Memory accounting")
+	class MemoryAccounting {
+
+		@Test
+		@DisplayName("the reported heap size grows with coverage")
+		void heapSizeGrowsWithCoverage() {
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			final long empty = tested.getHeapSizeInBytes();
+			assertTrue(empty > 0, "an empty map still occupies its own header and four sub-structures");
+
+			tested.registerIndex(INDEX_PK, new BaseBitmap(1, 2, 3, 4));
+			assertTrue(
+				tested.getHeapSizeInBytes() > empty,
+				"coverage entries must be accounted for - this figure feeds GlobalEntityIndex#getHeapSizeInBytes " +
+					"and hence the engine's own memory reporting"
+			);
+		}
+	}
+
+	/**
+	 * Materialises a bitmap as a set, so an assertion failure prints something a reader can act on.
+	 *
+	 * @param bitmap the bitmap to materialise
+	 * @return its contents
+	 */
+	@Nonnull
+	private static Set<Integer> toSet(@Nonnull Bitmap bitmap) {
+		final Set<Integer> result = new TreeSet<>();
+		final OfInt it = bitmap.iterator();
+		while (it.hasNext()) {
+			result.add(it.nextInt());
+		}
+		return result;
+	}
+
+	/**
+	 * Builds the member bitmap a maintenance call would pass in, from the owners the caller is tracking.
+	 *
+	 * @param members the owners the reduced index holds after the operation
+	 * @return the members as a bitmap
+	 */
+	@Nonnull
+	private static Bitmap bitmapOf(@Nonnull Set<Integer> members) {
+		final int[] values = new int[members.size()];
+		int index = 0;
+		for (final Integer member : members) {
+			values[index++] = member;
+		}
+		return new BaseBitmap(values);
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/membership/ReducedIndexMembershipTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/membership/ReducedIndexMembershipTest.java
@@ -234,6 +234,48 @@ class ReducedIndexMembershipTest {
 		}
 
 		@Test
+		@DisplayName("promotion keeps an entry built from a membership the index never had")
+		void promotionKeepsAnEntryBuiltFromDriftedMembership() {
+			// The companion to the test above, and the limit of what it proves. `dropCoverage` forgets one entry
+			// per member of the bitmap it is handed — the membership the index has AFTER the insert — so an entry
+			// built from a membership the index did not actually have survives the promotion, and the owner map
+			// goes on naming an index that is now RESIDUAL.
+			//
+			// The structure tolerates that by design: nothing it records is an answer, and a stale entry costs a
+			// probe that finds no affected owner. What it is NOT is disjointness at the level the sibling
+			// resolver uses. `ReevaluateExpressionExecutor#collectOwnersFromMembership` selects the indexes to
+			// probe out of THIS map rather than out of {@link ReducedIndexMembership#getCoveredIndexPrimaryKeys()},
+			// and never intersects the two — so in this state one index is probed by the covered half and by the
+			// residual half, and every owner it really holds is offered to
+			// `ReevaluateExpressionExecutor#probeReducedIndexForAffectedOwners` twice.
+			//
+			// That is free today, because `ReferenceIndexMutator#applyFacetDecisionMatrix` short-circuits through
+			// pure reads when the facet is already in its target bucket. This test pins the state so that a change
+			// which starts relying on those pairs being unique has something to fail against.
+			final ReducedIndexMembership tested = new ReducedIndexMembership(SMALL_THRESHOLD);
+			tested.registerIndex(INDEX_PK, new BaseBitmap(1, 2));
+			// an entry built from a membership naming an owner the index does not hold
+			tested.ownerAdded(INDEX_PK, 99, new BaseBitmap(1, 2, 99));
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getIndexPrimaryKeys(99)));
+
+			// the index crosses the threshold, carrying its REAL membership - which never included 99
+			tested.ownerAdded(INDEX_PK, 5, new BaseBitmap(1, 2, 3, 4, 5));
+
+			assertEquals(Set.of(INDEX_PK), toSet(tested.getResidualIndexPrimaryKeys()));
+			assertEquals(Set.of(), toSet(tested.getCoveredIndexPrimaryKeys()));
+			assertEquals(
+				Set.of(INDEX_PK), toSet(tested.getIndexPrimaryKeys(99)),
+				"the drifted entry survives the promotion, so the covered half of the resolution still selects " +
+					"an index the residual half probes as well"
+			);
+			assertTrue(
+				tested.getCoveredOwners().contains(99),
+				"and the owner stays in the union the affected set is intersected against, which is what puts " +
+					"the entry in front of the resolver at all"
+			);
+		}
+
+		@Test
 		@DisplayName("the hysteresis band is crossed once, not once per write")
 		void hysteresisBandDoesNotOscillate() {
 			// the shipped threshold, because the amortisation claim is made about this value

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/warmupload/CatalogCopySupport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/warmupload/CatalogCopySupport.java
@@ -50,6 +50,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Currency;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -381,6 +382,49 @@ public class CatalogCopySupport {
 	}
 
 	/**
+	 * Reference names promoted from `FOR_FILTERING` to `FOR_FILTERING_AND_PARTITIONING` on the target schema,
+	 * parsed once from the `evita.warmup.raiseReferences` system property. A single `*` promotes every plain
+	 * reference; an empty value (the default) replicates the source index types faithfully.
+	 *
+	 * This exists to measure the write path in the shape a client creates by flipping that one schema flag.
+	 * Raising a reference on an already-populated catalog is not supported (the engine does not rebuild
+	 * indexes on a schema change - issue #409), but the target catalog here is created empty and populated
+	 * afterwards, which is precisely the full-reindex path that *is* supported.
+	 */
+	private static final Set<String> RAISED_REFERENCES = parseRaisedReferences();
+
+	/**
+	 * Parses {@link #RAISED_REFERENCES} from the `evita.warmup.raiseReferences` system property.
+	 *
+	 * @return the reference names to promote, empty when the property is unset or blank
+	 */
+	@Nonnull
+	private static Set<String> parseRaisedReferences() {
+		final String raw = System.getProperty("evita.warmup.raiseReferences", "");
+		if (raw.isBlank()) {
+			return Set.of();
+		}
+		final Set<String> result = new HashSet<>(8);
+		for (final String name : raw.split(",")) {
+			final String trimmed = name.trim();
+			if (!trimmed.isEmpty()) {
+				result.add(trimmed);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Tells whether a reference should be promoted to `FOR_FILTERING_AND_PARTITIONING` on the target.
+	 *
+	 * @param referenceName name of the replicated reference
+	 * @return true when the reference is named by `evita.warmup.raiseReferences`, or that property is `*`
+	 */
+	private static boolean isRaisedToPartitioning(@Nonnull final String referenceName) {
+		return RAISED_REFERENCES.contains("*") || RAISED_REFERENCES.contains(referenceName);
+	}
+
+	/**
 	 * Applies the group type, per-scope index type, faceting, attributes and sortable attribute compounds
 	 * of a plain reference onto its target reference builder.
 	 *
@@ -401,9 +445,10 @@ public class CatalogCopySupport {
 
 		final List<Scope> forFiltering = new ArrayList<>(2);
 		final List<Scope> forFilteringAndPartitioning = new ArrayList<>(2);
+		final boolean raised = isRaisedToPartitioning(reference.getName());
 		for (final Scope scope : Scope.values()) {
 			switch (reference.getReferenceIndexType(scope)) {
-				case FOR_FILTERING -> forFiltering.add(scope);
+				case FOR_FILTERING -> (raised ? forFilteringAndPartitioning : forFiltering).add(scope);
 				case FOR_FILTERING_AND_PARTITIONING -> forFilteringAndPartitioning.add(scope);
 				case NONE -> {
 					// not indexed in this scope - nothing to do
@@ -415,6 +460,13 @@ public class CatalogCopySupport {
 		}
 		if (!forFilteringAndPartitioning.isEmpty()) {
 			editor.indexedForFilteringAndPartitioningInScope(forFilteringAndPartitioning.toArray(new Scope[0]));
+		}
+		if (raised) {
+			// printed so a measurement run proves the promotion actually applied, rather than assuming it did:
+			// a reflected reference never reaches this method, and would be silently left at its source type
+			System.out.println(
+				"[raise] " + reference.getName() + " -> FOR_FILTERING_AND_PARTITIONING in " + forFilteringAndPartitioning
+			);
 		}
 
 		final Scope[] facetedScopes = scopesWhere(reference::isFacetedInScope);

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/warmupload/CatalogCopySupport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/warmupload/CatalogCopySupport.java
@@ -87,6 +87,18 @@ import static io.evitadb.api.query.QueryConstraints.referenceContentWithAttribut
 public class CatalogCopySupport {
 
 	/**
+	 * Reference names promoted from `FOR_FILTERING` to `FOR_FILTERING_AND_PARTITIONING` on the target schema,
+	 * parsed once from the `evita.warmup.raiseReferences` system property. A single `*` promotes every plain
+	 * reference; an empty value (the default) replicates the source index types faithfully.
+	 *
+	 * This exists to measure the write path in the shape a client creates by flipping that one schema flag.
+	 * Raising a reference on an already-populated catalog is not supported (the engine does not rebuild
+	 * indexes on a schema change - issue #409), but the target catalog here is created empty and populated
+	 * afterwards, which is precisely the full-reindex path that *is* supported.
+	 */
+	private static final Set<String> RAISED_REFERENCES = parseRaisedReferences();
+
+	/**
 	 * Purely static helper - never instantiated.
 	 */
 	private CatalogCopySupport() {
@@ -380,18 +392,6 @@ public class CatalogCopySupport {
 			);
 		}
 	}
-
-	/**
-	 * Reference names promoted from `FOR_FILTERING` to `FOR_FILTERING_AND_PARTITIONING` on the target schema,
-	 * parsed once from the `evita.warmup.raiseReferences` system property. A single `*` promotes every plain
-	 * reference; an empty value (the default) replicates the source index types faithfully.
-	 *
-	 * This exists to measure the write path in the shape a client creates by flipping that one schema flag.
-	 * Raising a reference on an already-populated catalog is not supported (the engine does not rebuild
-	 * indexes on a schema change - issue #409), but the target catalog here is created empty and populated
-	 * afterwards, which is precisely the full-reindex path that *is* supported.
-	 */
-	private static final Set<String> RAISED_REFERENCES = parseRaisedReferences();
 
 	/**
 	 * Parses {@link #RAISED_REFERENCES} from the `evita.warmup.raiseReferences` system property.

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetMembershipReport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetMembershipReport.java
@@ -71,26 +71,30 @@ import static io.evitadb.roaringbitmap.PersistentRoaringBitmap.and;
  *
  * # What the timed arms measure, and where they diverge from the shipped resolver
  *
- * The RESOLUTION measured is **not** the shipped one. Both arms are re-implementations local to this class,
- * and they diverge from `ReevaluateExpressionExecutor` in two ways, in increasing order of consequence:
+ * Both arms are re-implementations local to this class. As of 2026-09-11 they mirror
+ * `ReevaluateExpressionExecutor` in everything that costs, with ONE deliberate exception named below.
  *
- * - **Both arms are probe-only.** They stop at the intersection and never call `getOrCreateIndexByPrimaryKey`,
- *   so neither pays the registering re-fetch nor the per-owner de-duplication of `SiblingReducedIndex`
- *   instances the shipped resolver pays. That matches how the 2026-09-09 decomposition defined "the walk"
- *   against the whole resolver, and it costs both arms the same, so it does not tilt one against the other.
- * - **The lookup arm's COVERED half diverges further, and only that half.** {@link #resolveWithLookup} emits
- *   the map's `(owner, index)` pairs straight out of {@link ReducedIndexMembership#getIndexPrimaryKeys},
- *   whereas `ReevaluateExpressionExecutor#collectOwnersFromMembership` uses the map as an index *selector*
- *   only — it collects the selected primary keys, then resolves each index and intersects its member bitmap
- *   against the affected owners, exactly as the residual half does. This arm performs none of that resolve
- *   and intersect.
+ * **What is mirrored.** Both arms reach every reduced index through the same {@link #probe} — resolve, intersect
+ * against the affected owners, allocate one sibling record per index that yields an owner, and accumulate into
+ * an owner-keyed map with the executor's own linear `contains` de-duplication. The lookup arm's covered half
+ * uses the map as an index *selector* only, collecting the keys the affected covered owners name and handing
+ * them to that same probe, which is what `collectOwnersFromMembership` does.
  *
- * The emitted pairs are the same either way, and the checksum proves it; the work is not. So the lookup arm's
- * timings are a **lower bound** on what the shipped lookup costs, and — because the walk arm is not short-cut
- * in the same way — the lookup-over-walk speedup printed here is an **upper bound** on the shipped one. Every
- * figure carried into `documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md` inherits both
- * bounds. Bringing the covered half in line with the shipped selector changes what is measured rather than how
- * it is described, so it is left to a deliberate re-measurement instead of being done in passing.
+ * **What is not, and why it cannot be.** Neither arm calls `getOrCreateIndexByPrimaryKey`, the registering
+ * accessor the executor uses once per yielding index. Calling it here would not measure the shipped cost, it
+ * would destroy the series: the accessor enrols the index in the bound transaction's dirty set, and this report
+ * runs 500 rounds inside ONE transaction, so the set would grow monotonically and every round would measure a
+ * different structure from the one before it. The shipped resolver enrols into a transaction that commits after
+ * a single trigger. That cost is therefore absent from both arms, and absent identically.
+ *
+ * **History of this section, because the numbers moved.** Until 2026-09-11 the covered half emitted the map's
+ * `(owner, index)` pairs straight out of {@link ReducedIndexMembership#getIndexPrimaryKeys}, resolving no index
+ * and intersecting no bitmap, and neither arm ran the accumulator. The emitted pairs were identical either way
+ * — the checksum gate proves the pairs, never the work — so the shortfall was invisible, and every lookup
+ * figure was a lower bound with every speedup an upper bound. The accumulator's absence did not tilt one arm
+ * against the other, both arms emitting the same pair set, but it inflated the RATIO by omitting a cost common
+ * to both. Figures in `documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md` taken before
+ * that date are not comparable with figures taken after it.
  *
  * # Reaching the high-cardinality case
  *
@@ -216,9 +220,9 @@ public class ConditionalFacetMembershipReport {
 	 * dense affected-owner shapes of the reference carrying the conditional facet.
 	 *
 	 * Both arms emit the same `(owner, index)` pairs; the checksum is compared so an arm computing a different
-	 * answer is never reported as merely faster. Both are also probe-only — they stop at the intersection and
-	 * never call `getOrCreateIndexByPrimaryKey` — and {@link #resolveWithLookup}'s covered half does not even
-	 * probe. Neither figure is the shipped resolver's; see the class javadoc for what that costs the reading.
+	 * answer is never reported as merely faster. It proves the PAIRS and nothing about the work done to reach
+	 * them, which is why the arms are held to the shipped resolver's shape by construction rather than by the
+	 * gate — see the class javadoc for the one cost both arms still omit, and why it cannot be added here.
 	 *
 	 * @param collection    the measured collection
 	 * @param globalIndex   the collection's global index, which carries the lookup
@@ -307,19 +311,26 @@ public class ConditionalFacetMembershipReport {
 	}
 
 	/**
-	 * Resolves the sibling reduced indexes through the lookup, in two halves that do NOT cost the same:
+	 * Resolves the sibling reduced indexes through the lookup, in the two halves the shipped resolver uses and
+	 * at the same cost as it pays for them:
 	 *
-	 * - the **residual** half probes, exactly as the shipped resolver does: it resolves each residual index and
-	 *   intersects its member bitmap against the affected owners;
-	 * - the **covered** half does not. It intersects the affected set against the lookup's covered-owner union,
-	 *   then emits `pair(owner, indexPk)` straight out of {@link ReducedIndexMembership#getIndexPrimaryKeys} —
-	 *   no index is resolved and no bitmap is intersected.
+	 * - the **residual** half resolves each residual index and intersects its member bitmap against the
+	 *   affected owners — `ReevaluateExpressionExecutor#collectOwnersOfProbedIndexes`;
+	 * - the **covered** half intersects the affected set against the lookup's covered-owner union, collects the
+	 *   distinct index keys those owners name, and hands them to the SAME probe —
+	 *   `ReevaluateExpressionExecutor#collectOwnersFromMembership`.
 	 *
-	 * `ReevaluateExpressionExecutor#collectOwnersFromMembership` probes both halves: it treats the lookup as an
-	 * index selector, collects the primary keys it names and hands them to the same probe the residual half
-	 * uses. The pairs agree, so the checksum passes; the cost does not, and this arm's covered half is the
-	 * reason every figure here is a lower bound on the shipped resolver. Fixing it is a measurement change and
-	 * is deliberately not made here — see the class javadoc.
+	 * Both halves therefore treat the lookup as an index SELECTOR rather than as the answer. That distinction
+	 * is the whole reason this method is shaped the way it is: emitting `pair(owner, indexPk)` straight out of
+	 * {@link ReducedIndexMembership#getIndexPrimaryKeys} produces the identical checksum while resolving no
+	 * index and intersecting no bitmap, so the gate cannot tell the two apart and every figure silently
+	 * becomes a lower bound. It measured that way until 2026-09-11; the numbers taken before that date are not
+	 * comparable with the ones taken after.
+	 *
+	 * One divergence from the shipped resolver remains, deliberately, and it is symmetric: neither arm here
+	 * accumulates into the `Map<Integer, List<SiblingReducedIndex>>` keyed by owner that the executor builds.
+	 * The walk pays that cost in the executor too, so including it would move both arms in the same direction
+	 * and the ratio — which is the only thing either arm is quoted for — is what this spike is protecting.
 	 *
 	 * @param collection  the measured collection
 	 * @param globalIndex the collection's global index
@@ -336,28 +347,38 @@ public class ConditionalFacetMembershipReport {
 		@Nonnull List<ReferenceSchemaContract> siblings,
 		@Nonnull PersistentRoaringBitmap affected
 	) {
+		// one accumulator per resolution, exactly as the executor builds one per trigger
+		final Map<Integer, List<SiblingIndex>> result = new HashMap<>();
 		long checksum = 0L;
 		for (final ReferenceSchemaContract sibling : siblings) {
 			final ReducedIndexMembership membership = simulated.containsKey(sibling.getName())
 				? simulated.get(sibling.getName())
 				: globalIndex.getReducedIndexMembership(sibling.getName());
 			if (membership == null) {
-				checksum += walkReference(collection, sibling.getName(), affected);
+				checksum += walkReference(collection, sibling.getName(), affected, result);
 				continue;
 			}
 			final Bitmap coveredOwners = membership.getCoveredOwners();
 			if (!coveredOwners.isEmpty()) {
+				// The lookup NAMES indexes; it does not answer the query. Collect the distinct keys the
+				// affected covered owners name, then probe each one exactly as the residual half does - which
+				// is `ReevaluateExpressionExecutor#collectOwnersFromMembership` handing its selected set to
+				// `collectOwnersOfProbedIndexes`. Collecting before probing is not an optimisation bolted on
+				// here: a covered index is named by up to `T` owners, so it turns `O(affected owners)` index
+				// resolutions into `O(indexes actually named)` ones, and the shipped resolver does it too.
+				final BaseBitmap selectedIndexPKs = new BaseBitmap();
 				for (final int owner : and(getRoaringBitmap(coveredOwners), affected).toArray()) {
-					final OfInt it = membership.getIndexPrimaryKeys(owner).iterator();
-					while (it.hasNext()) {
-						checksum += pair(owner, it.nextInt());
-					}
+					selectedIndexPKs.addAll(membership.getIndexPrimaryKeys(owner));
+				}
+				final OfInt selectedIt = selectedIndexPKs.iterator();
+				while (selectedIt.hasNext()) {
+					checksum += probe(collection, sibling.getName(), selectedIt.nextInt(), affected, result);
 				}
 			}
 			final OfInt residualIt = membership.getResidualIndexPrimaryKeys().iterator();
 			while (residualIt.hasNext()) {
 				final int indexPk = residualIt.nextInt();
-				checksum += probe(collection, indexPk, affected);
+				checksum += probe(collection, sibling.getName(), indexPk, affected, result);
 			}
 		}
 		return checksum;
@@ -377,9 +398,11 @@ public class ConditionalFacetMembershipReport {
 		@Nonnull List<ReferenceSchemaContract> siblings,
 		@Nonnull PersistentRoaringBitmap affected
 	) {
+		// one accumulator per resolution, exactly as the executor builds one per trigger
+		final Map<Integer, List<SiblingIndex>> result = new HashMap<>();
 		long checksum = 0L;
 		for (final ReferenceSchemaContract sibling : siblings) {
-			checksum += walkReference(collection, sibling.getName(), affected);
+			checksum += walkReference(collection, sibling.getName(), affected, result);
 		}
 		return checksum;
 	}
@@ -390,12 +413,14 @@ public class ConditionalFacetMembershipReport {
 	 * @param collection    the measured collection
 	 * @param referenceName the reference to walk
 	 * @param affected      affected owner primary keys
+	 * @param result        accumulator, keyed by owner PK, mirroring the executor's own
 	 * @return checksum contribution
 	 */
 	private static long walkReference(
 		@Nonnull EntityCollection collection,
 		@Nonnull String referenceName,
-		@Nonnull PersistentRoaringBitmap affected
+		@Nonnull PersistentRoaringBitmap affected,
+		@Nonnull Map<Integer, List<SiblingIndex>> result
 	) {
 		final long[] checksum = new long[1];
 		for (final EntityIndexType family : new EntityIndexType[]{
@@ -406,7 +431,7 @@ public class ConditionalFacetMembershipReport {
 				continue;
 			}
 			typeIndex.forEachReferenceIndexPrimaryKey(
-				pk -> checksum[0] += probe(collection, pk, affected)
+				pk -> checksum[0] += probe(collection, referenceName, pk, affected, result)
 			);
 		}
 		return checksum[0];
@@ -415,25 +440,57 @@ public class ConditionalFacetMembershipReport {
 	/**
 	 * Intersects one reduced index against the affected owners and folds the matches into a checksum.
 	 *
-	 * @param collection the measured collection
-	 * @param indexPk    primary key of the reduced index
-	 * @param affected   affected owner primary keys
+	 * @param collection    the measured collection
+	 * @param referenceName the reference the index was created for
+	 * @param indexPk       primary key of the reduced index
+	 * @param affected      affected owner primary keys
+	 * @param result        accumulator, keyed by owner PK, mirroring the executor's own
 	 * @return checksum contribution
 	 */
 	private static long probe(
 		@Nonnull EntityCollection collection,
+		@Nonnull String referenceName,
 		int indexPk,
-		@Nonnull PersistentRoaringBitmap affected
+		@Nonnull PersistentRoaringBitmap affected,
+		@Nonnull Map<Integer, List<SiblingIndex>> result
 	) {
 		final EntityIndex index = collection.getIndexByPrimaryKeyIfExists(indexPk);
 		if (index == null) {
 			return 0L;
 		}
+		final int[] owners = and(getRoaringBitmap(index.getAllPrimaryKeys()), affected).toArray();
+		if (owners.length == 0) {
+			return 0L;
+		}
+		// Mirrors `ReevaluateExpressionExecutor#probeReducedIndexForAffectedOwners`, which allocates its
+		// `SiblingReducedIndex` once per index that YIELDS an owner rather than once per probe - so an
+		// arm probing many barren indexes is not charged for them.
+		final SiblingIndex sibling = new SiblingIndex(index, referenceName);
 		long checksum = 0L;
-		for (final int owner : and(getRoaringBitmap(index.getAllPrimaryKeys()), affected).toArray()) {
+		for (final int owner : owners) {
+			// Mirrors `ReevaluateExpressionExecutor#addSibling`, including its LINEAR `contains` de-duplication:
+			// references sharing a reduced group index resolve to the same instance more than once. Both arms
+			// emit the identical pair set, so both are charged identically - the accumulator cannot tilt one
+			// against the other, but it is large enough at high affected-owner counts to compress the RATIO,
+			// which is why leaving it out overstated the speedup.
+			final List<SiblingIndex> indexes = result.computeIfAbsent(owner, __ -> new ArrayList<>(4));
+			if (!indexes.contains(sibling)) {
+				indexes.add(sibling);
+			}
 			checksum += pair(owner, indexPk);
 		}
 		return checksum;
+	}
+
+	/**
+	 * Stand-in for `ReevaluateExpressionExecutor`'s own `SiblingReducedIndex`, which is a private record and
+	 * cannot be reached from here. It carries the same two fields and therefore the same `equals` cost, which
+	 * is what the accumulator's linear de-duplication actually pays for.
+	 *
+	 * @param index         the reduced index holding the owner
+	 * @param referenceName the reference the index was created for, standing in for its schema
+	 */
+	private record SiblingIndex(@Nonnull EntityIndex index, @Nonnull String referenceName) {
 	}
 
 	/**

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetMembershipReport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetMembershipReport.java
@@ -24,18 +24,13 @@
 package io.evitadb.spike;
 
 import io.evitadb.api.CatalogContract;
-import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.configuration.EvitaConfiguration;
 import io.evitadb.api.configuration.ServerOptions;
 import io.evitadb.api.configuration.StorageOptions;
 import io.evitadb.api.configuration.ThreadPoolOptions;
 import io.evitadb.api.index.EntityIndexType;
-import io.evitadb.api.requestResponse.schema.SealedEntitySchema;
 import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
-import io.evitadb.api.requestResponse.schema.mutation.reference.SetReferenceSchemaIndexedMutation;
-import io.evitadb.api.requestResponse.schema.mutation.reference.ScopedReferenceIndexType;
-import io.evitadb.api.requestResponse.schema.mutation.catalog.ModifyEntitySchemaMutation;
 import io.evitadb.core.Evita;
 import io.evitadb.core.catalog.Catalog;
 import io.evitadb.core.transaction.Transaction;
@@ -60,7 +55,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PrimitiveIterator.OfInt;
-import java.util.function.Consumer;
 
 import static io.evitadb.index.bitmap.RoaringBitmapBackedBitmap.getRoaringBitmap;
 import static io.evitadb.roaringbitmap.PersistentRoaringBitmap.and;
@@ -556,6 +550,12 @@ public class ConditionalFacetMembershipReport {
 		);
 	}
 
+	/**
+	 * Resolves the collection's `LIVE` global index, or `null` when the scope holds none.
+	 *
+	 * @param collection the collection holding the indexes
+	 * @return the global index, or `null` when absent or of an unexpected type
+	 */
 	@Nullable
 	private static GlobalEntityIndex globalIndex(@Nonnull EntityCollection collection) {
 		final EntityIndex index = collection.getIndexByKeyIfExists(
@@ -564,6 +564,15 @@ public class ConditionalFacetMembershipReport {
 		return index instanceof final GlobalEntityIndex typed ? typed : null;
 	}
 
+	/**
+	 * Resolves one `REFERENCED_*_TYPE` index of a reference in the `LIVE` scope, whatever its declared index
+	 * type.
+	 *
+	 * @param collection    the collection holding the indexes
+	 * @param family        the referenced-type index family
+	 * @param referenceName the reference whose type index is resolved
+	 * @return the type index, or `null` when the reference has none of that kind
+	 */
 	@Nullable
 	private static ReferencedTypeEntityIndex typeIndex(
 		@Nonnull EntityCollection collection,
@@ -576,6 +585,13 @@ public class ConditionalFacetMembershipReport {
 		return index instanceof final ReferencedTypeEntityIndex typed ? typed : null;
 	}
 
+	/**
+	 * Opens an embedded engine over an existing storage directory, with the default thread-pool options — the
+	 * measurement is single-threaded, so nothing here is tuned for it.
+	 *
+	 * @param storageDirectory directory holding the catalog to read
+	 * @return the running engine, which the caller closes
+	 */
 	@Nonnull
 	private static Evita openEvita(@Nonnull Path storageDirectory) {
 		return new Evita(
@@ -590,6 +606,13 @@ public class ConditionalFacetMembershipReport {
 		);
 	}
 
+	/**
+	 * Waits until the catalog finishes its background load and becomes a usable {@link Catalog}.
+	 *
+	 * @param evita       the running engine
+	 * @param catalogName the catalog to wait for
+	 * @return the loaded catalog
+	 */
 	@Nonnull
 	private static Catalog awaitLoaded(@Nonnull Evita evita, @Nonnull String catalogName) {
 		final long deadline = System.nanoTime() + LOAD_TIMEOUT_NANOS;

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetMembershipReport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetMembershipReport.java
@@ -151,8 +151,9 @@ public class ConditionalFacetMembershipReport {
 				return;
 			}
 			System.out.printf(
-				"catalog v%d %s | collection `%s` | load %,.1f s%n%n",
-				catalog.getVersion(), catalog.getCatalogState(), collectionName, loadNanos / 1_000_000_000.0
+				"catalog v%d %s | collection `%s` | load %,.1f s | accumulator %s%n%n",
+				catalog.getVersion(), catalog.getCatalogState(), collectionName, loadNanos / 1_000_000_000.0,
+				System.getProperty("spike.accumulator", "FULL")
 			);
 
 			final long buildStart = System.nanoTime();
@@ -348,7 +349,7 @@ public class ConditionalFacetMembershipReport {
 		@Nonnull PersistentRoaringBitmap affected
 	) {
 		// one accumulator per resolution, exactly as the executor builds one per trigger
-		final Map<Integer, List<SiblingIndex>> result = new HashMap<>();
+		final Accumulator result = newAccumulator();
 		long checksum = 0L;
 		for (final ReferenceSchemaContract sibling : siblings) {
 			final ReducedIndexMembership membership = simulated.containsKey(sibling.getName())
@@ -399,7 +400,7 @@ public class ConditionalFacetMembershipReport {
 		@Nonnull PersistentRoaringBitmap affected
 	) {
 		// one accumulator per resolution, exactly as the executor builds one per trigger
-		final Map<Integer, List<SiblingIndex>> result = new HashMap<>();
+		final Accumulator result = newAccumulator();
 		long checksum = 0L;
 		for (final ReferenceSchemaContract sibling : siblings) {
 			checksum += walkReference(collection, sibling.getName(), affected, result);
@@ -413,14 +414,14 @@ public class ConditionalFacetMembershipReport {
 	 * @param collection    the measured collection
 	 * @param referenceName the reference to walk
 	 * @param affected      affected owner primary keys
-	 * @param result        accumulator, keyed by owner PK, mirroring the executor's own
+	 * @param result        accumulator mirroring the executor's own per-pair bookkeeping
 	 * @return checksum contribution
 	 */
 	private static long walkReference(
 		@Nonnull EntityCollection collection,
 		@Nonnull String referenceName,
 		@Nonnull PersistentRoaringBitmap affected,
-		@Nonnull Map<Integer, List<SiblingIndex>> result
+		@Nonnull Accumulator result
 	) {
 		final long[] checksum = new long[1];
 		for (final EntityIndexType family : new EntityIndexType[]{
@@ -444,7 +445,7 @@ public class ConditionalFacetMembershipReport {
 	 * @param referenceName the reference the index was created for
 	 * @param indexPk       primary key of the reduced index
 	 * @param affected      affected owner primary keys
-	 * @param result        accumulator, keyed by owner PK, mirroring the executor's own
+	 * @param result        accumulator mirroring the executor's own per-pair bookkeeping
 	 * @return checksum contribution
 	 */
 	private static long probe(
@@ -452,7 +453,7 @@ public class ConditionalFacetMembershipReport {
 		@Nonnull String referenceName,
 		int indexPk,
 		@Nonnull PersistentRoaringBitmap affected,
-		@Nonnull Map<Integer, List<SiblingIndex>> result
+		@Nonnull Accumulator result
 	) {
 		final EntityIndex index = collection.getIndexByPrimaryKeyIfExists(indexPk);
 		if (index == null) {
@@ -468,18 +469,146 @@ public class ConditionalFacetMembershipReport {
 		final SiblingIndex sibling = new SiblingIndex(index, referenceName);
 		long checksum = 0L;
 		for (final int owner : owners) {
-			// Mirrors `ReevaluateExpressionExecutor#addSibling`, including its LINEAR `contains` de-duplication:
-			// references sharing a reduced group index resolve to the same instance more than once. Both arms
-			// emit the identical pair set, so both are charged identically - the accumulator cannot tilt one
-			// against the other, but it is large enough at high affected-owner counts to compress the RATIO,
-			// which is why leaving it out overstated the speedup.
-			final List<SiblingIndex> indexes = result.computeIfAbsent(owner, __ -> new ArrayList<>(4));
-			if (!indexes.contains(sibling)) {
-				indexes.add(sibling);
-			}
+			result.record(owner, sibling);
 			checksum += pair(owner, indexPk);
 		}
 		return checksum;
+	}
+
+	/**
+	 * The per-pair bookkeeping `ReevaluateExpressionExecutor#addSibling` performs, behind a seam so its cost
+	 * can be attributed rather than argued about.
+	 *
+	 * The checksum is computed OUTSIDE this interface, so swapping variants cannot change what the arms
+	 * agree on and the gate cannot catch a variant that records the wrong thing. These are cost probes only:
+	 * `FULL` is the one that mirrors the executor, and it is the default.
+	 */
+	private interface Accumulator {
+
+		/**
+		 * Records that one affected owner is held by one sibling reduced index.
+		 *
+		 * @param owner   primary key of the affected owner
+		 * @param sibling the reduced index holding it
+		 */
+		void record(int owner, @Nonnull SiblingIndex sibling);
+
+	}
+
+	/**
+	 * Builds the accumulator named by `-Dspike.accumulator`, defaulting to the executor-faithful `FULL`.
+	 *
+	 * The four variants exist to subtract from one another: `FULL - OFF` is the accumulator's whole cost,
+	 * `FULL - NO_DEDUP` the linear `contains` scan alone, and `FULL - INT_KEYED` what the boxed `Integer` key
+	 * and its `HashMap` lookup cost over a primitive-keyed table.
+	 *
+	 * @return a fresh accumulator for one resolution
+	 */
+	@Nonnull
+	private static Accumulator newAccumulator() {
+		final String variant = System.getProperty("spike.accumulator", "FULL");
+		return switch (variant) {
+			case "FULL" -> new BoxedAccumulator(true);
+			case "NO_DEDUP" -> new BoxedAccumulator(false);
+			case "INT_KEYED" -> new IntKeyedAccumulator();
+			case "OFF" -> (owner, sibling) -> { };
+			default -> throw new IllegalArgumentException(
+				"unknown -Dspike.accumulator=" + variant + " (FULL|NO_DEDUP|INT_KEYED|OFF)"
+			);
+		};
+	}
+
+	/**
+	 * The executor's own structure: a `HashMap` keyed by a boxed owner primary key, holding a four-slot
+	 * `ArrayList` scanned linearly for duplicates.
+	 */
+	private static final class BoxedAccumulator implements Accumulator {
+		private final Map<Integer, List<SiblingIndex>> result = new HashMap<>();
+		private final boolean dedup;
+
+		BoxedAccumulator(boolean dedup) {
+			this.dedup = dedup;
+		}
+
+		@Override
+		public void record(int owner, @Nonnull SiblingIndex sibling) {
+			final List<SiblingIndex> indexes = this.result.computeIfAbsent(owner, __ -> new ArrayList<>(4));
+			if (this.dedup && indexes.contains(sibling)) {
+				return;
+			}
+			indexes.add(sibling);
+		}
+	}
+
+	/**
+	 * The same bookkeeping over an open-addressed primitive table, so the boxed key's cost can be priced.
+	 * Owner primary keys are positive in evitaDB, which is what lets `0` serve as the empty slot marker.
+	 *
+	 * This is a COST PROBE, not a proposed implementation - it is deliberately minimal, so the figure it
+	 * yields is an optimistic bound on what de-boxing could save rather than a prediction of any real
+	 * replacement.
+	 */
+	private static final class IntKeyedAccumulator implements Accumulator {
+		private int[] keys = new int[1 << 16];
+		private Object[] values = new Object[1 << 16];
+		private int mask = (1 << 16) - 1;
+		private int size;
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public void record(int owner, @Nonnull SiblingIndex sibling) {
+			int slot = mix(owner) & this.mask;
+			while (this.keys[slot] != 0) {
+				if (this.keys[slot] == owner) {
+					final List<SiblingIndex> indexes = (List<SiblingIndex>) this.values[slot];
+					if (!indexes.contains(sibling)) {
+						indexes.add(sibling);
+					}
+					return;
+				}
+				slot = (slot + 1) & this.mask;
+			}
+			final List<SiblingIndex> indexes = new ArrayList<>(4);
+			indexes.add(sibling);
+			this.keys[slot] = owner;
+			this.values[slot] = indexes;
+			if (++this.size > (this.mask + 1) * 2 / 3) {
+				grow();
+			}
+		}
+
+		/**
+		 * Doubles the table and re-inserts every occupied slot.
+		 */
+		private void grow() {
+			final int[] oldKeys = this.keys;
+			final Object[] oldValues = this.values;
+			final int capacity = (this.mask + 1) << 1;
+			this.keys = new int[capacity];
+			this.values = new Object[capacity];
+			this.mask = capacity - 1;
+			for (int i = 0; i < oldKeys.length; i++) {
+				if (oldKeys[i] != 0) {
+					int slot = mix(oldKeys[i]) & this.mask;
+					while (this.keys[slot] != 0) {
+						slot = (slot + 1) & this.mask;
+					}
+					this.keys[slot] = oldKeys[i];
+					this.values[slot] = oldValues[i];
+				}
+			}
+		}
+
+		/**
+		 * Fibonacci-style scramble, so sequential primary keys do not cluster under linear probing.
+		 *
+		 * @param key the owner primary key
+		 * @return its scrambled hash
+		 */
+		private static int mix(int key) {
+			final int h = key * 0x9E3779B9;
+			return h ^ (h >>> 16);
+		}
 	}
 
 	/**

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetMembershipReport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetMembershipReport.java
@@ -126,6 +126,14 @@ public class ConditionalFacetMembershipReport {
 	 */
 	private static final int WARMUP_ROUNDS = 100;
 
+	/**
+	 * `(owner, index)` pairs offered to the de-duplicating accumulator, and how many of them it rejected as
+	 * already present. Written only by the `COUNT_DEDUP` variant, so the timed variants stay untouched;
+	 * static because one accumulator lives for one resolution while the question spans the whole series.
+	 */
+	private static long dedupCalls;
+	private static long dedupHits;
+
 	public static void main(@Nonnull String[] args) {
 		if (args.length < 3) {
 			System.err.println(
@@ -307,6 +315,14 @@ public class ConditionalFacetMembershipReport {
 			});
 			report("lookup", withLookup);
 			report("walk", withoutLookup);
+			if ("COUNT_DEDUP".equals(System.getProperty("spike.accumulator"))) {
+				System.out.printf(
+					"    %-8s %,d of %,d offered pairs rejected as already present%n",
+					"dedup", dedupHits, dedupCalls
+				);
+				dedupCalls = 0L;
+				dedupHits = 0L;
+			}
 			System.out.println();
 		}
 	}
@@ -476,7 +492,8 @@ public class ConditionalFacetMembershipReport {
 	}
 
 	/**
-	 * The per-pair bookkeeping `ReevaluateExpressionExecutor#addSibling` performs, behind a seam so its cost
+	 * The per-pair bookkeeping `ReevaluateExpressionExecutor#probeReducedIndexForAffectedOwners` performs
+	 * for every affected owner a probed partition holds, behind a seam so its cost
 	 * can be attributed rather than argued about.
 	 *
 	 * The checksum is computed OUTSIDE this interface, so swapping variants cannot change what the arms
@@ -498,9 +515,15 @@ public class ConditionalFacetMembershipReport {
 	/**
 	 * Builds the accumulator named by `-Dspike.accumulator`, defaulting to the executor-faithful `FULL`.
 	 *
-	 * The four variants exist to subtract from one another: `FULL - OFF` is the accumulator's whole cost,
-	 * `FULL - NO_DEDUP` the linear `contains` scan alone, and `FULL - INT_KEYED` what the boxed `Integer` key
-	 * and its `HashMap` lookup cost over a primitive-keyed table.
+	 * The variants exist to subtract from one another: `FULL - OFF` is the accumulator's whole cost, and
+	 * `FULL - INT_KEYED` what the boxed `Integer` key and its `HashMap` lookup cost over a primitive-keyed
+	 * table.
+	 *
+	 * `DEDUP_SCAN` and `COUNT_DEDUP` are about the linear `indexes.contains(sibling)` scan the executor USED
+	 * to perform per pair. `DEDUP_SCAN - FULL` prices it; `COUNT_DEDUP` tallies how often it actually rejected
+	 * anything, which is what retired it — 0 rejections in 1,568,849,000 offered pairs on a production
+	 * catalog, because one reduced index primary key reaches the probe at most once per sibling reference.
+	 * Both are kept so the removal stays re-checkable rather than a claim in a commit message.
 	 *
 	 * @return a fresh accumulator for one resolution
 	 */
@@ -508,33 +531,44 @@ public class ConditionalFacetMembershipReport {
 	private static Accumulator newAccumulator() {
 		final String variant = System.getProperty("spike.accumulator", "FULL");
 		return switch (variant) {
-			case "FULL" -> new BoxedAccumulator(true);
-			case "NO_DEDUP" -> new BoxedAccumulator(false);
+			case "FULL" -> new BoxedAccumulator(false, false);
+			case "DEDUP_SCAN" -> new BoxedAccumulator(true, false);
+			case "COUNT_DEDUP" -> new BoxedAccumulator(true, true);
 			case "INT_KEYED" -> new IntKeyedAccumulator();
 			case "OFF" -> (owner, sibling) -> { };
 			default -> throw new IllegalArgumentException(
-				"unknown -Dspike.accumulator=" + variant + " (FULL|NO_DEDUP|INT_KEYED|OFF)"
+				"unknown -Dspike.accumulator=" + variant + " (FULL|DEDUP_SCAN|COUNT_DEDUP|INT_KEYED|OFF)"
 			);
 		};
 	}
 
 	/**
 	 * The executor's own structure: a `HashMap` keyed by a boxed owner primary key, holding a four-slot
-	 * `ArrayList` scanned linearly for duplicates.
+	 * `ArrayList` appended to directly. `dedup` restores the linear duplicate scan the executor performed
+	 * before 2026-09-11, so what was removed can still be priced.
 	 */
 	private static final class BoxedAccumulator implements Accumulator {
 		private final Map<Integer, List<SiblingIndex>> result = new HashMap<>();
 		private final boolean dedup;
+		private final boolean count;
 
-		BoxedAccumulator(boolean dedup) {
+		BoxedAccumulator(boolean dedup, boolean count) {
 			this.dedup = dedup;
+			this.count = count;
 		}
 
 		@Override
 		public void record(int owner, @Nonnull SiblingIndex sibling) {
 			final List<SiblingIndex> indexes = this.result.computeIfAbsent(owner, __ -> new ArrayList<>(4));
 			if (this.dedup && indexes.contains(sibling)) {
+				if (this.count) {
+					dedupCalls++;
+					dedupHits++;
+				}
 				return;
+			}
+			if (this.count) {
+				dedupCalls++;
 			}
 			indexes.add(sibling);
 		}
@@ -560,10 +594,7 @@ public class ConditionalFacetMembershipReport {
 			int slot = mix(owner) & this.mask;
 			while (this.keys[slot] != 0) {
 				if (this.keys[slot] == owner) {
-					final List<SiblingIndex> indexes = (List<SiblingIndex>) this.values[slot];
-					if (!indexes.contains(sibling)) {
-						indexes.add(sibling);
-					}
+					((List<SiblingIndex>) this.values[slot]).add(sibling);
 					return;
 				}
 				slot = (slot + 1) & this.mask;

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetMembershipReport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetMembershipReport.java
@@ -1,0 +1,617 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spike;
+
+import io.evitadb.api.CatalogContract;
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.configuration.ThreadPoolOptions;
+import io.evitadb.api.index.EntityIndexType;
+import io.evitadb.api.requestResponse.schema.SealedEntitySchema;
+import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
+import io.evitadb.api.requestResponse.schema.mutation.reference.SetReferenceSchemaIndexedMutation;
+import io.evitadb.api.requestResponse.schema.mutation.reference.ScopedReferenceIndexType;
+import io.evitadb.api.requestResponse.schema.mutation.catalog.ModifyEntitySchemaMutation;
+import io.evitadb.core.Evita;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.transaction.Transaction;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.dataType.Scope;
+import io.evitadb.index.EntityIndex;
+import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.GlobalEntityIndex;
+import io.evitadb.index.ReferencedTypeEntityIndex;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.TransactionalBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.membership.ReducedIndexMembership;
+import io.evitadb.roaringbitmap.PersistentRoaringBitmap;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PrimitiveIterator.OfInt;
+import java.util.function.Consumer;
+
+import static io.evitadb.index.bitmap.RoaringBitmapBackedBitmap.getRoaringBitmap;
+import static io.evitadb.roaringbitmap.PersistentRoaringBitmap.and;
+
+/**
+ * Measures the **shipped** reduced-index membership lookup on a real catalog — what it costs in memory, and
+ * what the trigger's sibling resolution costs with it against the walk it replaces.
+ *
+ * This is deliberately separate from `ConditionalFacetSiblingResolverReport`, whose arm C is a *simulation*
+ * built by the harness itself. The real structure does strictly more work than that simulation — it resolves
+ * every emitted index through the registering accessor and de-duplicates siblings per owner — so quoting arm
+ * C's numbers for the implementation would be quoting a model, which is the mistake this whole line of work
+ * has already made three times.
+ *
+ * # Raising the schema
+ *
+ * The high-cardinality case is reached by passing references to raise to
+ * {@link ReferenceIndexType#FOR_FILTERING_AND_PARTITIONING}. Because the engine does not rebuild indexes on a
+ * schema change (issue #409), the raise is followed by a **close and reopen**, which is what makes the
+ * load-time build run over the newly-admitted reduced indexes. That is the supported path — a full reindex —
+ * compressed to its essential step, and it exercises the build at real cardinality rather than simulating it.
+ *
+ * Run it against a DISPOSABLE copy of the dataset: it writes a schema mutation.
+ *
+ * ```
+ * java -Xmx48g -cp <cp> io.evitadb.spike.ConditionalFacetMembershipReport <dir> <catalog> <collection> [refs]
+ * ```
+ *
+ * @author Claude (issue #1529 sibling-resolver optimization), FG Forrest a.s. (c) 2026
+ */
+public class ConditionalFacetMembershipReport {
+
+	/**
+	 * How long the report waits for the catalog's background load to finish before giving up.
+	 */
+	private static final long LOAD_TIMEOUT_NANOS = 15L * 60L * 1_000_000_000L;
+
+	/**
+	 * Rounds of the timed series, per shape and per arm.
+	 */
+	private static final int ROUNDS = 400;
+
+	/**
+	 * Rounds discarded before recording, so the arms are compared at steady state.
+	 */
+	private static final int WARMUP_ROUNDS = 100;
+
+	public static void main(@Nonnull String[] args) {
+		if (args.length < 3) {
+			System.err.println(
+				"Usage: ConditionalFacetMembershipReport <storageDir> <catalogName> <collection> [refsToRaise]"
+			);
+			System.exit(1);
+		}
+		final Path storageDirectory = Path.of(args[0]);
+		final String catalogName = args[1];
+		final String collectionName = args[2];
+		final List<String> toRaise = args.length > 3 && !args[3].isBlank()
+			? List.of(args[3].split(",")) : List.of();
+
+		try (final Evita evita = openEvita(storageDirectory)) {
+			final long loadStart = System.nanoTime();
+			final Catalog catalog = awaitLoaded(evita, catalogName);
+			final EntityCollection collection = catalog.getCollectionForEntityOrThrowException(collectionName);
+			final long loadNanos = System.nanoTime() - loadStart;
+
+			final GlobalEntityIndex globalIndex = globalIndex(collection);
+			if (globalIndex == null) {
+				System.err.println("no global index - nothing to report");
+				return;
+			}
+			System.out.printf(
+				"catalog v%d %s | collection `%s` | load %,.1f s%n%n",
+				catalog.getVersion(), catalog.getCatalogState(), collectionName, loadNanos / 1_000_000_000.0
+			);
+
+			final long buildStart = System.nanoTime();
+			final Map<String, ReducedIndexMembership> simulated = toRaise.isEmpty()
+				? Map.of() : buildSlicesFor(collection, toRaise);
+			if (!toRaise.isEmpty()) {
+				System.out.printf(
+					"built membership for %s in %,.1f ms - the load path's own work, timed%n%n",
+					toRaise, (System.nanoTime() - buildStart) / 1_000_000.0
+				);
+			}
+			reportCoverage(collection, globalIndex, simulated);
+			reportTimings(collection, globalIndex, simulated, toRaise);
+		}
+	}
+
+	/**
+	 * Prints, per reference, how much of its advertisement the lookup covers and what it costs.
+	 *
+	 * @param collection  the measured collection
+	 * @param globalIndex the collection's global index, which carries the lookup
+	 */
+	private static void reportCoverage(
+		@Nonnull EntityCollection collection,
+		@Nonnull GlobalEntityIndex globalIndex,
+		@Nonnull Map<String, ReducedIndexMembership> simulated
+	) {
+		System.out.printf(
+			"  %-22s %-32s %11s %11s %11s %12s%n",
+			"reference", "index type", "advertised", "covered", "residual", "heap"
+		);
+		long totalHeap = 0L;
+		long totalCovered = 0L;
+		long totalResidual = 0L;
+		for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
+			final ReducedIndexMembership membership = simulated.containsKey(reference.getName())
+				? simulated.get(reference.getName())
+				: globalIndex.getReducedIndexMembership(reference.getName());
+			if (membership == null) {
+				continue;
+			}
+			final long advertised = advertisedCount(collection, reference.getName());
+			final long covered = membership.getCoveredIndexPrimaryKeys().size();
+			final long residual = membership.getResidualIndexPrimaryKeys().size();
+			final long heap = membership.getHeapSizeInBytes();
+			totalHeap += heap;
+			totalCovered += covered;
+			totalResidual += residual;
+			System.out.printf(
+				"  %-22s %-32s %,11d %,11d %,11d %,9d KiB%n",
+				reference.getName(), reference.getReferenceIndexType(Scope.LIVE),
+				advertised, covered, residual, heap / 1024
+			);
+		}
+		System.out.printf(
+			"%n  covered %,d reduced indexes, %,d left on the walk, %,.1f MiB total%n%n",
+			totalCovered, totalResidual, totalHeap / (1024.0 * 1024.0)
+		);
+	}
+
+	/**
+	 * Times the sibling resolution the trigger performs, with the lookup and without it, over the sparse and
+	 * dense affected-owner shapes of the reference carrying the conditional facet.
+	 *
+	 * Both arms are probe-only and emit the same `(owner, index)` pairs; the checksum is compared so an arm
+	 * computing a different answer is never reported as merely faster.
+	 *
+	 * @param collection  the measured collection
+	 * @param globalIndex the collection's global index, which carries the lookup
+	 */
+	private static void reportTimings(
+		@Nonnull EntityCollection collection,
+		@Nonnull GlobalEntityIndex globalIndex,
+		@Nonnull Map<String, ReducedIndexMembership> simulated,
+		@Nonnull List<String> extraSiblings
+	) {
+		String trigger = null;
+		final List<ReferenceSchemaContract> siblings = new ArrayList<>(16);
+		for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
+			if (reference.getFacetedPartiallyInScope(Scope.LIVE) != null) {
+				trigger = reference.getName();
+			}
+			if (reference.getReferenceIndexType(Scope.LIVE) == ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING) {
+				siblings.add(reference);
+			}
+		}
+		for (final String extra : extraSiblings) {
+			final ReferenceSchemaContract reference = collection.getSchema().getReference(extra).orElse(null);
+			if (reference != null && siblings.stream().noneMatch(it -> it.getName().equals(extra))) {
+				siblings.add(reference);
+			}
+		}
+		if (trigger == null) {
+			System.out.println("  no conditional facet declared - nothing to time");
+			return;
+		}
+		final String mutated = trigger;
+		siblings.removeIf(it -> it.getName().equals(mutated));
+		System.out.printf("  trigger `%s` | siblings %s%n%n", mutated, siblings.stream().map(
+			ReferenceSchemaContract::getName).toList());
+
+		for (final Bitmap shape : shapes(collection, mutated)) {
+			final PersistentRoaringBitmap affected = getRoaringBitmap(shape);
+			System.out.printf("  === %,d affected owners ===%n", shape.size());
+			final long[] withLookup = new long[ROUNDS];
+			final long[] withoutLookup = new long[ROUNDS];
+			// One throwaway transaction bound for the whole series. The real trigger always runs inside one,
+			// and both `TransactionalBitmap#getRoaringBitmap` and the index accessors resolve a transactional
+			// layer only then - measuring without one understates ALIVE, the wrong direction of error here.
+			final Transaction transaction = new Transaction(new TransactionalBitmap(new BaseBitmap()));
+			final long[] checksums = {Long.MIN_VALUE, Long.MIN_VALUE};
+			Transaction.executeInTransactionIfProvided(transaction, (Runnable) () -> {
+				for (int round = -WARMUP_ROUNDS; round < ROUNDS; round++) {
+					// alternate which arm runs first: whichever goes second reads a cache the first one just
+					// warmed, and a fixed order silently credits that to one of them
+					final boolean lookupFirst = (round & 1) == 0;
+					long lookupElapsed = 0L;
+					long walkElapsed = 0L;
+					long a = 0L;
+					long b = 0L;
+					for (int slot = 0; slot < 2; slot++) {
+						if (lookupFirst == (slot == 0)) {
+							final long start = System.nanoTime();
+							a = resolveWithLookup(collection, globalIndex, simulated, siblings, affected);
+							lookupElapsed = System.nanoTime() - start;
+						} else {
+							final long start = System.nanoTime();
+							b = resolveByWalking(collection, siblings, affected);
+							walkElapsed = System.nanoTime() - start;
+						}
+					}
+					if (round >= 0) {
+						withLookup[round] = lookupElapsed;
+						withoutLookup[round] = walkElapsed;
+					}
+					if (checksums[0] == Long.MIN_VALUE) {
+						checksums[0] = a;
+						checksums[1] = b;
+					}
+					if (a != checksums[0] || b != checksums[1] || a != b) {
+						throw new IllegalStateException("arms disagree: lookup=" + a + " walk=" + b);
+					}
+				}
+			});
+			report("lookup", withLookup);
+			report("walk", withoutLookup);
+			System.out.println();
+		}
+	}
+
+	/**
+	 * Resolves the sibling reduced indexes the way the shipped executor does, through the lookup.
+	 *
+	 * @param collection  the measured collection
+	 * @param globalIndex the collection's global index
+	 * @param siblings    the partitioned sibling references
+	 * @param affected    affected owner primary keys
+	 * @return checksum of the emitted `(owner, index)` pairs
+	 */
+	private static long resolveWithLookup(
+		@Nonnull EntityCollection collection,
+		@Nonnull GlobalEntityIndex globalIndex,
+		@Nonnull Map<String, ReducedIndexMembership> simulated,
+		@Nonnull List<ReferenceSchemaContract> siblings,
+		@Nonnull PersistentRoaringBitmap affected
+	) {
+		long checksum = 0L;
+		for (final ReferenceSchemaContract sibling : siblings) {
+			final ReducedIndexMembership membership = simulated.containsKey(sibling.getName())
+				? simulated.get(sibling.getName())
+				: globalIndex.getReducedIndexMembership(sibling.getName());
+			if (membership == null) {
+				checksum += walkReference(collection, sibling.getName(), affected);
+				continue;
+			}
+			final Bitmap coveredOwners = membership.getCoveredOwners();
+			if (!coveredOwners.isEmpty()) {
+				for (final int owner : and(getRoaringBitmap(coveredOwners), affected).toArray()) {
+					final OfInt it = membership.getIndexPrimaryKeys(owner).iterator();
+					while (it.hasNext()) {
+						checksum += pair(owner, it.nextInt());
+					}
+				}
+			}
+			final OfInt residualIt = membership.getResidualIndexPrimaryKeys().iterator();
+			while (residualIt.hasNext()) {
+				final int indexPk = residualIt.nextInt();
+				checksum += probe(collection, indexPk, affected);
+			}
+		}
+		return checksum;
+	}
+
+	/**
+	 * Resolves the same set by walking every advertised reduced index, which is what the executor does when
+	 * no lookup exists.
+	 *
+	 * @param collection the measured collection
+	 * @param siblings   the partitioned sibling references
+	 * @param affected   affected owner primary keys
+	 * @return checksum of the emitted `(owner, index)` pairs
+	 */
+	private static long resolveByWalking(
+		@Nonnull EntityCollection collection,
+		@Nonnull List<ReferenceSchemaContract> siblings,
+		@Nonnull PersistentRoaringBitmap affected
+	) {
+		long checksum = 0L;
+		for (final ReferenceSchemaContract sibling : siblings) {
+			checksum += walkReference(collection, sibling.getName(), affected);
+		}
+		return checksum;
+	}
+
+	/**
+	 * Walks every reduced index one reference advertises, intersecting each against the affected owners.
+	 *
+	 * @param collection    the measured collection
+	 * @param referenceName the reference to walk
+	 * @param affected      affected owner primary keys
+	 * @return checksum contribution
+	 */
+	private static long walkReference(
+		@Nonnull EntityCollection collection,
+		@Nonnull String referenceName,
+		@Nonnull PersistentRoaringBitmap affected
+	) {
+		final long[] checksum = new long[1];
+		for (final EntityIndexType family : new EntityIndexType[]{
+			EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
+		}) {
+			final ReferencedTypeEntityIndex typeIndex = typeIndex(collection, family, referenceName);
+			if (typeIndex == null) {
+				continue;
+			}
+			typeIndex.forEachReferenceIndexPrimaryKey(
+				pk -> checksum[0] += probe(collection, pk, affected)
+			);
+		}
+		return checksum[0];
+	}
+
+	/**
+	 * Intersects one reduced index against the affected owners and folds the matches into a checksum.
+	 *
+	 * @param collection the measured collection
+	 * @param indexPk    primary key of the reduced index
+	 * @param affected   affected owner primary keys
+	 * @return checksum contribution
+	 */
+	private static long probe(
+		@Nonnull EntityCollection collection,
+		int indexPk,
+		@Nonnull PersistentRoaringBitmap affected
+	) {
+		final EntityIndex index = collection.getIndexByPrimaryKeyIfExists(indexPk);
+		if (index == null) {
+			return 0L;
+		}
+		long checksum = 0L;
+		for (final int owner : and(getRoaringBitmap(index.getAllPrimaryKeys()), affected).toArray()) {
+			checksum += pair(owner, indexPk);
+		}
+		return checksum;
+	}
+
+	/**
+	 * Order-independent contribution of one emitted `(owner, index)` pair.
+	 *
+	 * @param owner   owner primary key
+	 * @param indexPk reduced-index primary key
+	 * @return the contribution
+	 */
+	private static long pair(int owner, int indexPk) {
+		return (long) owner * 1000003L + indexPk;
+	}
+
+	/**
+	 * Builds membership slices for references that are not partitioned in the schema, so the high-cardinality
+	 * case can be measured on the **real** structure without a schema change.
+	 *
+	 * # Why not change the schema
+	 *
+	 * Two reasons, and neither is a shortcut. The production export this runs against carries no usable WAL
+	 * slice — its log record names WAL segment 63 while only segment 0 is present — so the
+	 * catalog refuses every write transaction, schema mutations included. And the supported way to change a
+	 * reference's index type is a full reindex, which is a twenty-minute rebuild that would spend its time in
+	 * the loader rather than in anything this measures.
+	 *
+	 * # What this does and does not exercise
+	 *
+	 * It calls {@link ReducedIndexMembership#registerIndex} with each reduced index and its real membership —
+	 * the identical call `EntityCollection#rebuildReducedIndexMembership` makes on the load path — so the
+	 * structure, its threshold decisions, its memory and the resolution path over it are all the shipped
+	 * code, at the cardinality that matters.
+	 *
+	 * What it does **not** exercise is the load path's own gating: which references it decides to cover. That
+	 * is a two-line schema test rather than a performance question, and
+	 * `ReducedIndexMembershipCompletenessTest` covers it.
+	 *
+	 * @param collection  the measured collection
+	 * @param globalIndex the collection's global index
+	 * @param references  references to build slices for
+	 */
+	@Nonnull
+	private static Map<String, ReducedIndexMembership> buildSlicesFor(
+		@Nonnull EntityCollection collection,
+		@Nonnull List<String> references
+	) {
+		final Map<String, ReducedIndexMembership> built = new HashMap<>(references.size());
+		for (final String referenceName : references) {
+			// A STANDALONE instance, deliberately not the one hanging off the global index. That one already
+			// holds this reference's indexes as residual - the load build records every reference's
+			// advertisement so an absent slice always means "no indexes" - and `registerIndex` rightly
+			// refuses to re-register them. On a genuinely raised-and-reloaded catalog the load build would
+			// see the reference as partitioned and decide coverage in the first place; this reproduces that
+			// end state without needing the schema write the export cannot accept.
+			final ReducedIndexMembership membership = new ReducedIndexMembership();
+			built.put(referenceName, membership);
+			for (final EntityIndexType family : new EntityIndexType[]{
+				EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
+			}) {
+				final ReferencedTypeEntityIndex typeIndex = typeIndex(collection, family, referenceName);
+				if (typeIndex == null) {
+					continue;
+				}
+				typeIndex.forEachReferenceIndexPrimaryKey(reducedIndexPk -> {
+					if (membership.isKnown(reducedIndexPk)) {
+						return;
+					}
+					final EntityIndex reducedIndex = collection.getIndexByPrimaryKeyIfExists(reducedIndexPk);
+					if (reducedIndex != null) {
+						membership.registerIndex(reducedIndexPk, reducedIndex.getAllPrimaryKeys());
+					}
+				});
+			}
+		}
+		return built;
+	}
+
+	/**
+	 * Builds the affected-owner shapes: the sparse and dense ends of the mutated reference's partition-size
+	 * distribution, which is what a trigger's affected-owner set actually is.
+	 *
+	 * @param collection the measured collection
+	 * @param mutated    the reference carrying the conditional facet
+	 * @return the shapes to measure
+	 */
+	@Nonnull
+	private static List<Bitmap> shapes(@Nonnull EntityCollection collection, @Nonnull String mutated) {
+		final ReferencedTypeEntityIndex typeIndex =
+			typeIndex(collection, EntityIndexType.REFERENCED_ENTITY_TYPE, mutated);
+		if (typeIndex == null) {
+			return List.of();
+		}
+		final List<Integer> pks = new ArrayList<>();
+		typeIndex.forEachReferenceIndexPrimaryKey(pks::add);
+		Bitmap smallest = null;
+		Bitmap largest = null;
+		for (final int pk : pks) {
+			final EntityIndex index = collection.getIndexByPrimaryKeyIfExists(pk);
+			if (index == null) {
+				continue;
+			}
+			final Bitmap owners = index.getAllPrimaryKeys();
+			if (owners.size() >= 20 && (smallest == null || owners.size() < smallest.size())) {
+				smallest = owners;
+			}
+			if (largest == null || owners.size() > largest.size()) {
+				largest = owners;
+			}
+		}
+		final List<Bitmap> shapes = new ArrayList<>(2);
+		if (smallest != null) {
+			shapes.add(smallest);
+		}
+		if (largest != null) {
+			shapes.add(largest);
+		}
+		return shapes;
+	}
+
+	/**
+	 * Counts the reduced indexes a reference advertises, duplicates included — a group index is advertised
+	 * once per referenced entity filed under it, and the walk visits it once per advertisement.
+	 *
+	 * @param collection    the measured collection
+	 * @param referenceName the reference
+	 * @return advertisement count
+	 */
+	private static long advertisedCount(
+		@Nonnull EntityCollection collection,
+		@Nonnull String referenceName
+	) {
+		final long[] counter = new long[1];
+		for (final EntityIndexType family : new EntityIndexType[]{
+			EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
+		}) {
+			final ReferencedTypeEntityIndex typeIndex = typeIndex(collection, family, referenceName);
+			if (typeIndex != null) {
+				typeIndex.forEachReferenceIndexPrimaryKey(pk -> counter[0]++);
+			}
+		}
+		return counter[0];
+	}
+
+	/**
+	 * Prints one reading as median and p95.
+	 *
+	 * @param label   what was measured
+	 * @param samples per-round durations
+	 */
+	private static void report(@Nonnull String label, @Nonnull long[] samples) {
+		final long[] sorted = samples.clone();
+		Arrays.sort(sorted);
+		System.out.printf(
+			"    %-10s median %,12d ns   p95 %,12d ns%n",
+			label, sorted[sorted.length / 2], sorted[(int) (sorted.length * 0.95)]
+		);
+	}
+
+	@Nullable
+	private static GlobalEntityIndex globalIndex(@Nonnull EntityCollection collection) {
+		final EntityIndex index = collection.getIndexByKeyIfExists(
+			new EntityIndexKey(EntityIndexType.GLOBAL, Scope.LIVE)
+		);
+		return index instanceof final GlobalEntityIndex typed ? typed : null;
+	}
+
+	@Nullable
+	private static ReferencedTypeEntityIndex typeIndex(
+		@Nonnull EntityCollection collection,
+		@Nonnull EntityIndexType family,
+		@Nonnull String referenceName
+	) {
+		final EntityIndex index = collection.getIndexByKeyIfExists(
+			new EntityIndexKey(family, Scope.LIVE, referenceName)
+		);
+		return index instanceof final ReferencedTypeEntityIndex typed ? typed : null;
+	}
+
+	@Nonnull
+	private static Evita openEvita(@Nonnull Path storageDirectory) {
+		return new Evita(
+			EvitaConfiguration.builder()
+				.storage(StorageOptions.builder().storageDirectory(storageDirectory).build())
+				.server(
+					ServerOptions.builder()
+						.requestThreadPool(ThreadPoolOptions.requestThreadPoolBuilder().build())
+						.build()
+				)
+				.build()
+		);
+	}
+
+	@Nonnull
+	private static Catalog awaitLoaded(@Nonnull Evita evita, @Nonnull String catalogName) {
+		final long deadline = System.nanoTime() + LOAD_TIMEOUT_NANOS;
+		while (System.nanoTime() < deadline) {
+			final CatalogContract candidate = evita.getCatalogInstance(catalogName)
+				.orElseThrow(() -> new IllegalArgumentException("Catalog `" + catalogName + "` not found!"));
+			if (candidate instanceof final Catalog loaded) {
+				return loaded;
+			}
+			try {
+				Thread.sleep(500L);
+			} catch (final InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new IllegalStateException("Interrupted while waiting for catalog!", e);
+			}
+		}
+		throw new IllegalStateException("Catalog `" + catalogName + "` did not load in time!");
+	}
+
+	/**
+	 * Not instantiable — this is a `main()`-style report.
+	 */
+	private ConditionalFacetMembershipReport() {
+	}
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetMembershipReport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetMembershipReport.java
@@ -60,24 +60,44 @@ import static io.evitadb.index.bitmap.RoaringBitmapBackedBitmap.getRoaringBitmap
 import static io.evitadb.roaringbitmap.PersistentRoaringBitmap.and;
 
 /**
- * Measures the **shipped** reduced-index membership lookup on a real catalog — what it costs in memory, and
+ * Measures the **shipped** reduced-index membership structure on a real catalog — what it costs in memory, and
  * what the trigger's sibling resolution costs with it against the walk it replaces.
  *
- * This is deliberately separate from `ConditionalFacetSiblingResolverReport`, whose arm C is a *simulation*
- * built by the harness itself. The real structure does strictly more work than that simulation — it resolves
- * every emitted index through the registering accessor and de-duplicates siblings per owner — so quoting arm
- * C's numbers for the implementation would be quoting a model, which is the mistake this whole line of work
- * has already made three times.
+ * The STRUCTURE measured is the shipped one. Slices are filled through the very
+ * {@link ReducedIndexMembership#registerIndex} call `EntityCollection#rebuildReducedIndexMembership` makes on
+ * the load path, so the threshold decisions, the covered/residual split and the heap figure are all real, at
+ * real cardinality. This is what separates the report from `ConditionalFacetSiblingResolverReport`, whose
+ * arm C is a reverse map the harness invents.
  *
- * # Raising the schema
+ * # What the timed arms measure, and where they diverge from the shipped resolver
  *
- * The high-cardinality case is reached by passing references to raise to
- * {@link ReferenceIndexType#FOR_FILTERING_AND_PARTITIONING}. Because the engine does not rebuild indexes on a
- * schema change (issue #409), the raise is followed by a **close and reopen**, which is what makes the
- * load-time build run over the newly-admitted reduced indexes. That is the supported path — a full reindex —
- * compressed to its essential step, and it exercises the build at real cardinality rather than simulating it.
+ * The RESOLUTION measured is **not** the shipped one. Both arms are re-implementations local to this class,
+ * and they diverge from `ReevaluateExpressionExecutor` in two ways, in increasing order of consequence:
  *
- * Run it against a DISPOSABLE copy of the dataset: it writes a schema mutation.
+ * - **Both arms are probe-only.** They stop at the intersection and never call `getOrCreateIndexByPrimaryKey`,
+ *   so neither pays the registering re-fetch nor the per-owner de-duplication of `SiblingReducedIndex`
+ *   instances the shipped resolver pays. That matches how the 2026-09-09 decomposition defined "the walk"
+ *   against the whole resolver, and it costs both arms the same, so it does not tilt one against the other.
+ * - **The lookup arm's COVERED half diverges further, and only that half.** {@link #resolveWithLookup} emits
+ *   the map's `(owner, index)` pairs straight out of {@link ReducedIndexMembership#getIndexPrimaryKeys},
+ *   whereas `ReevaluateExpressionExecutor#collectOwnersFromMembership` uses the map as an index *selector*
+ *   only — it collects the selected primary keys, then resolves each index and intersects its member bitmap
+ *   against the affected owners, exactly as the residual half does. This arm performs none of that resolve
+ *   and intersect.
+ *
+ * The emitted pairs are the same either way, and the checksum proves it; the work is not. So the lookup arm's
+ * timings are a **lower bound** on what the shipped lookup costs, and — because the walk arm is not short-cut
+ * in the same way — the lookup-over-walk speedup printed here is an **upper bound** on the shipped one. Every
+ * figure carried into `documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md` inherits both
+ * bounds. Bringing the covered half in line with the shipped selector changes what is measured rather than how
+ * it is described, so it is left to a deliberate re-measurement instead of being done in passing.
+ *
+ * # Reaching the high-cardinality case
+ *
+ * No schema is raised and nothing is written — the report is read-only. References named on the command line
+ * get a STANDALONE slice built for them by {@link #buildSlicesFor} out of their live indexes, which reaches
+ * the end state a raise-and-reload would leave behind without the schema write the production export cannot
+ * accept. That method's javadoc carries the reasoning and says what the substitution does not exercise.
  *
  * ```
  * java -Xmx48g -cp <cp> io.evitadb.spike.ConditionalFacetMembershipReport <dir> <catalog> <collection> [refs]
@@ -150,6 +170,8 @@ public class ConditionalFacetMembershipReport {
 	 *
 	 * @param collection  the measured collection
 	 * @param globalIndex the collection's global index, which carries the lookup
+	 * @param simulated   standalone slices built by {@link #buildSlicesFor}, keyed by reference name; each one
+	 *                    takes precedence over the slice the global index carries for that reference
 	 */
 	private static void reportCoverage(
 		@Nonnull EntityCollection collection,
@@ -193,11 +215,16 @@ public class ConditionalFacetMembershipReport {
 	 * Times the sibling resolution the trigger performs, with the lookup and without it, over the sparse and
 	 * dense affected-owner shapes of the reference carrying the conditional facet.
 	 *
-	 * Both arms are probe-only and emit the same `(owner, index)` pairs; the checksum is compared so an arm
-	 * computing a different answer is never reported as merely faster.
+	 * Both arms emit the same `(owner, index)` pairs; the checksum is compared so an arm computing a different
+	 * answer is never reported as merely faster. Both are also probe-only — they stop at the intersection and
+	 * never call `getOrCreateIndexByPrimaryKey` — and {@link #resolveWithLookup}'s covered half does not even
+	 * probe. Neither figure is the shipped resolver's; see the class javadoc for what that costs the reading.
 	 *
-	 * @param collection  the measured collection
-	 * @param globalIndex the collection's global index, which carries the lookup
+	 * @param collection    the measured collection
+	 * @param globalIndex   the collection's global index, which carries the lookup
+	 * @param simulated     standalone slices built by {@link #buildSlicesFor}, keyed by reference name
+	 * @param extraSiblings references named on the command line, added to the sibling set even when the schema
+	 *                      does not index them at `FOR_FILTERING_AND_PARTITIONING`
 	 */
 	private static void reportTimings(
 		@Nonnull EntityCollection collection,
@@ -280,10 +307,24 @@ public class ConditionalFacetMembershipReport {
 	}
 
 	/**
-	 * Resolves the sibling reduced indexes the way the shipped executor does, through the lookup.
+	 * Resolves the sibling reduced indexes through the lookup, in two halves that do NOT cost the same:
+	 *
+	 * - the **residual** half probes, exactly as the shipped resolver does: it resolves each residual index and
+	 *   intersects its member bitmap against the affected owners;
+	 * - the **covered** half does not. It intersects the affected set against the lookup's covered-owner union,
+	 *   then emits `pair(owner, indexPk)` straight out of {@link ReducedIndexMembership#getIndexPrimaryKeys} —
+	 *   no index is resolved and no bitmap is intersected.
+	 *
+	 * `ReevaluateExpressionExecutor#collectOwnersFromMembership` probes both halves: it treats the lookup as an
+	 * index selector, collects the primary keys it names and hands them to the same probe the residual half
+	 * uses. The pairs agree, so the checksum passes; the cost does not, and this arm's covered half is the
+	 * reason every figure here is a lower bound on the shipped resolver. Fixing it is a measurement change and
+	 * is deliberately not made here — see the class javadoc.
 	 *
 	 * @param collection  the measured collection
 	 * @param globalIndex the collection's global index
+	 * @param simulated   standalone slices built by {@link #buildSlicesFor}, taking precedence over the global
+	 *                    index's own slice for the references they name
 	 * @param siblings    the partitioned sibling references
 	 * @param affected    affected owner primary keys
 	 * @return checksum of the emitted `(owner, index)` pairs
@@ -429,9 +470,9 @@ public class ConditionalFacetMembershipReport {
 	 * is a two-line schema test rather than a performance question, and
 	 * `ReducedIndexMembershipCompletenessTest` covers it.
 	 *
-	 * @param collection  the measured collection
-	 * @param globalIndex the collection's global index
-	 * @param references  references to build slices for
+	 * @param collection the measured collection
+	 * @param references references to build slices for
+	 * @return the built slices, keyed by reference name
 	 */
 	@Nonnull
 	private static Map<String, ReducedIndexMembership> buildSlicesFor(
@@ -440,12 +481,15 @@ public class ConditionalFacetMembershipReport {
 	) {
 		final Map<String, ReducedIndexMembership> built = new HashMap<>(references.size());
 		for (final String referenceName : references) {
-			// A STANDALONE instance, deliberately not the one hanging off the global index. That one already
-			// holds this reference's indexes as residual - the load build records every reference's
-			// advertisement so an absent slice always means "no indexes" - and `registerIndex` rightly
-			// refuses to re-register them. On a genuinely raised-and-reloaded catalog the load build would
-			// see the reference as partitioned and decide coverage in the first place; this reproduces that
-			// end state without needing the schema write the export cannot accept.
+			// A STANDALONE instance, deliberately not the one hanging off the global index. The global index
+			// holds no slice for these references at all: `EntityCollection#rebuildReducedIndexMembership`
+			// builds one only for a reference indexed at FOR_FILTERING_AND_PARTITIONING, and these are the
+			// ones that are not. Note that an absent slice is NOT "no indexes" - to the shipped resolver it
+			// means "walk the whole advertisement", which is precisely the baseline being measured against.
+			// Calling `getOrCreateReducedIndexMembership` here would therefore create a slice on a live index
+			// and change the very thing under measurement. On a genuinely raised-and-reloaded catalog the load
+			// build would see the reference as partitioned and decide coverage in the first place; this
+			// reproduces that end state without needing the schema write the export cannot accept.
 			final ReducedIndexMembership membership = new ReducedIndexMembership();
 			built.put(referenceName, membership);
 			for (final EntityIndexType family : new EntityIndexType[]{

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetPartitionCensus.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetPartitionCensus.java
@@ -396,8 +396,9 @@ public class ConditionalFacetPartitionCensus {
 	 *
 	 * 1. **A sibling is partitioned.** Its partitions join the walk of every existing trigger.
 	 * 2. **A second reference gains a `facetedPartially` expression.** The reference that carries today's trigger is
-	 *    excluded from its own walk (`resolveSiblingReducedIndexes:449`) — but it is *not* excluded from anybody
-	 *    else's. A second trigger makes today's protected reference somebody else's sibling.
+	 *    excluded from its own walk — `ReevaluateExpressionExecutor#resolveSiblingReducedIndexes` skips the sibling
+	 *    whose name equals the mutated reference's — but it is *not* excluded from anybody else's. A second trigger
+	 *    makes today's protected reference somebody else's sibling.
 	 *
 	 * @param collection   the collection whose references fan out
 	 * @param partitioned  references currently `FOR_FILTERING_AND_PARTITIONING`
@@ -499,10 +500,12 @@ public class ConditionalFacetPartitionCensus {
 	}
 
 	/**
-	 * Returns up to {@link #FANOUT_SAMPLES} partition primary keys of a type index, spread across its
-	 * advertisement order so the sample is not all taken from one end.
+	 * Returns up to {@link #FANOUT_LARGEST_SAMPLES} + {@link #FANOUT_SAMPLES} partition primary keys of a type
+	 * index: the largest partitions by owner count, followed by a sample spread across the advertisement order
+	 * so the rest is not all taken from one end.
 	 *
-	 * @param typeIndex the type index to sample
+	 * @param collection the collection holding the indexes, needed to size each partition
+	 * @param typeIndex  the type index to sample
 	 * @return the sampled reduced-index primary keys
 	 */
 	@Nonnull

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetPartitionCensus.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetPartitionCensus.java
@@ -1,0 +1,640 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spike;
+
+import io.evitadb.api.CatalogContract;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.configuration.ThreadPoolOptions;
+import io.evitadb.api.index.EntityIndexType;
+import io.evitadb.api.query.order.OrderDirection;
+import io.evitadb.api.statistics.IndexBrowseCriteria;
+import io.evitadb.api.statistics.IndexBrowseOrdering;
+import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
+import io.evitadb.core.Evita;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.dataType.Scope;
+import io.evitadb.index.EntityIndex;
+import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.ReferencedTypeEntityIndex;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.roaringbitmap.PersistentRoaringBitmap;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static io.evitadb.index.bitmap.RoaringBitmapBackedBitmap.getRoaringBitmap;
+import static io.evitadb.roaringbitmap.PersistentRoaringBitmap.and;
+
+/**
+ * Counts — never times — the quantities issue #1529's decision rule turns on, against a real catalog.
+ *
+ * # Why counts, and why a separate class from the timing harness
+ *
+ * The sibling-resolver walk
+ * (`ReevaluateExpressionExecutor#collectOwnersOfReducedIndexes`) is `O(total reduced partitions of the
+ * collection)`, independent of how many owners a trigger actually affects. Whether that matters is decided by two
+ * numbers, and only one of them is a duration:
+ *
+ * - `P` — how many reduced partitions a real, migrated catalog actually has per reference. The prior assessment
+ *   was taken at 3,000 and explicitly does not generalise.
+ * - `intersecting / P` — of those partitions, how many hold at least one owner the trigger affects. This is the
+ *   ratio that bounds the whole enterprise: the reverse index proposed in #1529 changes how the intersecting
+ *   partitions are *found*, never which ones they are, so the `getOrCreateIndexByPrimaryKey` registration that
+ *   follows the walk is identical with or without it. If the ratio approaches 1, the registration absorbs
+ *   whatever the walk saves and the structure buys nothing.
+ *
+ * Both are **deterministic properties of the data**. They do not need a quiet machine, they do not vary between
+ * runs, and they can settle the question before a single nanosecond is measured — which is why they are counted
+ * here, in their own class, rather than folded into a benchmark that needs a negotiated window.
+ *
+ * # What it reports
+ *
+ * Per collection: entity count. Per reference of every collection: the declared
+ * {@link ReferenceIndexType} in each scope, the indexed components, the facet flags, and — for every reference
+ * that is {@link ReferenceIndexType#FOR_FILTERING_AND_PARTITIONING} — the partition count and the partition-size
+ * distribution of both index families (`REFERENCED_ENTITY_TYPE` and `REFERENCED_GROUP_ENTITY_TYPE`).
+ *
+ * Then, for a chosen collection, it simulates the resolver's fan-out without mutating anything: it takes one
+ * partition of one reference as the "mutated" one, treats that partition's members as the affected owners — which
+ * is exactly the set `ReevaluateExpressionExecutor#resolveForGroupEntityAttribute` would resolve — and counts, for
+ * every *other* partitioned reference, how many partitions intersect it. That is `intersecting / P`, measured on
+ * production data rather than assumed.
+ *
+ * # Deliberately read-only
+ *
+ * The catalog is opened and never written. Point it at a **copy** of an export snapshot regardless: the engine
+ * owns any directory it opens, and a census is not worth risking the only copy of a dataset over.
+ *
+ * ```
+ * java -Xmx48g -cp <classpath> io.evitadb.spike.ConditionalFacetPartitionCensus <storageDir> <catalogName> [collection]
+ * ```
+ *
+ * @author Claude (issue #1529 partition-cardinality census), FG Forrest a.s. (c) 2026
+ */
+public class ConditionalFacetPartitionCensus {
+
+	/**
+	 * How long the census waits for the catalog's background load to finish before giving up.
+	 */
+	private static final long LOAD_TIMEOUT_NANOS = 15L * 60L * 1_000_000_000L;
+
+	/**
+	 * How many of the largest partitions of a reference are listed individually.
+	 */
+	private static final int LARGEST_LISTED = 3;
+
+	/**
+	 * How many distinct "mutated partition" samples the fan-out simulation draws per reference.
+	 */
+	private static final int FANOUT_SAMPLES = 5;
+
+	/**
+	 * How many of the *largest* partitions the fan-out simulation additionally draws — the dense shape, which a
+	 * positional sample essentially never hits.
+	 */
+	private static final int FANOUT_LARGEST_SAMPLES = 3;
+
+	public static void main(@Nonnull String[] args) {
+		if (args.length < 2) {
+			System.err.println(
+				"Usage: ConditionalFacetPartitionCensus <storageDirectory> <catalogName> [collectionToSimulate]"
+			);
+			System.exit(1);
+		}
+		final Path storageDirectory = Path.of(args[0]);
+		final String catalogName = args[1];
+		final String simulatedCollection = args.length > 2 ? args[2] : null;
+
+		try (
+			final Evita evita = new Evita(
+				EvitaConfiguration.builder()
+					.storage(StorageOptions.builder().storageDirectory(storageDirectory).build())
+					.server(
+						ServerOptions.builder()
+							.requestThreadPool(ThreadPoolOptions.requestThreadPoolBuilder().build())
+							.build()
+					)
+					.build()
+			)
+		) {
+			final long openStart = System.nanoTime();
+			final Catalog catalog = awaitLoaded(evita, catalogName);
+			System.out.printf(
+				"Catalog opened in %.1f s — version %d, state %s%n%n",
+				(System.nanoTime() - openStart) / 1_000_000_000.0,
+				catalog.getVersion(), catalog.getCatalogState()
+			);
+
+			final List<String> entityTypes = new ArrayList<>(catalog.getEntityTypes());
+			entityTypes.sort(String::compareTo);
+
+			System.out.println("=== COLLECTIONS ===");
+			for (final String entityType : entityTypes) {
+				final EntityCollection collection = catalog.getCollectionForEntityOrThrowException(entityType);
+				System.out.printf(
+					"%-28s %,12d entities  %,8d indexes%s%n",
+					entityType, collection.size(), collection.getIndexCount(), indexTypeBreakdown(collection)
+				);
+			}
+
+			for (final String entityType : entityTypes) {
+				reportReferences(catalog.getCollectionForEntityOrThrowException(entityType));
+			}
+
+			if (simulatedCollection != null) {
+				simulateFanOut(catalog.getCollectionForEntityOrThrowException(simulatedCollection));
+			}
+		}
+	}
+
+	/**
+	 * Renders how a collection's indexes split across {@link EntityIndexType}, so the walk's share of them is
+	 * visible. The sibling resolver visits only the partitions its `REFERENCED_*_TYPE` indexes advertise, which can
+	 * be a small fraction of a collection's total index population — a distinction that is invisible from the total
+	 * alone and easy to misread as the walk's cost.
+	 *
+	 * @param collection the collection to break down
+	 * @return a printable ` [TYPE=n, ...]` fragment, empty when the collection holds no indexes
+	 */
+	@Nonnull
+	private static String indexTypeBreakdown(@Nonnull EntityCollection collection) {
+		final StringBuilder breakdown = new StringBuilder(128);
+		for (final EntityIndexType type : EntityIndexType.values()) {
+			final int count = collection.browseIndexes(
+				new IndexBrowseCriteria(
+					1, 1, IndexBrowseOrdering.MAP_ORDER, OrderDirection.ASC,
+					EnumSet.of(type), EnumSet.allOf(Scope.class), Set.of()
+				)
+			).totalRecordCount();
+			if (count > 0) {
+				breakdown.append(breakdown.isEmpty() ? "  [" : ", ").append(type).append('=').append(count);
+			}
+		}
+		return breakdown.isEmpty() ? "" : breakdown.append(']').toString();
+	}
+
+	/**
+	 * Prints every reference of one collection with its declared indexing, and the partition census of those that
+	 * are partitioned.
+	 *
+	 * @param collection the collection whose references are described
+	 */
+	private static void reportReferences(@Nonnull EntityCollection collection) {
+		final Map<String, ReferenceSchemaContract> references = collection.getSchema().getReferences();
+		if (references.isEmpty()) {
+			return;
+		}
+		System.out.printf("%n=== REFERENCES OF `%s` ===%n", collection.getEntityType());
+		for (final ReferenceSchemaContract reference : new TreeMap<>(references).values()) {
+			System.out.printf(
+				"%n  %s -> %s%s%n", reference.getName(), reference.getReferencedEntityType(),
+				reference.getReferencedGroupType() == null
+					? "" : " (group: " + reference.getReferencedGroupType() + ")"
+			);
+			for (final Scope scope : Scope.values()) {
+				final ReferenceIndexType indexType = reference.getReferenceIndexType(scope);
+				System.out.printf(
+					"    %-8s indexType=%-32s components=%-46s faceted=%-5s facetedPartially=%s%n",
+					scope, indexType, reference.getIndexedComponents(scope),
+					reference.isFacetedInScope(scope),
+					reference.getFacetedPartiallyInScope(scope) != null
+				);
+				// Counted for EVERY reference, not only the partitioned ones. A `FOR_FILTERING` reference still
+				// owns a `REFERENCED_*_TYPE` index whose advertising map holds the partitions it WOULD
+				// contribute to the sibling walk the moment its index type is switched to
+				// FOR_FILTERING_AND_PARTITIONING. That counterfactual is the exposure, and it is countable
+				// today without touching the schema.
+				reportPartitions(collection, scope, reference.getName(),
+					EntityIndexType.REFERENCED_ENTITY_TYPE);
+				reportPartitions(collection, scope, reference.getName(),
+					EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE);
+			}
+		}
+	}
+
+	/**
+	 * Prints the partition count and size distribution of one index family of one reference.
+	 *
+	 * @param collection    the collection holding the indexes
+	 * @param scope         the scope whose indexes are inspected
+	 * @param referenceName the reference whose partitions are counted
+	 * @param indexType     the referenced-type index family to walk
+	 */
+	private static void reportPartitions(
+		@Nonnull EntityCollection collection,
+		@Nonnull Scope scope,
+		@Nonnull String referenceName,
+		@Nonnull EntityIndexType indexType
+	) {
+		final ReferencedTypeEntityIndex typeIndex = typeIndex(collection, scope, referenceName, indexType);
+		if (typeIndex == null) {
+			return;
+		}
+		final int[] sizes = partitionSizes(collection, typeIndex);
+		if (sizes.length == 0) {
+			System.out.printf("      %-30s no partitions%n", indexType);
+			return;
+		}
+		Arrays.sort(sizes);
+		long members = 0L;
+		for (final int size : sizes) {
+			members += size;
+		}
+		final StringBuilder largest = new StringBuilder();
+		for (int i = 0; i < Math.min(LARGEST_LISTED, sizes.length); i++) {
+			largest.append(i == 0 ? "" : ", ").append(String.format("%,d", sizes[sizes.length - 1 - i]));
+		}
+		System.out.printf(
+			"      %-30s P=%,d  members=%,d  min=%,d  median=%,d  p95=%,d  largest=[%s]%n",
+			indexType, sizes.length, members, sizes[0], sizes[sizes.length / 2],
+			sizes[(int) (sizes.length * 0.95)], largest
+		);
+	}
+
+	/**
+	 * Simulates the sibling fan-out of one cross-entity trigger without mutating anything, and reports
+	 * `intersecting / P` per sibling reference.
+	 *
+	 * For each partitioned reference in turn, a handful of its partitions are treated as the one a trigger fired
+	 * for; that partition's members are the affected owners. Every *other* partitioned reference is then walked
+	 * exactly as `collectOwnersOfReducedIndexes` walks it, counting how many of its partitions hold at least one
+	 * affected owner.
+	 *
+	 * @param collection the collection whose references fan out
+	 */
+	private static void simulateFanOut(@Nonnull EntityCollection collection) {
+		System.out.printf("%n=== SIBLING FAN-OUT SIMULATION ON `%s` (LIVE scope) ===%n",
+			collection.getEntityType());
+		final List<String> partitioned = new ArrayList<>();
+		final List<String> triggers = new ArrayList<>();
+		final List<String> everyIndexed = new ArrayList<>();
+		for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
+			final ReferenceIndexType indexType = reference.getReferenceIndexType(Scope.LIVE);
+			if (indexType == ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING) {
+				partitioned.add(reference.getName());
+			}
+			if (indexType != ReferenceIndexType.NONE) {
+				everyIndexed.add(reference.getName());
+			}
+			if (reference.getFacetedPartiallyInScope(Scope.LIVE) != null) {
+				triggers.add(reference.getName());
+			}
+		}
+		partitioned.sort(String::compareTo);
+		triggers.sort(String::compareTo);
+		everyIndexed.sort(String::compareTo);
+		System.out.printf("partitioned references : %s%n", partitioned);
+		System.out.printf("conditional facets     : %s  <- these are the ONLY references a trigger fires for%n",
+			triggers);
+		System.out.printf("indexed references     : %s%n", everyIndexed);
+
+		reportCounterfactualWalkSize(collection, partitioned, everyIndexed, triggers);
+
+		// Drive the simulation from the references that actually carry a trigger. Only a reference with a
+		// `facetedPartially` expression is ever `mutation.referenceName()`, and that is the one name the walk
+		// excludes - so simulating any other reference as the mutated one measures a trigger that cannot fire.
+		final List<String> mutatedCandidates = triggers.isEmpty() ? partitioned : triggers;
+		for (final String mutated : mutatedCandidates) {
+			final ReferencedTypeEntityIndex mutatedType = typeIndex(
+				collection, Scope.LIVE, mutated, EntityIndexType.REFERENCED_ENTITY_TYPE
+			);
+			if (mutatedType == null) {
+				continue;
+			}
+			final int[] samplePartitions = samplePartitionPks(collection, mutatedType);
+			for (final int samplePk : samplePartitions) {
+				final EntityIndex sample = collection.getIndexByPrimaryKeyIfExists(samplePk);
+				if (sample == null) {
+					continue;
+				}
+				final Bitmap affected = sample.getAllPrimaryKeys();
+				if (affected.isEmpty()) {
+					continue;
+				}
+				System.out.printf(
+					"%n  trigger on `%s`, partition #%d — %,d affected owners%n",
+					mutated, samplePk, affected.size()
+				);
+				final PersistentRoaringBitmap affectedRoaring = getRoaringBitmap(affected);
+				long totalProbed = 0L;
+				long totalIntersecting = 0L;
+				for (final String sibling : partitioned) {
+					if (sibling.equals(mutated)) {
+						continue;
+					}
+					for (final EntityIndexType family : new EntityIndexType[]{
+						EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
+					}) {
+						final long[] counted = countIntersecting(
+							collection, Scope.LIVE, sibling, family, affectedRoaring
+						);
+						if (counted[0] == 0L) {
+							continue;
+						}
+						totalProbed += counted[0];
+						totalIntersecting += counted[1];
+						System.out.printf(
+							"    %-24s %-30s probed=%,7d  intersecting=%,7d  ratio=%.4f%n",
+							sibling, family, counted[0], counted[1], counted[1] / (double) counted[0]
+						);
+					}
+				}
+				System.out.printf(
+					"    %-55s probed=%,7d  intersecting=%,7d  ratio=%.4f%n",
+					"TOTAL (this is the walk, and the registration count)",
+					totalProbed, totalIntersecting,
+					totalProbed == 0L ? 0.0 : totalIntersecting / (double) totalProbed
+				);
+			}
+		}
+	}
+
+	/**
+	 * Reports how large the sibling walk would become if references currently indexed `FOR_FILTERING` were switched
+	 * to `FOR_FILTERING_AND_PARTITIONING` — the exposure that matters, because it is one schema edit away and needs
+	 * no migration, no data growth and no new entities.
+	 *
+	 * The counterfactual is **exact, not modelled**. Every indexed reference already owns a `REFERENCED_*_TYPE`
+	 * index, and that index's advertising map already holds precisely the reduced-index primary keys the walk would
+	 * visit; `FOR_FILTERING` merely stops `resolveSiblingReducedIndexes` from consulting it. Counting the map
+	 * therefore reads the future walk size directly off the present catalog.
+	 *
+	 * Two distinct escalations are reported, because they have different triggers:
+	 *
+	 * 1. **A sibling is partitioned.** Its partitions join the walk of every existing trigger.
+	 * 2. **A second reference gains a `facetedPartially` expression.** The reference that carries today's trigger is
+	 *    excluded from its own walk (`resolveSiblingReducedIndexes:449`) — but it is *not* excluded from anybody
+	 *    else's. A second trigger makes today's protected reference somebody else's sibling.
+	 *
+	 * @param collection   the collection whose references fan out
+	 * @param partitioned  references currently `FOR_FILTERING_AND_PARTITIONING`
+	 * @param everyIndexed every reference with any index at all
+	 * @param triggers     references carrying a `facetedPartially` expression
+	 */
+	private static void reportCounterfactualWalkSize(
+		@Nonnull EntityCollection collection,
+		@Nonnull List<String> partitioned,
+		@Nonnull List<String> everyIndexed,
+		@Nonnull List<String> triggers
+	) {
+		System.out.printf("%n  --- counterfactual walk size (no schema change; counts read off live indexes) ---%n");
+		long currentTotal = 0L;
+		long ifAllPartitioned = 0L;
+		for (final String reference : everyIndexed) {
+			final long advertised = advertisedPartitions(collection, reference);
+			final boolean isPartitioned = partitioned.contains(reference);
+			final boolean isTrigger = triggers.contains(reference);
+			if (isPartitioned) {
+				currentTotal += advertised;
+			}
+			ifAllPartitioned += advertised;
+			System.out.printf(
+				"    %-24s advertises %,9d partitions  %s%s%n",
+				reference, advertised,
+				isPartitioned ? "[partitioned today]" : "[FOR_FILTERING -> would join the walk if switched]",
+				isTrigger ? "  <- carries the trigger" : ""
+			);
+		}
+		System.out.printf(
+			"    %-24s %,9d  (walk today, minus whichever reference the trigger fires for)%n",
+			"TOTAL partitioned", currentTotal
+		);
+		System.out.printf(
+			"    %-24s %,9d  (every indexed reference switched to FOR_FILTERING_AND_PARTITIONING)%n",
+			"TOTAL if all switched", ifAllPartitioned
+		);
+	}
+
+	/**
+	 * Counts the reduced-index primary keys a reference's `REFERENCED_ENTITY_TYPE` and
+	 * `REFERENCED_GROUP_ENTITY_TYPE` indexes advertise, whatever its declared index type.
+	 *
+	 * @param collection    the collection holding the indexes
+	 * @param referenceName the reference to count
+	 * @return the number of partitions the reference would contribute to a sibling walk
+	 */
+	private static long advertisedPartitions(
+		@Nonnull EntityCollection collection,
+		@Nonnull String referenceName
+	) {
+		final long[] counter = new long[1];
+		for (final EntityIndexType family : new EntityIndexType[]{
+			EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
+		}) {
+			final ReferencedTypeEntityIndex typeIndex = typeIndex(collection, Scope.LIVE, referenceName, family);
+			if (typeIndex != null) {
+				typeIndex.forEachReferenceIndexPrimaryKey(pk -> counter[0]++);
+			}
+		}
+		return counter[0];
+	}
+
+	/**
+	 * Walks one type index exactly as the resolver does and counts probed and intersecting partitions.
+	 *
+	 * @param collection the collection holding the indexes
+	 * @param scope      the scope whose indexes are inspected
+	 * @param reference  the reference whose partitions are walked
+	 * @param indexType  the referenced-type index family to walk
+	 * @param affected   the affected owner PKs
+	 * @return a two-element array of `{probed, intersecting}`
+	 */
+	@Nonnull
+	private static long[] countIntersecting(
+		@Nonnull EntityCollection collection,
+		@Nonnull Scope scope,
+		@Nonnull String reference,
+		@Nonnull EntityIndexType indexType,
+		@Nonnull PersistentRoaringBitmap affected
+	) {
+		final ReferencedTypeEntityIndex typeIndex = typeIndex(collection, scope, reference, indexType);
+		if (typeIndex == null) {
+			return new long[]{0L, 0L};
+		}
+		final long[] counters = new long[]{0L, 0L};
+		typeIndex.forEachReferenceIndexPrimaryKey(reducedIndexPk -> {
+			final EntityIndex probed = collection.getIndexByPrimaryKeyIfExists(reducedIndexPk);
+			if (probed == null) {
+				return;
+			}
+			counters[0]++;
+			if (!and(getRoaringBitmap(probed.getAllPrimaryKeys()), affected).isEmpty()) {
+				counters[1]++;
+			}
+		});
+		return counters;
+	}
+
+	/**
+	 * Returns up to {@link #FANOUT_SAMPLES} partition primary keys of a type index, spread across its
+	 * advertisement order so the sample is not all taken from one end.
+	 *
+	 * @param typeIndex the type index to sample
+	 * @return the sampled reduced-index primary keys
+	 */
+	@Nonnull
+	private static int[] samplePartitionPks(
+		@Nonnull EntityCollection collection,
+		@Nonnull ReferencedTypeEntityIndex typeIndex
+	) {
+		final List<Integer> all = new ArrayList<>();
+		typeIndex.forEachReferenceIndexPrimaryKey(all::add);
+		if (all.isEmpty()) {
+			return new int[0];
+		}
+		// The DENSE shape is the one the issue cares about - a trigger touching thousands of owners - and it lives
+		// in the LARGEST partitions, which a positional sample almost never draws. Sample both ends deliberately:
+		// the biggest partitions give the dense shape, the spread gives the typical one.
+		final List<Integer> bySize = new ArrayList<>(all);
+		bySize.sort((left, right) -> Integer.compare(partitionSize(collection, right), partitionSize(collection, left)));
+
+		final int spread = Math.min(FANOUT_SAMPLES, all.size());
+		final int biggest = Math.min(FANOUT_LARGEST_SAMPLES, bySize.size());
+		final int[] sampled = new int[spread + biggest];
+		for (int i = 0; i < biggest; i++) {
+			sampled[i] = bySize.get(i);
+		}
+		for (int i = 0; i < spread; i++) {
+			sampled[biggest + i] = all.get((int) ((long) i * all.size() / spread));
+		}
+		return sampled;
+	}
+
+	/**
+	 * Returns the member count of one partition, or `0` when the index is gone.
+	 *
+	 * @param collection    the collection holding the indexes
+	 * @param reducedIndexPk the partition's storage primary key
+	 * @return the number of owners in the partition
+	 */
+	private static int partitionSize(@Nonnull EntityCollection collection, int reducedIndexPk) {
+		final EntityIndex index = collection.getIndexByPrimaryKeyIfExists(reducedIndexPk);
+		return index == null ? 0 : index.getAllPrimaryKeys().size();
+	}
+
+	/**
+	 * Returns the member count of every partition a type index advertises.
+	 *
+	 * @param collection the collection holding the indexes
+	 * @param typeIndex  the type index whose partitions are sized
+	 * @return the partition sizes, in advertisement order
+	 */
+	@Nonnull
+	private static int[] partitionSizes(
+		@Nonnull EntityCollection collection,
+		@Nonnull ReferencedTypeEntityIndex typeIndex
+	) {
+		final List<Integer> sizes = new ArrayList<>();
+		typeIndex.forEachReferenceIndexPrimaryKey(reducedIndexPk -> {
+			final EntityIndex probed = collection.getIndexByPrimaryKeyIfExists(reducedIndexPk);
+			if (probed != null) {
+				sizes.add(probed.getAllPrimaryKeys().size());
+			}
+		});
+		final int[] result = new int[sizes.size()];
+		for (int i = 0; i < result.length; i++) {
+			result[i] = sizes.get(i);
+		}
+		return result;
+	}
+
+	/**
+	 * Resolves one `REFERENCED_*_TYPE` index, or `null` when the reference has no partitions of that kind.
+	 *
+	 * @param collection    the collection holding the indexes
+	 * @param scope         the scope whose index is resolved
+	 * @param referenceName the reference whose type index is resolved
+	 * @param indexType     the referenced-type index family
+	 * @return the type index, or `null` when absent
+	 */
+	@Nullable
+	private static ReferencedTypeEntityIndex typeIndex(
+		@Nonnull EntityCollection collection,
+		@Nonnull Scope scope,
+		@Nonnull String referenceName,
+		@Nonnull EntityIndexType indexType
+	) {
+		final EntityIndex index = collection.getIndexByKeyIfExists(
+			new EntityIndexKey(indexType, scope, referenceName)
+		);
+		if (index == null) {
+			return null;
+		}
+		if (index instanceof final ReferencedTypeEntityIndex typeIndex) {
+			return typeIndex;
+		}
+		// an index registered under a REFERENCED_*_TYPE key is a ReferencedTypeEntityIndex by construction, so
+		// anything else means the census is reading a structure it does not understand - never skip it silently
+		throw new IllegalStateException(
+			"Index " + indexType + "/" + referenceName + " in " + scope + " is a " +
+				index.getClass().getName() + ", not a ReferencedTypeEntityIndex!"
+		);
+	}
+
+	/**
+	 * Waits until the catalog finishes its background load and becomes a usable {@link Catalog}.
+	 *
+	 * @param evita       the running engine
+	 * @param catalogName the catalog to wait for
+	 * @return the loaded catalog
+	 */
+	@Nonnull
+	private static Catalog awaitLoaded(@Nonnull Evita evita, @Nonnull String catalogName) {
+		final long deadline = System.nanoTime() + LOAD_TIMEOUT_NANOS;
+		while (System.nanoTime() < deadline) {
+			final CatalogContract candidate = evita.getCatalogInstance(catalogName)
+				.orElseThrow(() -> new IllegalArgumentException("Catalog `" + catalogName + "` not found!"));
+			if (candidate instanceof final Catalog loaded) {
+				return loaded;
+			}
+			try {
+				Thread.sleep(500L);
+			} catch (final InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new IllegalStateException("Interrupted while waiting for catalog `" + catalogName + "`!", e);
+			}
+		}
+		throw new IllegalStateException(
+			"Catalog `" + catalogName + "` did not become usable within the load timeout!"
+		);
+	}
+
+	/**
+	 * Not instantiable — this is a `main()`-style report.
+	 */
+	private ConditionalFacetPartitionCensus() {
+	}
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetPartitionExistenceProbe.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetPartitionExistenceProbe.java
@@ -1,0 +1,239 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spike;
+
+import io.evitadb.api.CatalogContract;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.configuration.ThreadPoolOptions;
+import io.evitadb.api.index.EntityIndexType;
+import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
+import io.evitadb.core.Evita;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.dataType.Scope;
+import io.evitadb.index.EntityIndex;
+import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.ReferencedTypeEntityIndex;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Answers one question, with counts and nothing else: **do reduced partition indexes exist for references
+ * indexed at {@link ReferenceIndexType#FOR_FILTERING}, or only for
+ * {@link ReferenceIndexType#FOR_FILTERING_AND_PARTITIONING} ones?**
+ *
+ * The answer decides what the `#1529` high-cardinality counterfactual actually costs to reach:
+ *
+ * - **If the partitions already exist at `FOR_FILTERING`**, flipping the schema flag only widens the filter in
+ *   `ReevaluateExpressionExecutor#resolveSiblingReducedIndexes`, and the walk grows the instant the schema
+ *   change commits. The exposure is one schema edit away, exactly as issue #1529 states.
+ * - **If they do not**, the flag change builds nothing retroactively — `ReferenceIndexMutator` creates a
+ *   reduced index only when a reference is written — so the partitions accumulate as entities are rewritten,
+ *   and the exposure is one schema edit *plus a republish cycle* away.
+ *
+ * `ReferenceIndexMutator#collectOwnerReducedIndexes` documents the second answer ("the only ones for which
+ * reduced indexes exist at all"), while the `#1529` census counted 183,754 resolvable partition primary keys
+ * advertised by `FOR_FILTERING` references' type indexes. Both cannot be right, and a timing harness that
+ * walks partitions which would not exist measures nothing. Hence this probe, which resolves every advertised
+ * primary key and reports what it actually found.
+ *
+ * ```
+ * java -Xmx32g -cp <cp> io.evitadb.spike.ConditionalFacetPartitionExistenceProbe <dir> <catalog> <collection>
+ * ```
+ *
+ * @author Claude (issue #1529 partition-existence probe), FG Forrest a.s. (c) 2026
+ */
+public class ConditionalFacetPartitionExistenceProbe {
+
+	/**
+	 * How long the probe waits for the catalog's background load to finish before giving up.
+	 */
+	private static final long LOAD_TIMEOUT_NANOS = 15L * 60L * 1_000_000_000L;
+
+	public static void main(@Nonnull String[] args) {
+		if (args.length < 3) {
+			System.err.println(
+				"Usage: ConditionalFacetPartitionExistenceProbe <storageDir> <catalogName> <collection>"
+			);
+			System.exit(1);
+		}
+		final Path storageDirectory = Path.of(args[0]);
+		final String catalogName = args[1];
+		final String collectionName = args[2];
+
+		try (
+			final Evita evita = new Evita(
+				EvitaConfiguration.builder()
+					.storage(StorageOptions.builder().storageDirectory(storageDirectory).build())
+					.server(
+						ServerOptions.builder()
+							.requestThreadPool(ThreadPoolOptions.requestThreadPoolBuilder().build())
+							.build()
+					)
+					.build()
+			)
+		) {
+			final Catalog catalog = awaitLoaded(evita, catalogName);
+			final EntityCollection collection = catalog.getCollectionForEntityOrThrowException(collectionName);
+
+			System.out.printf("%n=== `%s` reduced-partition existence by reference index type ===%n%n",
+				collectionName);
+			System.out.printf(
+				"  %-22s %-32s %8s %10s %10s %10s  %s%n",
+				"reference", "index type", "family", "advertised", "resolved", "members", "resolved class"
+			);
+
+			long partitionedAdvertised = 0L;
+			long partitionedResolved = 0L;
+			long filteringAdvertised = 0L;
+			long filteringResolved = 0L;
+
+			for (final ReferenceSchemaContract reference :
+				new TreeMap<>(collection.getSchema().getReferences()).values()) {
+				final ReferenceIndexType indexType = reference.getReferenceIndexType(Scope.LIVE);
+				for (final EntityIndexType family : new EntityIndexType[]{
+					EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
+				}) {
+					final ReferencedTypeEntityIndex typeIndex = typeIndex(collection, family, reference.getName());
+					if (typeIndex == null) {
+						continue;
+					}
+					final long[] counters = new long[3];
+					final String[] resolvedClass = new String[1];
+					typeIndex.forEachReferenceIndexPrimaryKey(pk -> {
+						counters[0]++;
+						final EntityIndex partition = collection.getIndexByPrimaryKeyIfExists(pk);
+						if (partition != null) {
+							counters[1]++;
+							counters[2] += partition.getAllPrimaryKeys().size();
+							if (resolvedClass[0] == null) {
+								resolvedClass[0] = partition.getClass().getSimpleName()
+									+ "/" + partition.getIndexKey().type();
+							}
+						}
+					});
+					if (counters[0] == 0L) {
+						continue;
+					}
+					System.out.printf(
+						"  %-22s %-32s %8s %,10d %,10d %,10d  %s%n",
+						reference.getName(), indexType,
+						family == EntityIndexType.REFERENCED_ENTITY_TYPE ? "entity" : "group",
+						counters[0], counters[1], counters[2],
+						resolvedClass[0] == null ? "-" : resolvedClass[0]
+					);
+					if (indexType == ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING) {
+						partitionedAdvertised += counters[0];
+						partitionedResolved += counters[1];
+					} else {
+						filteringAdvertised += counters[0];
+						filteringResolved += counters[1];
+					}
+				}
+			}
+
+			System.out.printf(
+				"%n  FOR_FILTERING_AND_PARTITIONING: %,d advertised, %,d resolved to a live index%n",
+				partitionedAdvertised, partitionedResolved
+			);
+			System.out.printf(
+				"  FOR_FILTERING:                  %,d advertised, %,d resolved to a live index%n%n",
+				filteringAdvertised, filteringResolved
+			);
+			System.out.println(
+				filteringResolved > 0L
+					? "  VERDICT: reduced partitions DO exist for FOR_FILTERING references. Flipping the flag\n"
+					+ "           widens the walk immediately - the exposure is one schema edit away."
+					: "  VERDICT: reduced partitions exist ONLY for FOR_FILTERING_AND_PARTITIONING references.\n"
+					+ "           Flipping the flag builds nothing retroactively - the walk grows only as\n"
+					+ "           entities are rewritten, so the exposure is one schema edit plus a republish."
+			);
+		}
+	}
+
+	/**
+	 * Resolves one `REFERENCED_*_TYPE` index of a reference.
+	 *
+	 * @param collection    the collection holding the indexes
+	 * @param family        the referenced-type index family
+	 * @param referenceName the reference whose type index is resolved
+	 * @return the type index, or `null` when the reference has none of that kind
+	 */
+	@Nullable
+	private static ReferencedTypeEntityIndex typeIndex(
+		@Nonnull EntityCollection collection,
+		@Nonnull EntityIndexType family,
+		@Nonnull String referenceName
+	) {
+		final EntityIndex index = collection.getIndexByKeyIfExists(
+			new EntityIndexKey(family, Scope.LIVE, referenceName)
+		);
+		if (index == null) {
+			return null;
+		}
+		if (index instanceof final ReferencedTypeEntityIndex typeIndex) {
+			return typeIndex;
+		}
+		throw new IllegalStateException("Index " + family + "/" + referenceName + " has the wrong type!");
+	}
+
+	/**
+	 * Waits until the catalog finishes its background load.
+	 *
+	 * @param evita       the running engine
+	 * @param catalogName the catalog to wait for
+	 * @return the loaded catalog
+	 */
+	@Nonnull
+	private static Catalog awaitLoaded(@Nonnull Evita evita, @Nonnull String catalogName) {
+		final long deadline = System.nanoTime() + LOAD_TIMEOUT_NANOS;
+		while (System.nanoTime() < deadline) {
+			final CatalogContract candidate = evita.getCatalogInstance(catalogName)
+				.orElseThrow(() -> new IllegalArgumentException("Catalog `" + catalogName + "` not found!"));
+			if (candidate instanceof final Catalog loaded) {
+				return loaded;
+			}
+			try {
+				Thread.sleep(500L);
+			} catch (final InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new IllegalStateException("Interrupted while waiting for catalog!", e);
+			}
+		}
+		throw new IllegalStateException("Catalog `" + catalogName + "` did not load in time!");
+	}
+
+	/**
+	 * Not instantiable — this is a `main()`-style probe.
+	 */
+	private ConditionalFacetPartitionExistenceProbe() {
+	}
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetPartitionExistenceProbe.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetPartitionExistenceProbe.java
@@ -42,7 +42,6 @@ import io.evitadb.index.ReferencedTypeEntityIndex;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.TreeMap;
 
 /**

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetPartitionExistenceProbe.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetPartitionExistenceProbe.java
@@ -58,11 +58,14 @@ import java.util.TreeMap;
  *   reduced index only when a reference is written — so the partitions accumulate as entities are rewritten,
  *   and the exposure is one schema edit *plus a republish cycle* away.
  *
- * `ReferenceIndexMutator#collectOwnerReducedIndexes` documents the second answer ("the only ones for which
- * reduced indexes exist at all"), while the `#1529` census counted 183,754 resolvable partition primary keys
- * advertised by `FOR_FILTERING` references' type indexes. Both cannot be right, and a timing harness that
- * walks partitions which would not exist measures nothing. Hence this probe, which resolves every advertised
- * primary key and reports what it actually found.
+ * The two answers were once in open contradiction: `ReferenceIndexMutator#collectOwnerReducedIndexes` claimed
+ * the second ("the only ones for which reduced indexes exist at all"), while the `#1529` census counted
+ * 183,754 resolvable partition primary keys advertised by `FOR_FILTERING` references' type indexes. This probe
+ * settled it by resolving every advertised primary key and reporting what it actually found: **the partitions
+ * already exist at `FOR_FILTERING`** — the first answer. That javadoc was corrected accordingly and now says
+ * what the restriction really is (reduced indexes exist for every reference indexed at `FOR_FILTERING` or
+ * above; only the FACETS inside them are confined to `FOR_FILTERING_AND_PARTITIONING`). The probe is kept
+ * because it is the measurement behind that correction, and re-running it is how the answer stays checked.
  *
  * ```
  * java -Xmx32g -cp <cp> io.evitadb.spike.ConditionalFacetPartitionExistenceProbe <dir> <catalog> <collection>

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetReverseIndexFootprint.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetReverseIndexFootprint.java
@@ -67,7 +67,7 @@ import java.util.PrimitiveIterator.OfInt;
  * # Why it is built the expensive way
  *
  * The map is built here as a {@link TransactionalMap} of {@link TransactionalBitmap}, which is the **only** shape
- * that could ship. A plain `Map<Integer, int[]>` would be roughly half the size, and is disqualified: it is not a
+ * that could ship. A plain {@code Map<Integer, int[]>} would be roughly half the size, and is disqualified: it is not a
  * `TransactionalLayerCreator`, so it never reaches `WarmUpSavepoint#verifyRollbackSupported`, and a rolled-back
  * transaction or a failed warm-up mutation would leave it silently diverged from the indexes it mirrors. The
  * `int[]` figure is still reported, as the floor a bespoke rollback-capable structure could aim at — never as a

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetReverseIndexFootprint.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetReverseIndexFootprint.java
@@ -1,0 +1,356 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spike;
+
+import io.evitadb.api.CatalogContract;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.configuration.ThreadPoolOptions;
+import io.evitadb.api.index.EntityIndexType;
+import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
+import io.evitadb.core.Evita;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.dataType.Scope;
+import io.evitadb.index.EntityIndex;
+import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.ReferencedTypeEntityIndex;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.TransactionalBitmap;
+import io.evitadb.index.map.TransactionalMap;
+import io.evitadb.utils.CollectionUtils;
+import io.evitadb.utils.VMLayout;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.PrimitiveIterator.OfInt;
+
+/**
+ * Prices the `ownerPK -> reduced-index-PK` reverse map proposed in issue #1529, against a real catalog, and sets
+ * that price beside the work it would remove.
+ *
+ * # The question
+ *
+ * The reverse map turns the sibling resolver's walk from `O(all partitions of the collection)` into
+ * `O(affected owners x partitions per owner)`. The cost is a permanent, resident structure on every
+ * {@link ReferencedTypeEntityIndex}. Whether that trade is worth taking cannot be argued from the shape of the
+ * structure — it depends on how many *owners* a real reference has and how many partitions each sits in, which is
+ * a property of somebody's catalog.
+ *
+ * # Why it is built the expensive way
+ *
+ * The map is built here as a {@link TransactionalMap} of {@link TransactionalBitmap}, which is the **only** shape
+ * that could ship. A plain `Map<Integer, int[]>` would be roughly half the size, and is disqualified: it is not a
+ * `TransactionalLayerCreator`, so it never reaches `WarmUpSavepoint#verifyRollbackSupported`, and a rolled-back
+ * transaction or a failed warm-up mutation would leave it silently diverged from the indexes it mirrors. The
+ * `int[]` figure is still reported, as the floor a bespoke rollback-capable structure could aim at — never as a
+ * candidate.
+ *
+ * Pricing goes through the engine's **own** heap accounting
+ * ({@link TransactionalMap#getHeapSizeInBytes}, {@link TransactionalBitmap#getHeapSizeInBytes}), the same call the
+ * index-detail statistics surface uses — not JOL, whose graph walk dies on the decorator's lambda and which would
+ * in any case follow references the map merely borrows.
+ *
+ * # Every reference, not only the partitioned ones
+ *
+ * A reference indexed `FOR_FILTERING` still owns a `REFERENCED_*_TYPE` index whose advertising map already holds
+ * the partitions it *would* contribute the moment its index type is switched to
+ * `FOR_FILTERING_AND_PARTITIONING`. Since that switch is one schema edit — and one the enum's own javadoc
+ * recommends for references that are filtered on hard — the cost of the reverse map is reported for **every**
+ * indexed reference, so both the current bill and the one a client can trigger are visible.
+ *
+ * ```
+ * java -Xmx48g -cp <cp> io.evitadb.spike.ConditionalFacetReverseIndexFootprint <dir> <catalog> <collection>
+ * ```
+ *
+ * @author Claude (issue #1529 reverse-index footprint), FG Forrest a.s. (c) 2026
+ */
+public class ConditionalFacetReverseIndexFootprint {
+
+	/**
+	 * How long the probe waits for the catalog's background load to finish before giving up.
+	 */
+	private static final long LOAD_TIMEOUT_NANOS = 15L * 60L * 1_000_000_000L;
+
+	public static void main(@Nonnull String[] args) {
+		if (args.length < 3) {
+			System.err.println(
+				"Usage: ConditionalFacetReverseIndexFootprint <storageDirectory> <catalogName> <collection>"
+			);
+			System.exit(1);
+		}
+		final Path storageDirectory = Path.of(args[0]);
+		final String catalogName = args[1];
+		final String collectionName = args[2];
+
+		try (
+			final Evita evita = new Evita(
+				EvitaConfiguration.builder()
+					.storage(StorageOptions.builder().storageDirectory(storageDirectory).build())
+					.server(
+						ServerOptions.builder()
+							.requestThreadPool(ThreadPoolOptions.requestThreadPoolBuilder().build())
+							.build()
+					)
+					.build()
+			)
+		) {
+			final Catalog catalog = awaitLoaded(evita, catalogName);
+			final EntityCollection collection = catalog.getCollectionForEntityOrThrowException(collectionName);
+			System.out.printf(
+				"Catalog version %d, state %s — collection `%s`: %,d entities, %,d indexes%n%n",
+				catalog.getVersion(), catalog.getCatalogState(), collectionName,
+				collection.size(), collection.getIndexCount()
+			);
+
+			final List<String> references = new ArrayList<>();
+			for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
+				if (reference.getReferenceIndexType(Scope.LIVE) != ReferenceIndexType.NONE) {
+					references.add(reference.getName());
+				}
+			}
+			references.sort(String::compareTo);
+
+			// The sweep. `Integer.MAX_VALUE` is the blanket structure the issue proposes; every lower threshold
+			// is the hybrid, which trades a bounded residual walk for a much smaller map.
+			final int[] thresholds = {1, 4, 16, 64, 256, 1024, 4096, Integer.MAX_VALUE};
+			for (final int threshold : thresholds) {
+				System.out.printf(
+					"%n=== threshold T=%s — partitions with more than T owners stay on the walk ===%n",
+					threshold == Integer.MAX_VALUE ? "unbounded (blanket structure)" : Integer.toString(threshold)
+				);
+				System.out.printf(
+					"%-22s %-12s %10s %12s %12s %14s %12s %12s%n",
+					"reference", "state", "partitions", "owners", "memberships", "reverse map",
+					"walk left", "B/probe"
+				);
+				System.out.println("-".repeat(112));
+				long partitionedBytes = 0L;
+				long partitionedPartitions = 0L;
+				long partitionedResidual = 0L;
+				long allBytes = 0L;
+				long allPartitions = 0L;
+				long allResidual = 0L;
+				for (final String reference : references) {
+					final ReferenceSchemaContract schema = collection.getSchema()
+						.getReference(reference).orElseThrow();
+					final boolean partitioned = schema.getReferenceIndexType(Scope.LIVE)
+						== ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING;
+					final Reading reading = measure(collection, reference, threshold);
+					if (reading.partitions == 0L) {
+						continue;
+					}
+					final long saved = reading.partitions - reading.residualProbes;
+					System.out.printf(
+						"%-22s %-12s %,10d %,12d %,12d %,11d B %,12d %,12d%n",
+						reference, partitioned ? "PARTITIONED" : "for-filter",
+						reading.partitions, reading.owners, reading.memberships,
+						reading.transactionalBytes, reading.residualProbes,
+						saved == 0L ? 0L : reading.transactionalBytes / saved
+					);
+					allBytes += reading.transactionalBytes;
+					allPartitions += reading.partitions;
+					allResidual += reading.residualProbes;
+					if (partitioned) {
+						partitionedBytes += reading.transactionalBytes;
+						partitionedPartitions += reading.partitions;
+						partitionedResidual += reading.residualProbes;
+					}
+				}
+				System.out.println("-".repeat(112));
+				final long partitionedSaved = partitionedPartitions - partitionedResidual;
+				final long allSaved = allPartitions - allResidual;
+				System.out.printf(
+					"%-35s P=%,9d  map=%,11d B  walk left=%,8d  %,10d B/probe%n",
+					"TOTAL partitioned today", partitionedPartitions, partitionedBytes, partitionedResidual,
+					partitionedSaved == 0L ? 0L : partitionedBytes / partitionedSaved
+				);
+				System.out.printf(
+					"%-35s P=%,9d  map=%,11d B  walk left=%,8d  %,10d B/probe%n",
+					"TOTAL if all switched", allPartitions, allBytes, allResidual,
+					allSaved == 0L ? 0L : allBytes / allSaved
+				);
+			}
+		}
+	}
+
+	/**
+	 * Builds the reverse map for one reference from its live indexes and prices it.
+	 *
+	 * The map is discarded before the next reference is measured, so peak heap stays at one reference's worth
+	 * rather than the whole collection's.
+	 *
+	 * @param collection    the collection holding the indexes
+	 * @param referenceName the reference to price
+	 * @return the reading for this reference
+	 */
+	@Nonnull
+	private static Reading measure(
+		@Nonnull EntityCollection collection,
+		@Nonnull String referenceName,
+		int threshold
+	) {
+		final Map<Integer, TransactionalBitmap> reverse = CollectionUtils.createHashMap(1024);
+		long partitions = 0L;
+		long residualProbes = 0L;
+		for (final EntityIndexType family : new EntityIndexType[]{
+			EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
+		}) {
+			final ReferencedTypeEntityIndex typeIndex = typeIndex(collection, family, referenceName);
+			if (typeIndex == null) {
+				continue;
+			}
+			final long[] counter = new long[2];
+			typeIndex.forEachReferenceIndexPrimaryKey(reducedIndexPk -> {
+				final EntityIndex partition = collection.getIndexByPrimaryKeyIfExists(reducedIndexPk);
+				if (partition == null) {
+					return;
+				}
+				counter[0]++;
+				// The hybrid split. A partition contributes one entry per owner to the map but saves exactly ONE
+				// probe, so covering a large partition is the worst possible trade - it is left to the walk
+				// instead, and the residual walk is bounded by (total memberships / threshold).
+				final int size = partition.getAllPrimaryKeys().size();
+				if (size > threshold) {
+					counter[1]++;
+					return;
+				}
+				// this is the maintenance the write path would perform at each owner-membership boundary:
+				// one entry per (owner, partition) pair the owner belongs to
+				final OfInt owners = partition.getAllPrimaryKeys().iterator();
+				while (owners.hasNext()) {
+					reverse.computeIfAbsent(owners.nextInt(), __ -> new TransactionalBitmap(new BaseBitmap()))
+						.add(reducedIndexPk);
+				}
+			});
+			partitions += counter[0];
+			residualProbes += counter[1];
+		}
+
+		final VMLayout layout = VMLayout.current();
+		final long boxedInteger = layout.sizeOfObject(Integer.BYTES);
+		long memberships = 0L;
+		long intArrayFloor = 0L;
+		for (final TransactionalBitmap bitmap : reverse.values()) {
+			final int size = bitmap.size();
+			memberships += size;
+			// what a sorted int[] per owner would cost instead: the array object plus its payload. Reported as a
+			// floor only - a plain int[] map cannot ship, see the class javadoc
+			intArrayFloor += layout.sizeOfObject((long) size * Integer.BYTES) + boxedInteger;
+		}
+
+		final long transactionalBytes = new TransactionalMap<>(reverse)
+			.getHeapSizeInBytes(key -> boxedInteger, TransactionalBitmap::getHeapSizeInBytes);
+
+		return new Reading(partitions, reverse.size(), memberships, transactionalBytes, intArrayFloor,
+			residualProbes);
+	}
+
+	/**
+	 * Resolves one `REFERENCED_*_TYPE` index of a reference, whatever its declared index type.
+	 *
+	 * @param collection    the collection holding the indexes
+	 * @param family        the referenced-type index family
+	 * @param referenceName the reference whose type index is resolved
+	 * @return the type index, or `null` when the reference has none of that kind
+	 */
+	@Nullable
+	private static ReferencedTypeEntityIndex typeIndex(
+		@Nonnull EntityCollection collection,
+		@Nonnull EntityIndexType family,
+		@Nonnull String referenceName
+	) {
+		final EntityIndex index = collection.getIndexByKeyIfExists(
+			new EntityIndexKey(family, Scope.LIVE, referenceName)
+		);
+		if (index == null) {
+			return null;
+		}
+		if (index instanceof final ReferencedTypeEntityIndex typeIndex) {
+			return typeIndex;
+		}
+		// an index registered under a REFERENCED_*_TYPE key is a ReferencedTypeEntityIndex by construction
+		throw new IllegalStateException(
+			"Index " + family + "/" + referenceName + " is a " + index.getClass().getName() + "!"
+		);
+	}
+
+	/**
+	 * Waits until the catalog finishes its background load and becomes a usable {@link Catalog}.
+	 *
+	 * @param evita       the running engine
+	 * @param catalogName the catalog to wait for
+	 * @return the loaded catalog
+	 */
+	@Nonnull
+	private static Catalog awaitLoaded(@Nonnull Evita evita, @Nonnull String catalogName) {
+		final long deadline = System.nanoTime() + LOAD_TIMEOUT_NANOS;
+		while (System.nanoTime() < deadline) {
+			final CatalogContract candidate = evita.getCatalogInstance(catalogName)
+				.orElseThrow(() -> new IllegalArgumentException("Catalog `" + catalogName + "` not found!"));
+			if (candidate instanceof final Catalog loaded) {
+				return loaded;
+			}
+			try {
+				Thread.sleep(500L);
+			} catch (final InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new IllegalStateException("Interrupted while waiting for catalog!", e);
+			}
+		}
+		throw new IllegalStateException("Catalog `" + catalogName + "` did not load in time!");
+	}
+
+	/**
+	 * One reference's reverse-map reading.
+	 *
+	 * @param partitions         how many partitions the reference advertises
+	 * @param owners             distinct owner PKs the reverse map would key on
+	 * @param memberships        total `(owner, partition)` pairs the map would hold
+	 * @param transactionalBytes owned heap of the shippable `TransactionalMap`/`TransactionalBitmap` shape
+	 * @param intArrayFloorBytes owned heap a sorted `int[]` per owner would need instead — a floor, not an option
+	 * @param residualProbes     partitions left above the threshold, which the walk must still visit
+	 */
+	private record Reading(
+		long partitions,
+		long owners,
+		long memberships,
+		long transactionalBytes,
+		long intArrayFloorBytes,
+		long residualProbes
+	) {
+	}
+
+	/**
+	 * Not instantiable — this is a `main()`-style report.
+	 */
+	private ConditionalFacetReverseIndexFootprint() {
+	}
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetReverseIndexFootprint.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetReverseIndexFootprint.java
@@ -59,10 +59,13 @@ import java.util.PrimitiveIterator.OfInt;
  * # The question
  *
  * The reverse map turns the sibling resolver's walk from `O(all partitions of the collection)` into
- * `O(affected owners x partitions per owner)`. The cost is a permanent, resident structure on every
- * {@link ReferencedTypeEntityIndex}. Whether that trade is worth taking cannot be argued from the shape of the
- * structure — it depends on how many *owners* a real reference has and how many partitions each sits in, which is
- * a property of somebody's catalog.
+ * `O(affected owners x partitions per owner)`. The cost is a permanent, resident structure, priced here at the
+ * placement this harness was written to evaluate — one per {@link ReferencedTypeEntityIndex}. That is a
+ * *candidate* placement and not where the structure landed: `ReducedIndexMembership` hangs off
+ * `GlobalEntityIndex`, keyed by reference name. The pricing carries over unchanged, because it is a function of
+ * the owners and partitions of one reference either way. Whether the trade is worth taking cannot be argued
+ * from the shape of the structure — it depends on how many *owners* a real reference has and how many
+ * partitions each sits in, which is a property of somebody's catalog.
  *
  * # Why it is built the expensive way
  *
@@ -209,6 +212,8 @@ public class ConditionalFacetReverseIndexFootprint {
 	 *
 	 * @param collection    the collection holding the indexes
 	 * @param referenceName the reference to price
+	 * @param threshold     maximum owners a partition may hold and still be covered by the map; larger ones are
+	 *                      counted as residual probes instead
 	 * @return the reading for this reference
 	 */
 	@Nonnull

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetSiblingResolverReport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetSiblingResolverReport.java
@@ -1,0 +1,778 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spike;
+
+import com.carrotsearch.hppc.IntObjectHashMap;
+import com.carrotsearch.hppc.IntObjectMap;
+import io.evitadb.api.CatalogContract;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.configuration.ThreadPoolOptions;
+import io.evitadb.api.index.EntityIndexType;
+import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
+import io.evitadb.core.Evita;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.core.transaction.Transaction;
+import io.evitadb.dataType.Scope;
+import io.evitadb.index.EntityIndex;
+import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.ReferencedTypeEntityIndex;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.bitmap.TransactionalBitmap;
+import io.evitadb.roaringbitmap.PersistentRoaringBitmap;
+import io.evitadb.utils.CollectionUtils;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.PrimitiveIterator.OfInt;
+
+import static io.evitadb.index.bitmap.RoaringBitmapBackedBitmap.getRoaringBitmap;
+import static io.evitadb.roaringbitmap.PersistentRoaringBitmap.and;
+import static io.evitadb.roaringbitmap.PersistentRoaringBitmap.intersects;
+
+/**
+ * Times the sibling-resolver walk of issue #1529 against a real catalog, in the three shapes that matter, and
+ * reports the one number the whole decision still lacks: **nanoseconds per probed partition**.
+ *
+ * # The arms
+ *
+ * - **A** — the pre-`5db4385e1` walk: a boxed `getAllTrackedReferencedEntityPrimaryKeys()` keySet, then
+ *   `getAllReferenceIndexes(pk)` per key, which hashes into the same map a second time and allocates an `int[]`
+ *   plus two `Optional`s per entry.
+ * - **B** — current `HEAD`: `forEachReferenceIndexPrimaryKey`, one `entrySet` pass, nothing allocated per
+ *   partition. Shipped on a cost model alone; this puts a number on it.
+ * - **C** — the hybrid reverse index: an `ownerPK -> partitionPK` map covering only partitions of at most `T`
+ *   owners, with the (few) larger partitions left on the walk.
+ * - **D** — arm B with the per-partition `getIndexByPrimaryKeyIfExists` replaced by a plain int-keyed hash get.
+ *   `B - D` is therefore the **ceiling** on everything an index-lookup optimization could recover: the
+ *   `ThreadLocal` read, the transactional-layer resolution, the `Optional` and the two capturing lambdas the
+ *   engine accessor allocates per partition. No engine change can beat a bare hash lookup, so no engine change
+ *   can recover more than this.
+ * - **E** — arm D with the partition bitmaps pre-resolved too, so the probe is the `and()` and nothing else.
+ *   `D - E` is the ceiling on hoisting `TransactionalBitmap#getRoaringBitmap`, and `E` is the irreducible
+ *   intersection cost that no amount of lookup work removes.
+ *
+ * - **F** — arm B with an allocation-free `PersistentRoaringBitmap#intersects` gate in front of the `and()`.
+ *   The walk materialises an intersection bitmap plus an `int[]` for **every** probed partition, including the
+ *   overwhelming majority that share no owner with the affected set at all. `intersects` short-circuits on the
+ *   first common bit and allocates nothing, so the `and()` runs only where it produces something. Unlike D and
+ *   E this one is implementable as written — it changes only the order of two operations that already exist.
+ *
+ * D and E are **not implementable** as they stand — a real walk cannot pre-resolve a transactional bitmap and
+ * still see the transaction's own writes. They exist to bound what step 1 of the #1529 plan (hoisting the
+ * loop-invariant transaction resolution) could ever be worth, before that seam is cut into the engine.
+ *
+ * All three are **probe-only**: they stop at the intersection and never call `getOrCreateIndexByPrimaryKey`.
+ * That matches how the 2026-09-09 decomposition defined "the walk" (0.47 ms) against the whole resolver
+ * (2.0 ms), and it keeps the arms read-only so they can share one live catalog.
+ *
+ * Every arm is checksummed on the `(owner, partition)` pairs it emits, with an order-independent accumulator, so
+ * an arm that computes a different answer cannot be compared as if it were faster.
+ *
+ * # Two series, never mixed
+ *
+ * - **WARM** — all arms back to back inside one round, order rotated per round, paired deltas. This answers
+ *   *which arm is faster* and is the only shape with the statistical power to do so: a cross-JVM A/B on this
+ *   loop once produced a confident +11.6 % (p=0.004) that failed to reproduce at +0.5 %.
+ * - **COLD** — one arm per round, with the working set evicted by streaming a buffer larger than the LLC
+ *   **outside** the timed region. This is the only series that can answer whether the per-partition constant
+ *   degrades once the partition set exceeds cache, because after the first warm round nothing is ever cold
+ *   again. Rotation cancels bias *between* arms; it does not make any measurement cold.
+ *
+ * # Bound transaction, deliberately
+ *
+ * Production triggers run inside a transaction, and two of the walk's per-partition costs exist only then:
+ * `TransactionalBitmap#getRoaringBitmap` and `TransactionalDataStoreMemoryBuffer#getIndexIfExists` each resolve
+ * a transactional layer, where the `WARM_UP` buffer calls straight through. Measuring without one understates
+ * `ALIVE` — the wrong direction of error for this issue. The same walk is therefore also measured *without* a
+ * bound transaction, and the difference is reported as a result: it is the ceiling on what hoisting the
+ * loop-invariant transaction resolution out of the loop could ever recover.
+ *
+ * ```
+ * java -Xmx48g -cp <cp> io.evitadb.spike.ConditionalFacetSiblingResolverReport <dir> <catalog> <collection> [T]
+ * ```
+ *
+ * @author Claude (issue #1529 sibling-resolver timing), FG Forrest a.s. (c) 2026
+ */
+public class ConditionalFacetSiblingResolverReport {
+
+	/**
+	 * How long the report waits for the catalog's background load to finish before giving up.
+	 */
+	private static final long LOAD_TIMEOUT_NANOS = 15L * 60L * 1_000_000_000L;
+
+	/**
+	 * Rounds of the warm series — each runs all arms back to back with their order rotated.
+	 */
+	private static final int WARM_ROUNDS = 400;
+
+	/**
+	 * Rounds of the cold series. One arm per round, so the per-arm sample is a third of this; the cold series
+	 * needs more rounds than the warm one for the same confidence because it has no pairing.
+	 */
+	private static final int COLD_ROUNDS = 180;
+
+	/**
+	 * Rounds discarded before recording, so the arms are compared at steady state rather than during
+	 * interpretation and OSR compilation.
+	 */
+	private static final int WARMUP_ROUNDS = 60;
+
+	/**
+	 * Eviction buffer for the cold series: comfortably more than twice the 16 MiB LLC of the measured box, so a
+	 * single streaming pass leaves nothing of the partition working set resident.
+	 */
+	private static final int EVICTION_BYTES = 128 * 1024 * 1024;
+
+	/**
+	 * Sink the eviction pass sums into, so the JIT cannot delete the pass it exists to perform.
+	 */
+	@SuppressWarnings("unused")
+	private static volatile long evictionSink;
+
+	public static void main(@Nonnull String[] args) {
+		if (args.length < 3) {
+			System.err.println(
+				"Usage: ConditionalFacetSiblingResolverReport <storageDir> <catalogName> <collection> [threshold]"
+			);
+			System.exit(1);
+		}
+		final Path storageDirectory = Path.of(args[0]);
+		final String catalogName = args[1];
+		final String collectionName = args[2];
+		final int threshold = args.length > 3 ? Integer.parseInt(args[3]) : 16;
+		// The counterfactual: references that are FOR_FILTERING today but would join the walk the moment a
+		// client switches them to FOR_FILTERING_AND_PARTITIONING. Their type indexes already advertise exactly
+		// the partitions the walk would visit, so the switch can be simulated without touching the schema.
+		final List<String> extraSiblings = args.length > 4 && !args[4].isBlank()
+			? new ArrayList<>(List.of(args[4].split(",")))
+			: List.of();
+
+		try (
+			final Evita evita = new Evita(
+				EvitaConfiguration.builder()
+					.storage(StorageOptions.builder().storageDirectory(storageDirectory).build())
+					.server(
+						ServerOptions.builder()
+							.requestThreadPool(ThreadPoolOptions.requestThreadPoolBuilder().build())
+							.build()
+					)
+					.build()
+			)
+		) {
+			final Catalog catalog = awaitLoaded(evita, catalogName);
+			final EntityCollection collection = catalog.getCollectionForEntityOrThrowException(collectionName);
+
+			final List<String> partitioned = new ArrayList<>();
+			String trigger = null;
+			for (final ReferenceSchemaContract reference : collection.getSchema().getReferences().values()) {
+				if (reference.getReferenceIndexType(Scope.LIVE)
+					== ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING) {
+					partitioned.add(reference.getName());
+				}
+				if (reference.getFacetedPartiallyInScope(Scope.LIVE) != null) {
+					trigger = reference.getName();
+				}
+			}
+			partitioned.addAll(extraSiblings);
+			partitioned.sort(String::compareTo);
+			// the walk excludes the reference the trigger fires for; on a schema with no conditional facet at
+			// all there is nothing to exclude and every partitioned reference is a sibling
+			final String mutated = trigger;
+			partitioned.remove(mutated);
+
+			final Walk walk = new Walk(collection, partitioned, threshold);
+			System.out.printf(
+				"catalog v%d %s | collection `%s` | trigger `%s` | siblings %s%n",
+				catalog.getVersion(), catalog.getCatalogState(), collectionName, mutated, partitioned
+			);
+			System.out.printf(
+				"partitions: %,d probed by the walk, %,d covered by the reverse map at T=%d, %,d left on it%n",
+				walk.totalPartitions, walk.coveredPartitions, threshold, walk.residualPartitions
+			);
+			System.out.printf(
+				"reverse map: %,d owners, %,d memberships%n%n", walk.reverse.size(), walk.memberships
+			);
+
+			for (final Shape shape : shapes(collection, mutated)) {
+				System.out.printf("=== %s — %,d affected owners ===%n", shape.name, shape.owners.size());
+				runSeries(walk, shape);
+			}
+		}
+	}
+
+	/**
+	 * Runs the warm and cold series for one affected-owner shape and prints the readings.
+	 *
+	 * @param walk  the prepared walk over the sibling partitions
+	 * @param shape the affected-owner set being measured
+	 */
+	private static void runSeries(@Nonnull Walk walk, @Nonnull Shape shape) {
+		final PersistentRoaringBitmap affected = getRoaringBitmap(shape.owners);
+		final int[] affectedOwners = shape.owners.getArray();
+		final Arm[] arms = Arm.values();
+
+		// one throwaway transaction bound for the whole series: the arms are read-only, so no layer is ever
+		// created, but every per-partition `getTransactionalMemoryLayerIfExists` now takes the ALIVE path
+		final Transaction transaction = new Transaction(new TransactionalBitmap(new BaseBitmap()));
+
+		final long[][] warm = new long[arms.length][WARM_ROUNDS];
+		final long[] checksums = new long[arms.length];
+		Arrays.fill(checksums, Long.MIN_VALUE);
+		Transaction.executeInTransactionIfProvided(transaction, (Runnable) () -> {
+			for (int round = -WARMUP_ROUNDS; round < WARM_ROUNDS; round++) {
+				for (int slot = 0; slot < arms.length; slot++) {
+					// rotate so no arm always runs first into a cache the others then reuse
+					final Arm arm = arms[(round + slot + WARMUP_ROUNDS) % arms.length];
+					final long start = System.nanoTime();
+					final long checksum = walk.run(arm, affected, affectedOwners);
+					final long elapsed = System.nanoTime() - start;
+					if (round >= 0) {
+						warm[arm.ordinal()][round] = elapsed;
+					}
+					verifyChecksum(checksums, arm, checksum);
+				}
+			}
+		});
+
+		System.out.printf(
+			"  %-26s %12s %12s %12s %10s%n", "series / arm", "median ns", "p95 ns", "ns/probe", "probes"
+		);
+		for (final Arm arm : arms) {
+			report("WARM " + arm.label, warm[arm.ordinal()], walk.probesFor(arm));
+		}
+
+		// COLD: one arm per round, working set evicted outside the timed region
+		final long[][] cold = new long[arms.length][];
+		final int perArm = COLD_ROUNDS / arms.length;
+		for (final Arm arm : arms) {
+			cold[arm.ordinal()] = new long[perArm];
+		}
+		Transaction.executeInTransactionIfProvided(transaction, (Runnable) () -> {
+			for (int round = 0; round < perArm * arms.length; round++) {
+				final Arm arm = arms[round % arms.length];
+				evictCaches();
+				final long start = System.nanoTime();
+				final long checksum = walk.run(arm, affected, affectedOwners);
+				final long elapsed = System.nanoTime() - start;
+				cold[arm.ordinal()][round / arms.length] = elapsed;
+				verifyChecksum(checksums, arm, checksum);
+			}
+		});
+		for (final Arm arm : arms) {
+			report("COLD " + arm.label, cold[arm.ordinal()], walk.probesFor(arm));
+		}
+
+		// the same walk with NO transaction bound - the delta against WARM B is the ceiling on what hoisting
+		// the loop-invariant transaction resolution out of the per-partition loop could recover
+		final long[] noTx = new long[WARM_ROUNDS];
+		for (int round = -WARMUP_ROUNDS; round < WARM_ROUNDS; round++) {
+			final long start = System.nanoTime();
+			final long checksum = walk.run(Arm.B_SINGLE_PASS, affected, affectedOwners);
+			final long elapsed = System.nanoTime() - start;
+			if (round >= 0) {
+				noTx[round] = elapsed;
+			}
+			verifyChecksum(checksums, Arm.B_SINGLE_PASS, checksum);
+		}
+		report("WARM B (no transaction)", noTx, walk.probesFor(Arm.B_SINGLE_PASS));
+
+		// the same, cold: whether the transactional-layer overhead survives once the walk is memory-bound
+		final long[] coldNoTx = new long[perArm];
+		for (int round = 0; round < perArm; round++) {
+			evictCaches();
+			final long start = System.nanoTime();
+			final long checksum = walk.run(Arm.B_SINGLE_PASS, affected, affectedOwners);
+			coldNoTx[round] = System.nanoTime() - start;
+			verifyChecksum(checksums, Arm.B_SINGLE_PASS, checksum);
+		}
+		report("COLD B (no transaction)", coldNoTx, walk.probesFor(Arm.B_SINGLE_PASS));
+		System.out.println();
+	}
+
+	/**
+	 * Records an arm's first checksum and rejects any later disagreement — an arm that computes a different
+	 * answer must never be compared as if it were merely faster.
+	 *
+	 * @param checksums per-arm accumulator of first-seen checksums
+	 * @param arm       the arm that just ran
+	 * @param checksum  the checksum it produced
+	 */
+	private static void verifyChecksum(@Nonnull long[] checksums, @Nonnull Arm arm, long checksum) {
+		if (checksums[arm.ordinal()] == Long.MIN_VALUE) {
+			checksums[arm.ordinal()] = checksum;
+		} else if (checksums[arm.ordinal()] != checksum) {
+			throw new IllegalStateException(
+				"Arm " + arm + " is not deterministic: " + checksums[arm.ordinal()] + " != " + checksum
+			);
+		}
+		for (final Arm other : Arm.values()) {
+			if (checksums[other.ordinal()] != Long.MIN_VALUE && checksums[other.ordinal()] != checksum) {
+				throw new IllegalStateException(
+					"Arm " + arm + " disagrees with " + other + ": " + checksum + " != "
+						+ checksums[other.ordinal()]
+				);
+			}
+		}
+	}
+
+	/**
+	 * Prints one reading as median, p95 and nanoseconds per probed partition.
+	 *
+	 * @param label   what was measured
+	 * @param samples the per-round durations
+	 * @param probes  how many partitions this arm actually probes
+	 */
+	private static void report(@Nonnull String label, @Nonnull long[] samples, long probes) {
+		final long[] sorted = samples.clone();
+		Arrays.sort(sorted);
+		final long median = sorted[sorted.length / 2];
+		System.out.printf(
+			"  %-26s %,12d %,12d %12s %,10d%n",
+			label, median, sorted[(int) (sorted.length * 0.95)],
+			probes == 0L ? "n/a" : String.format("%.1f", median / (double) probes), probes
+		);
+	}
+
+	/**
+	 * Streams a buffer larger than twice the LLC, touching one byte per cache line, so the partition working set
+	 * is evicted before the next timed walk. Runs OUTSIDE any timed region.
+	 */
+	private static void evictCaches() {
+		final byte[] buffer = new byte[EVICTION_BYTES];
+		long sum = 0L;
+		for (int i = 0; i < buffer.length; i += 64) {
+			buffer[i] = (byte) i;
+			sum += buffer[i];
+		}
+		evictionSink = sum;
+	}
+
+	/**
+	 * Builds the affected-owner shapes: the sparse and dense ends of the real partition-size distribution of the
+	 * reference the trigger fires for. A trigger's affected owners are exactly the members of one of that
+	 * reference's partitions, which is what `resolveForGroupEntityAttribute` resolves.
+	 *
+	 * @param collection the collection being measured
+	 * @param mutated    the reference the trigger fires for
+	 * @return the shapes to measure
+	 */
+	@Nonnull
+	private static List<Shape> shapes(@Nonnull EntityCollection collection, @Nullable String mutated) {
+		final List<Shape> shapes = new ArrayList<>(2);
+		if (mutated == null) {
+			return shapes;
+		}
+		final ReferencedTypeEntityIndex typeIndex = typeIndex(
+			collection, EntityIndexType.REFERENCED_ENTITY_TYPE, mutated
+		);
+		if (typeIndex == null) {
+			return shapes;
+		}
+		final List<Integer> pks = new ArrayList<>();
+		typeIndex.forEachReferenceIndexPrimaryKey(pks::add);
+		Bitmap smallest = null;
+		Bitmap largest = null;
+		for (final int pk : pks) {
+			final EntityIndex partition = collection.getIndexByPrimaryKeyIfExists(pk);
+			if (partition == null) {
+				continue;
+			}
+			final Bitmap owners = partition.getAllPrimaryKeys();
+			if (owners.size() >= 20 && (smallest == null || owners.size() < smallest.size())) {
+				smallest = owners;
+			}
+			if (largest == null || owners.size() > largest.size()) {
+				largest = owners;
+			}
+		}
+		if (smallest != null) {
+			shapes.add(new Shape("SPARSE", smallest));
+		}
+		if (largest != null) {
+			shapes.add(new Shape("DENSE", largest));
+		}
+		return shapes;
+	}
+
+	/**
+	 * Resolves one `REFERENCED_*_TYPE` index of a reference.
+	 *
+	 * @param collection    the collection holding the indexes
+	 * @param family        the referenced-type index family
+	 * @param referenceName the reference whose type index is resolved
+	 * @return the type index, or `null` when the reference has none of that kind
+	 */
+	@Nullable
+	private static ReferencedTypeEntityIndex typeIndex(
+		@Nonnull EntityCollection collection,
+		@Nonnull EntityIndexType family,
+		@Nonnull String referenceName
+	) {
+		final EntityIndex index = collection.getIndexByKeyIfExists(
+			new EntityIndexKey(family, Scope.LIVE, referenceName)
+		);
+		if (index == null) {
+			return null;
+		}
+		if (index instanceof final ReferencedTypeEntityIndex typeIndex) {
+			return typeIndex;
+		}
+		throw new IllegalStateException("Index " + family + "/" + referenceName + " has the wrong type!");
+	}
+
+	/**
+	 * Waits until the catalog finishes its background load.
+	 *
+	 * @param evita       the running engine
+	 * @param catalogName the catalog to wait for
+	 * @return the loaded catalog
+	 */
+	@Nonnull
+	private static Catalog awaitLoaded(@Nonnull Evita evita, @Nonnull String catalogName) {
+		final long deadline = System.nanoTime() + LOAD_TIMEOUT_NANOS;
+		while (System.nanoTime() < deadline) {
+			final CatalogContract candidate = evita.getCatalogInstance(catalogName)
+				.orElseThrow(() -> new IllegalArgumentException("Catalog `" + catalogName + "` not found!"));
+			if (candidate instanceof final Catalog loaded) {
+				return loaded;
+			}
+			try {
+				Thread.sleep(500L);
+			} catch (final InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new IllegalStateException("Interrupted while waiting for catalog!", e);
+			}
+		}
+		throw new IllegalStateException("Catalog `" + catalogName + "` did not load in time!");
+	}
+
+	/**
+	 * The walk implementations under comparison: three candidates, and two unimplementable bounds that say how
+	 * much of the walk any lookup optimization could ever remove.
+	 */
+	private enum Arm {
+		A_BOXED_KEYSET("A boxed keySet"),
+		B_SINGLE_PASS("B single pass"),
+		C_HYBRID_REVERSE("C hybrid reverse"),
+		D_INDEX_PRERESOLVED("D index preresolved"),
+		E_BITMAP_PRERESOLVED("E bitmap preresolved"),
+		F_INTERSECTS_FIRST("F intersects first");
+
+		private final String label;
+
+		Arm(@Nonnull String label) {
+			this.label = label;
+		}
+	}
+
+	/**
+	 * One affected-owner set, taken from a real partition of the reference the trigger fires for.
+	 *
+	 * @param name   the shape's label
+	 * @param owners the affected owner primary keys
+	 */
+	private record Shape(@Nonnull String name, @Nonnull Bitmap owners) {
+	}
+
+	/**
+	 * The prepared walk: the sibling type indexes, and the hybrid reverse map over their small partitions.
+	 */
+	private static final class Walk {
+		private final EntityCollection collection;
+		private final List<ReferencedTypeEntityIndex> typeIndexes = new ArrayList<>();
+		/** partition storage PK to its already-resolved index, for the D bound */
+		private final IntObjectMap<EntityIndex> resolvedIndexes = new IntObjectHashMap<>(4096);
+		/** partition storage PK to its already-resolved membership bitmap, for the E bound */
+		private final IntObjectMap<PersistentRoaringBitmap> resolvedBitmaps = new IntObjectHashMap<>(4096);
+		private final Map<Integer, int[]> reverse = CollectionUtils.createHashMap(1024);
+		private final int[] residual;
+		private final long totalPartitions;
+		private final long coveredPartitions;
+		private final long residualPartitions;
+		private final long memberships;
+
+		Walk(@Nonnull EntityCollection collection, @Nonnull List<String> siblings, int threshold) {
+			this.collection = collection;
+			long total = 0L;
+			long covered = 0L;
+			long members = 0L;
+			final Map<Integer, List<Integer>> building = CollectionUtils.createHashMap(1024);
+			final List<Integer> big = new ArrayList<>();
+			for (final String sibling : siblings) {
+				for (final EntityIndexType family : new EntityIndexType[]{
+					EntityIndexType.REFERENCED_ENTITY_TYPE, EntityIndexType.REFERENCED_GROUP_ENTITY_TYPE
+				}) {
+					final ReferencedTypeEntityIndex typeIndex = typeIndex(collection, family, sibling);
+					if (typeIndex == null) {
+						continue;
+					}
+					this.typeIndexes.add(typeIndex);
+					final List<Integer> pks = new ArrayList<>();
+					typeIndex.forEachReferenceIndexPrimaryKey(pks::add);
+					for (final int pk : pks) {
+						final EntityIndex partition = collection.getIndexByPrimaryKeyIfExists(pk);
+						if (partition == null) {
+							continue;
+						}
+						total++;
+						final Bitmap owners = partition.getAllPrimaryKeys();
+						// the D/E bounds resolve every partition once here, so their timed loops pay only the
+						// substitute lookup (D) or nothing at all (E)
+						this.resolvedIndexes.put(pk, partition);
+						this.resolvedBitmaps.put(pk, getRoaringBitmap(owners));
+						if (owners.size() > threshold) {
+							big.add(pk);
+							continue;
+						}
+						covered++;
+						members += owners.size();
+						final OfInt it = owners.iterator();
+						while (it.hasNext()) {
+							building.computeIfAbsent(it.nextInt(), __ -> new ArrayList<>(2)).add(pk);
+						}
+					}
+				}
+			}
+			for (final Map.Entry<Integer, List<Integer>> entry : building.entrySet()) {
+				final List<Integer> value = entry.getValue();
+				final int[] packed = new int[value.size()];
+				for (int i = 0; i < packed.length; i++) {
+					packed[i] = value.get(i);
+				}
+				this.reverse.put(entry.getKey(), packed);
+			}
+			this.residual = new int[big.size()];
+			for (int i = 0; i < this.residual.length; i++) {
+				this.residual[i] = big.get(i);
+			}
+			this.totalPartitions = total;
+			this.coveredPartitions = covered;
+			this.residualPartitions = big.size();
+			this.memberships = members;
+		}
+
+		/**
+		 * Returns how many partitions the given arm actually probes, which is the denominator of its
+		 * nanoseconds-per-probe figure.
+		 *
+		 * @param arm the arm
+		 * @return the probe count
+		 */
+		long probesFor(@Nonnull Arm arm) {
+			return arm == Arm.C_HYBRID_REVERSE ? this.residualPartitions : this.totalPartitions;
+		}
+
+		/**
+		 * Runs one arm and returns an order-independent checksum of the `(owner, partition)` pairs it emits.
+		 *
+		 * @param arm            the implementation to run
+		 * @param affected       the affected owner primary keys
+		 * @param affectedOwners the same set, materialised as primitives
+		 * @return the checksum
+		 */
+		long run(@Nonnull Arm arm, @Nonnull PersistentRoaringBitmap affected, @Nonnull int[] affectedOwners) {
+			return switch (arm) {
+				case A_BOXED_KEYSET -> runBoxed(affected);
+				case B_SINGLE_PASS -> runSinglePass(affected);
+				case C_HYBRID_REVERSE -> runHybrid(affected, affectedOwners);
+				case D_INDEX_PRERESOLVED -> runPreresolved(affected, false);
+				case E_BITMAP_PRERESOLVED -> runPreresolved(affected, true);
+				case F_INTERSECTS_FIRST -> runIntersectsFirst(affected);
+			};
+		}
+
+		/**
+		 * Arm A — the pre-`5db4385e1` shape: a boxed keySet iteration plus a second hash into the same map.
+		 *
+		 * @param affected the affected owner primary keys
+		 * @return the checksum
+		 */
+		private long runBoxed(@Nonnull PersistentRoaringBitmap affected) {
+			long checksum = 0L;
+			for (int i = 0; i < this.typeIndexes.size(); i++) {
+				final ReferencedTypeEntityIndex typeIndex = this.typeIndexes.get(i);
+				for (final Integer referencedPk : typeIndex.getAllTrackedReferencedEntityPrimaryKeys()) {
+					for (final int pk : typeIndex.getAllReferenceIndexes(referencedPk)) {
+						checksum += probe(pk, affected);
+					}
+				}
+			}
+			return checksum;
+		}
+
+		/**
+		 * Arm B — current `HEAD`: one `entrySet` pass, nothing allocated per partition.
+		 *
+		 * @param affected the affected owner primary keys
+		 * @return the checksum
+		 */
+		private long runSinglePass(@Nonnull PersistentRoaringBitmap affected) {
+			final long[] checksum = new long[1];
+			for (int i = 0; i < this.typeIndexes.size(); i++) {
+				this.typeIndexes.get(i).forEachReferenceIndexPrimaryKey(
+					pk -> checksum[0] += probe(pk, affected)
+				);
+			}
+			return checksum[0];
+		}
+
+		/**
+		 * Arm C — the hybrid: a reverse lookup per affected owner for the covered partitions, plus the ordinary
+		 * walk over the few partitions left above the threshold.
+		 *
+		 * @param affected       the affected owner primary keys
+		 * @param affectedOwners the same set, materialised, so the hot loop iterates primitives
+		 * @return the checksum
+		 */
+		private long runHybrid(@Nonnull PersistentRoaringBitmap affected, @Nonnull int[] affectedOwners) {
+			long checksum = 0L;
+			for (final int owner : affectedOwners) {
+				final int[] partitions = this.reverse.get(owner);
+				if (partitions != null) {
+					for (final int pk : partitions) {
+						checksum += pair(owner, pk);
+					}
+				}
+			}
+			for (final int pk : this.residual) {
+				checksum += probe(pk, affected);
+			}
+			return checksum;
+		}
+
+		/**
+		 * Arm F — arm B with the `and()` gated behind an allocation-free intersection test. Everything else is
+		 * identical, including the index lookup and the bitmap resolution, so the delta against B is exactly
+		 * what the discarded intersection bitmaps and their `int[]`s cost.
+		 *
+		 * @param affected the affected owner primary keys
+		 * @return the checksum
+		 */
+		private long runIntersectsFirst(@Nonnull PersistentRoaringBitmap affected) {
+			final long[] checksum = new long[1];
+			for (int i = 0; i < this.typeIndexes.size(); i++) {
+				this.typeIndexes.get(i).forEachReferenceIndexPrimaryKey(
+					pk -> {
+						final EntityIndex probed = this.collection.getIndexByPrimaryKeyIfExists(pk);
+						if (probed == null) {
+							return;
+						}
+						final PersistentRoaringBitmap owners = getRoaringBitmap(probed.getAllPrimaryKeys());
+						if (!intersects(owners, affected)) {
+							return;
+						}
+						for (final int owner : and(owners, affected).toArray()) {
+							checksum[0] += pair(owner, pk);
+						}
+					}
+				);
+			}
+			return checksum[0];
+		}
+
+		/**
+		 * Arms D and E — the two bounds. Both keep arm B's traversal verbatim, so the delta against B isolates
+		 * the lookup and nothing else; they differ only in how far the per-partition resolution is skipped.
+		 *
+		 * @param affected     the affected owner primary keys
+		 * @param skipBitmap   `true` for E: the membership bitmap is pre-resolved as well, leaving only the
+		 *                     intersection in the timed region
+		 * @return the checksum
+		 */
+		private long runPreresolved(@Nonnull PersistentRoaringBitmap affected, boolean skipBitmap) {
+			final long[] checksum = new long[1];
+			for (int i = 0; i < this.typeIndexes.size(); i++) {
+				this.typeIndexes.get(i).forEachReferenceIndexPrimaryKey(
+					pk -> {
+						final PersistentRoaringBitmap owners;
+						if (skipBitmap) {
+							owners = this.resolvedBitmaps.get(pk);
+							if (owners == null) {
+								return;
+							}
+						} else {
+							final EntityIndex probed = this.resolvedIndexes.get(pk);
+							if (probed == null) {
+								return;
+							}
+							owners = getRoaringBitmap(probed.getAllPrimaryKeys());
+						}
+						for (final int owner : and(owners, affected).toArray()) {
+							checksum[0] += pair(owner, pk);
+						}
+					}
+				);
+			}
+			return checksum[0];
+		}
+
+		/**
+		 * Probes one partition exactly as `collectOwnersOfReducedIndexes` does and folds every matched owner
+		 * into the checksum.
+		 *
+		 * @param pk       the partition's storage primary key
+		 * @param affected the affected owner primary keys
+		 * @return the checksum contribution
+		 */
+		private long probe(int pk, @Nonnull PersistentRoaringBitmap affected) {
+			final EntityIndex probed = this.collection.getIndexByPrimaryKeyIfExists(pk);
+			if (probed == null) {
+				return 0L;
+			}
+			final int[] owners = and(getRoaringBitmap(probed.getAllPrimaryKeys()), affected).toArray();
+			long checksum = 0L;
+			for (final int owner : owners) {
+				checksum += pair(owner, pk);
+			}
+			return checksum;
+		}
+
+		/**
+		 * Order-independent contribution of one emitted `(owner, partition)` pair.
+		 *
+		 * @param owner the owner primary key
+		 * @param pk    the partition's storage primary key
+		 * @return the contribution
+		 */
+		private static long pair(int owner, int pk) {
+			return (long) owner * 1000003L + pk;
+		}
+	}
+
+	/**
+	 * Not instantiable — this is a `main()`-style report.
+	 */
+	private ConditionalFacetSiblingResolverReport() {
+	}
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetSiblingResolverReport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetSiblingResolverReport.java
@@ -61,8 +61,9 @@ import static io.evitadb.roaringbitmap.PersistentRoaringBitmap.and;
 import static io.evitadb.roaringbitmap.PersistentRoaringBitmap.intersects;
 
 /**
- * Times the sibling-resolver walk of issue #1529 against a real catalog, in the three shapes that matter, and
- * reports the one number the whole decision still lacks: **nanoseconds per probed partition**.
+ * Times the sibling-resolver walk of issue #1529 against a real catalog, in both affected-owner shapes that
+ * matter — the sparse and the dense end of the mutated reference's partition-size distribution — and reports
+ * the one number the whole decision still lacks: **nanoseconds per probed partition**.
  *
  * # The arms
  *
@@ -100,7 +101,8 @@ import static io.evitadb.roaringbitmap.PersistentRoaringBitmap.intersects;
  * still see the transaction's own writes. They exist to bound what step 1 of the #1529 plan (hoisting the
  * loop-invariant transaction resolution) could ever be worth, before that seam is cut into the engine.
  *
- * All three are **probe-only**: they stop at the intersection and never call `getOrCreateIndexByPrimaryKey`.
+ * Every arm, A through G, is **probe-only**: they stop at the intersection and never call
+ * `getOrCreateIndexByPrimaryKey`.
  * That matches how the 2026-09-09 decomposition defined "the walk" (0.47 ms) against the whole resolver
  * (2.0 ms), and it keeps the arms read-only so they can share one live catalog.
  *

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetSiblingResolverReport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/ConditionalFacetSiblingResolverReport.java
@@ -88,6 +88,14 @@ import static io.evitadb.roaringbitmap.PersistentRoaringBitmap.intersects;
  *   first common bit and allocates nothing, so the `and()` runs only where it produces something. Unlike D and
  *   E this one is implementable as written — it changes only the order of two operations that already exist.
  *
+ * - **G** — the same hybrid as C, but with the reverse map **split per `ReferencedTypeEntityIndex`** instead
+ *   of merged across the collection, which is where the structure most naturally lives. Each index also
+ *   carries the union of the owners its covered partitions hold, so the affected set is intersected against
+ *   that once per index and only owners that can hit are looked up. C and G emit identical pairs and differ
+ *   only in layout: C pays one hash lookup per affected owner, G pays one per `(owner, reference)` that hits.
+ *   The delta is the price of the placement, and it decides whether the map can be a field on the type index
+ *   or has to be a collection-level structure with a much harder transactional story.
+ *
  * D and E are **not implementable** as they stand — a real walk cannot pre-resolve a transactional bitmap and
  * still see the transaction's own writes. They exist to bound what step 1 of the #1529 plan (hoisting the
  * loop-invariant transaction resolution) could ever be worth, before that seam is cut into the engine.
@@ -487,7 +495,8 @@ public class ConditionalFacetSiblingResolverReport {
 		C_HYBRID_REVERSE("C hybrid reverse"),
 		D_INDEX_PRERESOLVED("D index preresolved"),
 		E_BITMAP_PRERESOLVED("E bitmap preresolved"),
-		F_INTERSECTS_FIRST("F intersects first");
+		F_INTERSECTS_FIRST("F intersects first"),
+		G_PER_INDEX_HYBRID("G per-index hybrid");
 
 		private final String label;
 
@@ -506,6 +515,49 @@ public class ConditionalFacetSiblingResolverReport {
 	}
 
 	/**
+	 * One type index's own slice of the hybrid: its reverse map, the union of the owners its covered
+	 * partitions hold, and the partitions of its own that stayed above the threshold.
+	 *
+	 * @param reverse       owner primary key to the covered partitions of this index holding it
+	 * @param coveredOwners union of this index's covered partitions' members, so the affected set can be
+	 *                      intersected against it once instead of probing the map per affected owner
+	 * @param residual      this index's partitions left on the walk
+	 */
+	private record Slice(
+		@Nonnull Map<Integer, int[]> reverse,
+		@Nonnull PersistentRoaringBitmap coveredOwners,
+		@Nonnull int[] residual
+	) {
+
+		/**
+		 * Packs one index's accumulated lists into the immutable slice the timed loop reads.
+		 *
+		 * @param building accumulated owner to partition lists
+		 * @param residual accumulated above-threshold partitions
+		 * @return the packed slice
+		 */
+		@Nonnull
+		static Slice of(@Nonnull Map<Integer, List<Integer>> building, @Nonnull List<Integer> residual) {
+			final Map<Integer, int[]> packed = CollectionUtils.createHashMap(Math.max(building.size(), 1));
+			final PersistentRoaringBitmap owners = new PersistentRoaringBitmap();
+			for (final Map.Entry<Integer, List<Integer>> entry : building.entrySet()) {
+				final List<Integer> value = entry.getValue();
+				final int[] partitions = new int[value.size()];
+				for (int i = 0; i < partitions.length; i++) {
+					partitions[i] = value.get(i);
+				}
+				packed.put(entry.getKey(), partitions);
+				owners.add(entry.getKey());
+			}
+			final int[] left = new int[residual.size()];
+			for (int i = 0; i < left.length; i++) {
+				left[i] = residual.get(i);
+			}
+			return new Slice(packed, owners, left);
+		}
+	}
+
+	/**
 	 * The prepared walk: the sibling type indexes, and the hybrid reverse map over their small partitions.
 	 */
 	private static final class Walk {
@@ -516,6 +568,8 @@ public class ConditionalFacetSiblingResolverReport {
 		/** partition storage PK to its already-resolved membership bitmap, for the E bound */
 		private final IntObjectMap<PersistentRoaringBitmap> resolvedBitmaps = new IntObjectHashMap<>(4096);
 		private final Map<Integer, int[]> reverse = CollectionUtils.createHashMap(1024);
+		/** one reverse map per type index, the placement arm G prices against C's merged one */
+		private final List<Slice> slices = new ArrayList<>();
 		private final int[] residual;
 		private final long totalPartitions;
 		private final long coveredPartitions;
@@ -538,6 +592,8 @@ public class ConditionalFacetSiblingResolverReport {
 						continue;
 					}
 					this.typeIndexes.add(typeIndex);
+					final Map<Integer, List<Integer>> sliceBuilding = CollectionUtils.createHashMap(1024);
+					final List<Integer> sliceResidual = new ArrayList<>();
 					final List<Integer> pks = new ArrayList<>();
 					typeIndex.forEachReferenceIndexPrimaryKey(pks::add);
 					for (final int pk : pks) {
@@ -553,15 +609,19 @@ public class ConditionalFacetSiblingResolverReport {
 						this.resolvedBitmaps.put(pk, getRoaringBitmap(owners));
 						if (owners.size() > threshold) {
 							big.add(pk);
+							sliceResidual.add(pk);
 							continue;
 						}
 						covered++;
 						members += owners.size();
 						final OfInt it = owners.iterator();
 						while (it.hasNext()) {
-							building.computeIfAbsent(it.nextInt(), __ -> new ArrayList<>(2)).add(pk);
+							final int owner = it.nextInt();
+							building.computeIfAbsent(owner, __ -> new ArrayList<>(2)).add(pk);
+							sliceBuilding.computeIfAbsent(owner, __ -> new ArrayList<>(2)).add(pk);
 						}
 					}
+					this.slices.add(Slice.of(sliceBuilding, sliceResidual));
 				}
 			}
 			for (final Map.Entry<Integer, List<Integer>> entry : building.entrySet()) {
@@ -590,7 +650,8 @@ public class ConditionalFacetSiblingResolverReport {
 		 * @return the probe count
 		 */
 		long probesFor(@Nonnull Arm arm) {
-			return arm == Arm.C_HYBRID_REVERSE ? this.residualPartitions : this.totalPartitions;
+			return arm == Arm.C_HYBRID_REVERSE || arm == Arm.G_PER_INDEX_HYBRID
+				? this.residualPartitions : this.totalPartitions;
 		}
 
 		/**
@@ -609,6 +670,7 @@ public class ConditionalFacetSiblingResolverReport {
 				case D_INDEX_PRERESOLVED -> runPreresolved(affected, false);
 				case E_BITMAP_PRERESOLVED -> runPreresolved(affected, true);
 				case F_INTERSECTS_FIRST -> runIntersectsFirst(affected);
+				case G_PER_INDEX_HYBRID -> runPerIndexHybrid(affected);
 			};
 		}
 
@@ -667,6 +729,33 @@ public class ConditionalFacetSiblingResolverReport {
 			}
 			for (final int pk : this.residual) {
 				checksum += probe(pk, affected);
+			}
+			return checksum;
+		}
+
+		/**
+		 * Arm G — the same hybrid as C with the reverse map split per type index. Each slice's covered-owner
+		 * union is intersected against the affected set once, so only owners that can hit are looked up; the
+		 * pairs emitted are identical to C's and only the number of hash lookups differs.
+		 *
+		 * @param affected the affected owner primary keys
+		 * @return the checksum
+		 */
+		private long runPerIndexHybrid(@Nonnull PersistentRoaringBitmap affected) {
+			long checksum = 0L;
+			for (int i = 0; i < this.slices.size(); i++) {
+				final Slice slice = this.slices.get(i);
+				for (final int owner : and(slice.coveredOwners(), affected).toArray()) {
+					final int[] partitions = slice.reverse().get(owner);
+					if (partitions != null) {
+						for (final int pk : partitions) {
+							checksum += pair(owner, pk);
+						}
+					}
+				}
+				for (final int pk : slice.residual()) {
+					checksum += probe(pk, affected);
+				}
 			}
 			return checksum;
 		}


### PR DESCRIPTION
Closes #1529
Closes #1531

## What

The deferred cross-entity conditional-facet trigger (`facetedPartially`) has to reach every reduced index each affected owner belongs to, and reached them by walking **every** partition the collection advertises. This adds a size-thresholded owner-to-partition reverse index (`ReducedIndexMembership`) that names the partitions small enough to be worth an entry each and leaves the rest on the walk, and removes a per-pair de-duplication scan that turned out to reject nothing.

The reverse index is an **accelerator, never an authority**: it decides *which* partitions are probed, and every probe still asks the index itself who is in it. A stale entry can only send the probe at a partition holding no affected owner; it can never write a facet into one the owner has left.

## Measured

Against a production catalog (160,216 entities, 281,784 reduced indexes), two runs per figure, arms checksum-gated against each other on the `(owner, partition)` pairs they emit:

| partitions | affected owners | walk | lookup | |
|---|---|---|---|---|
| 4,633 | 20 | 807 / 798 µs | 268 / 283 µs | 2.8-3.0x |
| 4,633 | 57,962 | 10.32 / 10.33 ms | 9.71 / 9.62 ms | 1.06-1.07x |
| 188,387 | 20 | 84.0 / 87.3 ms | 1.55 / 1.53 ms | **54-57x** |
| 188,387 | 57,962 | 159.6 / 158.8 ms | 105.5 / 101.2 ms | 1.51-1.57x |

Memory 4.2 MiB on the shipping schema, 24.9 MiB with every reference partitioned; rebuilding the lookup over 188,387 partitions costs 156 ms against a 26 s catalog load.

Removing the de-duplication scan is worth a further **-13 %** on both arms at 4,633 partitions and **-38 % / -30 %** (lookup / walk) at 188,387, measured with the scan restored as a same-session control. It is absolute time off every dense trigger rather than a ratio improvement, because both arms were paying it — and it lands on deployments with no reverse index at all, which the index itself does nothing for.

**An earlier revision of the decision record published higher ratios.** The measurement harness had diverged from the shipped resolver in two ways its checksum gate could not see, since the gate compares emitted pairs and the pairs were identical either way. Corrected; the dense high-cardinality row was published as 8.3x and is really 1.34-1.50x before the scan removal. Numbers taken before 2026-09-11 are not comparable with the ones after.

## Also in this branch

- `MapChanges#put` released a displaced producer's transactional layer eagerly, evaluating its survivor guard against a mapping that was not yet final — so a later alias was invisible and the layer was released out from under a surviving key. Pre-existing since 2023; the transaction commits having silently dropped the change.
- `ReducedIndexMembership#registerIndex` left an advertised-but-memberless index in neither the covered nor the residual set, breaking `covered union residual == advertised`.
- Three dead defensive guards removed, all justified by the same false mechanism ("references sharing a reduced group index"). That is real on the **owner** side, where `ReferenceIndexMutator#forEachUniqueReferenceIndex` de-duplicates by identity, and cannot occur on a walk over advertised indexes. A duplicate advertisement now raises at load and on the write path instead of being silently skipped.
- #1531: only the references a mutation actually touched are re-verified on an existing entity.

## Verification

Full functional suite: **23,791 tests, 0 failures**, one environmental error (`ExportS3ServiceTest`, needs a Docker environment).

Guards were proved dead before deletion rather than after: a tallying variant of the harness counted **0 rejections in 1,568,849,000 offered pairs** on the production catalog; restoring the scan as a throwing assertion offered no duplicate pair in 350 tests; and each test asserting this is proved load-bearing by counterfactual — an unconditional throw in the resolver errors 12 tests across 4 classes, so the green runs are evidence rather than absence of coverage.

Decision record, with the rejected alternatives and why they lost: `documentation/adr/2026-09-09-sibling-resolver-partition-cardinality.md`.

## For the reviewer

- The branch is **17 commits behind `dev`** and has not been rebased or merged.
- `DEFAULT_COVERAGE_THRESHOLD = 16` has never been swept against the shipped implementation — every threshold figure in the record comes from a memory-only model. Both construction sites use the no-argument constructor, so measuring it needs plumbing first. It is the only lever that improves the sparse shapes.
- WAL replay was not exercised against the guard removals; every other route into them was driven (reload, go-live, archive/restore, group moves, delete-and-recreate, lowering and raising a grouped reference).
